### PR TITLE
redis: skip marshalling if []byte

### DIFF
--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -192,9 +192,15 @@ func (r *StateStore) setValue(req *state.SetRequest) error {
 		ver = 0
 	}
 
-	b, _ := r.json.Marshal(req.Value)
+	bt := []byte{}
+	b, ok := req.Value.([]byte)
+	if ok {
+		bt = b
+	} else {
+		bt, _ = r.json.Marshal(req.Value)
+	}
 
-	res := r.client.Do(context.Background(), "EVAL", setQuery, 1, req.Key, ver, b)
+	res := r.client.Do(context.Background(), "EVAL", setQuery, 1, req.Key, ver, bt)
 	if err := redis.AsError(res); err != nil {
 		return fmt.Errorf("failed to set key %s: %s", req.Key, err)
 	}


### PR DESCRIPTION
This PR allows the Redis implementation to accept byte array values and skip marshalling if so.