### PR TITLE
[golangci] Set modules-download-mode to vendor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,8 @@ run:
   skip-files:
   #  - ".*\\.my\\.go$"
   #  - lib/bad.go
+  
+  modules-download-mode: vendor
 
 # output configuration options
 output:


### PR DESCRIPTION
# Description

Set modules-download-mode to vendor. 

Reference: https://github.com/golangci/golangci-lint/issues/395

## Issue reference

N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
