### PR TITLE
Add TLS connection option to Redis pub sub

### DIFF
--- a/pubsub/redis/metadata.go
+++ b/pubsub/redis/metadata.go
@@ -9,4 +9,5 @@ type metadata struct {
 	host       string
 	password   string
 	consumerID string
+	enableTLS  bool
 }

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -79,9 +79,10 @@ func (r *redisStreams) Init(metadata pubsub.Metadata) error {
 		MaxRetryBackoff: time.Second * 2,
 	}
 
+	/* #nosec */
 	if r.metadata.enableTLS {
 		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: r.metadata.enableTLS, /* #nosec */
+			InsecureSkipVerify: r.metadata.enableTLS,
 		}
 	}
 

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -81,7 +81,7 @@ func (r *redisStreams) Init(metadata pubsub.Metadata) error {
 
 	if r.metadata.enableTLS {
 		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: r.metadata.enableTLS,
+			InsecureSkipVerify: r.metadata.enableTLS, /* #nosec */
 		}
 	}
 

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -19,11 +19,10 @@ import (
 )
 
 const (
-	host              = "redisHost"
-	password          = "redisPassword"
-	consumerID        = "consumerID"
-	enableTLS         = "enableTLS"
-	defaultSkipVerify = true
+	host       = "redisHost"
+	password   = "redisPassword"
+	consumerID = "consumerID"
+	enableTLS  = "enableTLS"
 )
 
 type redisStreams struct {
@@ -82,7 +81,7 @@ func (r *redisStreams) Init(metadata pubsub.Metadata) error {
 
 	if r.metadata.enableTLS {
 		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: defaultSkipVerify,
+			InsecureSkipVerify: r.metadata.enableTLS,
 		}
 	}
 

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	host       = "redisHost"
-	password   = "redisPassword"
-	consumerID = "consumerID"
-	enableTLS  = "enableTLS"
+	host              = "redisHost"
+	password          = "redisPassword"
+	consumerID        = "consumerID"
+	enableTLS         = "enableTLS"
+	defaultSkipVerify = true
 )
 
 type redisStreams struct {
@@ -81,7 +82,7 @@ func (r *redisStreams) Init(metadata pubsub.Metadata) error {
 
 	if r.metadata.enableTLS {
 		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: defaultSkipVerify,
 		}
 	}
 

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -6,8 +6,10 @@
 package redis
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -20,6 +22,7 @@ const (
 	host       = "redisHost"
 	password   = "redisPassword"
 	consumerID = "consumerID"
+	enableTLS  = "enableTLS"
 )
 
 type redisStreams struct {
@@ -44,6 +47,14 @@ func parseRedisMetadata(meta pubsub.Metadata) (metadata, error) {
 		m.password = val
 	}
 
+	if val, ok := meta.Properties[enableTLS]; ok && val != "" {
+		tls, err := strconv.ParseBool(val)
+		if err != nil {
+			return m, fmt.Errorf("redis streams error: can't parse enableTLS field: %s", err)
+		}
+		m.enableTLS = tls
+	}
+
 	if val, ok := meta.Properties[consumerID]; ok && val != "" {
 		m.consumerID = val
 	} else {
@@ -58,16 +69,23 @@ func (r *redisStreams) Init(metadata pubsub.Metadata) error {
 	if err != nil {
 		return err
 	}
-
 	r.metadata = m
 
-	client := redis.NewClient(&redis.Options{
+	options := &redis.Options{
 		Addr:            m.host,
 		Password:        m.password,
 		DB:              0,
 		MaxRetries:      3,
 		MaxRetryBackoff: time.Second * 2,
-	})
+	}
+
+	if r.metadata.enableTLS {
+		options.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
+	client := redis.NewClient(options)
 
 	_, err = client.Ping().Result()
 	if err != nil {

--- a/pubsub/redis/redis_test.go
+++ b/pubsub/redis/redis_test.go
@@ -21,6 +21,7 @@ func getFakeProperties() map[string]string {
 		consumerID: "fakeConsumer",
 		host:       "fake.redis.com",
 		password:   "fakePassword",
+		enableTLS:  "true",
 	}
 }
 
@@ -40,6 +41,7 @@ func TestParseRedisMetadata(t *testing.T) {
 		assert.Equal(t, fakeProperties[host], m.host)
 		assert.Equal(t, fakeProperties[password], m.password)
 		assert.Equal(t, fakeProperties[consumerID], m.consumerID)
+		assert.Equal(t, true, m.enableTLS)
 	})
 
 	t.Run("host is not given", func(t *testing.T) {


### PR DESCRIPTION
This PR allows Redis Pub/Sub to established a secured connection to TLS enabled Redis servers.

Closes #95.