### PR TITLE
Use consumerID for queue name

### DIFF
--- a/pubsub/nats/nats.go
+++ b/pubsub/nats/nats.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	natsURL            = "natsURL"
-	natsQueueGroupName = "natsQueueGroupName"
+	natsURL    = "natsURL"
+	consumerID = "consumerID"
 )
 
 type natsPubSub struct {
@@ -37,7 +37,7 @@ func parseNATSMetadata(meta pubsub.Metadata) (metadata, error) {
 		return m, errors.New("nats error: missing nats URL")
 	}
 
-	if val, ok := meta.Properties[natsQueueGroupName]; ok && val != "" {
+	if val, ok := meta.Properties[consumerID]; ok && val != "" {
 		m.natsQueueGroupName = val
 	} else {
 		return m, errors.New("nats error: missing queue name")

--- a/pubsub/nats/nats_test.go
+++ b/pubsub/nats/nats_test.go
@@ -17,8 +17,8 @@ import (
 func TestParseNATSMetadata(t *testing.T) {
 	t.Run("metadata is correct", func(t *testing.T) {
 		fakeProperties := map[string]string{
-			natsURL:            "foonats1",
-			natsQueueGroupName: "fooq1",
+			natsURL:    "foonats1",
+			consumerID: "fooq1",
 		}
 		fakeMetaData := pubsub.Metadata{
 			Properties: fakeProperties,
@@ -32,13 +32,13 @@ func TestParseNATSMetadata(t *testing.T) {
 		assert.NotEmpty(t, m.natsURL)
 		assert.NotEmpty(t, m.natsQueueGroupName)
 		assert.Equal(t, fakeProperties[natsURL], m.natsURL)
-		assert.Equal(t, fakeProperties[natsQueueGroupName], m.natsQueueGroupName)
+		assert.Equal(t, fakeProperties[consumerID], m.natsQueueGroupName)
 	})
 
 	t.Run("queue is not given", func(t *testing.T) {
 		fakeProperties := map[string]string{
-			natsURL:            "foonats2",
-			natsQueueGroupName: "",
+			natsURL:    "foonats2",
+			consumerID: "",
 		}
 
 		fakeMetaData := pubsub.Metadata{
@@ -55,8 +55,8 @@ func TestParseNATSMetadata(t *testing.T) {
 
 	t.Run("nats url is not given", func(t *testing.T) {
 		fakeProperties := map[string]string{
-			natsURL:            "",
-			natsQueueGroupName: "fooq2",
+			natsURL:    "",
+			consumerID: "fooq2",
 		}
 		fakeMetaData := pubsub.Metadata{
 			Properties: fakeProperties,


### PR DESCRIPTION
`consumerID` is the well known ID used by pub-sub implementations to create a group of logical consumers.

Dapr uses this known field to pass in the `daprID` associated with the application.

This is consistent with Redis Streams and the upcoming Azure Service Bus.