### PR TITLE
don't cache zeroconf resolver

### DIFF
--- a/servicediscovery/mdns/mdns.go
+++ b/servicediscovery/mdns/mdns.go
@@ -19,11 +19,10 @@ func NewMDNSResolver() servicediscovery.Resolver {
 }
 
 type resolver struct {
-	resolver *zeroconf.Resolver
 }
 
 func (z *resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, error) {
-	port, err := z.LookupPortMDNS(req.ID)
+	port, err := LookupPortMDNS(req.ID)
 	if err != nil {
 		return "", err
 	}
@@ -31,16 +30,12 @@ func (z *resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, erro
 }
 
 // LookupPortMDNS uses mdns to find the port of a given service entry on a local network
-func (z *resolver) LookupPortMDNS(id string) (int, error) {
-	var err error
-
-	if z.resolver == nil {
-		z.resolver, err = zeroconf.NewResolver(nil)
-		if err != nil {
-			return -1, fmt.Errorf("failed to initialize resolver: %e", err)
-		}
+func LookupPortMDNS(id string) (int, error) {	
+	resolver, err := zeroconf.NewResolver(nil)
+	if err != nil {
+		return -1, fmt.Errorf("failed to initialize resolver: %e", err)
 	}
-
+	
 	port := -1
 	entries := make(chan *zeroconf.ServiceEntry)
 
@@ -58,7 +53,7 @@ func (z *resolver) LookupPortMDNS(id string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 
-	err = z.resolver.Browse(ctx, id, "local.", entries)
+	err = resolver.Browse(ctx, id, "local.", entries)
 	if err != nil {
 		return -1, fmt.Errorf("failed to browse: %s", err.Error())
 	}


### PR DESCRIPTION
# Description

Don't cache zeroconf resolver.  For some reason if it's cached the first lookup works normally, but subsequent ones cannot resolve the target app.  

## Issue reference



## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
