### PR TITLE
Adding metadata to State Delete and Get requests

### DIFF
--- a/state/requests.go
+++ b/state/requests.go
@@ -10,6 +10,7 @@ import "time"
 // GetRequest is the object describing a state fetch request
 type GetRequest struct {
 	Key     string         `json:"key"`
+	Metadata map[string]string `json:"metadata"`
 	Options GetStateOption `json:"options,omitempty"`
 }
 
@@ -22,6 +23,7 @@ type GetStateOption struct {
 type DeleteRequest struct {
 	Key     string            `json:"key"`
 	ETag    string            `json:"etag,omitempty"`
+	Metadata map[string]string `json:"metadata"`
 	Options DeleteStateOption `json:"options,omitempty"`
 }
 


### PR DESCRIPTION
# Description

Currently custom metadata to a state store implementation is only supported through a SetRequest.

This proposes to add passing metadata with GetRequest and DeleteRequest also.

## Issue reference

#101 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
