### PR TITLE
Don't return nil for response when length of items is 0

### DIFF
--- a/state/cosmosdb/cosmosdb.go
+++ b/state/cosmosdb/cosmosdb.go
@@ -115,7 +115,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if err != nil {
 		return nil, err
 	} else if len(items) == 0 {
-		return nil, nil
+		return &state.GetResponse{}, nil
 	}
 
 	b, err := jsoniter.ConfigFastest.Marshal(&items[0].Value)


### PR DESCRIPTION
# Description

See https://github.com/dapr/components-contrib/issues/132.  The fix is to return default response.

## Issue reference

See https://github.com/dapr/components-contrib/issues/132

Please reference the issue this PR will close: #_132_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
