### PR TITLE
Rename SQLServer state ctor to existing pattern

### DIFF
--- a/state/azure/sqlserver/sqlserver.go
+++ b/state/azure/sqlserver/sqlserver.go
@@ -63,8 +63,8 @@ const (
 	defaultSchema    = "dbo"
 )
 
-// NewSQLServerStore creates a new instance of a Sql Server transaction store
-func NewSQLServerStore() *SQLServer {
+// NewSQLServerStateStore creates a new instance of a Sql Server transaction store
+func NewSQLServerStateStore() *SQLServer {
 	store := SQLServer{}
 	store.migratorFactory = newMigration
 

--- a/state/azure/sqlserver/sqlserver_integration_test.go
+++ b/state/azure/sqlserver/sqlserver_integration_test.go
@@ -121,7 +121,7 @@ func getTestStoreWithKeyType(t *testing.T, kt KeyType, indexedProperties string)
 	ensureDBIsValid(t)
 	schema := getUniqueDBSchema()
 	metadata := createMetadata(schema, kt, indexedProperties)
-	store := NewSQLServerStore()
+	store := NewSQLServerStateStore()
 	err := store.Init(metadata)
 	assert.Nil(t, err)
 
@@ -787,7 +787,7 @@ func testMultipleInitializations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			store := getTestStoreWithKeyType(t, test.kt, test.indexedProperties)
 
-			store2 := NewSQLServerStore()
+			store2 := NewSQLServerStateStore()
 			assert.Nil(t, store2.Init(createMetadata(store.schema, test.kt, test.indexedProperties)))
 		})
 	}

--- a/state/azure/sqlserver/sqlserver_test.go
+++ b/state/azure/sqlserver/sqlserver_test.go
@@ -119,7 +119,7 @@ func TestValidConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sqlStore := NewSQLServerStore()
+			sqlStore := NewSQLServerStateStore()
 			sqlStore.migratorFactory = func(s *SQLServer) migrator {
 				return &mockMigrator{}
 			}
@@ -234,7 +234,7 @@ func TestInvalidConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sqlStore := NewSQLServerStore()
+			sqlStore := NewSQLServerStateStore()
 
 			metadata := state.Metadata{
 				Properties: tt.props,


### PR DESCRIPTION
# Description

Rename SQLServer state constructor to follow current convention. From NewSQLServerStore to NewSQLServer**State**Store.

Current state stores:

```golang
// Load state stores
func Load() {
	RegisterStateStore("redis", func() state.Store {
		return redis.NewRedisStateStore()
	})
	RegisterStateStore("consul", func() state.Store {
		return consul.NewConsulStateStore()
	})
	RegisterStateStore("azure.cosmosdb", func() state.Store {
		return cosmosdb.NewCosmosDBStateStore()
	})
	RegisterStateStore("etcd", func() state.Store {
		return etcd.NewETCD()
	})
	RegisterStateStore("cassandra", func() state.Store {
		return cassandra.NewCassandraStateStore()
	})
	RegisterStateStore("memcached", func() state.Store {
		return memcached.NewMemCacheStateStore()
	})
	RegisterStateStore("mongodb", func() state.Store {
		return mongodb.NewMongoDB()
	})
	RegisterStateStore("zookeeper", func() state.Store {
		return zookeeper.NewZookeeperStateStore()
	})
	RegisterStateStore("gcp.firestore", func() state.Store {
		return firestore.NewFirestoreStateStore()
	})
}
```

## Issue reference

N/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
