### PR TITLE
Modify the AppResponse struct to have the store name 

### DIFF
--- a/bindings/responses.go
+++ b/bindings/responses.go
@@ -19,6 +19,7 @@ type ReadResponse struct {
 type AppResponse struct {
 	Data        interface{}        `json:"data"`
 	To          []string           `json:"to"`
-	State       []state.SetRequest `json:"state"`
+	StoreName   string             `json:"storeName"`
+	Requests    []state.SetRequest `json:"requests"`
 	Concurrency string             `json:"concurrency"`
 }

--- a/bindings/responses.go
+++ b/bindings/responses.go
@@ -17,9 +17,14 @@ type ReadResponse struct {
 
 // AppResponse is the object describing the response from user code after a bindings event
 type AppResponse struct {
-	Data        interface{}        `json:"data"`
-	To          []string           `json:"to"`
-	StoreName   string             `json:"storeName"`
-	Requests    []state.SetRequest `json:"requests"`
-	Concurrency string             `json:"concurrency"`
+	Data        interface{}  `json:"data"`
+	To          []string     `json:"to"`
+	State       StateRequest `json:"state"`
+	Concurrency string       `json:"concurrency"`
+}
+
+// StateRequest is the object describing the state request in response from user code after a bindings event
+type StateRequest struct {
+	StoreName string             `json:"storeName"`
+	Requests  []state.SetRequest `json:"requests"`
 }

--- a/bindings/responses.go
+++ b/bindings/responses.go
@@ -17,14 +17,9 @@ type ReadResponse struct {
 
 // AppResponse is the object describing the response from user code after a bindings event
 type AppResponse struct {
-	Data        interface{}  `json:"data"`
-	To          []string     `json:"to"`
-	State       StateRequest `json:"state"`
-	Concurrency string       `json:"concurrency"`
-}
-
-// StateRequest is the object describing the state request in response from user code after a bindings event
-type StateRequest struct {
-	StoreName string             `json:"storeName"`
-	Requests  []state.SetRequest `json:"requests"`
+	Data        interface{}        `json:"data"`
+	To          []string           `json:"to"`
+	StoreName   string             `json:"storeName"`
+	State       []state.SetRequest `json:"state"`
+	Concurrency string             `json:"concurrency"`
 }


### PR DESCRIPTION
Need to change the AppResponse struct to have the store name and state requests separately to support multiple state stores support in Dapr.

This is needed to support this requirement : dapr/dapr#636

# Description

Added the store name in the AppResponse and requests separately.

## Issue reference

#182 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
