### PR TITLE
[WIP] Adding support for Manage Identities in the Azure Key Vault Secret Store

### DIFF
--- a/secretstores/azure/keyvault/authutils.go
+++ b/secretstores/azure/keyvault/authutils.go
@@ -25,7 +25,8 @@ type CertConfig struct {
 
 // GetClientCert creates a config object from the available certificate credentials.
 // An error is returned if no certificate credentials are available.
-func (k keyvaultSecretStore) GetClientCert() (CertConfig, error) {
+func (k *keyvaultSecretStore) GetClientCert() (CertConfig, error) {
+	k.vaultName = k.metadata.Properties[componentVaultName]
 	props := k.metadata.Properties
 	certFilePath := props[componentSPNCertificateFile]
 	certBytes := []byte(props[componentSPNCertificate])
@@ -102,7 +103,8 @@ func NewMSIConfig() MSIConfig {
 }
 
 // GetMSI creates a MSI config object from the available client ID.
-func (k keyvaultSecretStore) GetMSI() MSIConfig {
+func (k *keyvaultSecretStore) GetMSI() MSIConfig {
+	k.vaultName = k.metadata.Properties[componentVaultName]
 	props := k.metadata.Properties
 	config := NewMSIConfig()
 	config.Resource = azure.PublicCloud.ResourceIdentifiers.KeyVault
@@ -136,8 +138,7 @@ func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
 // GetAuthorizer creates an Authorizer configured from environment variables in the order:
 // 1. Client certificate
 // 2. MSI
-func (k keyvaultSecretStore) GetAuthorizer() (autorest.Authorizer, error) {
-	k.vaultName = k.metadata.Properties[componentVaultName]
+func (k *keyvaultSecretStore) GetAuthorizer() (autorest.Authorizer, error) {
 	// 1. Client Certificate
 	if c, e := k.GetClientCert(); e == nil {
 		return c.Authorizer()

--- a/secretstores/azure/keyvault/authutils.go
+++ b/secretstores/azure/keyvault/authutils.go
@@ -23,18 +23,17 @@ type CertConfig struct {
 	CertificateData []byte
 }
 
-// GetClientCertificate creates a config object from the available certificate credentials.
+// GetClientCert creates a config object from the available certificate credentials.
 // An error is returned if no certificate credentials are available.
-func (k keyvaultSecretStore) GetClientCertificate() (CertConfig, error) {
+func (k keyvaultSecretStore) GetClientCert() (CertConfig, error) {
 	props := k.metadata.Properties
-	k.vaultName = props[componentVaultName]
 	certFilePath := props[componentSPNCertificateFile]
 	certBytes := []byte(props[componentSPNCertificate])
 	certPassword := props[componentSPNCertificatePassword]
 	clientID := props[componentSPNClientID]
 	tenantID := props[componentSPNTenantID]
 
-	if certPassword == "" {
+	if certFilePath == "" && certBytes == nil {
 		return CertConfig{}, fmt.Errorf("missing client secret")
 	}
 
@@ -138,8 +137,9 @@ func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
 // 1. Client certificate
 // 2. MSI
 func (k keyvaultSecretStore) GetAuthorizer() (autorest.Authorizer, error) {
+	k.vaultName = k.metadata.Properties[componentVaultName]
 	// 1. Client Certificate
-	if c, e := k.GetClientCertificate(); e == nil {
+	if c, e := k.GetClientCert(); e == nil {
 		return c.Authorizer()
 	}
 

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -34,11 +34,8 @@ func TestGetClientCert(t *testing.T) {
 		},
 	}
 
-	testSecretStore := keyvaultSecretStore{}
+	testCertConfig, _ := settings.GetClientCert()
 
-	testCertConfig, _ := testSecretStore.GetClientCert(settings)
-
-	assert.Equal(t, "vaultName", testSecretStore.vaultName)
 	assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 	assert.Equal(t, "testfile", testCertConfig.ClientCertificateConfig.CertificatePath)
 	assert.Equal(t, []byte("testcert"), testCertConfig.CertificateData)
@@ -65,9 +62,7 @@ func TestAuthorizorWithCertFile(t *testing.T) {
 		},
 	}
 
-	testSecretStore := keyvaultSecretStore{}
-
-	testCertConfig, _ := testSecretStore.GetClientCert(settings)
+	testCertConfig, _ := settings.GetClientCert()
 	assert.NotNil(t, testCertConfig)
 	assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
@@ -93,9 +88,7 @@ func TestAuthorizorWithCertBytes(t *testing.T) {
 			},
 		}
 
-		testSecretStore := keyvaultSecretStore{}
-
-		testCertConfig, _ := testSecretStore.GetClientCert(settings)
+		testCertConfig, _ := settings.GetClientCert()
 		assert.NotNil(t, testCertConfig)
 		assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
@@ -118,9 +111,7 @@ func TestAuthorizorWithCertBytes(t *testing.T) {
 			},
 		}
 
-		testSecretStore := keyvaultSecretStore{}
-
-		testCertConfig, _ := testSecretStore.GetClientCert(settings)
+		testCertConfig, _ := settings.GetClientCert()
 		assert.NotNil(t, testCertConfig)
 		assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
@@ -137,11 +128,8 @@ func TestGetMSI(t *testing.T) {
 		},
 	}
 
-	testSecretStore := keyvaultSecretStore{}
+	testCertConfig := settings.GetMSI()
 
-	testCertConfig := testSecretStore.GetMSI(settings)
-
-	assert.Equal(t, "vaultName", testSecretStore.vaultName)
 	assert.Equal(t, fakeClientID, testCertConfig.ClientID)
 	assert.Equal(t, "https://vault.azure.net", testCertConfig.Resource)
 }
@@ -154,9 +142,7 @@ func TestAuthorizorWithMSI(t *testing.T) {
 		},
 	}
 
-	testSecretStore := keyvaultSecretStore{}
-
-	testCertConfig := testSecretStore.GetMSI(settings)
+	testCertConfig := settings.GetMSI()
 	assert.NotNil(t, testCertConfig)
 
 	authorizer, err := testCertConfig.Authorizer()
@@ -172,9 +158,7 @@ func TestAuthorizorWithMSIAndUserAssignedID(t *testing.T) {
 		},
 	}
 
-	testSecretStore := keyvaultSecretStore{}
-
-	testCertConfig := testSecretStore.GetMSI(settings)
+	testCertConfig := settings.GetMSI()
 	assert.NotNil(t, testCertConfig)
 
 	authorizer, err := testCertConfig.Authorizer()

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dapr/components-contrib/secretstores"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,22 +23,20 @@ const (
 )
 
 func TestGetClientCert(t *testing.T) {
-	metadata := map[string]string{
-		componentSPNCertificateFile:     "testfile",
-		componentSPNCertificate:         "testcert",
-		componentSPNCertificatePassword: "1234",
-		componentSPNClientID:            fakeClientID,
-		componentSPNTenantID:            fakeTenantID,
-		componentVaultName:              "vaultName",
-	}
-
-	testSecretStore := keyvaultSecretStore{
-		metadata: secretstores.Metadata{
-			Properties: metadata,
+	settings := EnvironmentSettings{
+		Values: map[string]string{
+			componentSPNCertificateFile:     "testfile",
+			componentSPNCertificate:         "testcert",
+			componentSPNCertificatePassword: "1234",
+			componentSPNClientID:            fakeClientID,
+			componentSPNTenantID:            fakeTenantID,
+			componentVaultName:              "vaultName",
 		},
 	}
 
-	testCertConfig, _ := testSecretStore.GetClientCert()
+	testSecretStore := keyvaultSecretStore{}
+
+	testCertConfig, _ := testSecretStore.GetClientCert(settings)
 
 	assert.Equal(t, "vaultName", testSecretStore.vaultName)
 	assert.NotNil(t, testCertConfig.ClientCertificateConfig)
@@ -58,21 +55,19 @@ func TestAuthorizorWithCertFile(t *testing.T) {
 	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
 	assert.NoError(t, err)
 
-	metadata := map[string]string{
-		componentSPNCertificateFile:     testCertFileName,
-		componentSPNCertificatePassword: "",
-		componentSPNClientID:            fakeClientID,
-		componentSPNTenantID:            fakeTenantID,
-		componentVaultName:              "vaultName",
-	}
-
-	testSecretStore := keyvaultSecretStore{
-		metadata: secretstores.Metadata{
-			Properties: metadata,
+	settings := EnvironmentSettings{
+		Values: map[string]string{
+			componentSPNCertificateFile:     testCertFileName,
+			componentSPNCertificatePassword: "",
+			componentSPNClientID:            fakeClientID,
+			componentSPNTenantID:            fakeTenantID,
+			componentVaultName:              "vaultName",
 		},
 	}
 
-	testCertConfig, _ := testSecretStore.GetClientCert()
+	testSecretStore := keyvaultSecretStore{}
+
+	testCertConfig, _ := testSecretStore.GetClientCert(settings)
 	assert.NotNil(t, testCertConfig)
 	assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
@@ -88,21 +83,19 @@ func TestAuthorizorWithCertBytes(t *testing.T) {
 	t.Run("Certificate is valid", func(t *testing.T) {
 		certBytes := getTestCert()
 
-		metadata := map[string]string{
-			componentSPNCertificate:         string(certBytes),
-			componentSPNCertificatePassword: "",
-			componentSPNClientID:            fakeClientID,
-			componentSPNTenantID:            fakeTenantID,
-			componentVaultName:              "vaultName",
-		}
-
-		testSecretStore := keyvaultSecretStore{
-			metadata: secretstores.Metadata{
-				Properties: metadata,
+		settings := EnvironmentSettings{
+			Values: map[string]string{
+				componentSPNCertificate:         string(certBytes),
+				componentSPNCertificatePassword: "",
+				componentSPNClientID:            fakeClientID,
+				componentSPNTenantID:            fakeTenantID,
+				componentVaultName:              "vaultName",
 			},
 		}
 
-		testCertConfig, _ := testSecretStore.GetClientCert()
+		testSecretStore := keyvaultSecretStore{}
+
+		testCertConfig, _ := testSecretStore.GetClientCert(settings)
 		assert.NotNil(t, testCertConfig)
 		assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
@@ -115,21 +108,19 @@ func TestAuthorizorWithCertBytes(t *testing.T) {
 	t.Run("Certificate is invalid", func(t *testing.T) {
 		certBytes := getTestCert()
 
-		metadata := map[string]string{
-			componentSPNCertificate:         string(certBytes[0:20]),
-			componentSPNCertificatePassword: "",
-			componentSPNClientID:            fakeClientID,
-			componentSPNTenantID:            fakeTenantID,
-			componentVaultName:              "vaultName",
-		}
-
-		testSecretStore := keyvaultSecretStore{
-			metadata: secretstores.Metadata{
-				Properties: metadata,
+		settings := EnvironmentSettings{
+			Values: map[string]string{
+				componentSPNCertificate:         string(certBytes[0:20]),
+				componentSPNCertificatePassword: "",
+				componentSPNClientID:            fakeClientID,
+				componentSPNTenantID:            fakeTenantID,
+				componentVaultName:              "vaultName",
 			},
 		}
 
-		testCertConfig, _ := testSecretStore.GetClientCert()
+		testSecretStore := keyvaultSecretStore{}
+
+		testCertConfig, _ := testSecretStore.GetClientCert(settings)
 		assert.NotNil(t, testCertConfig)
 		assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
@@ -139,18 +130,16 @@ func TestAuthorizorWithCertBytes(t *testing.T) {
 }
 
 func TestGetMSI(t *testing.T) {
-	metadata := map[string]string{
-		componentSPNClientID: fakeClientID,
-		componentVaultName:   "vaultName",
-	}
-
-	testSecretStore := keyvaultSecretStore{
-		metadata: secretstores.Metadata{
-			Properties: metadata,
+	settings := EnvironmentSettings{
+		Values: map[string]string{
+			componentSPNClientID: fakeClientID,
+			componentVaultName:   "vaultName",
 		},
 	}
 
-	testCertConfig := testSecretStore.GetMSI()
+	testSecretStore := keyvaultSecretStore{}
+
+	testCertConfig := testSecretStore.GetMSI(settings)
 
 	assert.Equal(t, "vaultName", testSecretStore.vaultName)
 	assert.Equal(t, fakeClientID, testCertConfig.ClientID)
@@ -158,17 +147,16 @@ func TestGetMSI(t *testing.T) {
 }
 
 func TestAuthorizorWithMSI(t *testing.T) {
-	metadata := map[string]string{
-		componentVaultName: "vaultName",
-	}
-
-	testSecretStore := keyvaultSecretStore{
-		metadata: secretstores.Metadata{
-			Properties: metadata,
+	settings := EnvironmentSettings{
+		Values: map[string]string{
+			componentSPNClientID: fakeClientID,
+			componentVaultName:   "vaultName",
 		},
 	}
 
-	testCertConfig := testSecretStore.GetMSI()
+	testSecretStore := keyvaultSecretStore{}
+
+	testCertConfig := testSecretStore.GetMSI(settings)
 	assert.NotNil(t, testCertConfig)
 
 	authorizer, err := testCertConfig.Authorizer()
@@ -177,18 +165,16 @@ func TestAuthorizorWithMSI(t *testing.T) {
 }
 
 func TestAuthorizorWithMSIAndUserAssignedID(t *testing.T) {
-	metadata := map[string]string{
-		componentSPNClientID: fakeClientID,
-		componentVaultName:   "vaultName",
-	}
-
-	testSecretStore := keyvaultSecretStore{
-		metadata: secretstores.Metadata{
-			Properties: metadata,
+	settings := EnvironmentSettings{
+		Values: map[string]string{
+			componentSPNClientID: fakeClientID,
+			componentVaultName:   "vaultName",
 		},
 	}
 
-	testCertConfig := testSecretStore.GetMSI()
+	testSecretStore := keyvaultSecretStore{}
+
+	testCertConfig := testSecretStore.GetMSI(settings)
 	assert.NotNil(t, testCertConfig)
 
 	authorizer, err := testCertConfig.Authorizer()

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -5,92 +5,139 @@
 
 package keyvault
 
-// import (
-// 	"encoding/base64"
-// 	"io/ioutil"
-// 	"os"
-// 	"testing"
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"testing"
 
-// 	"github.com/stretchr/testify/assert"
-// )
+	"github.com/dapr/components-contrib/secretstores"
+	"github.com/stretchr/testify/assert"
+)
 
-// const (
-// 	fakeTenantID = "14bec2db-7f9a-4f3d-97ca-2d384ac83389"
-// 	fakeClientID = "04bec2db-7f9a-4f3d-97ca-3d384ac83389"
+const (
+	fakeTenantID = "14bec2db-7f9a-4f3d-97ca-2d384ac83389"
+	fakeClientID = "04bec2db-7f9a-4f3d-97ca-3d384ac83389"
 
-// 	// Base64 encoded test pfx cert - Expire date: 09/19/2119
-// 	testCert = "MIIKTAIBAzCCCgwGCSqGSIb3DQEHAaCCCf0Eggn5MIIJ9TCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAifAbe5KAL7IwICB9AEggTYZ3dAdDNqi5GoGJ/VfZhh8dxIIERUaC/SO5vKFhDfNu9VCQKF7Azr3eJ4cjzQmicfLd6FxJpB6d+8fbQuCcYPpTAdqf5zmLtZWMDWW8YZE0pV7b6sDZSw/NbT2zFhsx2uife6NnLK//Pj+GeALUDPfhVfqfLCfWZlCHxlbOipVZv9U4+TCVO2vyrGUq2XesT78cT+LhbHYkcrxTCsXNLWAvSJ9zXOIVA5HNS3Qv8pQJSSbqYVBbLk6FEbt5B3pk0xoA1hhM7dlCoGvPJ/ajvN3wAcEB5kmjJ4q59s2HeXloa7aAhXTFEkL2rZH+acgr1AO/DwcGXUqzJ2ooGYBfoqmgaXjydzyVLzYNccBGbzBR4Q0crMW6zDBXDlwvnLxmqZ7p05Ix9ZqISQyTm/DboNwQk1erOJd0fe6Brg1Dw4td6Uh/AXfM8m+XCGJFn79ZMCtd4rP8w9l008m8xe7rczSkMW0aRJVr0j3fFheene83jOHEB0q3KMKsVTkPWehnTGPj4TrsL+WwrmJpqrSloXMyaqvS9hvqAfPal0JI9taz6R5HFONaO6oi/ajpX3tYSX0rafQPKHmJpFLtJHYPopFYgP4akq8wKOCjq1IDg3ZW59G9nh8Vcw3IrAnr+C9iMgzPUvCHCinQK24cmbn5px6S0U0ARhY90KrSMFRyjvxNpZzc+A/AAaQ/wwuLVy1GyuZ2sRFyVSCTRMC6ZfXAUs+OijDO/B++BCdmqm5p5/aZpQYf1cb681AaDc/5XTHtCC3setYfpviMe1grvp4jaPVrjnG85pVenZJ0d+Xo7BnD38Ec5RsKpvtXIieiRIbnGqzTzxj/OU/cdglrKy8MLo6IJigXA6N3x14o4e3akq7cvLPRQZqlWyLqjlGnJdZKJlemFlOnDSluzwGBwwKF+PpXuRVSDhi/ARN3g8L+wVAQQMEylWJfK7sNDun41rimE8wGFjqlfZNVg/pCBKvw3p90pCkxVUEZBRrP1vaGzrIvOsMU/rrJqQU7Imv9y6nUrvHdcoRFUdbgWVWZus6VwTrgwRkfnPiLZo0r5Vh4kComH0+Tc4kgwbnnuQQWzn8J9Ur4Nu0MkknC/1jDwulq2XOIBPclmEPg9CSSwfKonyaRxz+3GoPy0kGdHwsOcXIq5qBIyiYAtM1g1cQLtOT16OCjapus+GIOLnItP2OAhO70dsTMUlsQSNEH+KxUxFb1pFuQGXnStmgZtHYI4LvC/d820tY0m0I6SgfabnoQpIXa6iInIt970awwyUP1P/6m9ie5bCRDWCj4R0bNiNQBjq9tHfO4xeGK+fUTyeU4OEBgiyisNVhijf6GlfPHKWwkInAN0WbS3UHHACjkP0jmRb70b/3VbWon/+K5S6bk2ohIDsbPPVolTvfMehRwKatqQTbTXlnDIHJQzk9SfHHWJzkrQXEIbXgGxHSHm5CmNetR/MYGlivjtGRVxOLr7Y1tK0GGEDMs9nhiSvlwWjAEuwIN+72T6Kx7hPRld1BvaTYLRYXfjnedo7D2AoR+8tGLWjU31rHJVua/JILjGC84ARCjk5LOFHOXUjOP1jJomh8ebjlVijNWP0gLUC14AE8UJsJ1Xi6xiNOTeMpeOIJl2kX81uvnNbQ0j4WajfXlox5eV+0iJ1yNfw5jGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IADgAZABlADYANgA5AGEAYQAtADUAZgAyAGMALQA0ADIANgBmAC0AYQA3ADAANwAtADIANgBmADkAOAAwADAANAAwAGEAYQAwMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIID1wYJKoZIhvcNAQcGoIIDyDCCA8QCAQAwggO9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAiT1ngppOJy/gICB9CAggOQt9iTz9CmP/3+EBQv3WM80jLHHyrkJM5nIckr+4fmcl3frhbZZajSf1eigjOaqWpz1cAu9KtSAb0Fa35AKr7r9du5SXwBxyYS6XzXsWekSrdvh3Dui0abXo/yh+lIfI/61sJLv5Gc7/DbJrwlHHOD1DR/ohmncAiSjGUYaO9/Y9xUV3cbzjZypqKkkbahaWVMC8+D9zUSkH64RUuLvSi5X5QKFsICNouBL1j/C2s3VZoyR9F0ajRCEMFnQsMfJ/1fP2iW/wwFIARBjphj1SaEaP3XkxQadslR0cwhf6Ujj/tXyd1zV5oI8rJ54r8eN5Vu8NxEX3kl+A7gCc9ACEC0klZ18mQUjb6eDpUSFM63/wx7ISDKaD7gyWCul1JwlUmYzvrRw8sAwjVEyXzc+n0oIOlk0lE6vk3mybkfcOxafRkdr0zVnd5L+XtV/V38sd3ExNojQgUDNy905PNTHdeVnvHt6E8XGNgGX7a/tB1r7Un3soL5Vjcuf/HMdyR57CF2lxFSrdZ1bNnw7Z1GJbQZHago2AovNw+BbBJfey0iuIRP+dgkIfle0nzl3E7T9jU0r2+GEQfN7YYjRL19XFX4n8kNpiTDDRxdNj/yKQDfC7f8prZY/yP8bJLaFBd+uoH+D4QKmWk7plwXTOLiNno9cOTrLYT48HCEghtBbnTgZglOg8eDZd35MR5KcCNWxVy/enEj3/BEtkH7qnJsxlFMu1WwAQzaVYK1u1sGCD8NGH2wtiJi0O5q+YsQItv7ia2x9lSL1JPagtRhxnIZbC5HaIx87bSrVY9XTrWlj9X0H+YSdbUrszRse+LLJkw6h8wXqBvrBKsxnPrfJyQWs3zqehk0FPF1pi+spoJzp7//nmZ5a7knRXYkxV++TiuX+RQSNR/cFxezEwR+2WUAJaJfPpSf06dp5M/gJNVJQGMNiLHCMc9w6CPLUFQA1FG5YdK8nFrSo0iclX7wAHWpCjkqHj7PgOT+Ia5qiOb2dN2GBWPh5N94PO15BLlS/9UUvGxvmWqmG3lpr3hP5B6OZdQl8lxBGc8KTq4GdoJrQ+Jmfej3LQa33mV5VZwJqdbH9iEHvUH2VYC8ru7r5drXBqP5IlZrkdIL5uzzaoHsnWtu0OKgjwRwXaAF24zM0GVXbueGXLXH3vwBwoO4GnDfJ0wN0qFEJBRexRdPP9JKjPfVmwbi89sx1zJMId3nCmetq5yGMDcwHzAHBgUrDgMCGgQUmQChLB4WJjopytxl4LNQ9NuCbPkEFO+tI0n+7a6hwK9hqzq7tghkXp08"
-// )
+	// Base64 encoded test pfx cert - Expire date: 09/19/2119
+	testCert = "MIIKTAIBAzCCCgwGCSqGSIb3DQEHAaCCCf0Eggn5MIIJ9TCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAifAbe5KAL7IwICB9AEggTYZ3dAdDNqi5GoGJ/VfZhh8dxIIERUaC/SO5vKFhDfNu9VCQKF7Azr3eJ4cjzQmicfLd6FxJpB6d+8fbQuCcYPpTAdqf5zmLtZWMDWW8YZE0pV7b6sDZSw/NbT2zFhsx2uife6NnLK//Pj+GeALUDPfhVfqfLCfWZlCHxlbOipVZv9U4+TCVO2vyrGUq2XesT78cT+LhbHYkcrxTCsXNLWAvSJ9zXOIVA5HNS3Qv8pQJSSbqYVBbLk6FEbt5B3pk0xoA1hhM7dlCoGvPJ/ajvN3wAcEB5kmjJ4q59s2HeXloa7aAhXTFEkL2rZH+acgr1AO/DwcGXUqzJ2ooGYBfoqmgaXjydzyVLzYNccBGbzBR4Q0crMW6zDBXDlwvnLxmqZ7p05Ix9ZqISQyTm/DboNwQk1erOJd0fe6Brg1Dw4td6Uh/AXfM8m+XCGJFn79ZMCtd4rP8w9l008m8xe7rczSkMW0aRJVr0j3fFheene83jOHEB0q3KMKsVTkPWehnTGPj4TrsL+WwrmJpqrSloXMyaqvS9hvqAfPal0JI9taz6R5HFONaO6oi/ajpX3tYSX0rafQPKHmJpFLtJHYPopFYgP4akq8wKOCjq1IDg3ZW59G9nh8Vcw3IrAnr+C9iMgzPUvCHCinQK24cmbn5px6S0U0ARhY90KrSMFRyjvxNpZzc+A/AAaQ/wwuLVy1GyuZ2sRFyVSCTRMC6ZfXAUs+OijDO/B++BCdmqm5p5/aZpQYf1cb681AaDc/5XTHtCC3setYfpviMe1grvp4jaPVrjnG85pVenZJ0d+Xo7BnD38Ec5RsKpvtXIieiRIbnGqzTzxj/OU/cdglrKy8MLo6IJigXA6N3x14o4e3akq7cvLPRQZqlWyLqjlGnJdZKJlemFlOnDSluzwGBwwKF+PpXuRVSDhi/ARN3g8L+wVAQQMEylWJfK7sNDun41rimE8wGFjqlfZNVg/pCBKvw3p90pCkxVUEZBRrP1vaGzrIvOsMU/rrJqQU7Imv9y6nUrvHdcoRFUdbgWVWZus6VwTrgwRkfnPiLZo0r5Vh4kComH0+Tc4kgwbnnuQQWzn8J9Ur4Nu0MkknC/1jDwulq2XOIBPclmEPg9CSSwfKonyaRxz+3GoPy0kGdHwsOcXIq5qBIyiYAtM1g1cQLtOT16OCjapus+GIOLnItP2OAhO70dsTMUlsQSNEH+KxUxFb1pFuQGXnStmgZtHYI4LvC/d820tY0m0I6SgfabnoQpIXa6iInIt970awwyUP1P/6m9ie5bCRDWCj4R0bNiNQBjq9tHfO4xeGK+fUTyeU4OEBgiyisNVhijf6GlfPHKWwkInAN0WbS3UHHACjkP0jmRb70b/3VbWon/+K5S6bk2ohIDsbPPVolTvfMehRwKatqQTbTXlnDIHJQzk9SfHHWJzkrQXEIbXgGxHSHm5CmNetR/MYGlivjtGRVxOLr7Y1tK0GGEDMs9nhiSvlwWjAEuwIN+72T6Kx7hPRld1BvaTYLRYXfjnedo7D2AoR+8tGLWjU31rHJVua/JILjGC84ARCjk5LOFHOXUjOP1jJomh8ebjlVijNWP0gLUC14AE8UJsJ1Xi6xiNOTeMpeOIJl2kX81uvnNbQ0j4WajfXlox5eV+0iJ1yNfw5jGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IADgAZABlADYANgA5AGEAYQAtADUAZgAyAGMALQA0ADIANgBmAC0AYQA3ADAANwAtADIANgBmADkAOAAwADAANAAwAGEAYQAwMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIID1wYJKoZIhvcNAQcGoIIDyDCCA8QCAQAwggO9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAiT1ngppOJy/gICB9CAggOQt9iTz9CmP/3+EBQv3WM80jLHHyrkJM5nIckr+4fmcl3frhbZZajSf1eigjOaqWpz1cAu9KtSAb0Fa35AKr7r9du5SXwBxyYS6XzXsWekSrdvh3Dui0abXo/yh+lIfI/61sJLv5Gc7/DbJrwlHHOD1DR/ohmncAiSjGUYaO9/Y9xUV3cbzjZypqKkkbahaWVMC8+D9zUSkH64RUuLvSi5X5QKFsICNouBL1j/C2s3VZoyR9F0ajRCEMFnQsMfJ/1fP2iW/wwFIARBjphj1SaEaP3XkxQadslR0cwhf6Ujj/tXyd1zV5oI8rJ54r8eN5Vu8NxEX3kl+A7gCc9ACEC0klZ18mQUjb6eDpUSFM63/wx7ISDKaD7gyWCul1JwlUmYzvrRw8sAwjVEyXzc+n0oIOlk0lE6vk3mybkfcOxafRkdr0zVnd5L+XtV/V38sd3ExNojQgUDNy905PNTHdeVnvHt6E8XGNgGX7a/tB1r7Un3soL5Vjcuf/HMdyR57CF2lxFSrdZ1bNnw7Z1GJbQZHago2AovNw+BbBJfey0iuIRP+dgkIfle0nzl3E7T9jU0r2+GEQfN7YYjRL19XFX4n8kNpiTDDRxdNj/yKQDfC7f8prZY/yP8bJLaFBd+uoH+D4QKmWk7plwXTOLiNno9cOTrLYT48HCEghtBbnTgZglOg8eDZd35MR5KcCNWxVy/enEj3/BEtkH7qnJsxlFMu1WwAQzaVYK1u1sGCD8NGH2wtiJi0O5q+YsQItv7ia2x9lSL1JPagtRhxnIZbC5HaIx87bSrVY9XTrWlj9X0H+YSdbUrszRse+LLJkw6h8wXqBvrBKsxnPrfJyQWs3zqehk0FPF1pi+spoJzp7//nmZ5a7knRXYkxV++TiuX+RQSNR/cFxezEwR+2WUAJaJfPpSf06dp5M/gJNVJQGMNiLHCMc9w6CPLUFQA1FG5YdK8nFrSo0iclX7wAHWpCjkqHj7PgOT+Ia5qiOb2dN2GBWPh5N94PO15BLlS/9UUvGxvmWqmG3lpr3hP5B6OZdQl8lxBGc8KTq4GdoJrQ+Jmfej3LQa33mV5VZwJqdbH9iEHvUH2VYC8ru7r5drXBqP5IlZrkdIL5uzzaoHsnWtu0OKgjwRwXaAF24zM0GVXbueGXLXH3vwBwoO4GnDfJ0wN0qFEJBRexRdPP9JKjPfVmwbi89sx1zJMId3nCmetq5yGMDcwHzAHBgUrDgMCGgQUmQChLB4WJjopytxl4LNQ9NuCbPkEFO+tI0n+7a6hwK9hqzq7tghkXp08"
+)
 
-// func TestClientAuthorizer(t *testing.T) {
-// 	testSecretStore := NewClientAuthorizer(
-// 		"testfile",
-// 		[]byte("testcert"),
-// 		"1234",
-// 		fakeClientID,
-// 		fakeTenantID)
+func TestGetClientCert(t *testing.T) {
+	metadata := map[string]string{
+		componentSPNCertificateFile:     "testfile",
+		componentSPNCertificate:         "testcert",
+		componentSPNCertificatePassword: "1234",
+		componentSPNClientID:            fakeClientID,
+		componentSPNTenantID:            fakeTenantID,
+		componentVaultName:              "vaultName",
+	}
 
-// 	assert.Equal(t, "testfile", testSecretStore.CertificatePath)
-// 	assert.Equal(t, []byte("testcert"), testSecretStore.CertificateData)
-// 	assert.Equal(t, "1234", testSecretStore.CertificatePassword)
-// 	assert.Equal(t, fakeClientID, testSecretStore.ClientID)
-// 	assert.Equal(t, fakeTenantID, testSecretStore.TenantID)
-// 	assert.Equal(t, "https://vault.azure.net", testSecretStore.Resource)
-// 	assert.Equal(t, "https://login.microsoftonline.com/", testSecretStore.AADEndpoint)
-// }
+	testSecretStore := keyvaultSecretStore{
+		metadata: secretstores.Metadata{
+			Properties: metadata,
+		},
+	}
 
-// func TestAuthorizorWithCertFile(t *testing.T) {
-// 	testCertFileName := "./.cert.pfx"
-// 	certBytes := getTestCert()
-// 	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
-// 	assert.NoError(t, err)
+	testCertConfig, _ := testSecretStore.GetClientCert()
 
-// 	testSecretStore := NewClientAuthorizer(
-// 		testCertFileName,
-// 		nil,
-// 		"", // No password for cert
-// 		fakeClientID,
-// 		fakeTenantID)
+	assert.NotNil(t, testCertConfig.ClientCertificateConfig)
+	assert.Equal(t, "testfile", testCertConfig.ClientCertificateConfig.CertificatePath)
+	assert.Equal(t, []byte("testcert"), testCertConfig.CertificateData)
+	assert.Equal(t, "1234", testCertConfig.ClientCertificateConfig.CertificatePassword)
+	assert.Equal(t, fakeClientID, testCertConfig.ClientCertificateConfig.ClientID)
+	assert.Equal(t, fakeTenantID, testCertConfig.ClientCertificateConfig.TenantID)
+	assert.Equal(t, "https://vault.azure.net", testCertConfig.ClientCertificateConfig.Resource)
+	assert.Equal(t, "https://login.microsoftonline.com/", testCertConfig.ClientCertificateConfig.AADEndpoint)
+}
 
-// 	authorizer, err := testSecretStore.Authorizer()
-// 	assert.NoError(t, err)
-// 	assert.NotNil(t, authorizer)
+func TestAuthorizorWithCertFile(t *testing.T) {
+	testCertFileName := "./.cert.pfx"
+	certBytes := getTestCert()
+	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
+	assert.NoError(t, err)
 
-// 	err = os.Remove(testCertFileName)
-// 	assert.NoError(t, err)
-// }
+	metadata := map[string]string{
+		componentSPNCertificateFile:     testCertFileName,
+		componentSPNCertificatePassword: "",
+		componentSPNClientID:            fakeClientID,
+		componentSPNTenantID:            fakeTenantID,
+		componentVaultName:              "vaultName",
+	}
 
-// func TestAuthorizorWithCertBytes(t *testing.T) {
-// 	t.Run("Certificate is valid", func(t *testing.T) {
-// 		certBytes := getTestCert()
-// 		testSecretStore := NewClientAuthorizer(
-// 			"", // ignore
-// 			certBytes,
-// 			"", // No password for cert
-// 			fakeClientID,
-// 			fakeTenantID)
+	testSecretStore := keyvaultSecretStore{
+		metadata: secretstores.Metadata{
+			Properties: metadata,
+		},
+	}
 
-// 		authorizer, err := testSecretStore.Authorizer()
+	testCertConfig, _ := testSecretStore.GetClientCert()
+	assert.NotNil(t, testCertConfig)
+	assert.NotNil(t, testCertConfig.ClientCertificateConfig)
 
-// 		assert.NoError(t, err)
-// 		assert.NotNil(t, authorizer)
-// 	})
+	authorizer, err := testCertConfig.Authorizer()
+	assert.NoError(t, err)
+	assert.NotNil(t, authorizer)
 
-// 	t.Run("Certificate is invalid", func(t *testing.T) {
-// 		certBytes := getTestCert()
-// 		testSecretStore := NewClientAuthorizer(
-// 			"", // ignore
-// 			certBytes[0:20],
-// 			"", // No password for cert
-// 			fakeClientID,
-// 			fakeTenantID)
+	err = os.Remove(testCertFileName)
+	assert.NoError(t, err)
+}
 
-// 		_, err := testSecretStore.Authorizer()
-// 		assert.Error(t, err)
-// 	})
-// }
+func TestAuthorizorWithCertBytes(t *testing.T) {
+	t.Run("Certificate is valid", func(t *testing.T) {
+		certBytes := getTestCert()
 
-// func getTestCert() []byte {
-// 	certBytes, _ := base64.StdEncoding.DecodeString(testCert)
-// 	return certBytes
-// }
+		metadata := map[string]string{
+			componentSPNCertificate:         string(certBytes[:]),
+			componentSPNCertificatePassword: "",
+			componentSPNClientID:            fakeClientID,
+			componentSPNTenantID:            fakeTenantID,
+			componentVaultName:              "vaultName",
+		}
+
+		testSecretStore := keyvaultSecretStore{
+			metadata: secretstores.Metadata{
+				Properties: metadata,
+			},
+		}
+
+		testCertConfig, _ := testSecretStore.GetClientCert()
+		assert.NotNil(t, testCertConfig)
+		assert.NotNil(t, testCertConfig.ClientCertificateConfig)
+
+		authorizer, err := testCertConfig.Authorizer()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, authorizer)
+	})
+
+	t.Run("Certificate is invalid", func(t *testing.T) {
+		certBytes := getTestCert()
+
+		metadata := map[string]string{
+			componentSPNCertificate:         string(certBytes[0:20]),
+			componentSPNCertificatePassword: "",
+			componentSPNClientID:            fakeClientID,
+			componentSPNTenantID:            fakeTenantID,
+			componentVaultName:              "vaultName",
+		}
+
+		testSecretStore := keyvaultSecretStore{
+			metadata: secretstores.Metadata{
+				Properties: metadata,
+			},
+		}
+
+		testCertConfig, _ := testSecretStore.GetClientCert()
+		assert.NotNil(t, testCertConfig)
+		assert.NotNil(t, testCertConfig.ClientCertificateConfig)
+
+		_, err := testCertConfig.Authorizer()
+		assert.Error(t, err)
+	})
+}
+
+func getTestCert() []byte {
+	certBytes, _ := base64.StdEncoding.DecodeString(testCert)
+	return certBytes
+}

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -88,7 +88,7 @@ func TestAuthorizorWithCertBytes(t *testing.T) {
 		certBytes := getTestCert()
 
 		metadata := map[string]string{
-			componentSPNCertificate:         string(certBytes[:]),
+			componentSPNCertificate:         string(certBytes),
 			componentSPNCertificatePassword: "",
 			componentSPNClientID:            fakeClientID,
 			componentSPNTenantID:            fakeTenantID,

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -5,92 +5,92 @@
 
 package keyvault
 
-import (
-	"encoding/base64"
-	"io/ioutil"
-	"os"
-	"testing"
+// import (
+// 	"encoding/base64"
+// 	"io/ioutil"
+// 	"os"
+// 	"testing"
 
-	"github.com/stretchr/testify/assert"
-)
+// 	"github.com/stretchr/testify/assert"
+// )
 
-const (
-	fakeTenantID = "14bec2db-7f9a-4f3d-97ca-2d384ac83389"
-	fakeClientID = "04bec2db-7f9a-4f3d-97ca-3d384ac83389"
+// const (
+// 	fakeTenantID = "14bec2db-7f9a-4f3d-97ca-2d384ac83389"
+// 	fakeClientID = "04bec2db-7f9a-4f3d-97ca-3d384ac83389"
 
-	// Base64 encoded test pfx cert - Expire date: 09/19/2119
-	testCert = "MIIKTAIBAzCCCgwGCSqGSIb3DQEHAaCCCf0Eggn5MIIJ9TCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAifAbe5KAL7IwICB9AEggTYZ3dAdDNqi5GoGJ/VfZhh8dxIIERUaC/SO5vKFhDfNu9VCQKF7Azr3eJ4cjzQmicfLd6FxJpB6d+8fbQuCcYPpTAdqf5zmLtZWMDWW8YZE0pV7b6sDZSw/NbT2zFhsx2uife6NnLK//Pj+GeALUDPfhVfqfLCfWZlCHxlbOipVZv9U4+TCVO2vyrGUq2XesT78cT+LhbHYkcrxTCsXNLWAvSJ9zXOIVA5HNS3Qv8pQJSSbqYVBbLk6FEbt5B3pk0xoA1hhM7dlCoGvPJ/ajvN3wAcEB5kmjJ4q59s2HeXloa7aAhXTFEkL2rZH+acgr1AO/DwcGXUqzJ2ooGYBfoqmgaXjydzyVLzYNccBGbzBR4Q0crMW6zDBXDlwvnLxmqZ7p05Ix9ZqISQyTm/DboNwQk1erOJd0fe6Brg1Dw4td6Uh/AXfM8m+XCGJFn79ZMCtd4rP8w9l008m8xe7rczSkMW0aRJVr0j3fFheene83jOHEB0q3KMKsVTkPWehnTGPj4TrsL+WwrmJpqrSloXMyaqvS9hvqAfPal0JI9taz6R5HFONaO6oi/ajpX3tYSX0rafQPKHmJpFLtJHYPopFYgP4akq8wKOCjq1IDg3ZW59G9nh8Vcw3IrAnr+C9iMgzPUvCHCinQK24cmbn5px6S0U0ARhY90KrSMFRyjvxNpZzc+A/AAaQ/wwuLVy1GyuZ2sRFyVSCTRMC6ZfXAUs+OijDO/B++BCdmqm5p5/aZpQYf1cb681AaDc/5XTHtCC3setYfpviMe1grvp4jaPVrjnG85pVenZJ0d+Xo7BnD38Ec5RsKpvtXIieiRIbnGqzTzxj/OU/cdglrKy8MLo6IJigXA6N3x14o4e3akq7cvLPRQZqlWyLqjlGnJdZKJlemFlOnDSluzwGBwwKF+PpXuRVSDhi/ARN3g8L+wVAQQMEylWJfK7sNDun41rimE8wGFjqlfZNVg/pCBKvw3p90pCkxVUEZBRrP1vaGzrIvOsMU/rrJqQU7Imv9y6nUrvHdcoRFUdbgWVWZus6VwTrgwRkfnPiLZo0r5Vh4kComH0+Tc4kgwbnnuQQWzn8J9Ur4Nu0MkknC/1jDwulq2XOIBPclmEPg9CSSwfKonyaRxz+3GoPy0kGdHwsOcXIq5qBIyiYAtM1g1cQLtOT16OCjapus+GIOLnItP2OAhO70dsTMUlsQSNEH+KxUxFb1pFuQGXnStmgZtHYI4LvC/d820tY0m0I6SgfabnoQpIXa6iInIt970awwyUP1P/6m9ie5bCRDWCj4R0bNiNQBjq9tHfO4xeGK+fUTyeU4OEBgiyisNVhijf6GlfPHKWwkInAN0WbS3UHHACjkP0jmRb70b/3VbWon/+K5S6bk2ohIDsbPPVolTvfMehRwKatqQTbTXlnDIHJQzk9SfHHWJzkrQXEIbXgGxHSHm5CmNetR/MYGlivjtGRVxOLr7Y1tK0GGEDMs9nhiSvlwWjAEuwIN+72T6Kx7hPRld1BvaTYLRYXfjnedo7D2AoR+8tGLWjU31rHJVua/JILjGC84ARCjk5LOFHOXUjOP1jJomh8ebjlVijNWP0gLUC14AE8UJsJ1Xi6xiNOTeMpeOIJl2kX81uvnNbQ0j4WajfXlox5eV+0iJ1yNfw5jGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IADgAZABlADYANgA5AGEAYQAtADUAZgAyAGMALQA0ADIANgBmAC0AYQA3ADAANwAtADIANgBmADkAOAAwADAANAAwAGEAYQAwMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIID1wYJKoZIhvcNAQcGoIIDyDCCA8QCAQAwggO9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAiT1ngppOJy/gICB9CAggOQt9iTz9CmP/3+EBQv3WM80jLHHyrkJM5nIckr+4fmcl3frhbZZajSf1eigjOaqWpz1cAu9KtSAb0Fa35AKr7r9du5SXwBxyYS6XzXsWekSrdvh3Dui0abXo/yh+lIfI/61sJLv5Gc7/DbJrwlHHOD1DR/ohmncAiSjGUYaO9/Y9xUV3cbzjZypqKkkbahaWVMC8+D9zUSkH64RUuLvSi5X5QKFsICNouBL1j/C2s3VZoyR9F0ajRCEMFnQsMfJ/1fP2iW/wwFIARBjphj1SaEaP3XkxQadslR0cwhf6Ujj/tXyd1zV5oI8rJ54r8eN5Vu8NxEX3kl+A7gCc9ACEC0klZ18mQUjb6eDpUSFM63/wx7ISDKaD7gyWCul1JwlUmYzvrRw8sAwjVEyXzc+n0oIOlk0lE6vk3mybkfcOxafRkdr0zVnd5L+XtV/V38sd3ExNojQgUDNy905PNTHdeVnvHt6E8XGNgGX7a/tB1r7Un3soL5Vjcuf/HMdyR57CF2lxFSrdZ1bNnw7Z1GJbQZHago2AovNw+BbBJfey0iuIRP+dgkIfle0nzl3E7T9jU0r2+GEQfN7YYjRL19XFX4n8kNpiTDDRxdNj/yKQDfC7f8prZY/yP8bJLaFBd+uoH+D4QKmWk7plwXTOLiNno9cOTrLYT48HCEghtBbnTgZglOg8eDZd35MR5KcCNWxVy/enEj3/BEtkH7qnJsxlFMu1WwAQzaVYK1u1sGCD8NGH2wtiJi0O5q+YsQItv7ia2x9lSL1JPagtRhxnIZbC5HaIx87bSrVY9XTrWlj9X0H+YSdbUrszRse+LLJkw6h8wXqBvrBKsxnPrfJyQWs3zqehk0FPF1pi+spoJzp7//nmZ5a7knRXYkxV++TiuX+RQSNR/cFxezEwR+2WUAJaJfPpSf06dp5M/gJNVJQGMNiLHCMc9w6CPLUFQA1FG5YdK8nFrSo0iclX7wAHWpCjkqHj7PgOT+Ia5qiOb2dN2GBWPh5N94PO15BLlS/9UUvGxvmWqmG3lpr3hP5B6OZdQl8lxBGc8KTq4GdoJrQ+Jmfej3LQa33mV5VZwJqdbH9iEHvUH2VYC8ru7r5drXBqP5IlZrkdIL5uzzaoHsnWtu0OKgjwRwXaAF24zM0GVXbueGXLXH3vwBwoO4GnDfJ0wN0qFEJBRexRdPP9JKjPfVmwbi89sx1zJMId3nCmetq5yGMDcwHzAHBgUrDgMCGgQUmQChLB4WJjopytxl4LNQ9NuCbPkEFO+tI0n+7a6hwK9hqzq7tghkXp08"
-)
+// 	// Base64 encoded test pfx cert - Expire date: 09/19/2119
+// 	testCert = "MIIKTAIBAzCCCgwGCSqGSIb3DQEHAaCCCf0Eggn5MIIJ9TCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAifAbe5KAL7IwICB9AEggTYZ3dAdDNqi5GoGJ/VfZhh8dxIIERUaC/SO5vKFhDfNu9VCQKF7Azr3eJ4cjzQmicfLd6FxJpB6d+8fbQuCcYPpTAdqf5zmLtZWMDWW8YZE0pV7b6sDZSw/NbT2zFhsx2uife6NnLK//Pj+GeALUDPfhVfqfLCfWZlCHxlbOipVZv9U4+TCVO2vyrGUq2XesT78cT+LhbHYkcrxTCsXNLWAvSJ9zXOIVA5HNS3Qv8pQJSSbqYVBbLk6FEbt5B3pk0xoA1hhM7dlCoGvPJ/ajvN3wAcEB5kmjJ4q59s2HeXloa7aAhXTFEkL2rZH+acgr1AO/DwcGXUqzJ2ooGYBfoqmgaXjydzyVLzYNccBGbzBR4Q0crMW6zDBXDlwvnLxmqZ7p05Ix9ZqISQyTm/DboNwQk1erOJd0fe6Brg1Dw4td6Uh/AXfM8m+XCGJFn79ZMCtd4rP8w9l008m8xe7rczSkMW0aRJVr0j3fFheene83jOHEB0q3KMKsVTkPWehnTGPj4TrsL+WwrmJpqrSloXMyaqvS9hvqAfPal0JI9taz6R5HFONaO6oi/ajpX3tYSX0rafQPKHmJpFLtJHYPopFYgP4akq8wKOCjq1IDg3ZW59G9nh8Vcw3IrAnr+C9iMgzPUvCHCinQK24cmbn5px6S0U0ARhY90KrSMFRyjvxNpZzc+A/AAaQ/wwuLVy1GyuZ2sRFyVSCTRMC6ZfXAUs+OijDO/B++BCdmqm5p5/aZpQYf1cb681AaDc/5XTHtCC3setYfpviMe1grvp4jaPVrjnG85pVenZJ0d+Xo7BnD38Ec5RsKpvtXIieiRIbnGqzTzxj/OU/cdglrKy8MLo6IJigXA6N3x14o4e3akq7cvLPRQZqlWyLqjlGnJdZKJlemFlOnDSluzwGBwwKF+PpXuRVSDhi/ARN3g8L+wVAQQMEylWJfK7sNDun41rimE8wGFjqlfZNVg/pCBKvw3p90pCkxVUEZBRrP1vaGzrIvOsMU/rrJqQU7Imv9y6nUrvHdcoRFUdbgWVWZus6VwTrgwRkfnPiLZo0r5Vh4kComH0+Tc4kgwbnnuQQWzn8J9Ur4Nu0MkknC/1jDwulq2XOIBPclmEPg9CSSwfKonyaRxz+3GoPy0kGdHwsOcXIq5qBIyiYAtM1g1cQLtOT16OCjapus+GIOLnItP2OAhO70dsTMUlsQSNEH+KxUxFb1pFuQGXnStmgZtHYI4LvC/d820tY0m0I6SgfabnoQpIXa6iInIt970awwyUP1P/6m9ie5bCRDWCj4R0bNiNQBjq9tHfO4xeGK+fUTyeU4OEBgiyisNVhijf6GlfPHKWwkInAN0WbS3UHHACjkP0jmRb70b/3VbWon/+K5S6bk2ohIDsbPPVolTvfMehRwKatqQTbTXlnDIHJQzk9SfHHWJzkrQXEIbXgGxHSHm5CmNetR/MYGlivjtGRVxOLr7Y1tK0GGEDMs9nhiSvlwWjAEuwIN+72T6Kx7hPRld1BvaTYLRYXfjnedo7D2AoR+8tGLWjU31rHJVua/JILjGC84ARCjk5LOFHOXUjOP1jJomh8ebjlVijNWP0gLUC14AE8UJsJ1Xi6xiNOTeMpeOIJl2kX81uvnNbQ0j4WajfXlox5eV+0iJ1yNfw5jGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IADgAZABlADYANgA5AGEAYQAtADUAZgAyAGMALQA0ADIANgBmAC0AYQA3ADAANwAtADIANgBmADkAOAAwADAANAAwAGEAYQAwMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIID1wYJKoZIhvcNAQcGoIIDyDCCA8QCAQAwggO9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAiT1ngppOJy/gICB9CAggOQt9iTz9CmP/3+EBQv3WM80jLHHyrkJM5nIckr+4fmcl3frhbZZajSf1eigjOaqWpz1cAu9KtSAb0Fa35AKr7r9du5SXwBxyYS6XzXsWekSrdvh3Dui0abXo/yh+lIfI/61sJLv5Gc7/DbJrwlHHOD1DR/ohmncAiSjGUYaO9/Y9xUV3cbzjZypqKkkbahaWVMC8+D9zUSkH64RUuLvSi5X5QKFsICNouBL1j/C2s3VZoyR9F0ajRCEMFnQsMfJ/1fP2iW/wwFIARBjphj1SaEaP3XkxQadslR0cwhf6Ujj/tXyd1zV5oI8rJ54r8eN5Vu8NxEX3kl+A7gCc9ACEC0klZ18mQUjb6eDpUSFM63/wx7ISDKaD7gyWCul1JwlUmYzvrRw8sAwjVEyXzc+n0oIOlk0lE6vk3mybkfcOxafRkdr0zVnd5L+XtV/V38sd3ExNojQgUDNy905PNTHdeVnvHt6E8XGNgGX7a/tB1r7Un3soL5Vjcuf/HMdyR57CF2lxFSrdZ1bNnw7Z1GJbQZHago2AovNw+BbBJfey0iuIRP+dgkIfle0nzl3E7T9jU0r2+GEQfN7YYjRL19XFX4n8kNpiTDDRxdNj/yKQDfC7f8prZY/yP8bJLaFBd+uoH+D4QKmWk7plwXTOLiNno9cOTrLYT48HCEghtBbnTgZglOg8eDZd35MR5KcCNWxVy/enEj3/BEtkH7qnJsxlFMu1WwAQzaVYK1u1sGCD8NGH2wtiJi0O5q+YsQItv7ia2x9lSL1JPagtRhxnIZbC5HaIx87bSrVY9XTrWlj9X0H+YSdbUrszRse+LLJkw6h8wXqBvrBKsxnPrfJyQWs3zqehk0FPF1pi+spoJzp7//nmZ5a7knRXYkxV++TiuX+RQSNR/cFxezEwR+2WUAJaJfPpSf06dp5M/gJNVJQGMNiLHCMc9w6CPLUFQA1FG5YdK8nFrSo0iclX7wAHWpCjkqHj7PgOT+Ia5qiOb2dN2GBWPh5N94PO15BLlS/9UUvGxvmWqmG3lpr3hP5B6OZdQl8lxBGc8KTq4GdoJrQ+Jmfej3LQa33mV5VZwJqdbH9iEHvUH2VYC8ru7r5drXBqP5IlZrkdIL5uzzaoHsnWtu0OKgjwRwXaAF24zM0GVXbueGXLXH3vwBwoO4GnDfJ0wN0qFEJBRexRdPP9JKjPfVmwbi89sx1zJMId3nCmetq5yGMDcwHzAHBgUrDgMCGgQUmQChLB4WJjopytxl4LNQ9NuCbPkEFO+tI0n+7a6hwK9hqzq7tghkXp08"
+// )
 
-func TestClientAuthorizer(t *testing.T) {
-	testSecretStore := NewClientAuthorizer(
-		"testfile",
-		[]byte("testcert"),
-		"1234",
-		fakeClientID,
-		fakeTenantID)
+// func TestClientAuthorizer(t *testing.T) {
+// 	testSecretStore := NewClientAuthorizer(
+// 		"testfile",
+// 		[]byte("testcert"),
+// 		"1234",
+// 		fakeClientID,
+// 		fakeTenantID)
 
-	assert.Equal(t, "testfile", testSecretStore.CertificatePath)
-	assert.Equal(t, []byte("testcert"), testSecretStore.CertificateData)
-	assert.Equal(t, "1234", testSecretStore.CertificatePassword)
-	assert.Equal(t, fakeClientID, testSecretStore.ClientID)
-	assert.Equal(t, fakeTenantID, testSecretStore.TenantID)
-	assert.Equal(t, "https://vault.azure.net", testSecretStore.Resource)
-	assert.Equal(t, "https://login.microsoftonline.com/", testSecretStore.AADEndpoint)
-}
+// 	assert.Equal(t, "testfile", testSecretStore.CertificatePath)
+// 	assert.Equal(t, []byte("testcert"), testSecretStore.CertificateData)
+// 	assert.Equal(t, "1234", testSecretStore.CertificatePassword)
+// 	assert.Equal(t, fakeClientID, testSecretStore.ClientID)
+// 	assert.Equal(t, fakeTenantID, testSecretStore.TenantID)
+// 	assert.Equal(t, "https://vault.azure.net", testSecretStore.Resource)
+// 	assert.Equal(t, "https://login.microsoftonline.com/", testSecretStore.AADEndpoint)
+// }
 
-func TestAuthorizorWithCertFile(t *testing.T) {
-	testCertFileName := "./.cert.pfx"
-	certBytes := getTestCert()
-	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
-	assert.NoError(t, err)
+// func TestAuthorizorWithCertFile(t *testing.T) {
+// 	testCertFileName := "./.cert.pfx"
+// 	certBytes := getTestCert()
+// 	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
+// 	assert.NoError(t, err)
 
-	testSecretStore := NewClientAuthorizer(
-		testCertFileName,
-		nil,
-		"", // No password for cert
-		fakeClientID,
-		fakeTenantID)
+// 	testSecretStore := NewClientAuthorizer(
+// 		testCertFileName,
+// 		nil,
+// 		"", // No password for cert
+// 		fakeClientID,
+// 		fakeTenantID)
 
-	authorizer, err := testSecretStore.Authorizer()
-	assert.NoError(t, err)
-	assert.NotNil(t, authorizer)
+// 	authorizer, err := testSecretStore.Authorizer()
+// 	assert.NoError(t, err)
+// 	assert.NotNil(t, authorizer)
 
-	err = os.Remove(testCertFileName)
-	assert.NoError(t, err)
-}
+// 	err = os.Remove(testCertFileName)
+// 	assert.NoError(t, err)
+// }
 
-func TestAuthorizorWithCertBytes(t *testing.T) {
-	t.Run("Certificate is valid", func(t *testing.T) {
-		certBytes := getTestCert()
-		testSecretStore := NewClientAuthorizer(
-			"", // ignore
-			certBytes,
-			"", // No password for cert
-			fakeClientID,
-			fakeTenantID)
+// func TestAuthorizorWithCertBytes(t *testing.T) {
+// 	t.Run("Certificate is valid", func(t *testing.T) {
+// 		certBytes := getTestCert()
+// 		testSecretStore := NewClientAuthorizer(
+// 			"", // ignore
+// 			certBytes,
+// 			"", // No password for cert
+// 			fakeClientID,
+// 			fakeTenantID)
 
-		authorizer, err := testSecretStore.Authorizer()
+// 		authorizer, err := testSecretStore.Authorizer()
 
-		assert.NoError(t, err)
-		assert.NotNil(t, authorizer)
-	})
+// 		assert.NoError(t, err)
+// 		assert.NotNil(t, authorizer)
+// 	})
 
-	t.Run("Certificate is invalid", func(t *testing.T) {
-		certBytes := getTestCert()
-		testSecretStore := NewClientAuthorizer(
-			"", // ignore
-			certBytes[0:20],
-			"", // No password for cert
-			fakeClientID,
-			fakeTenantID)
+// 	t.Run("Certificate is invalid", func(t *testing.T) {
+// 		certBytes := getTestCert()
+// 		testSecretStore := NewClientAuthorizer(
+// 			"", // ignore
+// 			certBytes[0:20],
+// 			"", // No password for cert
+// 			fakeClientID,
+// 			fakeTenantID)
 
-		_, err := testSecretStore.Authorizer()
-		assert.Error(t, err)
-	})
-}
+// 		_, err := testSecretStore.Authorizer()
+// 		assert.Error(t, err)
+// 	})
+// }
 
-func getTestCert() []byte {
-	certBytes, _ := base64.StdEncoding.DecodeString(testCert)
-	return certBytes
-}
+// func getTestCert() []byte {
+// 	certBytes, _ := base64.StdEncoding.DecodeString(testCert)
+// 	return certBytes
+// }

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -27,7 +27,6 @@ const (
 type keyvaultSecretStore struct {
 	vaultName   string
 	vaultClient kv.BaseClient
-	metadata    secretstores.Metadata
 }
 
 // NewAzureKeyvaultSecretStore returns a new Kubernetes secret store
@@ -40,8 +39,11 @@ func NewAzureKeyvaultSecretStore() secretstores.SecretStore {
 
 // Init creates a Kubernetes client
 func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
-	k.metadata = metadata
-	authorizer, err := k.GetAuthorizer()
+	settings := EnvironmentSettings{
+		Values: metadata.Properties,
+	}
+
+	authorizer, err := k.GetAuthorizer(settings)
 	if err == nil {
 		k.vaultClient.Authorizer = authorizer
 	}

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -43,10 +43,12 @@ func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
 		Values: metadata.Properties,
 	}
 
-	authorizer, err := k.GetAuthorizer(settings)
+	authorizer, err := settings.GetAuthorizer()
 	if err == nil {
 		k.vaultClient.Authorizer = authorizer
 	}
+
+	k.vaultName = settings.Values[componentVaultName]
 
 	return err
 }

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -25,9 +25,9 @@ const (
 )
 
 type keyvaultSecretStore struct {
-	vaultName        string
-	vaultClient      kv.BaseClient
-	clientAuthorizer ClientAuthorizer
+	vaultName   string
+	vaultClient kv.BaseClient
+	metadata    secretstores.Metadata
 }
 
 // NewAzureKeyvaultSecretStore returns a new Kubernetes secret store
@@ -40,20 +40,8 @@ func NewAzureKeyvaultSecretStore() secretstores.SecretStore {
 
 // Init creates a Kubernetes client
 func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
-	props := metadata.Properties
-	k.vaultName = props[componentVaultName]
-	certFilePath := props[componentSPNCertificateFile]
-	certBytes := []byte(props[componentSPNCertificate])
-	certPassword := props[componentSPNCertificatePassword]
-
-	k.clientAuthorizer = NewClientAuthorizer(
-		certFilePath,
-		certBytes,
-		certPassword,
-		props[componentSPNClientID],
-		props[componentSPNTenantID])
-
-	authorizer, err := k.clientAuthorizer.Authorizer()
+	k.metadata = metadata
+	authorizer, err := k.GetAuthorizer()
 	if err == nil {
 		k.vaultClient.Authorizer = authorizer
 	}


### PR DESCRIPTION
# Description

Adding support for Manage Identities in the Azure Key Vault Secret Store

Code in _authutils.go_ now extends _keyvaultSecretStore_ in such a way that calling the _GetAuthorizer()_ method result in using a client certificate to call the key vault if all the needed configuration is provided or fall back to using Managed Identities pretty much like the Azure SDK does when calling _GetAuthorizer_  in the autorest code found [here](https://github.com/Azure/go-autorest/blob/master/autorest/azure/auth/auth.go)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #184

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

If you think this is going in the right direction then I'll be glad to finish the implementation, update the tests and extend the documentation.

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation

