### PR TITLE
Azure Table Storage state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/fasthttp-contrib/sessions v0.0.0-20160905201309-74f6ac73d5d5
 	github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZ
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/state/Readme.md
+++ b/state/Readme.md
@@ -9,6 +9,7 @@ Currently supported state stores are:
 * Etcd
 * Cassandra
 * Azure CosmosDB
+* Azure Table Storage
 * Memcached
 * MongoDB
 * Zookeeper

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -192,7 +192,6 @@ func (r *StateStore) writeRow(req *state.SetRequest) error {
 			entity.OdataEtag = ""
 			return entity.Insert(storage.FullMetadata, nil)
 		}
-
 	}
 	return err
 }

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -1,0 +1,187 @@
+package tablestorage
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/dapr/components-contrib/state"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+const (
+	fullmetadata        = "application/json;odata=fullmetadata"
+	daprDelim           = "__delim__"
+	valueEntityProperty = "Value"
+
+	accountNameKey = "accountName"
+	accountKeyKey  = "accountKey"
+	tableNameKey   = "tableName"
+)
+
+type StateStore struct {
+	table *storage.Table
+	json  jsoniter.API
+}
+
+type tablesMetadata struct {
+	accountName string
+	accountKey  string
+	tableName   string
+}
+
+// ---- Store interface begin
+
+//initialises connection to table storage, optionally creates a table if it doesn't exist
+func (r *StateStore) Init(metadata state.Metadata) error {
+	meta, err := getTablesMetadata(metadata.Properties)
+	if err != nil {
+		return err
+	}
+
+	client, _ := storage.NewBasicClient(meta.accountName, meta.accountKey)
+	tables := client.GetTableService()
+	r.table = tables.GetTableReference(meta.tableName)
+
+	//check table exists
+	log.Debugf("using table '%s'", meta.tableName)
+	err = r.table.Create(100, fullmetadata, nil)
+	if err != nil {
+		if azureError, ok := err.(storage.AzureStorageServiceError); ok && azureError.Code == "TableAlreadyExists" {
+			//error creating table, but it already exists so we're fine
+			log.Debugf("table already exists")
+		} else {
+			return err
+		}
+	}
+
+	log.Printf("table initialised, account: %s, table: %s", meta.accountName, meta.tableName)
+
+	return nil
+}
+
+func (r *StateStore) Delete(req *state.DeleteRequest) error {
+	log.Debugf("delete one")
+	return nil
+}
+
+func (r *StateStore) BulkDelete(req []state.DeleteRequest) error {
+	log.Debugf("bulk delete")
+	return nil
+}
+
+func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	log.Debugf("GET ONE")
+	pk, rk := r.getPartitionAndRowKey(req.Key)
+	entity := r.table.GetEntityReference(pk, rk)
+	err := entity.Get(1000, fullmetadata, nil)
+
+	if err != nil {
+		if azureError, ok := err.(storage.AzureStorageServiceError); ok && azureError.Code == "ResourceNotFound" {
+			return &state.GetResponse{}, nil
+		}
+
+		return &state.GetResponse{}, err
+	}
+
+	data, err := r.unmarshal(entity)
+	return &state.GetResponse{
+		Data: data,
+	}, err
+}
+
+func (r *StateStore) Set(req *state.SetRequest) error {
+	log.Debugf("set ONE")
+
+	return r.writeRow(req)
+}
+
+func (r *StateStore) BulkSet(req []state.SetRequest) error {
+	log.Debugf("bulk set %v", len(req))
+
+	for _, s := range req {
+		err := r.Set(&s)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ---- Store interface end
+
+func NewAzureTablesStateStore() *StateStore {
+	return &StateStore{
+		json: jsoniter.ConfigFastest,
+	}
+}
+
+func getTablesMetadata(metadata map[string]string) (*tablesMetadata, error) {
+	meta := tablesMetadata{}
+
+	if val, ok := metadata[accountNameKey]; ok && val != "" {
+		meta.accountName = val
+	} else {
+		return nil, errors.New(fmt.Sprintf("missing or empty %s field from metadata", accountNameKey))
+	}
+
+	if val, ok := metadata[accountKeyKey]; ok && val != "" {
+		meta.accountKey = val
+	} else {
+		return nil, errors.New(fmt.Sprintf("missing of empty %s field from metadata", accountKeyKey))
+	}
+
+	if val, ok := metadata[tableNameKey]; ok && val != "" {
+		meta.tableName = val
+	} else {
+		return nil, errors.New(fmt.Sprintf("missing of empty %s field from metadata", tableNameKey))
+	}
+
+	return &meta, nil
+}
+
+func (r *StateStore) writeRow(req *state.SetRequest) error {
+	pk, rk := r.getPartitionAndRowKey(req.Key)
+	entity := r.table.GetEntityReference(pk, rk)
+	entity.Properties = map[string]interface{}{
+		valueEntityProperty: r.marshal(req),
+		"ETag":              req.ETag, //todo
+	}
+
+	return entity.InsertOrReplace(nil)
+}
+
+func (r *StateStore) getPartitionAndRowKey(key string) (string, string) {
+	pr := strings.Split(key, daprDelim)
+	return pr[0], pr[1]
+}
+
+func (r *StateStore) marshal(req *state.SetRequest) string {
+	var v string
+	b, ok := req.Value.([]byte)
+	if ok {
+		v = string(b)
+	} else {
+		v, _ = jsoniter.MarshalToString(req.Value)
+	}
+	return v
+}
+
+func (r *StateStore) unmarshal(row *storage.Entity) ([]byte, error) {
+	raw := row.Properties[valueEntityProperty]
+
+	//value column not present
+	if raw == nil {
+		return nil, nil
+	}
+
+	//must be a string
+	sv, ok := raw.(string)
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("expected string in column '%s'", valueEntityProperty))
+	}
+
+	return []byte(sv), nil
+}

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -197,16 +197,6 @@ func (r *StateStore) writeRow(req *state.SetRequest) error {
 	return err
 }
 
-func isConflictError(err error) bool {
-
-	// Unfortunately in case of conflict SDK does not provide specific error like AzureStorageError but a message only.
-	// Sample message:
-	//    Etag didn't match: storage: service returned error: StatusCode=412, ErrorCode=UpdateConditionNotSatisfied, ErrorMessage=The update condition specified in the request was not satisfied.
-
-	msg := err.Error()
-	return strings.Contains(msg, "StatusCode=412") && strings.Contains(msg, "ErrorCode=UpdateConditionNotSatisfied")
-}
-
 func isNotFoundError(err error) bool {
 	azureError, ok := err.(storage.AzureStorageServiceError)
 	return ok && azureError.Code == "ResourceNotFound"

--- a/state/azure/tablestorage/tablestorage_test.go
+++ b/state/azure/tablestorage/tablestorage_test.go
@@ -34,7 +34,7 @@ func TestGetTableStorageMetadata(t *testing.T) {
 
 func TestPartitionAndRowKey(t *testing.T) {
 	t.Run("Valid composite key", func(t *testing.T) {
-		pk, rk := getPartitionAndRowKey("pk__delim__rk")
+		pk, rk := getPartitionAndRowKey("pk||rk")
 		assert.Equal(t, "pk", pk)
 		assert.Equal(t, "rk", rk)
 	})

--- a/state/azure/tablestorage/tablestorage_test.go
+++ b/state/azure/tablestorage/tablestorage_test.go
@@ -1,0 +1,15 @@
+package tablestorage
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMetadataRequirements(t *testing.T) {
+	t.Run("Nothing at all", func(t *testing.T) {
+		m := make(map[string]string)
+		_, err := getTablesMetadata(m)
+
+		assert.NotNil(t, err)
+	})
+}

--- a/state/azure/tablestorage/tablestorage_test.go
+++ b/state/azure/tablestorage/tablestorage_test.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package tablestorage
 
 import (
@@ -5,11 +10,38 @@ import (
 	"testing"
 )
 
-func TestMetadataRequirements(t *testing.T) {
-	t.Run("Nothing at all", func(t *testing.T) {
+func TestGetTableStorageMetadata(t *testing.T) {
+	t.Run("Nothing at all passed", func(t *testing.T) {
 		m := make(map[string]string)
 		_, err := getTablesMetadata(m)
 
 		assert.NotNil(t, err)
+	})
+
+	t.Run("All parameters passed and parsed", func(t *testing.T) {
+		m := make(map[string]string)
+		m["accountName"] = "acc"
+		m["accountKey"] = "key"
+		m["tableName"] = "dapr"
+		meta, err := getTablesMetadata(m)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "acc", meta.accountName)
+		assert.Equal(t, "key", meta.accountKey)
+		assert.Equal(t, "dapr", meta.tableName)
+	})
+}
+
+func TestPartitionAndRowKey(t *testing.T) {
+	t.Run("Valid composite key", func(t *testing.T) {
+		pk, rk := getPartitionAndRowKey("pk__delim__rk")
+		assert.Equal(t, "pk", pk)
+		assert.Equal(t, "rk", rk)
+	})
+
+	t.Run("No delimiter present", func(t *testing.T) {
+		pk, rk := getPartitionAndRowKey("pk_rk")
+		assert.Equal(t, "pk_rk", pk)
+		assert.Equal(t, "", rk)
 	})
 }


### PR DESCRIPTION
# Description

Azure Table storage state provider. This is using the official Azure Go SDK from Microsoft.

## How did I test this?

1. Cloned dapr repository and changed cmd/daprd/main.go:

state store import:
```go
state_azure_tablestorage "github.com/dapr/components-contrib/state/azure/tablestorage"
```
registered the store:

```go
			state_loader.New("azure.tablestorage", func() state.Store {
				return state_azure_tablestorage.NewAzureTablesStateStore()
			}),

```

2. In dapr repo, changed `go.mod` to redirect to local copy of `components-contrib`:

```
replace (
	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+incompatible
	github.com/dapr/components-contrib => ../components-contrib
	github.com/dapr/components-contrib v0.0.0-20200116212630-381777dc3b3e => ../components-contrib
	k8s.io/client => github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36
)
```

2. Instead of building dapr main repo, I've created a launch configuration for IntelliJ with hardcoded daprd parameters, so I can re-run very quickly:

![image](https://user-images.githubusercontent.com/3155189/73002426-f1246000-3dfb-11ea-9fe0-1d582ad7e413.png)

For my convenience, the build **overwrites** daprd.exe in the default dapr folder, therefore I can test my local applications as well. Command-line set fixed ports for debugging as well:

`--dapr-id sws --dapr-http-port 64043 --dapr-grpc-port 64044 --log-level debug --max-concurrency -1 --protocol http --placement-address localhost:6050`

I can also debug and breakpoint from the IDE which is awesome! Build time after change is pretty fast as well.

3. My test application has the following component `tables.yaml`:

```yaml
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: statestore
spec:
  type: state.azure.tablestorage
  metadata:
  - name: accountName
    value: <storage account name>
  - name: accountKey
    value: <key>
  - name: tableName
    value: <table name>
```

4. To test quicker, after I start daprd.exe with required component registrations, I can also test storage provider in vscode using [this awesome http extension](https://marketplace.visualstudio.com/items?itemName=humao.rest-client). 

![image](https://user-images.githubusercontent.com/3155189/73002930-b0791680-3dfc-11ea-827c-ecebb55556e6.png)

full source for your convenience:

```
@daprPort = 64043
@storeName = statestore

## STATE MANAGEMENT

### get value from state
GET http://localhost:{{daprPort}}/v1.0/state/{{storeName}}/views

### set single value
POST http://localhost:{{daprPort}}/v1.0/state/{{storeName}}
Content-Type: application/json

[{
    "key": "views",
    "value": "8"
}]

### set multiple values
POST http://localhost:{{daprPort}}/v1.0/state/{{storeName}}
Content-Type: application/json

[{
    "key": "views",
    "value": "7"
}, {
    "key": "substance",
    "value": {
        "material": "black",
        "quantity": 5
    }
}]

### delete state item
DELETE http://localhost:{{daprPort}}/v1.0/state/{{storeName}}/views
```

5. Checking stuff works in Azure Storage Explorer:

![image](https://user-images.githubusercontent.com/3155189/73003040-dacad400-3dfc-11ea-9c1d-7c0e83871fec.png)

Note that this provider decomposes composite key and uses service name as partition key, and row key for key.


## Issue reference

#194 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
