### PR TITLE
Fixed issue preventing authentication fallback to MSI

### DIFF
--- a/secretstores/azure/keyvault/authutils.go
+++ b/secretstores/azure/keyvault/authutils.go
@@ -31,17 +31,17 @@ type CertConfig struct {
 // GetClientCert creates a config object from the available certificate credentials.
 // An error is returned if no certificate credentials are available.
 func (s EnvironmentSettings) GetClientCert() (CertConfig, error) {
-	certFilePath := s.Values[componentSPNCertificateFile]
-	certBytes := []byte(s.Values[componentSPNCertificate])
+	certFilePath, certFilePathPresent := s.Values[componentSPNCertificateFile]
+	certBytes, certBytesPresent := s.Values[componentSPNCertificate]
 	certPassword := s.Values[componentSPNCertificatePassword]
 	clientID := s.Values[componentSPNClientID]
 	tenantID := s.Values[componentSPNTenantID]
 
-	if certFilePath == "" && len(certBytes) == 0 {
+	if !certFilePathPresent && !certBytesPresent {
 		return CertConfig{}, fmt.Errorf("missing client secret")
 	}
 
-	authorizer := NewCertConfig(certFilePath, certBytes, certPassword, clientID, tenantID)
+	authorizer := NewCertConfig(certFilePath, []byte(certBytes), certPassword, clientID, tenantID)
 
 	return authorizer, nil
 }

--- a/secretstores/azure/keyvault/authutils.go
+++ b/secretstores/azure/keyvault/authutils.go
@@ -37,7 +37,7 @@ func (s EnvironmentSettings) GetClientCert() (CertConfig, error) {
 	clientID := s.Values[componentSPNClientID]
 	tenantID := s.Values[componentSPNTenantID]
 
-	if certFilePath == "" && certBytes == nil {
+	if certFilePath == "" && len(certBytes) == 0 {
 		return CertConfig{}, fmt.Errorf("missing client secret")
 	}
 

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -142,9 +142,9 @@ func TestFallbackToMSI(t *testing.T) {
 		},
 	}
 
-	testCertConfig, err := settings.GetAuthorizer()
+	authorizer, err := settings.GetAuthorizer()
 
-	assert.NotNil(t, testCertConfig)
+	assert.NotNil(t, authorizer)
 	assert.NoError(t, err)
 }
 

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -134,6 +134,20 @@ func TestGetMSI(t *testing.T) {
 	assert.Equal(t, "https://vault.azure.net", testCertConfig.Resource)
 }
 
+func TestFallbackToMSI(t *testing.T) {
+	settings := EnvironmentSettings{
+		Values: map[string]string{
+			componentSPNClientID: fakeClientID,
+			componentVaultName:   "vaultName",
+		},
+	}
+
+	testCertConfig, err := settings.GetAuthorizer()
+
+	assert.NotNil(t, testCertConfig)
+	assert.NoError(t, err)
+}
+
 func TestAuthorizorWithMSI(t *testing.T) {
 	settings := EnvironmentSettings{
 		Values: map[string]string{


### PR DESCRIPTION
# Description

Wrong condition was preventing the Key Vault secret store to fallback to MSI authentication when needed.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ x] Code compiles correctly
* [ x] Created/updated tests
* [ ] Extended the documentation
