### PR TITLE
Added check to handle nil request body in nethttpadaptor

### DIFF
--- a/middleware/http/nethttpadaptor/nethttpadaptor.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor.go
@@ -17,12 +17,14 @@ func NewNetHTTPHandlerFunc(h fasthttp.RequestHandler) http.HandlerFunc {
 		remoteAddr := net.IPAddr{remoteIP, ""} //nolint
 		c.Init(&fasthttp.Request{}, &remoteAddr, nil)
 
-		reqBody, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			log.Errorf("error reading request body, %+v", err)
-			return
+		if r.Body != nil {
+			reqBody, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				log.Errorf("error reading request body, %+v", err)
+				return
+			}
+			c.Request.SetBody(reqBody)
 		}
-		c.Request.SetBody(reqBody)
 		c.Request.SetRequestURI(r.URL.RequestURI())
 		c.Request.URI().SetScheme(r.URL.Scheme)
 		c.Request.SetHost(r.Host)

--- a/middleware/http/nethttpadaptor/nethttpadaptor_test.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor_test.go
@@ -286,6 +286,18 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 				}
 			},
 		},
+		{
+			"nil body is handled",
+			func() *http.Request {
+				req, _ := http.NewRequest("GET", "https://localhost:8080", nil)
+				return req
+			},
+			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
+				return func(ctx *fasthttp.RequestCtx) {
+					assert.Equal(t, 0, len(ctx.Request.Body()))
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
Add a check for `nil` body in input `http.Request` in `nethttpadaptor.NewNetHTTPHandlerFunc`.
Add a new unit test to cover this scenario.

## Issue reference
Please reference the issue this PR will close: #217

## Checklist
Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
