### PR TITLE
Reduce Redis Streams block time

### DIFF
--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -123,6 +123,7 @@ func (r *redisStreams) readFromStream(stream, consumerID, start string) ([]redis
 		Group:    consumerID,
 		Consumer: consumerID,
 		Streams:  []string{stream, start},
+		Block:    0,
 	}).Result()
 	if err != nil {
 		return nil, err

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -123,7 +123,7 @@ func (r *redisStreams) readFromStream(stream, consumerID, start string) ([]redis
 		Group:    consumerID,
 		Consumer: consumerID,
 		Streams:  []string{stream, start},
-		Block:    0,
+		Block:    time.Millisecond * 100,
 	}).Result()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds a `100ms` block timeout to Redis Streams to reduce blocking time between XRead commands without hammering Redis.

Closes #220 