### PR TITLE
Changed how proto header is converted to string

### DIFF
--- a/middleware/http/nethttpadaptor/nethttpadaptor.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
@@ -30,8 +31,10 @@ func NewNetHTTPHandlerFunc(h fasthttp.RequestHandler) http.HandlerFunc {
 		c.Request.SetHost(r.Host)
 		c.Request.Header.SetMethod(r.Method)
 		c.Request.Header.Set("Proto", r.Proto)
-		c.Request.Header.Set("ProtoMajor", string(r.ProtoMajor))
-		c.Request.Header.Set("ProtoMinor", string(r.ProtoMinor))
+		major := strconv.Itoa(r.ProtoMajor)
+		minor := strconv.Itoa(r.ProtoMinor)
+		c.Request.Header.Set("Protomajor", major)
+		c.Request.Header.Set("Protominor", minor)
 		c.Request.Header.SetContentType(r.Header.Get("Content-Type"))
 		c.Request.Header.SetContentLength(int(r.ContentLength))
 		c.Request.Header.SetReferer(r.Referer())

--- a/middleware/http/nethttpadaptor/nethttpadaptor_test.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor_test.go
@@ -298,6 +298,30 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 				}
 			},
 		},
+		{
+			"proto headers are handled",
+			func() *http.Request {
+				req, _ := http.NewRequest("GET", "https://localhost:8080", nil)
+				return req
+			},
+			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
+				return func(ctx *fasthttp.RequestCtx) {
+					var major, minor string
+					ctx.Request.Header.VisitAll(func(k []byte, v []byte) {
+						if string(k) == "Protomajor" {
+							major = string(v)
+						}
+						if string(k) == "Protominor" {
+							minor = string(v)
+						}
+					})
+					assert.NotEqual(t, "", major)
+					assert.NotEqual(t, "", minor)
+					assert.Equal(t, "1", major)
+					assert.Equal(t, "1", minor)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/middleware/http/nethttpadaptor/nethttpadaptor_test.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor_test.go
@@ -308,15 +308,13 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 				return func(ctx *fasthttp.RequestCtx) {
 					var major, minor string
 					ctx.Request.Header.VisitAll(func(k []byte, v []byte) {
-						if string(k) == "Protomajor" {
+						if strings.EqualFold(string(k), "protomajor") {
 							major = string(v)
 						}
-						if string(k) == "Protominor" {
+						if strings.EqualFold(string(k), "protominor") {
 							minor = string(v)
 						}
 					})
-					assert.NotEqual(t, "", major)
-					assert.NotEqual(t, "", minor)
 					assert.Equal(t, "1", major)
 					assert.Equal(t, "1", minor)
 				}


### PR DESCRIPTION
# Description

Originally I was converting the protomajor and protominor from ints to string using a basic cast, however, this results in the string being a UTF encoded unicode code point which is not what we want. I've updated it to use an explicit conversion.

## Issue reference

Please reference the issue this PR will close: [dapr #1060](https://github.com/dapr/dapr/issues/1060)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
