### PR TITLE
change version params for aws secrets manager

### DIFF
--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	VersionID    = "VersionID"
-	VersionStage = "VersionStage"
+	VersionID    = "version_id"
+	VersionStage = "version_stage"
 )
 
 // NewSecretManager returns a new secret manager store


### PR DESCRIPTION
This PR makes consistent the `version_id` metadata property between GCP and AWS Secret managers and conforms `version_stage` to the casing format.