### PR TITLE
Twilio Binding - Get To Number from Request

### DIFF
--- a/bindings/twilio/sms.go
+++ b/bindings/twilio/sms.go
@@ -80,7 +80,7 @@ func (t *SMS) Write(req *bindings.WriteRequest) error {
 	if toNumberValue == "" {
 		toNumberFromRequest, ok := req.Metadata[toNumber]
 		if !ok || toNumberFromRequest == "" {
-			return errors.New("twillio missing \"to\"")
+			return errors.New("twilio missing \"toNumber\" field")
 		}
 		toNumberValue = toNumberFromRequest
 	}

--- a/bindings/twilio/sms.go
+++ b/bindings/twilio/sms.go
@@ -22,8 +22,9 @@ const (
 )
 
 type SMS struct {
-	metadata twilioMetadata
-	logger   logger.Logger
+	metadata   twilioMetadata
+	logger     logger.Logger
+	httpClient *http.Client
 }
 
 type twilioMetadata struct {
@@ -35,7 +36,10 @@ type twilioMetadata struct {
 }
 
 func NewSMS(logger logger.Logger) *SMS {
-	return &SMS{logger: logger}
+	return &SMS{
+		logger:     logger,
+		httpClient: &http.Client{},
+	}
 }
 
 func (t *SMS) Init(metadata bindings.Metadata) error {
@@ -43,9 +47,6 @@ func (t *SMS) Init(metadata bindings.Metadata) error {
 		timeout: time.Minute * 5,
 	}
 
-	if metadata.Properties[toNumber] == "" {
-		return errors.New("\"to\" is a required field")
-	}
 	if metadata.Properties[fromNumber] == "" {
 		return errors.New("\"fromNumber\" is a required field")
 	}
@@ -69,19 +70,26 @@ func (t *SMS) Init(metadata bindings.Metadata) error {
 	}
 
 	t.metadata = twilioM
+	t.httpClient.Timeout = twilioM.timeout
+
 	return nil
 }
 
 func (t *SMS) Write(req *bindings.WriteRequest) error {
+	toNumberValue := t.metadata.toNumber
+	if toNumberValue == "" {
+		toNumberFromRequest, ok := req.Metadata[toNumber]
+		if !ok || toNumberFromRequest == "" {
+			return errors.New("twillio missing \"to\"")
+		}
+		toNumberValue = toNumberFromRequest
+	}
+
 	v := url.Values{}
-	v.Set("To", t.metadata.toNumber)
+	v.Set("To", toNumberValue)
 	v.Set("From", t.metadata.fromNumber)
 	v.Set("Body", string(req.Data))
 	vDr := *strings.NewReader(v.Encode())
-
-	client := &http.Client{
-		Timeout: t.metadata.timeout,
-	}
 
 	twilioURL := fmt.Sprintf("%s%s/Messages.json", twilioURLBase, t.metadata.accountSid)
 	httpReq, err := http.NewRequest("POST", twilioURL, &vDr)
@@ -92,7 +100,7 @@ func (t *SMS) Write(req *bindings.WriteRequest) error {
 	httpReq.Header.Add("Accept", "application/json")
 	httpReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := client.Do(httpReq)
+	resp, err := t.httpClient.Do(httpReq)
 	if err != nil {
 		return err
 	}

--- a/bindings/twilio/sms_test.go
+++ b/bindings/twilio/sms_test.go
@@ -6,12 +6,35 @@
 package twilio
 
 import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
+
+type mockTransport struct {
+	response     *http.Response
+	errToReturn  error
+	request      *http.Request
+	requestCount int32
+}
+
+func (t *mockTransport) reset() {
+	atomic.StoreInt32(&t.requestCount, 0)
+	t.request = nil
+}
+
+func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&t.requestCount, 1)
+	t.request = req
+	return t.response, t.errToReturn
+}
 
 func TestInit(t *testing.T) {
 	m := bindings.Metadata{}
@@ -28,4 +51,92 @@ func TestParseDuration(t *testing.T) {
 	tw := NewSMS(logger.NewLogger("test"))
 	err := tw.Init(m)
 	assert.NotNil(t, err)
+}
+
+func TestWriteShouldSucceed(t *testing.T) {
+	httpTransport := &mockTransport{
+		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
+	}
+	m := bindings.Metadata{}
+	m.Properties = map[string]string{"toNumber": "toNumber", "fromNumber": "fromNumber",
+		"accountSid": "accountSid", "authToken": "authToken"}
+	tw := NewSMS(logger.NewLogger("test"))
+	tw.httpClient = &http.Client{
+		Transport: httpTransport,
+	}
+	err := tw.Init(m)
+	assert.Nil(t, err)
+
+	t.Run("Should succeed with expected url and headers", func(t *testing.T) {
+		httpTransport.reset()
+		err := tw.Write(&bindings.WriteRequest{
+			Data: []byte("hello world"),
+			Metadata: map[string]string{
+				toNumber: "toNumber",
+			},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, int32(1), httpTransport.requestCount)
+		assert.Equal(t, "https://api.twilio.com/2010-04-01/Accounts/accountSid/Messages.json", httpTransport.request.URL.String())
+		assert.NotNil(t, httpTransport.request)
+		assert.Equal(t, "application/x-www-form-urlencoded", httpTransport.request.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", httpTransport.request.Header.Get("Accept"))
+		authUserName, authPassword, _ := httpTransport.request.BasicAuth()
+		assert.Equal(t, "accountSid", authUserName)
+		assert.Equal(t, "authToken", authPassword)
+	})
+}
+
+func TestWriteShouldFail(t *testing.T) {
+	httpTransport := &mockTransport{
+		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
+	}
+	m := bindings.Metadata{}
+	m.Properties = map[string]string{"fromNumber": "fromNumber",
+		"accountSid": "accountSid", "authToken": "authToken"}
+	tw := NewSMS(logger.NewLogger("test"))
+	tw.httpClient = &http.Client{
+		Transport: httpTransport,
+	}
+	err := tw.Init(m)
+	assert.Nil(t, err)
+
+	t.Run("Missing 'to' should fail", func(t *testing.T) {
+		httpTransport.reset()
+		err := tw.Write(&bindings.WriteRequest{
+			Data:     []byte("hello world"),
+			Metadata: map[string]string{},
+		})
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Twilio call failed should be returned", func(t *testing.T) {
+		httpTransport.reset()
+		httpErr := errors.New("twilio fake error")
+		httpTransport.errToReturn = httpErr
+		err := tw.Write(&bindings.WriteRequest{
+			Data: []byte("hello world"),
+			Metadata: map[string]string{
+				toNumber: "toNumber",
+			},
+		})
+
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), httpErr.Error())
+	})
+
+	t.Run("Twilio call returns status not >=200 and <300", func(t *testing.T) {
+		httpTransport.reset()
+		httpTransport.response.StatusCode = 401
+		err := tw.Write(&bindings.WriteRequest{
+			Data: []byte("hello world"),
+			Metadata: map[string]string{
+				toNumber: "toNumber",
+			},
+		})
+
+		assert.NotNil(t, err)
+	})
 }


### PR DESCRIPTION
# Description

In Twilio Binding spec the toNumber is required in the metadata. The application is NOT able to send the recipient number dynamically from the POST endpoint data. The toNumber passed in metadata is not used to send in Twilio API.

Changing this implementation to

1. Optional toNumber field in metadata.
2. The toNumber can be both configured as metadata or send as POST data to the endpoint.
3. Added tests to make sure the call to Twilio is covered. 
4. Change the code to mock the HTTP client in tests.

## Issue reference

Please reference the issue this PR will close: #255 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
