### PR TITLE
Add Kinesis data stream binding

### DIFF
--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package kinesis
 
 import (

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -1,0 +1,341 @@
+package kinesis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/logger"
+	"github.com/google/uuid"
+	"github.com/vmware/vmware-go-kcl/clientlibrary/config"
+	"github.com/vmware/vmware-go-kcl/clientlibrary/interfaces"
+	"github.com/vmware/vmware-go-kcl/clientlibrary/worker"
+)
+
+// AWSKinesis allows receiving and sending data to/from AWS Kinesis stream
+type AWSKinesis struct {
+	client   *kinesis.Kinesis
+	metadata *kinesisMetadata
+
+	worker       *worker.Worker
+	workerConfig *config.KinesisClientLibConfiguration
+
+	streamARN   *string
+	consumerARN *string
+	logger      logger.Logger
+}
+
+type kinesisMetadata struct {
+	StreamName          string              `json:"streamName"`
+	ConsumerName        string              `json:"consumerName"`
+	Region              string              `json:"region"`
+	AccessKey           string              `json:"accessKey"`
+	SecretKey           string              `json:"secretKey"`
+	KinesisConsumerMode kinesisConsumerMode `json:"mode"`
+}
+
+type kinesisConsumerMode string
+
+const (
+	//ExtendedFanout - dedicated throughput through data stream api
+	ExtendedFanout kinesisConsumerMode = "extended"
+
+	//SharedThroughput - shared throughput using checkpoint and monitoring
+	SharedThroughput kinesisConsumerMode = "shared"
+
+	partitionKeyName = "partitionKey"
+)
+
+// recordProcessorFactory
+type recordProcessorFactory struct {
+	logger  logger.Logger
+	handler func(*bindings.ReadResponse) error
+}
+
+type recordProcessor struct {
+	logger  logger.Logger
+	handler func(*bindings.ReadResponse) error
+}
+
+// NewAWSKinesis returns a new AWS Kinesis instance
+func NewAWSKinesis(logger logger.Logger) *AWSKinesis {
+	return &AWSKinesis{logger: logger}
+}
+
+// Init does metadata parsing and connection creation
+func (a *AWSKinesis) Init(metadata bindings.Metadata) error {
+	m, err := a.parseMetadata(metadata)
+	if err != nil {
+		return err
+	}
+
+	if m.KinesisConsumerMode == "" {
+		m.KinesisConsumerMode = SharedThroughput
+	}
+
+	if m.KinesisConsumerMode != SharedThroughput && m.KinesisConsumerMode != ExtendedFanout {
+		return fmt.Errorf("%s invalid \"mode\" field %s", "aws.kinesis", m.KinesisConsumerMode)
+	}
+
+	client, err := a.getClient(m)
+	if err != nil {
+		return err
+	}
+
+	streamName := aws.String(m.StreamName)
+	stream, err := client.DescribeStream(&kinesis.DescribeStreamInput{
+		StreamName: streamName,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if m.KinesisConsumerMode == SharedThroughput {
+		kclConfig := config.NewKinesisClientLibConfigWithCredential(m.ConsumerName,
+			m.StreamName, m.Region, m.ConsumerName,
+			credentials.NewStaticCredentials(m.AccessKey, m.SecretKey, ""))
+		a.workerConfig = kclConfig
+	}
+
+	a.streamARN = stream.StreamDescription.StreamARN
+	a.metadata = m
+	a.client = client
+	return nil
+}
+
+func (a *AWSKinesis) Write(req *bindings.WriteRequest) error {
+	partitionKey := req.Metadata[partitionKeyName]
+	if partitionKey == "" {
+		partitionKey = uuid.New().String()
+	}
+	_, err := a.client.PutRecord(&kinesis.PutRecordInput{
+		StreamName:   &a.metadata.StreamName,
+		Data:         req.Data,
+		PartitionKey: &partitionKey,
+	})
+	return err
+}
+
+func (a *AWSKinesis) Read(handler func(*bindings.ReadResponse) error) error {
+
+	if kinesisConsumerMode(a.metadata.KinesisConsumerMode) == SharedThroughput {
+		a.worker = worker.NewWorker(a.recordProcessorFactory(handler), a.workerConfig, nil)
+		err := a.worker.Start()
+		if err != nil {
+			return err
+		}
+	} else if kinesisConsumerMode(a.metadata.KinesisConsumerMode) == ExtendedFanout {
+		ctx := context.Background()
+		stream, err := a.client.DescribeStream(&kinesis.DescribeStreamInput{StreamName: &a.metadata.StreamName})
+		if err != nil {
+			return err
+		}
+		go a.Subscribe(ctx, *stream.StreamDescription, handler)
+	}
+
+	exitChan := make(chan os.Signal, 1)
+	signal.Notify(exitChan, os.Interrupt, syscall.SIGTERM)
+	<-exitChan
+
+	if kinesisConsumerMode(a.metadata.KinesisConsumerMode) == SharedThroughput {
+		go a.worker.Shutdown()
+	} else if kinesisConsumerMode(a.metadata.KinesisConsumerMode) == ExtendedFanout {
+		go a.deregisterConsumer(a.streamARN, a.consumerARN)
+	}
+
+	return nil
+}
+
+// Subscribe to all shards
+func (a *AWSKinesis) Subscribe(ctx context.Context, streamDesc kinesis.StreamDescription, handler func(*bindings.ReadResponse) error) error {
+	consumerARN, err := a.ensureConsumer(streamDesc.StreamARN)
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	a.consumerARN = consumerARN
+
+	for {
+		var wg sync.WaitGroup
+		wg.Add(len(streamDesc.Shards))
+		for i, shard := range streamDesc.Shards {
+			go func(idx int, s *kinesis.Shard) error {
+				defer wg.Done()
+				sub, err := a.client.SubscribeToShardWithContext(ctx, &kinesis.SubscribeToShardInput{
+					ConsumerARN:      consumerARN,
+					ShardId:          s.ShardId,
+					StartingPosition: &kinesis.StartingPosition{Type: aws.String(kinesis.ShardIteratorTypeLatest)},
+				})
+
+				if err != nil {
+					a.logger.Error(err)
+					return err
+				}
+
+				for event := range sub.EventStream.Events() {
+					switch e := event.(type) {
+					case *kinesis.SubscribeToShardEvent:
+						for _, rec := range e.Records {
+							handler(&bindings.ReadResponse{
+								Data: rec.Data,
+							})
+						}
+					}
+				}
+
+				return nil
+			}(i, shard)
+		}
+		wg.Wait()
+		time.Sleep(time.Minute * 5)
+	}
+}
+
+func (a *AWSKinesis) ensureConsumer(streamARN *string) (*string, error) {
+	consumer, err := a.client.DescribeStreamConsumer(&kinesis.DescribeStreamConsumerInput{
+		ConsumerName: &a.metadata.ConsumerName,
+		StreamARN:    streamARN,
+	})
+
+	if err != nil {
+		arn, err := a.registerConsumer(streamARN)
+		return arn, err
+	}
+
+	return consumer.ConsumerDescription.ConsumerARN, nil
+}
+
+func (a *AWSKinesis) registerConsumer(streamARN *string) (*string, error) {
+	consumer, err := a.client.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+		ConsumerName: &a.metadata.ConsumerName,
+		StreamARN:    streamARN,
+	})
+
+	err = a.waitUntilConsumerExists(context.Background(), &kinesis.DescribeStreamConsumerInput{
+		ConsumerName: &a.metadata.ConsumerName,
+		StreamARN:    streamARN,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return consumer.Consumer.ConsumerARN, nil
+}
+
+func (a *AWSKinesis) deregisterConsumer(streamARN *string, consumerARN *string) error {
+	if a.consumerARN != nil {
+		_, err := a.client.DeregisterStreamConsumer(&kinesis.DeregisterStreamConsumerInput{
+			ConsumerARN:  consumerARN,
+			StreamARN:    streamARN,
+			ConsumerName: &a.metadata.ConsumerName,
+		})
+		return err
+	}
+
+	return nil
+}
+
+func (a *AWSKinesis) waitUntilConsumerExists(ctx aws.Context, input *kinesis.DescribeStreamConsumerInput, opts ...request.WaiterOption) error {
+	w := request.Waiter{
+		Name:        "WaitUntilConsumerExists",
+		MaxAttempts: 18,
+		Delay:       request.ConstantWaiterDelay(10 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathWaiterMatch, Argument: "ConsumerDescription.ConsumerStatus",
+				Expected: "ACTIVE",
+			},
+		},
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			var inCpy *kinesis.DescribeStreamConsumerInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := a.client.DescribeStreamConsumerRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}
+
+func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(metadata.Region),
+		Credentials: credentials.NewStaticCredentials(metadata.AccessKey, metadata.SecretKey, ""),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	k := kinesis.New(sess)
+	return k, nil
+}
+
+func (a *AWSKinesis) parseMetadata(metadata bindings.Metadata) (*kinesisMetadata, error) {
+	b, err := json.Marshal(metadata.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	var m kinesisMetadata
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (a *AWSKinesis) recordProcessorFactory(handler func(*bindings.ReadResponse) error) interfaces.IRecordProcessorFactory {
+	return &recordProcessorFactory{logger: a.logger, handler: handler}
+}
+
+func (r *recordProcessorFactory) CreateProcessor() interfaces.IRecordProcessor {
+	return &recordProcessor{logger: r.logger, handler: r.handler}
+}
+
+func (p *recordProcessor) Initialize(input *interfaces.InitializationInput) {
+	p.logger.Infof("Processing ShardId: %v at checkpoint: %v", input.ShardId, aws.StringValue(input.ExtendedSequenceNumber.SequenceNumber))
+}
+
+func (p *recordProcessor) ProcessRecords(input *interfaces.ProcessRecordsInput) {
+	// don't process empty record
+	if len(input.Records) == 0 {
+		return
+	}
+
+	for _, v := range input.Records {
+		p.handler(&bindings.ReadResponse{
+			Data: v.Data,
+		})
+	}
+
+	// checkpoint it after processing this batch
+	lastRecordSequenceNubmer := input.Records[len(input.Records)-1].SequenceNumber
+	input.Checkpointer.Checkpoint(lastRecordSequenceNubmer)
+}
+
+func (p *recordProcessor) Shutdown(input *interfaces.ShutdownInput) {
+	if input.ShutdownReason == interfaces.TERMINATE {
+		input.Checkpointer.Checkpoint(nil)
+	}
+}

--- a/bindings/aws/kinesis/kinesis_test.go
+++ b/bindings/aws/kinesis/kinesis_test.go
@@ -1,0 +1,29 @@
+package kinesis
+
+import (
+	"testing"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMetadata(t *testing.T) {
+	m := bindings.Metadata{}
+	m.Properties = map[string]string{
+		"AccessKey":    "key",
+		"Region":       "region",
+		"SecretKey":    "secret",
+		"ConsumerName": "test",
+		"StreamName":   "stream",
+		"Mode":         "extended",
+	}
+	kinesis := AWSKinesis{}
+	meta, err := kinesis.parseMetadata(m)
+	assert.Nil(t, err)
+	assert.Equal(t, "key", meta.AccessKey)
+	assert.Equal(t, "region", meta.Region)
+	assert.Equal(t, "secret", meta.SecretKey)
+	assert.Equal(t, "test", meta.ConsumerName)
+	assert.Equal(t, "stream", meta.StreamName)
+	assert.Equal(t, kinesisConsumerMode("extended"), meta.KinesisConsumerMode)
+}

--- a/bindings/aws/kinesis/kinesis_test.go
+++ b/bindings/aws/kinesis/kinesis_test.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package kinesis
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/tidwall/pretty v1.0.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200122045848-3419fae592fc // indirect
 	github.com/valyala/fasthttp v1.6.0
+	github.com/vmware/vmware-go-kcl v0.0.0-20191104173950-b6c74c3fe74e
 	go.etcd.io/etcd v3.3.17+incompatible
 	go.mongodb.org/mongo-driver v1.1.2
 	go.opencensus.io v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798 h1:2T/jmrHeTezcCM58lvEQXs0UpQJCo5SoGAcg+mbSTIg=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -121,6 +122,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 h1:EFSB7Zo9Eg91v7MJPVsifUysc/wPdN+NOnVe6bWbdBM=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.19.38/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.0 h1:MyXUdCesJLBvSSKYcaKeeEwxNUwUpG6/uqVYeH/Zzfo=
 github.com/aws/aws-sdk-go v1.25.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -140,6 +142,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -179,6 +183,7 @@ github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mz
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/didip/tollbooth v4.0.2+incompatible h1:fVSa33JzSz0hoh2NxpwZtksAzAgd7zjmGO20HCZtF4M=
 github.com/didip/tollbooth v4.0.2+incompatible/go.mod h1:A9b0665CE6l1KmzpDws2++elm/CsuWBMa5Jv4WY0PEY=
 github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZPc=
@@ -459,6 +464,8 @@ github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -550,6 +557,7 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nats-io/stan.go v0.5.0/go.mod h1:dYqB+vMN3C2F9pT1FRQpg9eHbjPj6mP0yYuyBNuXHZE=
 github.com/nats-io/stan.go v0.6.0 h1:26IJPeykh88d8KVLT4jJCIxCyUBOC5/IQup8oWD/QYY=
 github.com/nats-io/stan.go v0.6.0/go.mod h1:eIcD5bi3pqbHT/xIIvXMwvzXYElgouBvaVRftaE+eac=
+github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -596,6 +604,7 @@ github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prY
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
+github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
@@ -606,7 +615,9 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
@@ -615,12 +626,15 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.0-20190523193104-a7aeb8df3389/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qiangxue/fasthttp-routing v0.0.0-20160225050629-6ccdc2a18d87/go.mod h1:zwr0xP4ZJxwCS/g2d+AUOUwfq/j2NC7a1rK3F0ZbVYM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -654,6 +668,7 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -694,6 +709,10 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.6.0 h1:uWF8lgKmeaIewWVPwi4GRq2P6+R46IgYZdxWtM+GtEY=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/vmware/vmware-go-kcl v0.0.0-20191104173950-b6c74c3fe74e h1:KeXc49gLugrPowKxekYZBZ34FEQW5+R6lP8B56B02mo=
+github.com/vmware/vmware-go-kcl v0.0.0-20191104173950-b6c74c3fe74e/go.mod h1:JFn5wAwfmRZgv/VScA9aUc51zOVL5395yPKGxPi3eNo=
+github.com/vmware/vmware-go-kcl v0.0.0-20200310160057-7d5bfbb7a17b h1:cAQLc/0P+YG+tdN8QPUIFEAH8ABg911N0d12H/N3t8o=
+github.com/vmware/vmware-go-kcl v0.0.0-20200310160057-7d5bfbb7a17b/go.mod h1:JFn5wAwfmRZgv/VScA9aUc51zOVL5395yPKGxPi3eNo=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
@@ -738,6 +757,8 @@ go.uber.org/multierr v1.2.0 h1:6I+W7f5VwC5SV9dNrZ3qXrDB9mD0dyGOi/ZJmYw03T4=
 go.uber.org/multierr v1.2.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+go.uber.org/zap v1.11.0 h1:gSmpCfs+R47a4yQPAI4xJ0IPDLTRGXskm6UelqNXpqE=
+go.uber.org/zap v1.11.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -799,6 +820,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -847,6 +869,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190528012530-adf421d2caf4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190620070143-6f217b454f45/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -987,6 +1010,8 @@ gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 gopkg.in/kataras/go-serializer.v0 v0.0.4 h1:mVy3gjU4zZZBe+8JbZDRTMPJdrB0lzBNsLLREBcKGgU=
 gopkg.in/kataras/go-serializer.v0 v0.0.4/go.mod h1:v2jHg/3Wp7uncDNzenTsX75PRDxhzlxoo/qDvM4ZGxk=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.4.1 h1:H0TmLt7/KmzlrDOpa1F+zr0Tk90PbJYBfsVUmRLrf9Y=
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=


### PR DESCRIPTION
# Description

Implemented the bindings for the AWS Kinesis data stream. This binding supports both shared throughput mode and extended fanout mode.

1. The metadata includes AWS credentials, Stream Name, Consumer Name, and mode.
2. If the mode is "Shared throughput",  the worker-client is created to process the records and track checkpoints in dynamodb and monitor using cloud watch alarms. There is no internal support in [aws-sdk-go](https://github.com/aws/aws-sdk-go) library. Used the [vmware/vmware-go-kcl](https://github.com/vmware/vmware-go-kcl) - Kinesis client library with custom checkpoint implementation using dynamodb.
3. If the mode is "Extended Fanout - Dedicated throughput", subscribing to all shards using kinesis subscriber API using [aws-sdk-go](https://github.com/aws/aws-sdk-go)  library.

```
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: receive-event
spec:
  type: bindings.aws.kinesis
  metadata:
  - name: region
    value: us-east-1
  - name: accessKey
    value: AWS_ACCESS_KEY # replace
  - name: secretKey
    value: AWS_SECRET_KEY #replace
  - name: streamName
    value: KINESIS_STREAM_NAME # Kinesis stream name
  - name: consumerName 
    value: KINESIS_CONSUMER_NAME # Kinesis consumer name 
  - name: mode
    value: shared # shared - Shared throughput or extended - Extended fanout
```

## Issue reference

This PR will close: #272

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
