### PR TITLE
Memcached state store: don't treat non-existent keys as errors

### DIFF
--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -132,7 +132,7 @@ func (m *Memcached) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if err != nil {
 		// Return nil for status 204
 		if err == memcache.ErrCacheMiss {
-			return nil, nil
+			return &state.GetResponse{}, nil
 		}
 		return &state.GetResponse{}, err
 	}


### PR DESCRIPTION
# Description

Updated implementation to ensure that non-existent keys are not treated as errors

## Issue reference

Issue #263 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
