### PR TITLE
Empty response when aerospike state key not found

### DIFF
--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	as "github.com/aerospike/aerospike-client-go"
+	"github.com/aerospike/aerospike-client-go/types"
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -161,6 +162,9 @@ func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) 
 	}
 	record, err := aspike.client.Get(policy, asKey)
 	if err != nil {
+		if err == types.ErrKeyNotFound {
+			return &state.GetResponse{}, nil
+		}
 		return nil, fmt.Errorf("aerospike: failed to get value for key %s - %v", req.Key, err)
 	}
 	value, err := aspike.json.Marshal(record.Bins)


### PR DESCRIPTION
# Description

If the err is ErrKeyNotFound, return an empty response for the aerospike datastore

## Issue reference

PR will close: #260 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
