### PR TITLE
Zookeeper state store: don't treat non-existent keys as errors

### DIFF
--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -141,6 +141,9 @@ func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	value, stat, err := s.conn.Get(s.prefixedKey(req.Key))
 
 	if err != nil {
+		if err == zk.ErrNoNode {
+			return &state.GetResponse{}, nil
+		}
 		return nil, err
 	}
 

--- a/state/zookeeper/zk_test.go
+++ b/state/zookeeper/zk_test.go
@@ -81,8 +81,8 @@ func TestGet(t *testing.T) {
 		conn.EXPECT().Get("foo").Return(nil, nil, zk.ErrNoNode).Times(1)
 
 		res, err := s.Get(&state.GetRequest{Key: "foo"})
-		assert.Nil(t, res, "Key must be non-exists")
-		assert.EqualError(t, err, "zk: node does not exist")
+		assert.Equal(t, &state.GetResponse{}, res, "Response must be empty")
+		assert.NoError(t, err, "Non-existent key must not be treated as error")
 	})
 }
 


### PR DESCRIPTION
# Description

- updated implementation to return an empty response with non-existent keys
- updated corresponding test cases

## Issue reference

issue #264 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
