### PR TITLE
Add TLS support for bindings.redis

### DIFF
--- a/bindings/redis/metadata.go
+++ b/bindings/redis/metadata.go
@@ -1,0 +1,16 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package redis
+
+import "time"
+
+type metadata struct {
+	host            string
+	password        string
+	enableTLS       bool
+	maxRetries      int
+	maxRetryBackoff time.Duration
+}

--- a/bindings/redis/redis.go
+++ b/bindings/redis/redis.go
@@ -28,7 +28,6 @@ const (
 	defaultBase            = 10
 	defaultBitSize         = 0
 	defaultDB              = 0
-	defaultExpirationTime  = 0
 	defaultMaxRetries      = 3
 	defaultMaxRetryBackoff = time.Second * 2
 	defaultEnableTLS       = false

--- a/bindings/redis/redis.go
+++ b/bindings/redis/redis.go
@@ -7,25 +7,37 @@ package redis
 
 import (
 	"context"
-	"encoding/json"
+	"crypto/tls"
 	"errors"
+	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
 
-	"github.com/joomcode/redispipe/redis"
-	"github.com/joomcode/redispipe/redisconn"
+	redis "github.com/go-redis/redis/v7"
+)
+
+const (
+	host                   = "redisHost"
+	password               = "redisPassword"
+	enableTLS              = "enableTLS"
+	maxRetries             = "maxRetries"
+	maxRetryBackoff        = "maxRetryBackoff"
+	defaultBase            = 10
+	defaultBitSize         = 0
+	defaultDB              = 0
+	defaultExpirationTime  = 0
+	defaultMaxRetries      = 3
+	defaultMaxRetryBackoff = time.Second * 2
+	defaultEnableTLS       = false
 )
 
 // Redis is a redis output binding
 type Redis struct {
-	client *redis.SyncCtx
+	client *redis.Client
 	logger logger.Logger
-}
-
-type redisMetadata struct {
-	Host     string `json:"redisHost"`
-	Password string `json:"redisPassword"`
 }
 
 // NewRedis returns a new redis bindings instance
@@ -34,46 +46,84 @@ func NewRedis(logger logger.Logger) *Redis {
 }
 
 // Init performs metadata parsing and connection creation
-func (r *Redis) Init(metadata bindings.Metadata) error {
-	m, err := r.parseMetadata(metadata)
+func (r *Redis) Init(meta bindings.Metadata) error {
+	m, err := r.parseMetadata(meta)
 	if err != nil {
 		return err
 	}
-	ctx := context.Background()
-	opts := redisconn.Opts{
-		DB:       0,
-		Password: m.Password,
+
+	opts := &redis.Options{
+		Addr:            m.host,
+		Password:        m.password,
+		DB:              defaultDB,
+		MaxRetries:      m.maxRetries,
+		MaxRetryBackoff: m.maxRetryBackoff,
 	}
-	conn, err := redisconn.Connect(ctx, m.Host, opts)
+
+	/* #nosec */
+	if m.enableTLS {
+		opts.TLSConfig = &tls.Config{
+			InsecureSkipVerify: m.enableTLS,
+		}
+	}
+
+	r.client = redis.NewClient(opts)
+	_, err = r.client.Ping().Result()
 	if err != nil {
-		return err
+		return fmt.Errorf("redis binding: error connecting to redis at %s: %s", m.host, err)
 	}
-	r.client = &redis.SyncCtx{
-		S: conn,
-	}
-	return nil
+
+	return err
 }
 
-func (r *Redis) parseMetadata(metadata bindings.Metadata) (*redisMetadata, error) {
-	connInfo := metadata.Properties
-	b, err := json.Marshal(connInfo)
-	if err != nil {
-		return nil, err
+func (r *Redis) parseMetadata(meta bindings.Metadata) (metadata, error) {
+	m := metadata{}
+
+	if val, ok := meta.Properties[host]; ok && val != "" {
+		m.host = val
+	} else {
+		return m, errors.New("redis binding error: missing host address")
 	}
 
-	var m redisMetadata
-	err = json.Unmarshal(b, &m)
-	if err != nil {
-		return nil, err
+	if val, ok := meta.Properties[password]; ok && val != "" {
+		m.password = val
 	}
-	return &m, nil
+
+	m.enableTLS = defaultEnableTLS
+	if val, ok := meta.Properties[enableTLS]; ok && val != "" {
+		tls, err := strconv.ParseBool(val)
+		if err != nil {
+			return m, fmt.Errorf("redis binding error: can't parse enableTLS field: %s", err)
+		}
+		m.enableTLS = tls
+	}
+
+	m.maxRetries = defaultMaxRetries
+	if val, ok := meta.Properties[maxRetries]; ok && val != "" {
+		parsedVal, err := strconv.ParseInt(val, defaultBase, defaultBitSize)
+		if err != nil {
+			return m, fmt.Errorf("redis binding error: can't parse maxRetries field: %s", err)
+		}
+		m.maxRetries = int(parsedVal)
+	}
+
+	m.maxRetryBackoff = defaultMaxRetryBackoff
+	if val, ok := meta.Properties[maxRetryBackoff]; ok && val != "" {
+		parsedVal, err := strconv.ParseInt(val, defaultBase, defaultBitSize)
+		if err != nil {
+			return m, fmt.Errorf("redis binding error: can't parse maxRetries field: %s", err)
+		}
+		m.maxRetryBackoff = time.Duration(parsedVal)
+	}
+
+	return m, nil
 }
 
 func (r *Redis) Write(req *bindings.WriteRequest) error {
 	if val, ok := req.Metadata["key"]; ok && val != "" {
 		key := val
-		res := r.client.Do(context.Background(), "SET", key, req.Data)
-		if err := redis.AsError(res); err != nil {
+		_, err := r.client.DoContext(context.Background(), "SET", key, req.Data).Result()
+		if err != nil {
 			return err
 		}
 		return nil

--- a/bindings/redis/redis_test.go
+++ b/bindings/redis/redis_test.go
@@ -7,6 +7,7 @@ package redis
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
@@ -15,10 +16,13 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"redisHost": "host", "redisPassword": "password"}
+	m.Properties = map[string]string{"redisHost": "host", "redisPassword": "password", "enableTLS": "true", "maxRetries": "3", "maxRetryBackoff": "10000"}
 	r := Redis{logger: logger.NewLogger("test")}
 	redisM, err := r.parseMetadata(m)
 	assert.Nil(t, err)
-	assert.Equal(t, "host", redisM.Host)
-	assert.Equal(t, "password", redisM.Password)
+	assert.Equal(t, "host", redisM.host)
+	assert.Equal(t, "password", redisM.password)
+	assert.Equal(t, true, redisM.enableTLS)
+	assert.Equal(t, 3, redisM.maxRetries)
+	assert.Equal(t, time.Duration(10000), redisM.maxRetryBackoff)
 }

--- a/go.mod
+++ b/go.mod
@@ -40,8 +40,6 @@ require (
 	github.com/hashicorp/consul/api v1.2.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a
-	github.com/joomcode/errorx v1.0.1 // indirect
-	github.com/joomcode/redispipe v0.9.0
 	github.com/json-iterator/go v1.1.8
 	github.com/kubernetes-client/go v0.0.0-20190625181339-cd8e39e789c7
 	github.com/nats-io/gnatsd v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,6 @@ github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/joomcode/errorx v1.0.0 h1:RJAKLTy1Sv2Tszhu14m5RZP4VGRlhXutG/XlL1En5VM=
 github.com/joomcode/errorx v1.0.0/go.mod h1:kgco15ekB6cs+4Xjzo7SPeXzx38PbJzBwbnu9qfVNHQ=
-github.com/joomcode/errorx v1.0.1 h1:CalpDWz14ZHd68fIqluJasJosAewpz2TFaJALrUxjrk=
-github.com/joomcode/errorx v1.0.1/go.mod h1:kgco15ekB6cs+4Xjzo7SPeXzx38PbJzBwbnu9qfVNHQ=
 github.com/joomcode/redispipe v0.9.0 h1:NukwwIvxhg6r2lVxa1RJhEZXYPZZF/OX9WZJk+2cK1Q=
 github.com/joomcode/redispipe v0.9.0/go.mod h1:4S/gpBCZ62pB/3+XLNWDH7jQnB0vxmpddAMBva2adpM=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7 h1:K//n/AqR5HjG3qxbrBCL4vJPW0MVFSs9CPK1OOJdRME=
@@ -715,8 +713,6 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vmware/vmware-go-kcl v0.0.0-20191104173950-b6c74c3fe74e h1:KeXc49gLugrPowKxekYZBZ34FEQW5+R6lP8B56B02mo=
 github.com/vmware/vmware-go-kcl v0.0.0-20191104173950-b6c74c3fe74e/go.mod h1:JFn5wAwfmRZgv/VScA9aUc51zOVL5395yPKGxPi3eNo=
-github.com/vmware/vmware-go-kcl v0.0.0-20200310160057-7d5bfbb7a17b h1:cAQLc/0P+YG+tdN8QPUIFEAH8ABg911N0d12H/N3t8o=
-github.com/vmware/vmware-go-kcl v0.0.0-20200310160057-7d5bfbb7a17b/go.mod h1:JFn5wAwfmRZgv/VScA9aUc51zOVL5395yPKGxPi3eNo=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=


### PR DESCRIPTION
# Description 

Added TLS support for bindings.redis component.
 * Refactored to use go-redis library instead of joomcode/redis 

## Issue reference

Please reference the issue this PR will close: [#_[286]_](https://github.com/dapr/components-contrib/issues/286)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
