### PR TITLE
Fixed SQL Server state store integration tests (#324)

### DIFF
--- a/state/sqlserver/sqlserver_integration_test.go
+++ b/state/sqlserver/sqlserver_integration_test.go
@@ -165,7 +165,7 @@ func assertLoadedUserIsEqual(t *testing.T, store *SQLServer, key string, expecte
 
 func assertUserDoesNotExist(t *testing.T, store *SQLServer, key string) {
 	_, err := store.Get(&state.GetRequest{Key: key})
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 }
 
 func assertDBQuery(t *testing.T, store *SQLServer, query string, assertReader func(t *testing.T, rows *sql.Rows)) {


### PR DESCRIPTION
# Description

When asserting that a user does not exist in the state store, changed an ```assert.NotNil``` statement to ```assert.Nil```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #324
