### PR TITLE
Fix issue with ASB pubsub throttling

### DIFF
--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -13,7 +13,7 @@ type metadata struct {
 	TimeoutInSec                   int    `json:"timeoutInSec"`
 	HandlerTimeoutInSec            int    `json:"handlerTimeoutInSec"`
 	LockRenewalInSec               int    `json:"lockRenewalInSec"`
-	MaxActiveMessage               int    `json:"maxActiveMessages"`
+	MaxActiveMessages              int    `json:"maxActiveMessages"`
 	MaxActiveMessagesRecoveryInSec int    `json:"maxActiveMessagesRecoveryInSec"`
 	DisableEntityManagement        bool   `json:"disableEntityManagement"`
 	MaxDeliveryCount               *int   `json:"maxDeliveryCount"`

--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -8,16 +8,18 @@ package servicebus
 // Reference for settings:
 // https://github.com/Azure/azure-service-bus-go/blob/54b2faa53e5216616e59725281be692acc120c34/subscription_manager.go#L101
 type metadata struct {
-	ConnectionString              string `json:"connectionString"`
-	ConsumerID                    string `json:"consumerID"`
-	TimeoutInSec                  int    `json:"timeoutInSec"`
-	HandlerTimeoutInSec           int    `json:"handlerTimeoutInSec"`
-	LockRenewalInSec              int    `json:"lockRenewalInSec"`
-	DisableEntityManagement       bool   `json:"disableEntityManagement"`
-	MaxDeliveryCount              *int   `json:"maxDeliveryCount"`
-	LockDurationInSec             *int   `json:"lockDurationInSec"`
-	DefaultMessageTimeToLiveInSec *int   `json:"defaultMessageTimeToLiveInSec"`
-	AutoDeleteOnIdleInSec         *int   `json:"autoDeleteOnIdleInSec"`
-	NumConcurrentHandlers         *int   `json:"numConcurrentHandlers"`
-	PrefetchCount                 *int   `json:"prefetchCount"`
+	ConnectionString               string `json:"connectionString"`
+	ConsumerID                     string `json:"consumerID"`
+	TimeoutInSec                   int    `json:"timeoutInSec"`
+	HandlerTimeoutInSec            int    `json:"handlerTimeoutInSec"`
+	LockRenewalInSec               int    `json:"lockRenewalInSec"`
+	MaxActiveMessage               int    `json:"maxActiveMessages"`
+	MaxActiveMessagesRecoveryInSec int    `json:"maxActiveMessagesRecoveryInSec"`
+	DisableEntityManagement        bool   `json:"disableEntityManagement"`
+	MaxDeliveryCount               *int   `json:"maxDeliveryCount"`
+	LockDurationInSec              *int   `json:"lockDurationInSec"`
+	DefaultMessageTimeToLiveInSec  *int   `json:"defaultMessageTimeToLiveInSec"`
+	AutoDeleteOnIdleInSec          *int   `json:"autoDeleteOnIdleInSec"`
+	NumConcurrentHandlers          *int   `json:"numConcurrentHandlers"`
+	PrefetchCount                  *int   `json:"prefetchCount"`
 }

--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -12,6 +12,7 @@ type metadata struct {
 	ConsumerID                    string `json:"consumerID"`
 	TimeoutInSec                  int    `json:"timeoutInSec"`
 	HandlerTimeoutInSec           int    `json:"handlerTimeoutInSec"`
+	LockRenewalInSec              int    `json:"lockRenewalInSec"`
 	DisableEntityManagement       bool   `json:"disableEntityManagement"`
 	MaxDeliveryCount              *int   `json:"maxDeliveryCount"`
 	LockDurationInSec             *int   `json:"lockDurationInSec"`

--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -20,6 +20,6 @@ type metadata struct {
 	LockDurationInSec              *int   `json:"lockDurationInSec"`
 	DefaultMessageTimeToLiveInSec  *int   `json:"defaultMessageTimeToLiveInSec"`
 	AutoDeleteOnIdleInSec          *int   `json:"autoDeleteOnIdleInSec"`
-	NumConcurrentHandlers          *int   `json:"numConcurrentHandlers"`
+	MaxConcurrentHandlers          *int   `json:"maxConcurrentHandlers"`
 	PrefetchCount                  *int   `json:"prefetchCount"`
 }

--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -19,4 +19,5 @@ type metadata struct {
 	DefaultMessageTimeToLiveInSec *int   `json:"defaultMessageTimeToLiveInSec"`
 	AutoDeleteOnIdleInSec         *int   `json:"autoDeleteOnIdleInSec"`
 	NumConcurrentHandlers         *int   `json:"numConcurrentHandlers"`
+	PrefetchCount                 *int   `json:"prefetchCount"`
 }

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -44,7 +44,6 @@ const (
 	defaultMaxActiveMessages              = 10000
 	defaultMaxActiveMessagesRecoveryInSec = 2
 	defaultDisableEntityManagement        = false
-	minPrefetchCount                      = 1
 )
 
 type handler = struct{}
@@ -188,19 +187,6 @@ func parseAzureServiceBusMetadata(meta pubsub.Metadata) (metadata, error) {
 		m.PrefetchCount = &valAsInt
 	}
 
-	/* Apply constraints */
-	mpc := minPrefetchCount
-	if m.PrefetchCount != nil {
-		// If prefetchCount is set, we must maintain this many
-		// active messages as a minimum to avoid lock expiration.
-		if *m.PrefetchCount > mpc {
-			mpc = *m.PrefetchCount
-		}
-	}
-	if m.MaxActiveMessage < mpc {
-		m.MaxActiveMessage = mpc
-	}
-
 	return m, nil
 }
 
@@ -209,8 +195,6 @@ func (a *azureServiceBus) Init(metadata pubsub.Metadata) error {
 	if err != nil {
 		return err
 	}
-
-	a.logger.Debugf("metdata set: %+v", m)
 
 	a.metadata = m
 	a.namespace, err = azservicebus.NewNamespace(azservicebus.NamespaceWithConnectionString(a.metadata.ConnectionString))

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -268,13 +268,13 @@ func (a *azureServiceBus) getHandlerFunc(topic string, daprHandler func(msg *pub
 		a.logger.Debugf("Calling app's handler for message %s", message.ID)
 		err := daprHandler(msg)
 		if err != nil {
-			return a.abondonMessage(ctx, message)
+			return a.abandonMessage(ctx, message)
 		}
 		return a.completeMessage(ctx, message)
 	}
 }
 
-func (a *azureServiceBus) abondonMessage(ctx context.Context, m *azservicebus.Message) error {
+func (a *azureServiceBus) abandonMessage(ctx context.Context, m *azservicebus.Message) error {
 	a.logger.Debugf("Removing message %s from active messages", m.ID)
 	a.mu.Lock()
 	delete(a.activeMessages, m.ID)

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -291,15 +291,13 @@ func (a *azureServiceBus) handleSubscriptionMessages(topic string, sub *azservic
 		a.activeMessages[msg.ID] = msg
 		a.mu.Unlock()
 
-		if limitNumConcurrentHandlers {
-			a.logger.Debugf("Attempting to take message handler")
-			<-handlers // Take or wait on a free handler before getting a new message
-			a.logger.Debugf("Taken message handler")
-		}
-
 		// Process messages asynchronously
 		go func() {
 			if limitNumConcurrentHandlers {
+				a.logger.Debugf("Attempting to take message handler")
+				<-handlers // Take or wait on a free handler before getting a new message
+				a.logger.Debugf("Taken message handler")
+
 				defer func() {
 					a.logger.Debugf("Releasing message handler")
 					handlers <- handler{} // Release a handler

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -30,6 +30,7 @@ func getFakeProperties() map[string]string {
 		lockDurationInSec:             "120",
 		lockRenewalInSec:              "15",
 		numConcurrentHandlers:         "1",
+		prefetchCount:                 "10",
 	}
 }
 
@@ -65,6 +66,8 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 1, *m.NumConcurrentHandlers)
 		assert.NotNil(t, m.LockRenewalInSec)
 		assert.Equal(t, 15, m.LockRenewalInSec)
+		assert.NotNil(t, m.PrefetchCount)
+		assert.Equal(t, 10, m.PrefetchCount)
 	})
 
 	t.Run("missing required connectionString", func(t *testing.T) {
@@ -380,6 +383,38 @@ func TestParseServiceBusMetadata(t *testing.T) {
 			Properties: fakeProperties,
 		}
 		fakeMetaData.Properties[numConcurrentHandlers] = invalidNumber
+
+		// act
+		_, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert
+		assert.Error(t, err)
+		assertValidErrorMessage(t, err)
+	})
+
+	t.Run("missing nullable prefetchCount", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[prefetchCount] = ""
+
+		// act
+		m, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert
+		assert.Nil(t, m.PrefetchCount)
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid nullable prefetchCount", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[prefetchCount] = invalidNumber
 
 		// act
 		_, err := parseAzureServiceBusMetadata(fakeMetaData)

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -57,8 +57,8 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 30, m.HandlerTimeoutInSec)
 		assert.NotNil(t, m.LockRenewalInSec)
 		assert.Equal(t, 15, m.LockRenewalInSec)
-		assert.NotNil(t, m.MaxActiveMessage)
-		assert.Equal(t, 100, m.MaxActiveMessage)
+		assert.NotNil(t, m.MaxActiveMessages)
+		assert.Equal(t, 100, m.MaxActiveMessages)
 		assert.NotNil(t, m.MaxActiveMessagesRecoveryInSec)
 		assert.Equal(t, 5, m.MaxActiveMessagesRecoveryInSec)
 
@@ -250,7 +250,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		m, err := parseAzureServiceBusMetadata(fakeMetaData)
 
 		// assert
-		assert.Equal(t, 10000, m.MaxActiveMessage)
+		assert.Equal(t, 10000, m.MaxActiveMessages)
 		assert.Nil(t, err)
 	})
 

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -67,7 +67,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.NotNil(t, m.LockRenewalInSec)
 		assert.Equal(t, 15, m.LockRenewalInSec)
 		assert.NotNil(t, m.PrefetchCount)
-		assert.Equal(t, 10, m.PrefetchCount)
+		assert.Equal(t, 10, *m.PrefetchCount)
 	})
 
 	t.Run("missing required connectionString", func(t *testing.T) {
@@ -200,6 +200,22 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assertValidErrorMessage(t, err)
 	})
 
+	t.Run("invalid optional lockRenewalInSec", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[lockRenewalInSec] = invalidNumber
+
+		// act
+		_, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert
+		assert.Error(t, err)
+		assertValidErrorMessage(t, err)
+	})
+
 	t.Run("missing nullable maxDeliveryCount", func(t *testing.T) {
 		fakeProperties := getFakeProperties()
 
@@ -319,38 +335,6 @@ func TestParseServiceBusMetadata(t *testing.T) {
 			Properties: fakeProperties,
 		}
 		fakeMetaData.Properties[lockDurationInSec] = invalidNumber
-
-		// act
-		_, err := parseAzureServiceBusMetadata(fakeMetaData)
-
-		// assert
-		assert.Error(t, err)
-		assertValidErrorMessage(t, err)
-	})
-
-	t.Run("missing nullable lockRenewalInSec", func(t *testing.T) {
-		fakeProperties := getFakeProperties()
-
-		fakeMetaData := pubsub.Metadata{
-			Properties: fakeProperties,
-		}
-		fakeMetaData.Properties[lockRenewalInSec] = ""
-
-		// act
-		m, err := parseAzureServiceBusMetadata(fakeMetaData)
-
-		// assert
-		assert.Nil(t, m.LockRenewalInSec)
-		assert.Nil(t, err)
-	})
-
-	t.Run("invalid nullable lockRenewalInSec", func(t *testing.T) {
-		fakeProperties := getFakeProperties()
-
-		fakeMetaData := pubsub.Metadata{
-			Properties: fakeProperties,
-		}
-		fakeMetaData.Properties[lockRenewalInSec] = invalidNumber
 
 		// act
 		_, err := parseAzureServiceBusMetadata(fakeMetaData)

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -28,6 +28,7 @@ func getFakeProperties() map[string]string {
 		autoDeleteOnIdleInSec:         "240",
 		defaultMessageTimeToLiveInSec: "2400",
 		lockDurationInSec:             "120",
+		lockRenewalInSec:              "15",
 		numConcurrentHandlers:         "1",
 	}
 }
@@ -62,6 +63,8 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 120, *m.LockDurationInSec)
 		assert.NotNil(t, m.NumConcurrentHandlers)
 		assert.Equal(t, 1, *m.NumConcurrentHandlers)
+		assert.NotNil(t, m.LockRenewalInSec)
+		assert.Equal(t, 15, m.LockRenewalInSec)
 	})
 
 	t.Run("missing required connectionString", func(t *testing.T) {
@@ -313,6 +316,38 @@ func TestParseServiceBusMetadata(t *testing.T) {
 			Properties: fakeProperties,
 		}
 		fakeMetaData.Properties[lockDurationInSec] = invalidNumber
+
+		// act
+		_, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert
+		assert.Error(t, err)
+		assertValidErrorMessage(t, err)
+	})
+
+	t.Run("missing nullable lockRenewalInSec", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[lockRenewalInSec] = ""
+
+		// act
+		m, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert
+		assert.Nil(t, m.LockRenewalInSec)
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid nullable lockRenewalInSec", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[lockRenewalInSec] = invalidNumber
 
 		// act
 		_, err := parseAzureServiceBusMetadata(fakeMetaData)

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -29,7 +29,7 @@ func getFakeProperties() map[string]string {
 		defaultMessageTimeToLiveInSec:  "2400",
 		lockDurationInSec:              "120",
 		lockRenewalInSec:               "15",
-		numConcurrentHandlers:          "1",
+		maxConcurrentHandlers:          "1",
 		prefetchCount:                  "10",
 		maxActiveMessages:              "100",
 		maxActiveMessagesRecoveryInSec: "5",
@@ -70,11 +70,10 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 2400, *m.DefaultMessageTimeToLiveInSec)
 		assert.NotNil(t, m.LockDurationInSec)
 		assert.Equal(t, 120, *m.LockDurationInSec)
-		assert.NotNil(t, m.NumConcurrentHandlers)
-		assert.Equal(t, 1, *m.NumConcurrentHandlers)
+		assert.NotNil(t, m.MaxConcurrentHandlers)
+		assert.Equal(t, 1, *m.MaxConcurrentHandlers)
 		assert.NotNil(t, m.PrefetchCount)
 		assert.Equal(t, 10, *m.PrefetchCount)
-
 	})
 
 	t.Run("missing required connectionString", func(t *testing.T) {
@@ -431,29 +430,29 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assertValidErrorMessage(t, err)
 	})
 
-	t.Run("missing nullable numConcurrentHandlers", func(t *testing.T) {
+	t.Run("missing nullable maxConcurrentHandlers", func(t *testing.T) {
 		fakeProperties := getFakeProperties()
 
 		fakeMetaData := pubsub.Metadata{
 			Properties: fakeProperties,
 		}
-		fakeMetaData.Properties[numConcurrentHandlers] = ""
+		fakeMetaData.Properties[maxConcurrentHandlers] = ""
 
 		// act
 		m, err := parseAzureServiceBusMetadata(fakeMetaData)
 
 		// assert
-		assert.Nil(t, m.NumConcurrentHandlers)
+		assert.Nil(t, m.MaxConcurrentHandlers)
 		assert.Nil(t, err)
 	})
 
-	t.Run("invalid nullable numConcurrentHandlers", func(t *testing.T) {
+	t.Run("invalid nullable maxConcurrentHandlers", func(t *testing.T) {
 		fakeProperties := getFakeProperties()
 
 		fakeMetaData := pubsub.Metadata{
 			Properties: fakeProperties,
 		}
-		fakeMetaData.Properties[numConcurrentHandlers] = invalidNumber
+		fakeMetaData.Properties[maxConcurrentHandlers] = invalidNumber
 
 		// act
 		_, err := parseAzureServiceBusMetadata(fakeMetaData)


### PR DESCRIPTION
# Description
Rather than just applying concurrency controls to the message handlers, I've update it to handle it in the receiver as well. This way dapr doesn't pull a message it cannot immediately process.
More details in the original [issue](https://github.com/dapr/dapr/issues/1526).

I've smoke tested this locally, I'd like to check this resolves @programaka issue before merging.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/1526

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
