### PR TITLE
Add support for UserValues in Nethttpadaptor

### DIFF
--- a/middleware/http/nethttpadaptor/nethttpadaptor.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor.go
@@ -48,6 +48,14 @@ func NewNetHTTPHandlerFunc(logger logger.Logger, h fasthttp.RequestHandler) http
 			}
 		}
 
+		ctx := r.Context()
+		reqCtx, ok := ctx.(*fasthttp.RequestCtx)
+		if ok {
+			reqCtx.VisitUserValues(func(k []byte, v interface{}) {
+				c.SetUserValueBytes(k, v)
+			})
+		}
+
 		h(&c)
 
 		c.Response.Header.VisitAll(func(k []byte, v []byte) {


### PR DESCRIPTION
# Description
This change copies the uservalues from the original request context into the new request.

## Issue reference
Please reference the issue this PR will close: #332 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
