### PR TITLE
Use shared aws auth package

### DIFF
--- a/authentication/aws/aws.go
+++ b/authentication/aws/aws.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
-func GetClient(accessKey string, secretKey string, region string) (*session.Session, error) {
+func GetClient(accessKey string, secretKey string, region string, endpoint string) (*session.Session, error) {
 	awsConfig := aws.NewConfig()
 
 	if region != "" {
@@ -14,6 +14,10 @@ func GetClient(accessKey string, secretKey string, region string) (*session.Sess
 	}
 	if accessKey != "" && secretKey != "" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(accessKey, secretKey, ""))
+	}
+
+	if endpoint != "" {
+		awsConfig = awsConfig.WithEndpoint(endpoint)
 	}
 
 	awsSession, err := session.NewSession(awsConfig)

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -7,12 +7,11 @@ package dynamodb
 
 import (
 	"encoding/json"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/dapr/dapr/pkg/logger"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/dapr/components-contrib/bindings"
@@ -93,11 +92,8 @@ func (d *DynamoDB) getDynamoDBMetadata(spec bindings.Metadata) (*dynamoDBMetadat
 	return &meta, nil
 }
 
-func (d *DynamoDB) getClient(meta *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(meta.Region),
-		Credentials: credentials.NewStaticCredentials(meta.AccessKey, meta.SecretKey, ""),
-	})
+func (d *DynamoDB) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -94,7 +94,7 @@ func (d *DynamoDB) getDynamoDBMetadata(spec bindings.Metadata) (*dynamoDBMetadat
 }
 
 func (d *DynamoDB) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -27,6 +27,7 @@ type DynamoDB struct {
 
 type dynamoDBMetadata struct {
 	Region    string `json:"region"`
+	Endpoint  string `json:"endpoint"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
 	Table     string `json:"table"`
@@ -94,7 +95,7 @@ func (d *DynamoDB) getDynamoDBMetadata(spec bindings.Metadata) (*dynamoDBMetadat
 }
 
 func (d *DynamoDB) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -7,6 +7,7 @@ package dynamodb
 
 import (
 	"encoding/json"
+
 	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
 	"github.com/dapr/dapr/pkg/logger"

--- a/bindings/aws/dynamodb/dynamodb_test.go
+++ b/bindings/aws/dynamodb/dynamodb_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"AccessKey": "a", "Region": "a", "SecretKey": "a", "Table": "a"}
+	m.Properties = map[string]string{"AccessKey": "a", "Region": "a", "SecretKey": "a", "Table": "a", "Endpoint": "a"}
 	dy := DynamoDB{}
 	meta, err := dy.getDynamoDBMetadata(m)
 	assert.Nil(t, err)
@@ -22,4 +22,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", meta.Region)
 	assert.Equal(t, "a", meta.SecretKey)
 	assert.Equal(t, "a", meta.Table)
+	assert.Equal(t, "a", meta.Endpoint)
 }

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"os"
 	"os/signal"
 	"sync"
@@ -18,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
@@ -287,10 +287,7 @@ func (a *AWSKinesis) waitUntilConsumerExists(ctx aws.Context, input *kinesis.Des
 }
 
 func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(metadata.Region),
-		Credentials: credentials.NewStaticCredentials(metadata.AccessKey, metadata.SecretKey, ""),
-	})
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -287,7 +288,7 @@ func (a *AWSKinesis) waitUntilConsumerExists(ctx aws.Context, input *kinesis.Des
 }
 
 func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -46,6 +46,7 @@ type kinesisMetadata struct {
 	StreamName          string              `json:"streamName"`
 	ConsumerName        string              `json:"consumerName"`
 	Region              string              `json:"region"`
+	Endpoint            string              `json:"endpoint"`
 	AccessKey           string              `json:"accessKey"`
 	SecretKey           string              `json:"secretKey"`
 	KinesisConsumerMode kinesisConsumerMode `json:"mode"`
@@ -288,7 +289,7 @@ func (a *AWSKinesis) waitUntilConsumerExists(ctx aws.Context, input *kinesis.Des
 }
 
 func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/kinesis/kinesis_test.go
+++ b/bindings/aws/kinesis/kinesis_test.go
@@ -21,6 +21,7 @@ func TestParseMetadata(t *testing.T) {
 		"ConsumerName": "test",
 		"StreamName":   "stream",
 		"Mode":         "extended",
+		"Endpoint":     "endpoint",
 	}
 	kinesis := AWSKinesis{}
 	meta, err := kinesis.parseMetadata(m)
@@ -30,5 +31,6 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "secret", meta.SecretKey)
 	assert.Equal(t, "test", meta.ConsumerName)
 	assert.Equal(t, "stream", meta.StreamName)
+	assert.Equal(t, "endpoint", meta.Endpoint)
 	assert.Equal(t, kinesisConsumerMode("extended"), meta.KinesisConsumerMode)
 }

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -8,6 +8,7 @@ package s3
 import (
 	"bytes"
 	"encoding/json"
+
 	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -8,13 +8,12 @@ package s3
 import (
 	"bytes"
 	"encoding/json"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/google/uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
 )
@@ -86,10 +85,7 @@ func (s *AWSS3) parseMetadata(metadata bindings.Metadata) (*s3Metadata, error) {
 }
 
 func (s *AWSS3) getClient(metadata *s3Metadata) (*s3manager.Uploader, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(metadata.Region),
-		Credentials: credentials.NewStaticCredentials(metadata.AccessKey, metadata.SecretKey, ""),
-	})
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -28,6 +28,7 @@ type AWSS3 struct {
 
 type s3Metadata struct {
 	Region    string `json:"region"`
+	Endpoint  string `json:"endpoint"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
 	Bucket    string `json:"bucket"`
@@ -86,7 +87,7 @@ func (s *AWSS3) parseMetadata(metadata bindings.Metadata) (*s3Metadata, error) {
 }
 
 func (s *AWSS3) getClient(metadata *s3Metadata) (*s3manager.Uploader, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -86,7 +86,7 @@ func (s *AWSS3) parseMetadata(metadata bindings.Metadata) (*s3Metadata, error) {
 }
 
 func (s *AWSS3) getClient(metadata *s3Metadata) (*s3manager.Uploader, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test"}
+	m.Properties = map[string]string{"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint"}
 	s3 := AWSS3{}
 	meta, err := s3.parseMetadata(m)
 	assert.Nil(t, err)
@@ -22,4 +22,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "region", meta.Region)
 	assert.Equal(t, "secret", meta.SecretKey)
 	assert.Equal(t, "test", meta.Bucket)
+	assert.Equal(t, "endpoint", meta.Endpoint)
 }

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -72,7 +72,7 @@ func (a *AWSSNS) parseMetadata(metadata bindings.Metadata) (*snsMetadata, error)
 }
 
 func (a *AWSSNS) getClient(metadata *snsMetadata) (*sns.SNS, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -8,12 +8,10 @@ package sns
 import (
 	"encoding/json"
 	"fmt"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/dapr/dapr/pkg/logger"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/dapr/components-contrib/bindings"
 )
@@ -73,10 +71,7 @@ func (a *AWSSNS) parseMetadata(metadata bindings.Metadata) (*snsMetadata, error)
 }
 
 func (a *AWSSNS) getClient(metadata *snsMetadata) (*sns.SNS, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(metadata.Region),
-		Credentials: credentials.NewStaticCredentials(metadata.AccessKey, metadata.SecretKey, ""),
-	})
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -28,6 +28,7 @@ type AWSSNS struct {
 type snsMetadata struct {
 	TopicArn  string `json:"topicArn"`
 	Region    string `json:"region"`
+	Endpoint  string `json:"endpoint"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
 }
@@ -72,7 +73,7 @@ func (a *AWSSNS) parseMetadata(metadata bindings.Metadata) (*snsMetadata, error)
 }
 
 func (a *AWSSNS) getClient(metadata *snsMetadata) (*sns.SNS, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -8,6 +8,7 @@ package sns
 import (
 	"encoding/json"
 	"fmt"
+
 	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 
 	"github.com/dapr/dapr/pkg/logger"

--- a/bindings/aws/sns/sns_test.go
+++ b/bindings/aws/sns/sns_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"TopicArn": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a"}
+	m.Properties = map[string]string{"TopicArn": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a"}
 	s := AWSSNS{}
 	snsM, err := s.parseMetadata(m)
 	assert.Nil(t, err)
@@ -22,4 +22,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", snsM.Region)
 	assert.Equal(t, "a", snsM.AccessKey)
 	assert.Equal(t, "a", snsM.SecretKey)
+	assert.Equal(t, "a", snsM.Endpoint)
 }

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -27,6 +27,7 @@ type AWSSQS struct {
 type sqsMetadata struct {
 	QueueName string `json:"queueName"`
 	Region    string `json:"region"`
+	Endpoint  string `json:"endpoint"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
 }
@@ -124,7 +125,7 @@ func (a *AWSSQS) parseSQSMetadata(metadata bindings.Metadata) (*sqsMetadata, err
 }
 
 func (a *AWSSQS) getClient(metadata *sqsMetadata) (*sqs.SQS, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -124,7 +124,7 @@ func (a *AWSSQS) parseSQSMetadata(metadata bindings.Metadata) (*sqsMetadata, err
 }
 
 func (a *AWSSQS) getClient(metadata *sqsMetadata) (*sqs.SQS, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sqs/sqs_test.go
+++ b/bindings/aws/sqs/sqs_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"QueueName": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a"}
+	m.Properties = map[string]string{"QueueName": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a"}
 	s := AWSSQS{}
 	sqsM, err := s.parseSQSMetadata(m)
 	assert.Nil(t, err)
@@ -22,4 +22,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", sqsM.Region)
 	assert.Equal(t, "a", sqsM.AccessKey)
 	assert.Equal(t, "a", sqsM.SecretKey)
+	assert.Equal(t, "a", sqsM.Endpoint)
 }

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -8,12 +8,11 @@ import (
 	"strconv"
 	"strings"
 
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
+
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/dapr/dapr/pkg/logger"
 
-	//aws_client "github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/session"
 	sns "github.com/aws/aws-sdk-go/service/sns"
 	sqs "github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/dapr/components-contrib/pubsub"
@@ -211,22 +210,13 @@ func (s *snsSqs) Init(metadata pubsub.Metadata) error {
 	s.topics = make(map[string]string)
 	s.topicHash = make(map[string]string)
 	s.queues = make(map[string]*sqsQueueInfo)
-	config := aws.NewConfig()
-	endpoint := md.awsEndpoint
 	s.awsAcctID = md.awsAccountID
-	config.Credentials = credentials.NewStaticCredentials(s.awsAcctID, md.awsSecret, md.awsToken)
-	config.Endpoint = &endpoint
-	config.Region = aws.String(md.awsRegion)
-	sesh, err := session.NewSession(config)
-
+	sess, err := aws_auth.GetClient(s.awsAcctID, md.awsSecret, md.awsRegion, md.awsEndpoint)
 	if err != nil {
-		// rather than using session.Must, defer pass the error up to the runtime
 		return err
 	}
-
-	s.snsClient = sns.New(sesh)
-	s.sqsClient = sqs.New(sesh)
-
+	s.snsClient = sns.New(sess)
+	s.sqsClient = sqs.New(sess)
 	return nil
 }
 

--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -9,13 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
+
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/dapr/dapr/pkg/logger"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/dapr/components-contrib/secretstores"
 )
 
@@ -87,10 +86,7 @@ func (s *smSecretStore) GetSecret(req secretstores.GetSecretRequest) (secretstor
 }
 
 func (s *smSecretStore) getClient(metadata *secretManagerMetaData) (*secretsmanager.SecretsManager, error) {
-	sess, err := session.NewSession(aws.NewConfig().
-		WithRegion(*aws.String(metadata.Region)).
-		WithCredentials(credentials.NewStaticCredentials(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken)))
-
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}
@@ -107,9 +103,6 @@ func (s *smSecretStore) getSecretManagerMetadata(spec secretstores.Metadata) (*s
 	err = json.Unmarshal(b, &meta)
 	if err != nil {
 		return nil, err
-	}
-	if meta.SecretKey == "" || meta.AccessKey == "" || meta.Region == "" || meta.SessionToken == "" {
-		return nil, fmt.Errorf("missing aws credentials in metadata")
 	}
 	return &meta, nil
 }

--- a/secretstores/aws/secretmanager/secretmanager_test.go
+++ b/secretstores/aws/secretmanager/secretmanager_test.go
@@ -34,20 +34,12 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"AccessKey":    "a",
 			"Region":       "a",
+			"Endpoint":     "a",
 			"SecretKey":    "a",
 			"SessionToken": "a",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)
-	})
-
-	t.Run("Init with missing metadata", func(t *testing.T) {
-		m.Properties = map[string]string{
-			"Dummy": "a",
-		}
-		err := s.Init(m)
-		assert.NotNil(t, err)
-		assert.Equal(t, err, fmt.Errorf("missing aws credentials in metadata"))
 	})
 }
 

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
+
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/dapr/components-contrib/state"
 )
@@ -22,6 +22,7 @@ type StateStore struct {
 
 type dynamoDBMetadata struct {
 	Region       string `json:"region"`
+	Endpoint     string `json:"endpoint"`
 	AccessKey    string `json:"accessKey"`
 	SecretKey    string `json:"secretKey"`
 	SessionToken string `json:"sessionToken"`
@@ -155,15 +156,11 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 	return &meta, nil
 }
 
-func (d *StateStore) getClient(meta *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(meta.Region),
-		Credentials: credentials.NewStaticCredentials(meta.AccessKey, meta.SecretKey, meta.SessionToken),
-	})
+func (d *StateStore) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}
-
 	c := dynamodb.New(sess)
 	return c, nil
 }


### PR DESCRIPTION
# Description
This PR builds on the changes made in #340 , using the shared credentials resolver package for all aws clients. I also discovered that the `sqssns` pubsub package implements an "endpoint" parameter, so I added that to the auth abstraction package, and implemented it in all aws packages. This is especially powerful when developing locally against a local DynamoDB container instead of an actual DynamoDB Table running at AWS - should allow some new and interesting integration test scenarios aswell, using libraries such as https://github.com/spulec/moto to mock various aws services.

The only package I'm unsure of is the `sqssns` pubsub package. It uses different param names than all other aws-related packages in dapr, and the best would probably be to get everything aligned now that the project is still in alpha, but this would introduce a breaking change. I'd like the maintainers' thoughts on this.

## Issue reference

Fixes #339 - docs should probably be updated before that issue is closed.

## Checklist
* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
