### PR TITLE
Upgrade go version to 1.14.3 and linter version to 1.26.0

### DIFF
--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.14
+      GOVER: 1.14.3
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -21,11 +21,11 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.13.7
+      GOVER: 1.14
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
-      GOLANGCI_LINT_VER: v1.23.2
+      GOLANGCI_LINT_VER: v1.27.0
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -25,7 +25,7 @@ jobs:
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
-      GOLANGCI_LINT_VER: v1.27.0
+      GOLANGCI_LINT_VER: v1.26.0
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -225,3 +225,6 @@ linters:
     - unparam
     - wsl
     - gomnd
+    - godot
+    - testpackage
+    - goerr113

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/components-contrib
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.52.0

--- a/middleware/http/nethttpadaptor/nethttpadaptor_test.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor_test.go
@@ -1,7 +1,6 @@
 package nethttpadaptor
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -419,10 +418,10 @@ func TestNewNetHTTPHandlerFuncResponses(t *testing.T) {
 						gzip = true
 					}
 				}
-				assert.True(t, chunked, fmt.Sprintf("expected chunked to be true but was false"))
-				assert.True(t, compress, fmt.Sprintf("expected compress to be true but was false"))
-				assert.True(t, deflate, fmt.Sprintf("expected deflate to be true but was false"))
-				assert.True(t, gzip, fmt.Sprintf("expected gzip to be true but was false"))
+				assert.True(t, chunked, "expected chunked to be true but was false")
+				assert.True(t, compress, "expected compress to be true but was false")
+				assert.True(t, deflate, "expected deflate to be true but was false")
+				assert.True(t, gzip, "expected gzip to be true but was false")
 			},
 		},
 	}

--- a/middleware/http/oauth2/oauth2_middleware.go
+++ b/middleware/http/oauth2/oauth2_middleware.go
@@ -71,6 +71,7 @@ func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(h fasthttp.R
 				return
 			}
 			state := string(ctx.FormValue(stateParam))
+			//nolint:nestif
 			if state == "" {
 				id, _ := uuid.NewUUID()
 				session.Set(savedState, id.String())

--- a/pubsub/natsstreaming/natsstreaming.go
+++ b/pubsub/natsstreaming/natsstreaming.go
@@ -213,7 +213,7 @@ func (n *natsStreamingPubSub) subscriptionOptions() ([]stan.SubscriptionOption, 
 	switch {
 	case n.metadata.deliverNew == deliverNewTrue:
 		options = append(options, stan.StartAt(pb.StartPosition_NewOnly))
-	case n.metadata.startAtSequence >= 1:
+	case n.metadata.startAtSequence >= 1: //messages index start from 1, this is a valid check
 		options = append(options, stan.StartAtSequence(n.metadata.startAtSequence))
 	case n.metadata.startWithLastReceived == startWithLastReceivedTrue:
 		options = append(options, stan.StartWithLastReceived())

--- a/pubsub/natsstreaming/natsstreaming.go
+++ b/pubsub/natsstreaming/natsstreaming.go
@@ -97,6 +97,7 @@ func parseNATSStreamingMetadata(meta pubsub.Metadata) (metadata, error) {
 		m.durableSubscriptionName = val
 	}
 
+	//nolint:nestif
 	// subscription options - only one can be used
 	if val, ok := meta.Properties[startAtSequence]; ok && val != "" {
 		// nats streaming accepts a uint64 as sequence
@@ -209,20 +210,20 @@ func (n *natsStreamingPubSub) subscriptionOptions() ([]stan.SubscriptionOption, 
 		options = append(options, stan.DurableName(n.metadata.durableSubscriptionName))
 	}
 
-	if n.metadata.deliverNew == deliverNewTrue {
+	switch {
+	case n.metadata.deliverNew == deliverNewTrue:
 		options = append(options, stan.StartAt(pb.StartPosition_NewOnly))
-	} else if n.metadata.startAtSequence >= 1 { //messages index start from 1, this is a valid check
+	case n.metadata.startAtSequence >= 1:
 		options = append(options, stan.StartAtSequence(n.metadata.startAtSequence))
-	} else if n.metadata.startWithLastReceived == startWithLastReceivedTrue {
+	case n.metadata.startWithLastReceived == startWithLastReceivedTrue:
 		options = append(options, stan.StartWithLastReceived())
-	} else if n.metadata.deliverAll == deliverAllTrue {
+	case n.metadata.deliverAll == deliverAllTrue:
 		options = append(options, stan.DeliverAllAvailable())
-	} else if n.metadata.startAtTimeDelta > (1 * time.Nanosecond) { //as long as its a valid time.Duration
+	case n.metadata.startAtTimeDelta > (1 * time.Nanosecond): //as long as its a valid time.Duration
 		options = append(options, stan.StartAtTimeDelta(n.metadata.startAtTimeDelta))
-	} else if n.metadata.startAtTime != "" {
+	case n.metadata.startAtTime != "":
 		if n.metadata.startAtTimeFormat != "" {
 			startTime, err := time.Parse(n.metadata.startAtTimeFormat, n.metadata.startAtTime)
-
 			if err != nil {
 				return nil, err
 			}

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -138,6 +138,7 @@ func (r *rabbitMQ) handleMessage(d amqp.Delivery, topic string, handler func(msg
 		r.logger.Errorf("%s error handling message from topic '%s', %s", logMessagePrefix, topic, err)
 	}
 
+	//nolint:nestif
 	// if message is not auto acked we need to ack/nack
 	if !r.metadata.autoAck {
 		if err != nil {

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func createAmqpMessage(body string) amqp.Delivery {
+func createAMQPMessage(body string) amqp.Delivery {
 	return amqp.Delivery{Body: []byte(body)}
 }
 
@@ -39,11 +39,11 @@ func TestProcessSubscriberMessage(t *testing.T) {
 
 	go testRabbitMQSubscriber.listenMessages(ch, topic, fakeHandler)
 	assert.Equal(t, messageCount, 0)
-	ch <- createAmqpMessage("{ \"msg\": \"1\"}")
-	ch <- createAmqpMessage("{ \"msg\": \"2\"}")
+	ch <- createAMQPMessage("{ \"msg\": \"1\"}")
+	ch <- createAMQPMessage("{ \"msg\": \"2\"}")
 	assert.GreaterOrEqual(t, messageCount, 1)
 	assert.LessOrEqual(t, messageCount, 2)
-	ch <- createAmqpMessage("{ \"msg\": \"3\"}")
+	ch <- createAMQPMessage("{ \"msg\": \"3\"}")
 	assert.GreaterOrEqual(t, messageCount, 2)
 	assert.LessOrEqual(t, messageCount, 3)
 }

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -49,7 +49,7 @@ func TestGetClientCert(t *testing.T) {
 func TestAuthorizorWithCertFile(t *testing.T) {
 	testCertFileName := "./.cert.pfx"
 	certBytes := getTestCert()
-	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
+	err := ioutil.WriteFile(testCertFileName, certBytes, 0600)
 	assert.NoError(t, err)
 
 	settings := EnvironmentSettings{

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -46,10 +46,11 @@ func TestGetClientCert(t *testing.T) {
 	assert.Equal(t, "https://login.microsoftonline.com/", testCertConfig.ClientCertificateConfig.AADEndpoint)
 }
 
+//nolint:gosec
 func TestAuthorizorWithCertFile(t *testing.T) {
 	testCertFileName := "./.cert.pfx"
 	certBytes := getTestCert()
-	err := ioutil.WriteFile(testCertFileName, certBytes, 0600)
+	err := ioutil.WriteFile(testCertFileName, certBytes, 0644)
 	assert.NoError(t, err)
 
 	settings := EnvironmentSettings{

--- a/secretstores/get_secret_request.go
+++ b/secretstores/get_secret_request.go
@@ -5,7 +5,7 @@
 
 package secretstores
 
-// GetSecretRequest describes a get secret request from a secret store
+// GetSecretRequest describes a get secret request from a secret store.
 type GetSecretRequest struct {
 	Name     string            `json:"name"`
 	Metadata map[string]string `json:"metadata"`

--- a/servicediscovery/kubernetes/kubernetes_test.go
+++ b/servicediscovery/kubernetes/kubernetes_test.go
@@ -6,7 +6,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/dapr/components-contrib/servicediscovery"
@@ -18,7 +17,7 @@ func TestResolve(t *testing.T) {
 	resolver := NewKubernetesResolver(logger.NewLogger("test"))
 	request := servicediscovery.ResolveRequest{ID: "myid", Namespace: "abc", Port: 1234}
 
-	u := fmt.Sprintf("myid-dapr.abc.svc.cluster.local:1234")
+	u := "myid-dapr.abc.svc.cluster.local:1234"
 	target, err := resolver.ResolveID(request)
 
 	assert.Nil(t, err)

--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -137,8 +137,8 @@ func (aspike *Aerospike) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulks save operation
 func (aspike *Aerospike) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := aspike.Set(&s)
+	for i := range req {
+		err := aspike.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -219,8 +219,8 @@ func (aspike *Aerospike) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (aspike *Aerospike) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := aspike.Delete(&re)
+	for i := range req {
+		err := aspike.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -103,8 +103,8 @@ func (d *StateStore) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulk set operation
 func (d *StateStore) BulkSet(req []state.SetRequest) error {
-	for _, r := range req {
-		err := d.Set(&r)
+	for i := range req {
+		err := d.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -128,8 +128,8 @@ func (d *StateStore) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (d *StateStore) BulkDelete(req []state.DeleteRequest) error {
-	for _, r := range req {
-		err := d.Delete(&r)
+	for i := range req {
+		err := d.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -162,8 +162,8 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulk set operation
 func (c *StateStore) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := c.Set(&s)
+	for i := range req {
+		err := c.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -199,8 +199,8 @@ func (c *StateStore) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (c *StateStore) BulkDelete(req []state.DeleteRequest) error {
-	for _, r := range req {
-		err := c.Delete(&r)
+	for i := range req {
+		err := c.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -98,8 +98,8 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 
 func (r *StateStore) BulkDelete(req []state.DeleteRequest) error {
 	r.logger.Debugf("bulk delete %v key(s)", len(req))
-	for _, s := range req {
-		err := r.Delete(&s)
+	for i := range req {
+		err := r.Delete(&req[i])
 		if err != nil {
 			return err
 		}
@@ -137,8 +137,8 @@ func (r *StateStore) Set(req *state.SetRequest) error {
 func (r *StateStore) BulkSet(req []state.SetRequest) error {
 	r.logger.Debugf("bulk set %v key(s)", len(req))
 
-	for _, s := range req {
-		err := r.Set(&s)
+	for i := range req {
+		err := r.Set(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/cassandra/cassandra.go
+++ b/state/cassandra/cassandra.go
@@ -214,8 +214,8 @@ func (c *Cassandra) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (c *Cassandra) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := c.Delete(&re)
+	for i := range req {
+		err := c.Delete(&req[i])
 		if err != nil {
 			return err
 		}
@@ -300,8 +300,8 @@ func (c *Cassandra) createSession(consistency gocql.Consistency) (*gocql.Session
 
 // BulkSet performs a bulks save operation
 func (c *Cassandra) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := c.Set(&s)
+	for i := range req {
+		err := c.Set(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/cloudstate/cloudstate_crdt.go
+++ b/state/cloudstate/cloudstate_crdt.go
@@ -534,8 +534,8 @@ func (c *CRDT) BulkDelete(req []state.DeleteRequest) error {
 		return err
 	}
 
-	for _, r := range req {
-		err = c.Delete(&r)
+	for i := range req {
+		err = c.Delete(&req[i])
 		if err != nil {
 			return err
 		}
@@ -579,8 +579,8 @@ func (c *CRDT) BulkSet(req []state.SetRequest) error {
 		return err
 	}
 
-	for _, r := range req {
-		err = c.Set(&r)
+	for i := range req {
+		err = c.Set(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/couchbase/couchbase.go
+++ b/state/couchbase/couchbase.go
@@ -139,6 +139,7 @@ func (cbs *Couchbase) Set(req *state.SetRequest) error {
 		return fmt.Errorf("couchbase error: failed to convert value %v", err)
 	}
 
+	//nolint:nestif
 	//key already exists (use Replace)
 	if req.ETag != "" {
 		//compare-and-swap (CAS) for managing concurrent modifications - https://docs.couchbase.com/go-sdk/current/concurrent-mutations-cluster.html
@@ -169,8 +170,8 @@ func (cbs *Couchbase) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulks save operation
 func (cbs *Couchbase) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := cbs.Set(&s)
+	for i := range req {
+		err := cbs.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -230,8 +231,8 @@ func (cbs *Couchbase) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (cbs *Couchbase) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := cbs.Delete(&re)
+	for i := range req {
+		err := cbs.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -174,8 +174,8 @@ func (r *ETCD) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (r *ETCD) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := r.Delete(&re)
+	for i := range req {
+		err := r.Delete(&req[i])
 		if err != nil {
 			return err
 		}
@@ -217,8 +217,8 @@ func (r *ETCD) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulks save operation
 func (r *ETCD) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := r.Set(&s)
+	for i := range req {
+		err := r.Set(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -8,6 +8,7 @@ package firestore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"cloud.google.com/go/datastore"
@@ -80,9 +81,9 @@ func (f *Firestore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	var entity StateEntity
 	err := f.client.Get(context.Background(), entityKey, &entity)
 
-	if err != nil && err != datastore.ErrNoSuchEntity {
+	if err != nil && !errors.Is(err, datastore.ErrNoSuchEntity) {
 		return nil, err
-	} else if err == datastore.ErrNoSuchEntity {
+	} else if errors.Is(err, datastore.ErrNoSuchEntity) {
 		return &state.GetResponse{}, nil
 	}
 
@@ -126,8 +127,8 @@ func (f *Firestore) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulk set operation
 func (f *Firestore) BulkSet(req []state.SetRequest) error {
-	for _, r := range req {
-		err := f.Set(&r)
+	for i := range req {
+		err := f.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -154,8 +155,8 @@ func (f *Firestore) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (f *Firestore) BulkDelete(req []state.DeleteRequest) error {
-	for _, r := range req {
-		err := f.Delete(&r)
+	for i := range req {
+		err := f.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -128,8 +128,8 @@ func (c *Consul) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulk save operation
 func (c *Consul) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := c.Set(&s)
+	for i := range req {
+		err := c.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -151,8 +151,8 @@ func (c *Consul) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (c *Consul) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := c.Delete(&re)
+	for i := range req {
+		err := c.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/hazelcast/hazelcast.go
+++ b/state/hazelcast/hazelcast.go
@@ -94,8 +94,8 @@ func (store *Hazelcast) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulks save operation
 func (store *Hazelcast) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := store.Set(&s)
+	for i := range req {
+		err := store.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -141,8 +141,8 @@ func (store *Hazelcast) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (store *Hazelcast) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := store.Delete(&re)
+	for i := range req {
+		err := store.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -118,8 +118,8 @@ func (m *Memcached) Delete(req *state.DeleteRequest) error {
 }
 
 func (m *Memcached) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := m.Delete(&re)
+	for i := range req {
+		err := m.Delete(&req[i])
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func (m *Memcached) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	item, err := m.client.Get(req.Key)
 	if err != nil {
 		// Return nil for status 204
-		if err == memcache.ErrCacheMiss {
+		if errors.Is(err, memcache.ErrCacheMiss) {
 			return &state.GetResponse{}, nil
 		}
 		return &state.GetResponse{}, err
@@ -147,8 +147,8 @@ func (m *Memcached) Set(req *state.SetRequest) error {
 }
 
 func (m *Memcached) BulkSet(req []state.SetRequest) error {
-	for _, r := range req {
-		err := m.Set(&r)
+	for i := range req {
+		err := m.Set(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -174,8 +174,8 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 // BulkSet performs a bulks save operation
 func (m *MongoDB) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := m.Set(&s)
+	for i := range req {
+		err := m.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -211,8 +211,8 @@ func (m *MongoDB) deleteInternal(ctx context.Context, req *state.DeleteRequest) 
 
 // BulkDelete performs a bulk delete operation
 func (m *MongoDB) BulkDelete(req []state.DeleteRequest) error {
-	for _, r := range req {
-		err := m.Delete(&r)
+	for i := range req {
+		err := m.Delete(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -188,8 +188,8 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 
 // BulkDelete performs a bulk delete operation
 func (r *StateStore) BulkDelete(req []state.DeleteRequest) error {
-	for _, re := range req {
-		err := r.Delete(&re)
+	for i := range req {
+		err := r.Delete(&req[i])
 		if err != nil {
 			return err
 		}
@@ -282,8 +282,8 @@ func (r *StateStore) Set(req *state.SetRequest) error {
 
 // BulkSet performs a bulks save operation
 func (r *StateStore) BulkSet(req []state.SetRequest) error {
-	for _, s := range req {
-		err := r.Set(&s)
+	for i := range req {
+		err := r.Set(&req[i])
 		if err != nil {
 			return err
 		}

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -158,6 +158,7 @@ func (s *SQLServer) Init(metadata state.Metadata) error {
 		s.keyType = StringKeyType
 	}
 
+	//nolint:nestif
 	if s.keyType == StringKeyType {
 		if val, ok := metadata.Properties[keyLengthKey]; ok && val != "" {
 			var err error
@@ -183,6 +184,7 @@ func (s *SQLServer) Init(metadata state.Metadata) error {
 		s.schema = defaultSchema
 	}
 
+	//nolint:nestif
 	if val, ok := metadata.Properties[indexedPropertiesKey]; ok && val != "" {
 		var indexedProperties []IndexedProperty
 		err := json.Unmarshal([]byte(val), &indexedProperties)
@@ -300,8 +302,8 @@ func (s *SQLServer) executeMulti(sets []state.SetRequest, deletes []state.Delete
 	}
 
 	if len(sets) > 0 {
-		for _, set := range sets {
-			err = s.executeSet(tx, &set)
+		for i := range sets {
+			err = s.executeSet(tx, &sets[i])
 			if err != nil {
 				tx.Rollback()
 				return err
@@ -521,8 +523,8 @@ func (s *SQLServer) BulkSet(req []state.SetRequest) error {
 		return err
 	}
 
-	for _, r := range req {
-		err = s.executeSet(tx, &r)
+	for i := range req {
+		err = s.executeSet(tx, &req[i])
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -141,7 +141,7 @@ func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	value, stat, err := s.conn.Get(s.prefixedKey(req.Key))
 
 	if err != nil {
-		if err == zk.ErrNoNode {
+		if errors.Is(err, zk.ErrNoNode) {
 			return &state.GetResponse{}, nil
 		}
 		return nil, err
@@ -162,7 +162,7 @@ func (s *StateStore) Delete(req *state.DeleteRequest) error {
 
 	return state.DeleteWithRetries(func(req *state.DeleteRequest) error {
 		err := s.conn.Delete(r.Path, r.Version)
-		if err == zk.ErrNoNode {
+		if errors.Is(err, zk.ErrNoNode) {
 			return nil
 		}
 		return err
@@ -173,8 +173,8 @@ func (s *StateStore) Delete(req *state.DeleteRequest) error {
 func (s *StateStore) BulkDelete(reqs []state.DeleteRequest) error {
 	ops := make([]interface{}, 0, len(reqs))
 
-	for _, req := range reqs {
-		req, err := s.newDeleteRequest(&req)
+	for i := range reqs {
+		req, err := s.newDeleteRequest(&reqs[i])
 		if err != nil {
 			return err
 		}
@@ -188,7 +188,7 @@ func (s *StateStore) BulkDelete(reqs []state.DeleteRequest) error {
 	}
 
 	for _, res := range res {
-		if res.Error != nil && res.Error != zk.ErrNoNode {
+		if res.Error != nil && !errors.Is(res.Error, zk.ErrNoNode) {
 			err = multierror.Append(err, res.Error)
 		}
 	}
@@ -206,7 +206,7 @@ func (s *StateStore) Set(req *state.SetRequest) error {
 	return state.SetWithRetries(func(req *state.SetRequest) error {
 		_, err = s.conn.Set(r.Path, r.Data, r.Version)
 
-		if err == zk.ErrNoNode {
+		if errors.Is(err, zk.ErrNoNode) {
 			_, err = s.conn.Create(r.Path, r.Data, 0, nil)
 		}
 
@@ -218,8 +218,8 @@ func (s *StateStore) Set(req *state.SetRequest) error {
 func (s *StateStore) BulkSet(reqs []state.SetRequest) error {
 	ops := make([]interface{}, 0, len(reqs))
 
-	for _, req := range reqs {
-		req, err := s.newSetDataRequest(&req)
+	for i := range reqs {
+		req, err := s.newSetDataRequest(&reqs[i])
 		if err != nil {
 			return err
 		}
@@ -236,7 +236,7 @@ func (s *StateStore) BulkSet(reqs []state.SetRequest) error {
 
 		for i, res := range res {
 			if res.Error != nil {
-				if res.Error == zk.ErrNoNode {
+				if errors.Is(res.Error, zk.ErrNoNode) {
 					if req, ok := ops[i].(*zk.SetDataRequest); ok {
 						retry = append(retry, s.newCreateRequest(req))
 						continue
@@ -315,7 +315,8 @@ func (s *StateStore) prefixedKey(key string) string {
 
 func (s *StateStore) parseETag(etag string) int32 {
 	if etag != "" {
-		version, err := strconv.Atoi(etag)
+		// Since the version is taken to be int32
+		version, err := strconv.ParseInt(etag, 10, 32)
 		if err == nil {
 			return int32(version)
 		}


### PR DESCRIPTION
# Description

Upgrade go version to 1.14 
Upgrade linter version to 1.26.0

[Linters](https://golangci-lint.run/usage/linters/)

For now removed following linters:
[godot](https://github.com/tetafro/godot) --- 90+ files being touched 
[goerr113](https://github.com/Djarvur/go-err113) --- touches so many files (should probably be done as a separate work)
[testpackage](https://github.com/maratori/testpackage) --- changing package of `_test` files might break code 

Some Changes: 
* fixed int32 parsing for ETag
* fixed implicit reference in ranged for loop to indexed, base references 
* fixed a WriteFile permission in a test file to 600 

## Issue reference
#334 
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
