### PR TITLE
Cancel context when service is discovered

### DIFF
--- a/servicediscovery/requests.go
+++ b/servicediscovery/requests.go
@@ -5,8 +5,10 @@
 
 package servicediscovery
 
+// DefaultNamespace is the default kubernetes namespace.
 const DefaultNamespace = "default"
 
+// ResolveRequest represents service discovery resolver request.
 type ResolveRequest struct {
 	ID        string
 	Namespace string
@@ -14,6 +16,7 @@ type ResolveRequest struct {
 	Data      map[string]string
 }
 
+// NewResolveRequest creates ResolveRequest with the default namespace.
 func NewResolveRequest() *ResolveRequest {
 	return &ResolveRequest{Namespace: DefaultNamespace}
 }

--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -5,6 +5,7 @@
 
 package servicediscovery
 
+// Resolver is the interface of service discovery resolver.
 type Resolver interface {
 	ResolveID(req ResolveRequest) (string, error)
 }


### PR DESCRIPTION
# Description

Cancel context when service is found. 

The current implementation is always waiting for 1 second even if service is discovered. So we can always see 1 second delay for service invocation. This will cancel earlier to fix this issue when service is discovered.

Before (using helloworld python app)
```
ℹ️  Updating metadata for app command: python3 app.py
✅  You're up and running! Both Dapr and your app logs will appear here.

== APP == Time elapsed: 1.0576

== APP == Time elapsed: 1.0166
```

After this fix
```
== APP == Time elapsed: 0.0151

ℹ️  Updating metadata for app command: python3 app.py
✅  You're up and running! Both Dapr and your app logs will appear here.

== APP == Time elapsed: 0.0085

== APP == Time elapsed: 0.0097

== APP == Time elapsed: 0.0097

== APP == Time elapsed: 0.0100

== APP == Time elapsed: 0.0096
```

## Issue reference

#311 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
