### PR TITLE
Handle errors in AzureEventHubs.Read

### DIFF
--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -169,9 +169,13 @@ func (a *AzureEventHubs) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRe
 // Read gets messages from eventhubs in a non-blocking fashion
 func (a *AzureEventHubs) Read(handler func(*bindings.ReadResponse) error) error {
 	if !a.metadata.partitioned() {
-		a.RegisterEventProcessor(handler)
+		if err := a.RegisterEventProcessor(handler); err != nil {
+			return err
+		}
 	} else {
-		a.RegisterPartitionedEventProcessor(handler)
+		if err := a.RegisterPartitionedEventProcessor(handler); err != nil {
+			return err
+		}
 	}
 
 	// close Event Hubs when application exits


### PR DESCRIPTION
# Description

Handle errors in AzureEventHubs.Read.

While following [this article](https://dev.to/azure/learn-how-to-use-azure-event-hubs-with-the-dapr-framework-333h) on how to use dapr with Azure EventHubs, I was facing the problem that the `storageAccountKey` was in the wrong format (only base64 value was required, but I was using this format instead `DefaultEndpointsProtocol=https;AccountName=daprazure;AccountKey=<the key which was needed as base64>==;EndpointSuffix=core.windows.net`.

The problem is that the error was not visible in the logs of the dapr sidecar.

Now they are:
```
time="2020-06-26T09:05:12.490481193Z" level=error msg="error reading from input binding eventhubs-input: illegal base64 data at input byte 24" app_id=goapp-input-bindingapp instance=goapp-input-binding-7cf48cfc46-jhvsj scope=dapr.runtime type=log ver=edge
```

Credits go also to @k15r

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
