### PR TITLE
Implement the Multi() interface method adding transaction support in …

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -8,11 +8,11 @@ package cosmosdb
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/dapr/dapr/pkg/logger"
-	jsoniter "github.com/json-iterator/go"
+	"strings"
 
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/a8m/documentdb"
 )
@@ -22,6 +22,7 @@ type StateStore struct {
 	client     *documentdb.DocumentDB
 	collection *documentdb.Collection
 	db         *documentdb.Database
+	sp         *documentdb.Sproc
 
 	logger logger.Logger
 }
@@ -36,9 +37,20 @@ type credentials struct {
 // CosmosItem is a wrapper around a CosmosDB document
 type CosmosItem struct {
 	documentdb.Document
-	ID    string      `json:"id"`
-	Value interface{} `json:"value"`
+	ID           string      `json:"id"`
+	Value        interface{} `json:"value"`
+	PartitionKey string      `json:"partitionkey"`
 }
+
+type storedProcedureDefinition struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+const (
+	storedProcedureName  = "__dapr__"
+	metadataPartitionKey = "partitionkey"
+)
 
 // NewCosmosDBStateStore returns a new CosmosDB state store
 func NewCosmosDBStateStore(logger logger.Logger) *StateStore {
@@ -47,6 +59,8 @@ func NewCosmosDBStateStore(logger logger.Logger) *StateStore {
 
 // Init does metadata and connection parsing
 func (c *StateStore) Init(metadata state.Metadata) error {
+	c.logger.Debugf("Cosmos init start")
+
 	connInfo := metadata.Properties
 	b, err := json.Marshal(connInfo)
 	if err != nil {
@@ -87,12 +101,37 @@ func (c *StateStore) Init(metadata state.Metadata) error {
 	if err != nil {
 		return err
 	} else if len(colls) == 0 {
-		return fmt.Errorf("collection %s for CosmosDB state store not found", creds.Collection)
+		return fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", creds.Collection)
 	}
 
 	c.collection = &colls[0]
 	c.client = client
 
+	sps, err := c.client.ReadStoredProcedures(c.collection.Self)
+	if err != nil {
+		return err
+	}
+
+	// get a link to the sp
+	for i := 0; i < len(sps); i++ {
+		if sps[i].Id == storedProcedureName {
+			c.sp = &sps[i]
+		}
+	}
+
+	if c.sp == nil {
+		// register the stored procedure
+		createspBody := storedProcedureDefinition{ID: storedProcedureName, Body: spDefinition}
+		c.sp, err = c.client.CreateStoredProcedure(c.collection.Self, createspBody)
+		if err != nil {
+			// if it already exists that is success
+			if !strings.HasPrefix(err.Error(), "Conflict") {
+				return err
+			}
+		}
+	}
+
+	c.logger.Debug("cosmos Init done")
 	return nil
 }
 
@@ -100,8 +139,10 @@ func (c *StateStore) Init(metadata state.Metadata) error {
 func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	key := req.Key
 
+	partitionKey := populatePartitionMetadata(req.Key, req.Metadata)
+
 	items := []CosmosItem{}
-	options := []documentdb.CallOption{documentdb.PartitionKey(req.Key)}
+	options := []documentdb.CallOption{documentdb.PartitionKey(partitionKey)}
 	if req.Options.Consistency == state.Strong {
 		options = append(options, documentdb.ConsistencyLevel(documentdb.Strong))
 	}
@@ -139,7 +180,8 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 		return err
 	}
 
-	options := []documentdb.CallOption{documentdb.PartitionKey(req.Key)}
+	partitionKey := populatePartitionMetadata(req.Key, req.Metadata)
+	options := []documentdb.CallOption{documentdb.PartitionKey(partitionKey)}
 
 	if req.ETag != "" {
 		options = append(options, documentdb.IfMatch((req.ETag)))
@@ -151,7 +193,7 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 		options = append(options, documentdb.ConsistencyLevel(documentdb.Eventual))
 	}
 
-	_, err = c.client.UpsertDocument(c.collection.Self, CosmosItem{ID: req.Key, Value: req.Value}, options...)
+	_, err = c.client.UpsertDocument(c.collection.Self, CosmosItem{ID: req.Key, Value: req.Value, PartitionKey: partitionKey}, options...)
 
 	if err != nil {
 		return err
@@ -179,9 +221,21 @@ func (c *StateStore) Delete(req *state.DeleteRequest) error {
 		return err
 	}
 
-	selfLink := fmt.Sprintf("dbs/%s/colls/%s/docs/%s", c.db.Id, c.collection.Id, req.Key)
+	partitionKey := populatePartitionMetadata(req.Key, req.Metadata)
+	options := []documentdb.CallOption{documentdb.PartitionKey(partitionKey)}
 
-	options := []documentdb.CallOption{documentdb.PartitionKey(req.Key)}
+	items := []CosmosItem{}
+	_, err = c.client.QueryDocuments(
+		c.collection.Self,
+		documentdb.NewQuery("SELECT * FROM ROOT r WHERE r.id=@id", documentdb.P{Name: "@id", Value: req.Key}),
+		&items,
+		options...,
+	)
+	if err != nil {
+		return err
+	} else if len(items) == 0 {
+		return nil
+	}
 
 	if req.ETag != "" {
 		options = append(options, documentdb.IfMatch((req.ETag)))
@@ -193,7 +247,10 @@ func (c *StateStore) Delete(req *state.DeleteRequest) error {
 		options = append(options, documentdb.ConsistencyLevel(documentdb.Eventual))
 	}
 
-	_, err = c.client.DeleteDocument(selfLink, options...)
+	_, err = c.client.DeleteDocument(items[0].Self, options...)
+	if err != nil {
+		c.logger.Debugf("Error from cosmos.DeleteDocument e=%e, e.Error=%s", err, err.Error())
+	}
 	return err
 }
 
@@ -207,4 +264,59 @@ func (c *StateStore) BulkDelete(req []state.DeleteRequest) error {
 	}
 
 	return nil
+}
+
+// Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail
+func (c *StateStore) Multi(operations []state.TransactionalRequest) error {
+	upserts := []CosmosItem{}
+	deletes := []CosmosItem{}
+
+	partitionKey := "UNKNOWN"
+	for _, o := range operations {
+		if o.Operation == state.Upsert {
+			req := o.Request.(state.SetRequest)
+
+			partitionKey = populatePartitionMetadata(req.Key, req.Metadata)
+			upsertOperation := CosmosItem{
+				ID:           req.Key,
+				Value:        req.Value,
+				PartitionKey: partitionKey}
+
+			upserts = append(upserts, upsertOperation)
+
+		} else if o.Operation == state.Delete {
+			req := o.Request.(state.DeleteRequest)
+
+			partitionKey = populatePartitionMetadata(req.Key, req.Metadata)
+
+			deleteOperation := CosmosItem{
+				ID:           req.Key,
+				Value:        "", // Value does not need to be specified
+				PartitionKey: partitionKey}
+			deletes = append(deletes, deleteOperation)
+		}
+	}
+
+	c.logger.Debugf("#upserts=%d,#deletes=%d, partitionkey=%s", len(upserts), len(deletes), partitionKey)
+
+	options := []documentdb.CallOption{documentdb.PartitionKey(partitionKey)}
+	var retString string
+
+	// The stored procedure throws if it failed, which sets err to non-nil.  It doesn't return anything else.
+	err := c.client.ExecuteStoredProcedure(c.sp.Self, [...]interface{}{upserts, deletes}, &retString, options...)
+	if err != nil {
+		c.logger.Debugf("error=%e", err)
+		return err
+	}
+
+	return nil
+}
+
+// This is a helper to return the partition key to use.  If if metadata["partitionkey"] is present,
+// use that, otherwise use what's in "key".
+func populatePartitionMetadata(key string, requestMetadata map[string]string) string {
+	if val, found := requestMetadata[metadataPartitionKey]; found {
+		return val
+	}
+	return key
 }

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -283,7 +283,6 @@ func (c *StateStore) Multi(operations []state.TransactionalRequest) error {
 				PartitionKey: partitionKey}
 
 			upserts = append(upserts, upsertOperation)
-
 		} else if o.Operation == state.Delete {
 			req := o.Request.(state.DeleteRequest)
 

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -115,7 +115,6 @@ func (c *StateStore) Init(metadata state.Metadata) error {
 	}
 
 	// get a link to the sp
-	//for i := 0; i < len(sps); i++ {
 	for _, proc := range sps {
 		if proc.Id == storedProcedureName {
 			c.sp = &proc

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -115,9 +115,10 @@ func (c *StateStore) Init(metadata state.Metadata) error {
 	}
 
 	// get a link to the sp
-	for i := 0; i < len(sps); i++ {
-		if sps[i].Id == storedProcedureName {
-			c.sp = &sps[i]
+	//for i := 0; i < len(sps); i++ {
+	for _, proc := range sps {
+		if proc.Id == storedProcedureName {
+			c.sp = &proc
 			break
 		}
 	}

--- a/state/azure/cosmosdb/storedprocedure.go
+++ b/state/azure/cosmosdb/storedprocedure.go
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cosmosdb
+
+const spDefinition string = `// upserts - an array of objects to upsert
+// deletes - an array of objects to delete
+
+function sample(upserts, deletes) {
+    var context = getContext();
+    var container = context.getCollection();
+    var response = context.getResponse();
+    
+    if (typeof upserts === "string") {
+        throw new Error("first arg is a string, expected array of objects");
+    }
+
+    if (typeof deletes === "string") {
+        throw new Error("second arg is a string, expected array of objects");
+    }
+
+    // create the query string used to look up deletes
+    var query = "select * from n where n.id = ";
+    if (deletes.length > 0) {
+        query += ("'" + deletes[0].id + "'");
+
+        for (let j = 1; j < deletes.length; j++) {
+            query += (" or n.id = '" + deletes[j].id + "'");
+        }
+    }
+    
+    var upsertCount = 0;
+    var deleteCount = 0;
+      
+    var collectionLink = container.getSelfLink();
+
+    // do the upserts first    
+    if (upserts.length != 0) {
+        tryCreate(upserts[upsertCount], callback);
+    } else {
+        tryQueryAndDelete();
+    }
+
+    function tryCreate(doc, callback) {        
+        var isAccepted = container.upsertDocument(collectionLink, doc, callback);
+        
+        // fail if we hit execution bounds
+        if (!isAccepted) {            
+            // TODO log here for diagnostics, 0 commited
+            throw new Error("upsertDocument() not accepted, please retry");
+        }
+    }
+
+    function callback(err, doc, options) {        
+        if (err) throw err;
+
+        upsertCount++;
+
+        if (upsertCount >= upserts.length) {
+            
+            // upserts are done, start the deletes, if any
+            if (deletes.length > 0) {
+                tryQueryAndDelete()
+            }
+        } else {            
+            tryCreate(upserts[upsertCount], callback);
+        }
+    }
+
+    function tryQueryAndDelete(continuation) {        
+        var requestOptions = { continuation: continuation };
+        
+        var isAccepted = container.queryDocuments(collectionLink, query, requestOptions, function (err, retrievedDocs, responseOptions) {
+            if (err) {
+                throw err;
+            }
+
+            if (retrievedDocs == null) {                
+                response.setBody(JSON.stringify("success"));
+            } else if (retrievedDocs.length > 0) {                
+                tryDelete(retrievedDocs);
+            } else if (responseOptions.continuation) {                
+                tryQueryAndDelete(responseOptions.continuation);
+            } else {                
+                // done with all deletes                
+                response.setBody(JSON.stringify("success"));
+            }
+        });
+
+        // fail if we hit execution bounds
+        if (!isAccepted) {
+            throw new Error("queryDocuments() not accepted, please retry");
+        }
+    }
+
+    function tryDelete(documents) {
+        if (documents.length > 0) {
+            // Delete the first document in the array.
+            var isAccepted = container.deleteDocument(documents[0]._self, {}, function (err, responseOptions) {
+                if (err) throw err;
+
+                deleteCount++;
+                documents.shift();
+                // Delete the next document in the array.
+                tryDelete(documents);
+            });
+
+            // fail if we hit execution bounds
+            if (!isAccepted) {
+                throw new Error("deleteDocument() not accepted, please retry");
+            }
+        } else {
+            // If the document array is empty, query for more documents.
+            tryQueryAndDelete();
+        }
+    }
+}`

--- a/state/azure/cosmosdb/storedprocedure.go
+++ b/state/azure/cosmosdb/storedprocedure.go
@@ -8,7 +8,7 @@ package cosmosdb
 const spDefinition string = `// upserts - an array of objects to upsert
 // deletes - an array of objects to delete
 
-function sample(upserts, deletes) {
+function dapr_multi(upserts, deletes) {
     var context = getContext();
     var container = context.getCollection();
     var response = context.getResponse();
@@ -68,9 +68,8 @@ function sample(upserts, deletes) {
         }
     }
 
-    function tryQueryAndDelete(continuation) {        
-        var requestOptions = { continuation: continuation };
-        
+    function tryQueryAndDelete() {    
+		var requestOptions = {};            
         var isAccepted = container.queryDocuments(collectionLink, query, requestOptions, function (err, retrievedDocs, responseOptions) {
             if (err) {
                 throw err;
@@ -79,9 +78,7 @@ function sample(upserts, deletes) {
             if (retrievedDocs == null) {                
                 response.setBody(JSON.stringify("success"));
             } else if (retrievedDocs.length > 0) {                
-                tryDelete(retrievedDocs);
-            } else if (responseOptions.continuation) {                
-                tryQueryAndDelete(responseOptions.continuation);
+                tryDelete(retrievedDocs);			
             } else {                
                 // done with all deletes                
                 response.setBody(JSON.stringify("success"));

--- a/state/azure/cosmosdb/storedprocedure.go
+++ b/state/azure/cosmosdb/storedprocedure.go
@@ -47,8 +47,7 @@ function sample(upserts, deletes) {
         var isAccepted = container.upsertDocument(collectionLink, doc, callback);
         
         // fail if we hit execution bounds
-        if (!isAccepted) {            
-            // TODO log here for diagnostics, 0 commited
+        if (!isAccepted) {                        
             throw new Error("upsertDocument() not accepted, please retry");
         }
     }

--- a/state/azure/cosmosdb/storedprocedure.go
+++ b/state/azure/cosmosdb/storedprocedure.go
@@ -21,16 +21,18 @@ function dapr_multi(upserts, deletes) {
         throw new Error("second arg is a string, expected array of objects");
     }
 
-    // create the query string used to look up deletes
-    var query = "select * from n where n.id = ";
-    if (deletes.length > 0) {
-        query += ("'" + deletes[0].id + "'");
+    // create the query string used to look up deletes    
+    var query = "select * from n where n.id in ";
+    if (deletes.length > 0) {        
+        query += ("('" + deletes[0].id + "'");
 
-        for (let j = 1; j < deletes.length; j++) {
-            query += (" or n.id = '" + deletes[j].id + "'");
+        for (let j = 1; j < deletes.length; j++) {            
+            query += ", '" + deletes[j].id + "'" 
         }
     }
-    
+
+    query += ')'
+    console.log("query" + query)
     var upsertCount = 0;
     var deleteCount = 0;
       

--- a/state/requests.go
+++ b/state/requests.go
@@ -27,6 +27,16 @@ type DeleteRequest struct {
 	Options  DeleteStateOption `json:"options,omitempty"`
 }
 
+// Key gets the Key on a DeleteRequest
+func (r DeleteRequest) GetKey() string {
+	return r.Key
+}
+
+// Metadata gets the Metadata on a DeleteRequest
+func (r DeleteRequest) GetMetadata() map[string]string {
+	return r.Metadata
+}
+
 // DeleteStateOption controls how a state store reacts to a delete request
 type DeleteStateOption struct {
 	Concurrency string      `json:"concurrency,omitempty"` //"concurrency"
@@ -41,6 +51,16 @@ type SetRequest struct {
 	ETag     string            `json:"etag,omitempty"`
 	Metadata map[string]string `json:"metadata"`
 	Options  SetStateOption    `json:"options,omitempty"`
+}
+
+// Key gets the Key on a SetRequest
+func (r SetRequest) GetKey() string {
+	return r.Key
+}
+
+// Metadata gets the Key on a SetRequest
+func (r SetRequest) GetMetadata() map[string]string {
+	return r.Metadata
 }
 
 //RetryPolicy describes how retries should be handled
@@ -71,4 +91,10 @@ const Delete OperationType = "delete"
 type TransactionalRequest struct {
 	Operation OperationType `json:"operation"`
 	Request   interface{}   `json:"request"`
+}
+
+// KeyInt is an interface that allows gets of the Key and Metadata inside requests
+type KeyInt interface {
+	GetKey() string
+	GetMetadata() map[string]string
 }


### PR DESCRIPTION
# Description

Implement the Multi() interface method adding transaction support in the cosmos db component.  The implementation uses a stored procedure to do this.  The stored procedure is registered in the component's Init().

This is a breaking change because the current implementation uses the "id" field as the partition key and id must be unique. 
 However transactions can only be performed over items with the same partition key.  Therefore this pr requires that the cosmos db container be created with a partition key of `/partitionkey`.  For actors, daprd will use a partition key value of 

```
appid + actortype + actorid
```

to ensure all actor state for the same actor ends up in the same partition.  This doesn't apply to reminders because reminders are not saved under Multi() (also reminder state is saved by actor type and some other info today), so the partition key for that sort of data will simply have the value as the id field.

This document will be updated with the new cosmos setup instructions:
https://github.com/dapr/docs/blob/master/howto/setup-state-store/setup-azure-cosmosdb.md


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #152 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
