### PR TITLE
Cloudevent fix double wrap

### DIFF
--- a/bindings/cron/cron.go
+++ b/bindings/cron/cron.go
@@ -1,0 +1,94 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package twitter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/logger"
+	"github.com/pkg/errors"
+	"github.com/robfig/cron/v3"
+)
+
+// Binding represents Cron input binding
+type Binding struct {
+	logger   logger.Logger
+	schedule string
+	stopCh   chan bool
+	parser   cron.Parser
+}
+
+var _ = bindings.InputBinding(&Binding{})
+
+// NewCron returns a new Cron event input binding
+func NewCron(logger logger.Logger) *Binding {
+	return &Binding{
+		logger: logger,
+		stopCh: make(chan bool),
+		parser: cron.NewParser(
+			cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+		),
+	}
+}
+
+// Init initializes the Cron binding
+// Examples from https://godoc.org/github.com/robfig/cron:
+//   "15 * * * * *" - Every 15 sec
+//   "0 30 * * * *" - Every 30 min
+func (b *Binding) Init(metadata bindings.Metadata) error {
+	s, f := metadata.Properties["schedule"]
+	if !f || s == "" {
+		return fmt.Errorf("schedule not set")
+	}
+	_, err := b.parser.Parse(s)
+	if err != nil {
+		return errors.Wrapf(err, "invalid schedule format: %s", s)
+	}
+	b.schedule = s
+	return nil
+}
+
+// Read triggers the Cron scheduler
+func (b *Binding) Read(handler func(*bindings.ReadResponse) error) error {
+	c := cron.New(cron.WithParser(b.parser))
+	id, err := c.AddFunc(b.schedule, func() {
+		b.logger.Debugf("schedule fired: %v", time.Now())
+		handler(&bindings.ReadResponse{
+			Metadata: map[string]string{
+				"timeZone":    c.Location().String(),
+				"readTimeUTC": time.Now().UTC().String(),
+			},
+		})
+	})
+	if err != nil {
+		return errors.Wrapf(err, "error scheduling %s", b.schedule)
+	}
+	c.Start()
+	b.logger.Debugf("next run: %v", c.Entry(id).Next.Sub(time.Now()))
+	for {
+		select {
+		case stop := <-b.stopCh:
+			if stop {
+				c.Stop()
+				return nil
+			}
+		}
+	}
+}
+
+// Invoke exposes way to stop previously started cron
+func (b *Binding) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	b.logger.Debugf("operation: %v", req.Operation)
+	if req.Operation == bindings.DeleteOperation {
+		b.logger.Debugf("stopping schedule: %s", b.schedule)
+		b.stopCh <- true
+	}
+	return &bindings.InvokeResponse{
+		Metadata: req.Metadata,
+	}, nil
+}

--- a/bindings/cron/cron_test.go
+++ b/bindings/cron/cron_test.go
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package twitter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestMetadata(schedule string) bindings.Metadata {
+	m := bindings.Metadata{}
+	m.Properties = map[string]string{
+		"schedule": schedule,
+	}
+	return m
+}
+
+// go test -v -timeout 15s -count=1 ./bindings/cron/
+func TestInitSuccess(t *testing.T) {
+	c := NewCron(logger.NewLogger("test"))
+	err := c.Init(getTestMetadata("@every 1h"))
+	assert.Nilf(t, err, "error initializing valid schedule")
+}
+
+func TestInitFailure(t *testing.T) {
+	c := NewCron(logger.NewLogger("test"))
+	err := c.Init(getTestMetadata("invalid schedule"))
+	assert.NotNilf(t, err, "no error while initializing invalid schedule")
+}
+
+// TestRead excutes the Read method
+// go test -v -count=1 -timeout 15s -run TestRead ./bindings/cron/
+func TestRead(t *testing.T) {
+	l := logger.NewLogger("test")
+	l.SetOutputLevel(logger.DebugLevel)
+	c := NewCron(l)
+	err := c.Init(getTestMetadata("@every 1s"))
+	assert.Nilf(t, err, "error initializing valid schedule")
+
+	h := func(res *bindings.ReadResponse) error {
+		assert.NotNil(t, res)
+		os.Exit(0)
+		return nil
+	}
+
+	err = c.Read(h)
+	assert.Nilf(t, err, "error on read")
+}

--- a/bindings/twitter/twitter.go
+++ b/bindings/twitter/twitter.go
@@ -8,9 +8,11 @@ package twitter
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
@@ -20,28 +22,22 @@ import (
 	"github.com/dghubble/oauth1"
 )
 
-type twitterInput struct {
-	consumerKey    string
-	consumerSecret string
-	accessToken    string
-	accessSecret   string
-	query          string
-	logger         logger.Logger
+// Binding represents Twitter input/output binding
+type Binding struct {
+	client *twitter.Client
+	query  string
+	logger logger.Logger
 }
 
-var _ = bindings.InputBinding(&twitterInput{})
+var _ = bindings.InputBinding(&Binding{})
 
 // NewTwitter returns a new Twitter event input binding
-func NewTwitter(logger logger.Logger) bindings.InputBinding {
-	return &twitterInput{logger: logger}
+func NewTwitter(logger logger.Logger) *Binding {
+	return &Binding{logger: logger}
 }
 
 // Init initializes the Twitter binding
-func (t *twitterInput) Init(metadata bindings.Metadata) error {
-	return t.parseMetadata(metadata)
-}
-
-func (t *twitterInput) parseMetadata(metadata bindings.Metadata) error {
+func (t *Binding) Init(metadata bindings.Metadata) error {
 	ck, f := metadata.Properties["consumerKey"]
 	if !f || ck == "" {
 		return fmt.Errorf("consumerKey not set")
@@ -58,36 +54,34 @@ func (t *twitterInput) parseMetadata(metadata bindings.Metadata) error {
 	if !f || as == "" {
 		return fmt.Errorf("accessSecret not set")
 	}
+
+	// query set only on input binding
+	// in output binding scenario the query is provided on create
 	q, f := metadata.Properties["query"]
-	if !f || q == "" {
-		return fmt.Errorf("query not set")
+	if !f && q != "" {
+		t.query = q
 	}
 
-	t.consumerKey = ck
-	t.consumerSecret = cs
-	t.accessToken = at
-	t.accessSecret = as
-	t.query = q
+	config := oauth1.NewConfig(ck, cs)
+	token := oauth1.NewToken(at, as)
 
+	httpClient := config.Client(oauth1.NoContext, token)
+	t.client = twitter.NewClient(httpClient)
 	return nil
 }
 
+// Operations returns list of operations supported by twitter binding
+func (t *Binding) Operations() []bindings.OperationKind {
+	return []bindings.OperationKind{bindings.GetOperation}
+}
+
 // Read triggers the Twitter search and events on each result tweet
-func (t *twitterInput) Read(handler func(*bindings.ReadResponse) error) error {
-	config := oauth1.NewConfig(t.consumerKey, t.consumerSecret)
-	token := oauth1.NewToken(t.accessToken, t.accessSecret)
-
-	httpClient := config.Client(oauth1.NoContext, token)
-	client := twitter.NewClient(httpClient)
-
-	limit, _, err := client.RateLimits.Status(nil)
-	if err != nil {
-		return errors.Wrapf(err, "error checking rate status: %v", err)
+func (t *Binding) Read(handler func(*bindings.ReadResponse) error) error {
+	if t.query == "" {
+		return nil
 	}
-	t.logger.Debugf("rate limit: %+v", limit)
 
 	demux := twitter.NewSwitchDemux()
-
 	demux.Tweet = func(tweet *twitter.Tweet) {
 		t.logger.Debugf("raw tweet: %+v", tweet)
 		data, marshalErr := json.Marshal(tweet)
@@ -117,7 +111,7 @@ func (t *twitterInput) Read(handler func(*bindings.ReadResponse) error) error {
 	}
 
 	t.logger.Debug("starting stream for query: %s", t.query)
-	stream, err := client.Streams.Filter(filterParams)
+	stream, err := t.client.Streams.Filter(filterParams)
 	if err != nil {
 		return errors.Wrapf(err, "error executing stream filter: %+v", filterParams)
 	}
@@ -146,4 +140,68 @@ func (t *twitterInput) Read(handler func(*bindings.ReadResponse) error) error {
 		}
 	}
 	return nil
+}
+
+// Invoke handles all operations
+func (t *Binding) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	t.logger.Debugf("operation: %v", req.Operation)
+	if req.Metadata == nil {
+		return nil, fmt.Errorf("metadata not set")
+	}
+	// required
+	q, f := req.Metadata["query"]
+	if !f || q == "" {
+		return nil, fmt.Errorf("query not set")
+	}
+
+	// optionals
+	l, f := req.Metadata["lang"]
+	if !f || l == "" {
+		l = "en"
+	}
+	r, f := req.Metadata["result"]
+	if !f || r == "" {
+		// mixed : Include both popular and real time results in the response
+		// recent : return only the most recent results in the response
+		// popular : return only the most popular results in the response
+		r = "recent"
+	}
+
+	sq := &twitter.SearchTweetParams{
+		Count:           100, // max
+		Lang:            l,
+		Query:           q,
+		ResultType:      r,
+		IncludeEntities: twitter.Bool(true),
+	}
+
+	t.logger.Debug("starting stream for: %+v", sq)
+	search, resp, err := t.client.Search.Tweets(sq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error executing search filter: %+v", sq)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Wrapf(err, "invalid search API response status code: %d", resp.StatusCode)
+	}
+	if search == nil || search.Statuses == nil {
+		return nil, errors.Wrapf(err, "nil search result from: %+v", sq)
+	}
+
+	t.logger.Debugf("raw response: %+v", search.Statuses)
+	data, marshalErr := json.Marshal(search.Statuses)
+	if marshalErr != nil {
+		t.logger.Errorf("error marshaling tweet: %v", marshalErr)
+		return nil, errors.Wrapf(err, "error parsing response from: %+v", sq)
+	}
+
+	req.Metadata["max-tweet-id"] = search.Metadata.MaxIDStr
+	req.Metadata["tweet-count"] = string(search.Metadata.Count)
+	req.Metadata["search-ts"] = time.Now().UTC().String()
+
+	ir := &bindings.InvokeResponse{
+		Data:     data,
+		Metadata: req.Metadata,
+	}
+
+	return ir, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,6 @@ require (
 )
 
 replace (
-	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+incompatible
 	k8s.io/client => github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36
+	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+incompatible
 )

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/nats-io/stan.go v0.6.0
 	github.com/openzipkin/zipkin-go v0.1.6
 	github.com/pkg/errors v0.9.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/satori/go.uuid v1.2.0
 	github.com/sendgrid/rest v2.4.1+incompatible // indirect
@@ -82,6 +83,6 @@ require (
 )
 
 replace (
-	k8s.io/client => github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+incompatible
+	k8s.io/client => github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36
 )

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/Azure/go-autorest/autorest v0.9.2 h1:6AWuh3uWrsZJcNoCHrCF/+g4aKPCU39k
 github.com/Azure/go-autorest/autorest v0.9.2/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3 h1:OZEIaBbMdUE/Js+BQKlpO81XlISgipr6yDJ+PSwsgi4=
 github.com/Azure/go-autorest/autorest v0.9.3/go.mod h1:GsRuLYvwzLjjjRoWEIyMUaYq8GNUx2nRB378IPt/1p0=
-github.com/Azure/go-autorest/autorest v0.10.0 h1:mvdtztBqcL8se7MdrUweNieTNi4kfNG6GOJuurQJpuY=
-github.com/Azure/go-autorest/autorest v0.10.0/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest v0.10.2 h1:NuSF3gXetiHyUbVdneJMEVyPUYAe5wh+aN08JYAf1tI=
 github.com/Azure/go-autorest/autorest v0.10.2/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest/adal v0.5.0 h1:q2gDruN08/guU9vAjuPWff0+QIrpH6ediguzdAzXAUU=
@@ -212,7 +210,6 @@ github.com/dghubble/oauth1 v0.6.0/go.mod h1:8pFdfPkv/jr8mkChVbNVuJ0suiHe278BtWI4
 github.com/dghubble/sling v1.3.0 h1:pZHjCJq4zJvc6qVQ5wN1jo5oNZlNE0+8T/h0XeXBUKU=
 github.com/dghubble/sling v1.3.0/go.mod h1:XXShWaBWKzNLhu2OxikSNFrlsvowtz4kyRuXUG7oQKY=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dgrijalva/jwt-go v1.0.2 h1:KPldsxuKGsS2FPWsNeg9ZO18aCrGKujPoWXn2yo+KQM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -675,6 +672,8 @@ github.com/qiangxue/fasthttp-routing v0.0.0-20160225050629-6ccdc2a18d87/go.mod h
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -930,6 +929,7 @@ golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 h1:gZpLHxUX5BdYLA08Lj4YCJNN/
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -15,7 +15,7 @@ const (
 	// CloudEventsSpecVersion is the specversion used by Dapr for the cloud events implementation
 	CloudEventsSpecVersion = "0.3"
 	//ContentType is the Cloud Events HTTP content type
-	ContentType = "application/cloudevents+json"
+	ContentType = "application/json"
 )
 
 // CloudEventsEnvelope describes the Dapr implementation of the Cloud Events spec
@@ -30,29 +30,55 @@ type CloudEventsEnvelope struct {
 	Subject         string      `json:"subject"`
 }
 
-// NewCloudEventsEnvelope returns a new CloudEventsEnvelope
+// NewCloudEventsEnvelope returns CloudEventsEnvelope from data or a new one when data content was not
+// already an existing CE. Invoked by either the HTTP or gRPC pug handles where:
+//  id = new UUID
+// 	source = handling app ID
+//  eventType = const DefaultCloudEventType from this package ("com.dapr.event.sent")
+//  subject = diagnostics span context W3C as string
 func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) *CloudEventsEnvelope {
-	if eventType == "" {
-		eventType = DefaultCloudEventType
-	}
-	contentType := ""
-
-	var i interface{}
-	err := jsoniter.Unmarshal(data, &i)
+	var ce CloudEventsEnvelope
+	err := jsoniter.Unmarshal(data, &ce)
 	if err != nil {
-		i = string(data)
-		contentType = "text/plain"
-	} else {
-		contentType = "application/json"
+		// data content is not JSON
+		ce = CloudEventsEnvelope{
+			Data:            string(data),
+			DataContentType: "text/plain",
+		}
 	}
 
-	return &CloudEventsEnvelope{
-		ID:              id,
-		Source:          source,
-		Type:            eventType,
-		Data:            i,
-		SpecVersion:     CloudEventsSpecVersion,
-		DataContentType: contentType,
-		Subject:         subject,
+	// populate the values where CloudEvent has none
+	if ce.ID == "" {
+		ce.ID = id
 	}
+
+	if ce.Source == "" {
+		ce.Source = source
+	}
+
+	if ce.Type == "" {
+		if eventType == "" {
+			ce.Type = DefaultCloudEventType
+		} else {
+			ce.Type = eventType
+		}
+	}
+
+	if ce.SpecVersion == "" {
+		ce.SpecVersion = CloudEventsSpecVersion
+	}
+
+	if ce.DataContentType == "" {
+		ce.DataContentType = ContentType
+	}
+
+	if ce.Data == nil {
+		ce.Data = data
+	}
+
+	if ce.Subject == "" {
+		ce.Subject = subject
+	}
+
+	return &ce
 }


### PR DESCRIPTION
Given the findings in [Dapr PR 1741](https://github.com/dapr/dapr/issues/1741) it makes sense to unmarshal the content into actual CloudEventEnvelope vs `interface{}`. 

This A) prevents an existing CloudEvent content from being wrapped into yet another develop, and B) allows for submission of v1.0 CloudEvents 

* [x] Code compiles correctly
* [x] Created/updated tests

