### PR TITLE
Fizes JSON array envelope parsing, adds unit tests

### DIFF
--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -95,7 +95,6 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) 
 		Subject:         subject,
 		Data:            string(data),
 	}
-
 }
 
 func getStrVal(m map[string]interface{}, key string) string {

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -35,17 +35,7 @@ type CloudEventsEnvelope struct {
 
 // NewCloudEventsEnvelope returns CloudEventsEnvelope from data or a new one when data content was not
 func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) *CloudEventsEnvelope {
-	var ce CloudEventsEnvelope
-	err := jsoniter.Unmarshal(data, &ce)
-
-	if err == nil && ce.ID != "" && ce.SpecVersion != "" && ce.Type != "" && ce.Source != "" && ce.DataContentType != "" {
-		// data was already CloudEvent
-		// assuming the likelihood of other structures having all these
-		//CloudEvent-specific fields is very unlikely
-		return &ce
-	}
-
-	// ensure valid input parameters
+	// defaults
 	if id == "" {
 		id = uuid.New().String()
 	}
@@ -55,22 +45,64 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) 
 	if eventType == "" {
 		eventType = DefaultCloudEventType
 	}
+	if subject == "" {
+		subject = DefaultCloudEventSource
+	}
 
-	// create new envelope
-	ce = CloudEventsEnvelope{
+	// check if JSON
+	var j interface{}
+	err := jsoniter.Unmarshal(data, &j)
+	if err != nil {
+		// not JSON, return new envelope
+		return &CloudEventsEnvelope{
+			ID:              id,
+			SpecVersion:     CloudEventsSpecVersion,
+			DataContentType: "text/plain",
+			Source:          source,
+			Type:            eventType,
+			Subject:         subject,
+			Data:            string(data),
+		}
+	}
+
+	// handle CloudEvent
+	m, isMap := j.(map[string]interface{})
+	if isMap {
+		if _, isCE := m["specversion"]; isCE {
+			ce := &CloudEventsEnvelope{
+				ID:              getStrVal(m, "id"),
+				SpecVersion:     getStrVal(m, "specversion"),
+				DataContentType: getStrVal(m, "datacontenttype"),
+				Source:          getStrVal(m, "source"),
+				Type:            getStrVal(m, "type"),
+				Subject:         getStrVal(m, "subject"),
+				Data:            m["data"],
+			}
+			// check if CE is valid
+			if ce.ID != "" && ce.SpecVersion != "" && ce.DataContentType != "" {
+				return ce
+			}
+		}
+	}
+
+	// content was JSON but not a valid CloudEvent, make one
+	return &CloudEventsEnvelope{
 		ID:              id,
 		SpecVersion:     CloudEventsSpecVersion,
 		DataContentType: "application/json",
 		Source:          source,
 		Type:            eventType,
 		Subject:         subject,
+		Data:            string(data),
 	}
 
-	// if content was not JSON, set data and its type to text
-	if err != nil {
-		ce.Data = string(data)
-		ce.DataContentType = "text/plain"
-	}
+}
 
-	return &ce
+func getStrVal(m map[string]interface{}, key string) string {
+	if v, k := m[key]; k {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -6,6 +6,7 @@
 package pubsub
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,44 @@ import (
 func TestCreateCloudEventsEnvelope(t *testing.T) {
 	envelope := NewCloudEventsEnvelope("a", "source", "eventType", "", nil)
 	assert.NotNil(t, envelope)
+}
+
+func TestEnvelopeUsingExistingCloudEvents(t *testing.T) {
+	t.Run("cloud event content", func(t *testing.T) {
+		str := `{
+			"specversion" : "1.0",
+			"type" : "com.github.pull.create",
+			"source" : "https://github.com/cloudevents/spec/pull",
+			"subject" : "123",
+			"id" : "A234-1234-1234",
+			"time" : "2018-04-05T17:31:00Z",
+			"comexampleextension1" : "value",
+			"comexampleothervalue" : 5,
+			"datacontenttype" : "text/xml",
+			"data" : "<much wow=\"xml\"/>"
+		}`
+		envelope := NewCloudEventsEnvelope("a", "", "", "", []byte(str))
+		assert.Equal(t, "A234-1234-1234", envelope.ID)
+		assert.Equal(t, "text/xml", envelope.DataContentType)
+		assert.Equal(t, "1.0", envelope.SpecVersion)
+	})
+}
+
+func TestCreateFromJSON(t *testing.T) {
+	t.Run("has JSON object", func(t *testing.T) {
+		data := `{ "data": ["v1", "v2", "v3"] }`
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte(data))
+		t.Logf("data: %v", envelope.Data)
+		assert.Equal(t, "application/json", envelope.DataContentType)
+		assert.Equal(t, data, envelope.Data.(string))
+	})
+	t.Run("has JSON list", func(t *testing.T) {
+		data := `["v1", "v2", "v3"]`
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte(data))
+		t.Logf("data: %v", envelope.Data)
+		assert.Equal(t, "application/json", envelope.DataContentType)
+		assert.Equal(t, data, envelope.Data.(string))
+	})
 }
 
 func TestCreateCloudEventsEnvelopeDefaults(t *testing.T) {
@@ -32,39 +71,17 @@ func TestCreateCloudEventsEnvelopeDefaults(t *testing.T) {
 		assert.Equal(t, CloudEventsSpecVersion, envelope.SpecVersion)
 	})
 
-	t.Run("has data", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte("data"))
+	t.Run("quoted data", func(t *testing.T) {
+		list := []string{"v1", "v2", "v3"}
+		data := strings.Join(list, ",")
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte(data))
 		t.Logf("data: %v", envelope.Data)
-		assert.Equal(t, "data", envelope.Data.(string))
+		assert.Equal(t, "text/plain", envelope.DataContentType)
+		assert.Equal(t, data, envelope.Data.(string))
 	})
 
 	t.Run("string data content type", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte("data"))
 		assert.Equal(t, "text/plain", envelope.DataContentType)
-	})
-
-	t.Run("json data content type", func(t *testing.T) {
-		str := `{ "data": "1" }`
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte(str))
-		assert.Equal(t, "application/json", envelope.DataContentType)
-	})
-
-	t.Run("cloud event content", func(t *testing.T) {
-		str := `{
-			"specversion" : "1.0",
-			"type" : "com.github.pull.create",
-			"source" : "https://github.com/cloudevents/spec/pull",
-			"subject" : "123",
-			"id" : "A234-1234-1234",
-			"time" : "2018-04-05T17:31:00Z",
-			"comexampleextension1" : "value",
-			"comexampleothervalue" : 5,
-			"datacontenttype" : "text/xml",
-			"data" : "<much wow=\"xml\"/>"
-		}`
-		envelope := NewCloudEventsEnvelope("a", "", "", "", []byte(str))
-		assert.Equal(t, "A234-1234-1234", envelope.ID)
-		assert.Equal(t, "text/xml", envelope.DataContentType)
-		assert.Equal(t, "1.0", envelope.SpecVersion)
 	})
 }


### PR DESCRIPTION
This fixes the issue with string array not being parsed as valid JSON and adds unit tests based on what's tested in end to end tests to catch early