### PR TITLE
Add topic to cloud events envelope

### DIFF
--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -31,10 +31,11 @@ type CloudEventsEnvelope struct {
 	DataContentType string      `json:"datacontenttype"`
 	Data            interface{} `json:"data"`
 	Subject         string      `json:"subject"`
+	Topic           string      `json:"topic"`
 }
 
 // NewCloudEventsEnvelope returns CloudEventsEnvelope from data or a new one when data content was not
-func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) *CloudEventsEnvelope {
+func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string, data []byte) *CloudEventsEnvelope {
 	// defaults
 	if id == "" {
 		id = uuid.New().String()
@@ -61,6 +62,7 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) 
 			Source:          source,
 			Type:            eventType,
 			Subject:         subject,
+			Topic:           topic,
 			Data:            string(data),
 		}
 	}
@@ -76,6 +78,7 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) 
 				Source:          getStrVal(m, "source"),
 				Type:            getStrVal(m, "type"),
 				Subject:         getStrVal(m, "subject"),
+				Topic:           topic,
 				Data:            m["data"],
 			}
 			// check if CE is valid
@@ -93,6 +96,7 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, data []byte) 
 		Source:          source,
 		Type:            eventType,
 		Subject:         subject,
+		Topic:           topic,
 		Data:            j,
 	}
 }

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCreateCloudEventsEnvelope(t *testing.T) {
-	envelope := NewCloudEventsEnvelope("a", "source", "eventType", "", nil)
+	envelope := NewCloudEventsEnvelope("a", "source", "eventType", "", "", nil)
 	assert.NotNil(t, envelope)
 }
 
@@ -32,10 +32,11 @@ func TestEnvelopeUsingExistingCloudEvents(t *testing.T) {
 			"datacontenttype" : "text/xml",
 			"data" : "<much wow=\"xml\"/>"
 		}`
-		envelope := NewCloudEventsEnvelope("a", "", "", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", []byte(str))
 		assert.Equal(t, "A234-1234-1234", envelope.ID)
 		assert.Equal(t, "text/xml", envelope.DataContentType)
 		assert.Equal(t, "1.0", envelope.SpecVersion)
+		assert.Equal(t, "routed.topic", envelope.Topic)
 	})
 }
 
@@ -49,7 +50,7 @@ func TestCreateFromJSON(t *testing.T) {
 			1,
 		}
 		data, _ := json.Marshal(obj1)
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", data)
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", data)
 		t.Logf("data: %v", envelope.Data)
 		assert.Equal(t, "application/json", envelope.DataContentType)
 
@@ -66,31 +67,31 @@ func TestCreateFromJSON(t *testing.T) {
 
 func TestCreateCloudEventsEnvelopeDefaults(t *testing.T) {
 	t.Run("default event type", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", nil)
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", nil)
 		assert.Equal(t, DefaultCloudEventType, envelope.Type)
 	})
 
 	t.Run("non-default event type", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "e1", "", nil)
+		envelope := NewCloudEventsEnvelope("a", "source", "e1", "", "", nil)
 		assert.Equal(t, "e1", envelope.Type)
 	})
 
 	t.Run("spec version", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", nil)
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", nil)
 		assert.Equal(t, CloudEventsSpecVersion, envelope.SpecVersion)
 	})
 
 	t.Run("quoted data", func(t *testing.T) {
 		list := []string{"v1", "v2", "v3"}
 		data := strings.Join(list, ",")
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte(data))
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", []byte(data))
 		t.Logf("data: %v", envelope.Data)
 		assert.Equal(t, "text/plain", envelope.DataContentType)
 		assert.Equal(t, data, envelope.Data.(string))
 	})
 
 	t.Run("string data content type", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", []byte("data"))
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", []byte("data"))
 		assert.Equal(t, "text/plain", envelope.DataContentType)
 	})
 }


### PR DESCRIPTION
# Description
As referenced in https://github.com/dapr/dapr/pull/1803

This change adds the topic to the Cloud Event envelope at publish time.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/1786 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
