### PR TITLE
Add metadata property to TransactionalRequest

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -294,14 +294,14 @@ func (c *StateStore) BulkDelete(req []state.DeleteRequest) error {
 }
 
 // Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail
-func (c *StateStore) Multi(operations []state.TransactionalRequest) error {
+func (c *StateStore) Multi(request *state.TransactionalStateRequest) error {
 	upserts := []CosmosItem{}
 	deletes := []CosmosItem{}
 
 	partitionKey := unknownPartitionKey
 	previousPartitionKey := unknownPartitionKey
 
-	for _, o := range operations {
+	for _, o := range request.Operations {
 		t := o.Request.(state.KeyInt)
 		key := t.GetKey()
 		metadata := t.GetMetadata()

--- a/state/postgresql/postgresql.go
+++ b/state/postgresql/postgresql.go
@@ -64,10 +64,10 @@ func (p *PostgreSQL) BulkSet(req []state.SetRequest) error {
 }
 
 // Multi handles multiple transactions. Implements TransactionalStore.
-func (p *PostgreSQL) Multi(reqs []state.TransactionalRequest) error {
+func (p *PostgreSQL) Multi(request *state.TransactionalStateRequest) error {
 	var deletes []state.DeleteRequest
 	var sets []state.SetRequest
-	for _, req := range reqs {
+	for _, req := range request.Operations {
 		switch req.Operation {
 		case state.Upsert:
 			if setReq, ok := req.Request.(state.SetRequest); ok {

--- a/state/postgresql/postgresql_integration_test.go
+++ b/state/postgresql/postgresql_integration_test.go
@@ -186,7 +186,7 @@ func deleteItemThatDoesNotExist(t *testing.T, pgs *PostgreSQL) {
 }
 
 func multiWithSetOnly(t *testing.T, pgs *PostgreSQL) {
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 	var setRequests []state.SetRequest
 	for i := 0; i < 3; i++ {
 		req := state.SetRequest{
@@ -194,13 +194,15 @@ func multiWithSetOnly(t *testing.T, pgs *PostgreSQL) {
 			Value: randomJSON(),
 		}
 		setRequests = append(setRequests, req)
-		multiRequest = append(multiRequest, state.TransactionalRequest{
+		operations = append(operations, state.TransactionalStateOperation{
 			Operation: state.Upsert,
 			Request:   req,
 		})
 	}
 
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.Nil(t, err)
 
 	for _, set := range setRequests {
@@ -210,7 +212,7 @@ func multiWithSetOnly(t *testing.T, pgs *PostgreSQL) {
 }
 
 func multiWithDeleteOnly(t *testing.T, pgs *PostgreSQL) {
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 	var deleteRequests []state.DeleteRequest
 	for i := 0; i < 3; i++ {
 		req := state.DeleteRequest{Key: randomKey()}
@@ -222,13 +224,15 @@ func multiWithDeleteOnly(t *testing.T, pgs *PostgreSQL) {
 		deleteRequests = append(deleteRequests, req)
 
 		// Add the item to the multi transaction request
-		multiRequest = append(multiRequest, state.TransactionalRequest{
+		operations = append(operations, state.TransactionalStateOperation{
 			Operation: state.Delete,
 			Request:   req,
 		})
 	}
 
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.Nil(t, err)
 
 	for _, delete := range deleteRequests {
@@ -237,7 +241,7 @@ func multiWithDeleteOnly(t *testing.T, pgs *PostgreSQL) {
 }
 
 func multiWithDeleteAndSet(t *testing.T, pgs *PostgreSQL) {
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 	var deleteRequests []state.DeleteRequest
 	for i := 0; i < 3; i++ {
 		req := state.DeleteRequest{Key: randomKey()}
@@ -249,7 +253,7 @@ func multiWithDeleteAndSet(t *testing.T, pgs *PostgreSQL) {
 		deleteRequests = append(deleteRequests, req)
 
 		// Add the item to the multi transaction request
-		multiRequest = append(multiRequest, state.TransactionalRequest{
+		operations = append(operations, state.TransactionalStateOperation{
 			Operation: state.Delete,
 			Request:   req,
 		})
@@ -263,13 +267,15 @@ func multiWithDeleteAndSet(t *testing.T, pgs *PostgreSQL) {
 			Value: randomJSON(),
 		}
 		setRequests = append(setRequests, req)
-		multiRequest = append(multiRequest, state.TransactionalRequest{
+		operations = append(operations, state.TransactionalStateOperation{
 			Operation: state.Upsert,
 			Request:   req,
 		})
 	}
 
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.Nil(t, err)
 
 	for _, delete := range deleteRequests {

--- a/state/postgresql/postgresql_test.go
+++ b/state/postgresql/postgresql_test.go
@@ -60,79 +60,91 @@ func TestInitRunsDBAccessInit(t *testing.T) {
 
 func TestMultiWithNoRequestsReturnsNil(t *testing.T) {
 	t.Parallel()
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 	pgs := createPostgreSQL(t)
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.Nil(t, err)
 }
 
 func TestInvalidMultiAction(t *testing.T) {
 	t.Parallel()
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 
-	multiRequest = append(multiRequest, state.TransactionalRequest{
+	operations = append(operations, state.TransactionalStateOperation{
 		Operation: "Something invalid",
 		Request:   createSetRequest(),
 	})
 
 	pgs := createPostgreSQL(t)
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.NotNil(t, err)
 }
 
 func TestValidSetRequest(t *testing.T) {
 	t.Parallel()
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 
-	multiRequest = append(multiRequest, state.TransactionalRequest{
+	operations = append(operations, state.TransactionalStateOperation{
 		Operation: state.Upsert,
 		Request:   createSetRequest(),
 	})
 
 	pgs := createPostgreSQL(t)
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.Nil(t, err)
 }
 
 func TestInvalidMultiSetRequest(t *testing.T) {
 	t.Parallel()
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 
-	multiRequest = append(multiRequest, state.TransactionalRequest{
+	operations = append(operations, state.TransactionalStateOperation{
 		Operation: state.Upsert,
 		Request:   createDeleteRequest(), // Delete request is not valid for Upsert operation
 	})
 
 	pgs := createPostgreSQL(t)
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.NotNil(t, err)
 }
 
 func TestValidMultiDeleteRequest(t *testing.T) {
 	t.Parallel()
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 
-	multiRequest = append(multiRequest, state.TransactionalRequest{
+	operations = append(operations, state.TransactionalStateOperation{
 		Operation: state.Delete,
 		Request:   createDeleteRequest(),
 	})
 
 	pgs := createPostgreSQL(t)
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.Nil(t, err)
 }
 
 func TestInvalidMultiDeleteRequest(t *testing.T) {
 	t.Parallel()
-	var multiRequest []state.TransactionalRequest
+	var operations []state.TransactionalStateOperation
 
-	multiRequest = append(multiRequest, state.TransactionalRequest{
+	operations = append(operations, state.TransactionalStateOperation{
 		Operation: state.Delete,
 		Request:   createSetRequest(), // Set request is not valid for Delete operation
 	})
 
 	pgs := createPostgreSQL(t)
-	err := pgs.Multi(multiRequest)
+	err := pgs.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
 	assert.NotNil(t, err)
 }
 

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -293,9 +293,9 @@ func (r *StateStore) BulkSet(req []state.SetRequest) error {
 }
 
 // Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail
-func (r *StateStore) Multi(operations []state.TransactionalRequest) error {
+func (r *StateStore) Multi(request *state.TransactionalStateRequest) error {
 	pipe := r.client.TxPipeline()
-	for _, o := range operations {
+	for _, o := range request.Operations {
 		if o.Operation == state.Upsert {
 			req := o.Request.(state.SetRequest)
 			b, _ := r.json.Marshal(req.Value)

--- a/state/requests.go
+++ b/state/requests.go
@@ -46,16 +46,16 @@ type SetRequest struct {
 	Key      string            `json:"key"`
 	Value    interface{}       `json:"value"`
 	ETag     string            `json:"etag,omitempty"`
-	Metadata map[string]string `json:"metadata"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	Options  SetStateOption    `json:"options,omitempty"`
 }
 
-// Key gets the Key on a SetRequest
+// GetKey gets the Key on a SetRequest
 func (r SetRequest) GetKey() string {
 	return r.Key
 }
 
-// Metadata gets the Key on a SetRequest
+// GetMetadata gets the Key on a SetRequest
 func (r SetRequest) GetMetadata() map[string]string {
 	return r.Metadata
 }
@@ -75,9 +75,15 @@ const Upsert OperationType = "upsert"
 // Delete is a delete operation
 const Delete OperationType = "delete"
 
-// TransactionalRequest describes a transactional operation against a state store that comprises multiple types of operations
+// TransactionalStateRequest describes a transactional operation against a state store that comprises multiple types of operations
 // The Request field is either a DeleteRequest or SetRequest
-type TransactionalRequest struct {
+type TransactionalStateRequest struct {
+	Operations []TransactionalStateOperation `json:"operations"`
+	Metadata   map[string]string             `json:"metadata,omitempty"`
+}
+
+// TransactionalStateOperation describes operation type, key, and value for transactional operation.
+type TransactionalStateOperation struct {
 	Operation OperationType `json:"operation"`
 	Request   interface{}   `json:"request"`
 }

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -244,10 +244,10 @@ func (s *SQLServer) Init(metadata state.Metadata) error {
 }
 
 // Multi performs multiple updates on a Sql server store
-func (s *SQLServer) Multi(reqs []state.TransactionalRequest) error {
+func (s *SQLServer) Multi(request *state.TransactionalStateRequest) error {
 	var deletes []state.DeleteRequest
 	var sets []state.SetRequest
-	for _, req := range reqs {
+	for _, req := range request.Operations {
 		switch req.Operation {
 		case state.Upsert:
 			setReq, ok := req.Request.(state.SetRequest)

--- a/state/sqlserver/sqlserver_integration_test.go
+++ b/state/sqlserver/sqlserver_integration_test.go
@@ -371,9 +371,11 @@ func testMultiOperations(t *testing.T) {
 				modified := original.user
 				modified.FavoriteBeverage = beverageTea
 
-				localErr := store.Multi([]state.TransactionalRequest{
-					{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified}},
+				localErr := store.Multi(&state.TransactionalStateRequest{
+					Operations: []state.TransactionalStateOperation{
+						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified}},
+					},
 				})
 				assert.Nil(t, localErr)
 				assertLoadedUserIsEqual(t, store, modified.ID, modified)
@@ -392,10 +394,12 @@ func testMultiOperations(t *testing.T) {
 				modified := toModify.user
 				modified.FavoriteBeverage = beverageTea
 
-				err = store.Multi([]state.TransactionalRequest{
-					{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: toDelete.etag}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: toModify.etag}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: toInsert.ID, Value: toInsert}},
+				err = store.Multi(&state.TransactionalStateRequest{
+					Operations: []state.TransactionalStateOperation{
+						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: toDelete.etag}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: toModify.etag}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: toInsert.ID, Value: toInsert}},
+					},
 				})
 				assert.Nil(t, err)
 				assertLoadedUserIsEqual(t, store, modified.ID, modified)
@@ -414,10 +418,11 @@ func testMultiOperations(t *testing.T) {
 				modified := toModify.user
 				modified.FavoriteBeverage = beverageTea
 
-				err = store.Multi([]state.TransactionalRequest{
-					{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: toDelete.etag}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: toModify.etag}},
-				})
+				err = store.Multi(&state.TransactionalStateRequest{
+					Operations: []state.TransactionalStateOperation{
+						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: toDelete.etag}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: toModify.etag}},
+					}})
 				assert.Nil(t, err)
 				assertLoadedUserIsEqual(t, store, modified.ID, modified)
 				assertUserDoesNotExist(t, store, toDelete.ID)
@@ -432,10 +437,11 @@ func testMultiOperations(t *testing.T) {
 				toDelete := loadedUsers[userIndex]
 				toInsert := user{keyGen.NextKey(), "Wont-be-inserted", "Beer"}
 
-				err = store.Multi([]state.TransactionalRequest{
-					{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: invalidEtag}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: toInsert.ID, Value: toInsert}},
-				})
+				err = store.Multi(&state.TransactionalStateRequest{
+					Operations: []state.TransactionalStateOperation{
+						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: invalidEtag}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: toInsert.ID, Value: toInsert}},
+					}})
 
 				assert.NotNil(t, err)
 				assertUserDoesNotExist(t, store, toInsert.ID)
@@ -450,10 +456,11 @@ func testMultiOperations(t *testing.T) {
 				modified := toModify.user
 				modified.FavoriteBeverage = beverageTea
 
-				err = store.Multi([]state.TransactionalRequest{
-					{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: invalidEtag}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified}},
-				})
+				err = store.Multi(&state.TransactionalStateRequest{
+					Operations: []state.TransactionalStateOperation{
+						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: invalidEtag}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified}},
+					}})
 				assert.NotNil(t, err)
 				assertLoadedUserIsEqual(t, store, toDelete.ID, toDelete.user)
 				assertLoadedUserIsEqual(t, store, toModify.ID, toModify.user)
@@ -467,10 +474,11 @@ func testMultiOperations(t *testing.T) {
 				modified := toModify.user
 				modified.FavoriteBeverage = beverageTea
 
-				err = store.Multi([]state.TransactionalRequest{
-					{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID}},
-					{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: invalidEtag}},
-				})
+				err = store.Multi(&state.TransactionalStateRequest{
+					Operations: []state.TransactionalStateOperation{
+						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID}},
+						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: invalidEtag}},
+					}})
 
 				assert.NotNil(t, err)
 				assertLoadedUserIsEqual(t, store, toDelete.ID, toDelete.user)

--- a/state/transactional_store.go
+++ b/state/transactional_store.go
@@ -8,5 +8,5 @@ package state
 // TransactionalStore is an interface for initialization and support multiple transactional requests
 type TransactionalStore interface {
 	Init(metadata Metadata) error
-	Multi(reqs []TransactionalRequest) error
+	Multi(request *TransactionalStateRequest) error
 }


### PR DESCRIPTION
# Description

Introduce metadata for transactional request. This metadata is used for custom options for transactional operations.

## Issue reference

https://github.com/dapr/dapr/issues/1736

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
