### PR TITLE
Fix consumer exclusivity

### DIFF
--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -10,7 +10,6 @@ import (
 type metadata struct {
 	consumerID       string
 	host             string
-	durable          bool
 	deleteWhenUnused bool
 	autoAck          bool
 	requeueInFailure bool
@@ -39,12 +38,6 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 				return &result, fmt.Errorf("%s invalid RabbitMQ delivery mode, accepted values are between 0 and 2", errorMessagePrefix)
 			}
 			result.deliveryMode = uint8(intVal)
-		}
-	}
-
-	if val, found := pubSubMetadata.Properties[metadataDurableKey]; found && val != "" {
-		if boolVal, err := strconv.ParseBool(val); err == nil {
-			result.durable = boolVal
 		}
 	}
 

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -41,7 +41,6 @@ func TestCreateMetadata(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, fakeProperties[metadataHostKey], m.host)
 		assert.Equal(t, fakeProperties[metadataConsumerIDKey], m.consumerID)
-		assert.Equal(t, false, m.durable)
 		assert.Equal(t, false, m.autoAck)
 		assert.Equal(t, false, m.requeueInFailure)
 		assert.Equal(t, true, m.deleteWhenUnused)
@@ -190,7 +189,6 @@ func TestCreateMetadata(t *testing.T) {
 			fakeMetaData := pubsub.Metadata{
 				Properties: fakeProperties,
 			}
-			fakeMetaData.Properties[metadataDurableKey] = tt.in
 
 			// act
 			m, err := createMetadata(fakeMetaData)
@@ -199,7 +197,6 @@ func TestCreateMetadata(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, fakeProperties[metadataHostKey], m.host)
 			assert.Equal(t, fakeProperties[metadataConsumerIDKey], m.consumerID)
-			assert.Equal(t, tt.expected, m.durable)
 		})
 	}
 }

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -15,7 +15,6 @@ const (
 
 	metadataHostKey             = "host"
 	metadataConsumerIDKey       = "consumerID"
-	metadataDurableKey          = "durable"
 	metadataDeleteWhenUnusedKey = "deletedWhenUnused"
 	metadataAutoAckKey          = "autoAck"
 	metadataDeliveryModeKey     = "deliveryMode"
@@ -91,7 +90,7 @@ func (r *rabbitMQ) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubs
 	queueName := fmt.Sprintf("%s-%s", r.metadata.consumerID, req.Topic)
 
 	r.logger.Debugf("%s declaring queue '%s'", logMessagePrefix, queueName)
-	q, err := r.channel.QueueDeclare(queueName, r.metadata.durable, r.metadata.deleteWhenUnused, true, false, nil)
+	q, err := r.channel.QueueDeclare(queueName, true, r.metadata.deleteWhenUnused, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -104,11 +103,11 @@ func (r *rabbitMQ) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubs
 
 	msgs, err := r.channel.Consume(
 		q.Name,
-		queueName,           // consumerId
-		r.metadata.autoAck,  // autoAck
-		!r.metadata.durable, // exclusive
-		false,               // noLocal
-		false,               // noWait
+		queueName,          // consumerId
+		r.metadata.autoAck, // autoAck
+		false,
+		false, // noLocal
+		false, // noWait
 		nil,
 	)
 


### PR DESCRIPTION
This PR does the following:

1. Adhere to Dapr's pub/sub consumer group guarantees for allowing a scale out of multiple consumers within a group, by setting exclusive to `false`.

2. The implementation confused durability with exclusivity. This PR enables durability by default for Dapr's at-least-once delivery guarantees.