### PR TITLE
refactors local secret, adds env var imp dapr issue #1961

### DIFF
--- a/secretstores/local/env/envstore.go
+++ b/secretstores/local/env/envstore.go
@@ -32,7 +32,7 @@ func (s *envSecretStore) Init(metadata secretstores.Metadata) error {
 func (s *envSecretStore) GetSecret(req secretstores.GetSecretRequest) (secretstores.GetSecretResponse, error) {
 	return secretstores.GetSecretResponse{
 		Data: map[string]string{
-			req.Name: os.Getenv("req.Name"),
+			req.Name: os.Getenv(req.Name),
 		},
 	}, nil
 }

--- a/secretstores/local/env/envstore.go
+++ b/secretstores/local/env/envstore.go
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package env
+
+import (
+	"os"
+
+	"github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/dapr/pkg/logger"
+)
+
+type envSecretStore struct {
+	logger logger.Logger
+}
+
+// NewEnvSecretStore returns a new env var secret store
+func NewEnvSecretStore(logger logger.Logger) secretstores.SecretStore {
+	return &envSecretStore{
+		logger: logger,
+	}
+}
+
+// Init creates a Local secret store
+func (s *envSecretStore) Init(metadata secretstores.Metadata) error {
+	return nil
+}
+
+// GetSecret retrieves a secret from env var using provided key
+func (s *envSecretStore) GetSecret(req secretstores.GetSecretRequest) (secretstores.GetSecretResponse, error) {
+	return secretstores.GetSecretResponse{
+		Data: map[string]string{
+			req.Name: os.Getenv("req.Name"),
+		},
+	}, nil
+}

--- a/secretstores/local/env/envstore_test.go
+++ b/secretstores/local/env/envstore_test.go
@@ -1,0 +1,40 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package env
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/dapr/pkg/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+const secretValue = "secret"
+
+func TestInit(t *testing.T) {
+	secret := "secret1"
+	key := "TEST_SECRET"
+
+	s := envSecretStore{logger: logger.NewLogger("test")}
+
+	os.Setenv(key, secret)
+	assert.Equal(t, secret, os.Getenv(key))
+
+	t.Run("Test init", func(t *testing.T) {
+		err := s.Init(secretstores.Metadata{})
+		assert.Nil(t, err)
+	})
+
+	t.Run("Test set and get", func(t *testing.T) {
+		err := s.Init(secretstores.Metadata{})
+		assert.Nil(t, err)
+		resp, err := s.GetSecret(secretstores.GetSecretRequest{Name: key})
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, secret, resp.Data[key])
+	})
+}

--- a/secretstores/local/env/envstore_test.go
+++ b/secretstores/local/env/envstore_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const secretValue = "secret"
-
 func TestInit(t *testing.T) {
 	secret := "secret1"
 	key := "TEST_SECRET"

--- a/secretstores/local/file/filestore.go
+++ b/secretstores/local/file/filestore.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package localsecretstore
+package file
 
 import (
 	"encoding/json"

--- a/secretstores/local/file/filestore_test.go
+++ b/secretstores/local/file/filestore_test.go
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------------------------------
-package localsecretstore
+package file
 
 import (
 	"fmt"


### PR DESCRIPTION
# Description

Refactors local secrets (used for development) into `local.file` and adds `local.env` implementation. 

## Issue reference

[dapr issue #1961](https://github.com/dapr/dapr/issues/1961)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Created docs issue in the https://github.com/dapr/docs/pull/766
