### PR TITLE
Properly handle serialization deserizliation for redis transaction api.

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -306,6 +306,7 @@ func (c *StateStore) Multi(request *state.TransactionalStateRequest) error {
 		if o.Operation == state.Upsert {
 			req := o.Request.(state.SetRequest)
 
+			// Value need not be marshaled here. It is handled by cosmosdb client.
 			upsertOperation := CosmosItem{
 				ID:           req.Key,
 				Value:        req.Value,

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
 	jsoniter "github.com/json-iterator/go"
 )
@@ -94,12 +95,7 @@ func getMemcachedMetadata(metadata state.Metadata) (*memcachedMetadata, error) {
 
 func (m *Memcached) setValue(req *state.SetRequest) error {
 	var bt []byte
-	b, ok := req.Value.([]byte)
-	if ok {
-		bt = b
-	} else {
-		bt, _ = m.json.Marshal(req.Value)
-	}
+	bt, _ = utils.Marshal(req.Value, m.json.Marshal)
 	err := m.client.Set(&memcache.Item{Key: req.Key, Value: bt})
 
 	if err != nil {

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -93,14 +93,15 @@ func (p *postgresDBAccess) setValue(req *state.SetRequest) error {
 		return fmt.Errorf("missing key in set operation")
 	}
 
-	var valueBytes []byte
-
 	// Convert to json string
-	valueBytes, err = json.Marshal(req.Value)
-	if err != nil {
-		return err
+	var bt []byte
+	b, ok := req.Value.([]byte)
+	if ok {
+		bt = b
+	} else {
+		bt, _ = json.Marshal(req.Value)
 	}
-	value := string(valueBytes)
+	value := string(bt)
 
 	var result sql.Result
 

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
 
 	// Blank import for the underlying PostgreSQL driver
@@ -94,13 +95,7 @@ func (p *postgresDBAccess) setValue(req *state.SetRequest) error {
 	}
 
 	// Convert to json string
-	var bt []byte
-	b, ok := req.Value.([]byte)
-	if ok {
-		bt = b
-	} else {
-		bt, _ = json.Marshal(req.Value)
-	}
+	bt, _ := utils.Marshal(req.Value, json.Marshal)
 	value := string(bt)
 
 	var result sql.Result

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -298,8 +298,16 @@ func (r *StateStore) Multi(request *state.TransactionalStateRequest) error {
 	for _, o := range request.Operations {
 		if o.Operation == state.Upsert {
 			req := o.Request.(state.SetRequest)
-			b, _ := r.json.Marshal(req.Value)
-			pipe.Set(req.Key, b, defaultExpirationTime)
+
+			var bt []byte
+			b, ok := req.Value.([]byte)
+			if ok {
+				bt = b
+			} else {
+				bt, _ = r.json.Marshal(req.Value)
+			}
+
+			pipe.Set(req.Key, bt, defaultExpirationTime)
 		} else if o.Operation == state.Delete {
 			req := o.Request.(state.DeleteRequest)
 			pipe.Del(req.Key)

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
 
 	jsoniter "github.com/json-iterator/go"
@@ -252,13 +253,7 @@ func (r *StateStore) setValue(req *state.SetRequest) error {
 		ver = 0
 	}
 
-	var bt []byte
-	b, ok := req.Value.([]byte)
-	if ok {
-		bt = b
-	} else {
-		bt, _ = r.json.Marshal(req.Value)
-	}
+	bt, _ := utils.Marshal(req.Value, r.json.Marshal)
 
 	_, err = r.client.DoContext(context.Background(), "EVAL", setQuery, 1, req.Key, ver, bt).Result()
 	if err != nil {
@@ -299,13 +294,7 @@ func (r *StateStore) Multi(request *state.TransactionalStateRequest) error {
 		if o.Operation == state.Upsert {
 			req := o.Request.(state.SetRequest)
 
-			var bt []byte
-			b, ok := req.Value.([]byte)
-			if ok {
-				bt = b
-			} else {
-				bt, _ = r.json.Marshal(req.Value)
-			}
+			bt, _ := utils.Marshal(req.Value, r.json.Marshal)
 
 			pipe.Set(req.Key, bt, defaultExpirationTime)
 		} else if o.Operation == state.Delete {

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
 	mssql "github.com/denisenkom/go-mssqldb"
 )
@@ -452,16 +453,10 @@ type dbExecutor interface {
 func (s *SQLServer) executeSet(db dbExecutor, req *state.SetRequest) error {
 	var err error
 	var bytes []byte
-	b, ok := req.Value.([]byte)
-	if ok {
-		bytes = b
-	} else {
-		bytes, err = json.Marshal(req.Value)
-		if err != nil {
-			return err
-		}
+	bytes, err = utils.Marshal(req.Value, json.Marshal)
+	if err != nil {
+		return err
 	}
-
 	etag := sql.Named(rowVersionColumnName, nil)
 	if req.ETag != "" {
 		var b []byte

--- a/state/utils/utils.go
+++ b/state/utils/utils.go
@@ -1,0 +1,12 @@
+package utils
+
+func Marshal(val interface{}, marshaler func(interface{}) ([]byte, error)) ([]byte, error) {
+	var err error
+	bt, ok := val.([]byte)
+	err = nil
+	if !ok {
+		bt, err = marshaler(val)
+	}
+
+	return bt, err
+}

--- a/state/utils/utils.go
+++ b/state/utils/utils.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package utils
 
 func Marshal(val interface{}, marshaler func(interface{}) ([]byte, error)) ([]byte, error) {

--- a/state/utils/utils.go
+++ b/state/utils/utils.go
@@ -6,9 +6,8 @@
 package utils
 
 func Marshal(val interface{}, marshaler func(interface{}) ([]byte, error)) ([]byte, error) {
-	var err error
+	var err error = nil
 	bt, ok := val.([]byte)
-	err = nil
 	if !ok {
 		bt, err = marshaler(val)
 	}


### PR DESCRIPTION
# Description

Found an issue for Transaction API via Java Integration Tests. 

When the state is stored via an **upsert** call made and the got back via the normal getState API call, it can be observed that there is an extra Json Marshal happening in the code. 

Example:
```json
data: "\"{\\\"propertyA\\\":\\\"data in property A\\\",\\\"propertyB\\\":\\\"data in property B\\\"}\""
```
Instead of 
```json
data: "{\"propertyA\":\"data in property A\",\"propertyB\":\"data in property B\"}"
````
The second output is what we have when we have a normal save and get state call done via Dapr. 

The code change here, checks if the incoming request value is a byte array or not and then properly serializes the value. 
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
