### PR TITLE
Fix Dapr home bin directory in dev doc

### DIFF
--- a/docs/developing-component.md
+++ b/docs/developing-component.md
@@ -68,7 +68,7 @@ make DEBUG=1 build
 ```bash
 # Back up the current daprd
 mv /usr/local/bin/daprd /usr/local/bin/daprd.bak
-cp ./dist/darwin_amd64/debug/daprd /usr/local/bin
+cp ./dist/darwin_amd64/debug/daprd ~/.dapr/bin
 ```
 > Linux Debuggable Binary: ./dist/linux_amd64/debug/daprd
 > Windows Debuggable Binary: .\dist\windows_amd64\debug\daprd


### PR DESCRIPTION
# Description

Fix Dapr home bin directory in dev doc

## Issue reference

n/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
