### PR TITLE
Add metadata to pubsub message

### DIFF
--- a/pubsub/requests.go
+++ b/pubsub/requests.go
@@ -19,6 +19,7 @@ type SubscribeRequest struct {
 
 // NewMessage is an event arriving from a message bus instance
 type NewMessage struct {
-	Data  []byte `json:"data"`
-	Topic string `json:"topic"`
+	Data     []byte            `json:"data"`
+	Topic    string            `json:"topic"`
+	Metadata map[string]string `json:"metadata"`
 }


### PR DESCRIPTION
This adds optional metadata for both pub/sub implementations to be able to send additional data and for consumers to pass in additional context.