### PR TITLE
Fixing bug where trx del in redis fails without etag.

### DIFF
--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -343,6 +343,9 @@ func (r *StateStore) Multi(request *state.TransactionalStateRequest) error {
 			pipe.Do("EVAL", setQuery, 1, req.Key, ver, bt)
 		} else if o.Operation == state.Delete {
 			req := o.Request.(state.DeleteRequest)
+			if req.ETag == "" {
+				req.ETag = "0"
+			}
 			pipe.Do("EVAL", delQuery, 1, req.Key, req.ETag)
 		}
 	}


### PR DESCRIPTION
# Description

Fixing redis delete without etag on trx.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/2126

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
