### PR TITLE
Upgrade golang lint to 1.31

### DIFF
--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -25,7 +25,7 @@ jobs:
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
-      GOLANGCI_LINT_VER: v1.26.0
+      GOLANGCI_LINT_VER: v1.31
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -49,13 +49,11 @@ jobs:
           go-version: ${{ env.GOVER }}
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: Install golangci-lint ${{ env.GOLANGCI_LINT_VER }}
-        if: matrix.target_arch != 'arm'
-        run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${{ env.GOROOT }}/bin" "${{ env.GOLANGCI_LINT_VER }}"
-      - name: Run make lint
-        if: matrix.target_arch != 'arm' && matrix.target_os != 'windows'
-        run: make lint
+      - name: Run golangci-lint
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        uses: golangci/golangci-lint-action@v2.2.1
+        with:
+          version: ${{ env.GOLANGCI_LINT_VER }}
       - name: Run make go.mod check-diff
         if: matrix.target_arch != 'arm'
         run: make go.mod check-diff

--- a/authentication/aws/aws.go
+++ b/authentication/aws/aws.go
@@ -24,5 +24,6 @@ func GetClient(accessKey string, secretKey string, region string, endpoint strin
 	if err != nil {
 		return nil, err
 	}
+
 	return awsSession, nil
 }

--- a/authentication/kubernetes/client.go
+++ b/authentication/kubernetes/client.go
@@ -9,11 +9,10 @@ import (
 	"flag"
 	"path/filepath"
 
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/homedir"
-
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 // nolint:gochecknoglobals
@@ -42,5 +41,6 @@ func GetKubeClient() (*kubernetes.Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return clientset, nil
 }

--- a/bindings/alicloud/oss/oss.go
+++ b/bindings/alicloud/oss/oss.go
@@ -9,11 +9,10 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/google/uuid"
-
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 )
 
 // AliCloudOSS is a binding for an AliCloud OSS storage bucket
@@ -47,6 +46,7 @@ func (s *AliCloudOSS) Init(metadata bindings.Metadata) error {
 	}
 	s.metadata = m
 	s.client = client
+
 	return nil
 }
 
@@ -63,9 +63,7 @@ func (s *AliCloudOSS) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespo
 		s.logger.Debugf("key not found. generating key %s", key)
 	}
 
-	//r := bytes.NewReader(req.Data)
 	bucket, err := s.client.Bucket(s.metadata.Bucket)
-
 	if err != nil {
 		return nil, err
 	}
@@ -90,12 +88,12 @@ func (s *AliCloudOSS) parseMetadata(metadata bindings.Metadata) (*ossMetadata, e
 	if err != nil {
 		return nil, err
 	}
+
 	return &m, nil
 }
 
 func (s *AliCloudOSS) getClient(metadata *ossMetadata) (*oss.Client, error) {
 	client, err := oss.New(metadata.Endpoint, metadata.AccessKeyID, metadata.AccessKey)
-
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/apns/apns.go
+++ b/bindings/apns/apns.go
@@ -177,6 +177,7 @@ func (a *APNS) makeURLPrefix(metadata bindings.Metadata) error {
 func (a *APNS) extractKeyID(metadata bindings.Metadata) error {
 	if value, ok := metadata.Properties[keyIDKey]; ok && value != "" {
 		a.authorizationBuilder.keyID = value
+
 		return nil
 	}
 
@@ -186,6 +187,7 @@ func (a *APNS) extractKeyID(metadata bindings.Metadata) error {
 func (a *APNS) extractTeamID(metadata bindings.Metadata) error {
 	if value, ok := metadata.Properties[teamIDKey]; ok && value != "" {
 		a.authorizationBuilder.teamID = value
+
 		return nil
 	}
 

--- a/bindings/apns/apns_test.go
+++ b/bindings/apns/apns_test.go
@@ -212,6 +212,7 @@ func TestInvoke(t *testing.T) {
 		testBinding := makeTestBinding(t, testLogger)
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Authorization")
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -222,6 +223,7 @@ func TestInvoke(t *testing.T) {
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Apns-Push-Type")
 			assert.Equal(t, "alert", req.Header.Get(pushTypeKey))
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -232,6 +234,7 @@ func TestInvoke(t *testing.T) {
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Apns-Id")
 			assert.Equal(t, "123", req.Header.Get(messageIDKey))
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -242,6 +245,7 @@ func TestInvoke(t *testing.T) {
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Apns-Expiration")
 			assert.Equal(t, "1234567890", req.Header.Get(expirationKey))
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -252,6 +256,7 @@ func TestInvoke(t *testing.T) {
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Apns-Priority")
 			assert.Equal(t, "10", req.Header.Get(priorityKey))
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -262,6 +267,7 @@ func TestInvoke(t *testing.T) {
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Apns-Topic")
 			assert.Equal(t, "test", req.Header.Get(topicKey))
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -272,6 +278,7 @@ func TestInvoke(t *testing.T) {
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			assert.Contains(t, req.Header, "Apns-Collapse-Id")
 			assert.Equal(t, "1234567", req.Header.Get(collapseIDKey))
+
 			return successResponse()
 		})
 		_, _ = testBinding.Invoke(successRequest)
@@ -296,6 +303,7 @@ func TestInvoke(t *testing.T) {
 		testBinding := makeTestBinding(t, testLogger)
 		testBinding.client = newTestClient(func(req *http.Request) *http.Response {
 			body := "{\"reason\":\"BadDeviceToken\"}"
+
 			return &http.Response{
 				StatusCode: http.StatusBadRequest,
 				Body:       ioutil.NopCloser(strings.NewReader(body)),
@@ -328,6 +336,7 @@ func successResponse() *http.Response {
 		Header:     http.Header{},
 	}
 	response.Header.Add(messageIDKey, "12345")
+
 	return response
 }
 

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -8,17 +8,15 @@ package dynamodb
 import (
 	"encoding/json"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
-	"github.com/dapr/dapr/pkg/logger"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
-//DynamoDB allows performing stateful operations on AWS DynamoDB
+// DynamoDB allows performing stateful operations on AWS DynamoDB
 type DynamoDB struct {
 	client *dynamodb.DynamoDB
 	table  string
@@ -52,6 +50,7 @@ func (d *DynamoDB) Init(metadata bindings.Metadata) error {
 
 	d.client = client
 	d.table = meta.Table
+
 	return nil
 }
 
@@ -95,6 +94,7 @@ func (d *DynamoDB) getDynamoDBMetadata(spec bindings.Metadata) (*dynamoDBMetadat
 	if err != nil {
 		return nil, err
 	}
+
 	return &meta, nil
 }
 
@@ -105,5 +105,6 @@ func (d *DynamoDB) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, er
 	}
 
 	c := dynamodb.New(sess)
+
 	return c, nil
 }

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -15,12 +15,11 @@ import (
 	"syscall"
 	"time"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/google/uuid"
@@ -55,10 +54,10 @@ type kinesisMetadata struct {
 type kinesisConsumerMode string
 
 const (
-	//ExtendedFanout - dedicated throughput through data stream api
+	// ExtendedFanout - dedicated throughput through data stream api
 	ExtendedFanout kinesisConsumerMode = "extended"
 
-	//SharedThroughput - shared throughput using checkpoint and monitoring
+	// SharedThroughput - shared throughput using checkpoint and monitoring
 	SharedThroughput kinesisConsumerMode = "shared"
 
 	partitionKeyName = "partitionKey"
@@ -104,7 +103,6 @@ func (a *AWSKinesis) Init(metadata bindings.Metadata) error {
 	stream, err := client.DescribeStream(&kinesis.DescribeStreamInput{
 		StreamName: streamName,
 	})
-
 	if err != nil {
 		return err
 	}
@@ -119,6 +117,7 @@ func (a *AWSKinesis) Init(metadata bindings.Metadata) error {
 	a.streamARN = stream.StreamDescription.StreamARN
 	a.metadata = m
 	a.client = client
+
 	return nil
 }
 
@@ -136,6 +135,7 @@ func (a *AWSKinesis) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespon
 		Data:         req.Data,
 		PartitionKey: &partitionKey,
 	})
+
 	return nil, err
 }
 
@@ -173,6 +173,7 @@ func (a *AWSKinesis) Subscribe(ctx context.Context, streamDesc kinesis.StreamDes
 	consumerARN, err := a.ensureConsumer(streamDesc.StreamARN)
 	if err != nil {
 		a.logger.Error(err)
+
 		return err
 	}
 
@@ -189,9 +190,9 @@ func (a *AWSKinesis) Subscribe(ctx context.Context, streamDesc kinesis.StreamDes
 					ShardId:          s.ShardId,
 					StartingPosition: &kinesis.StartingPosition{Type: aws.String(kinesis.ShardIteratorTypeLatest)},
 				})
-
 				if err != nil {
 					a.logger.Error(err)
+
 					return err
 				}
 
@@ -219,9 +220,9 @@ func (a *AWSKinesis) ensureConsumer(streamARN *string) (*string, error) {
 		ConsumerName: &a.metadata.ConsumerName,
 		StreamARN:    streamARN,
 	})
-
 	if err != nil {
 		arn, err := a.registerConsumer(streamARN)
+
 		return arn, err
 	}
 
@@ -233,7 +234,6 @@ func (a *AWSKinesis) registerConsumer(streamARN *string) (*string, error) {
 		ConsumerName: &a.metadata.ConsumerName,
 		StreamARN:    streamARN,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -257,6 +257,7 @@ func (a *AWSKinesis) deregisterConsumer(streamARN *string, consumerARN *string) 
 			StreamARN:    streamARN,
 			ConsumerName: &a.metadata.ConsumerName,
 		})
+
 		return err
 	}
 
@@ -284,6 +285,7 @@ func (a *AWSKinesis) waitUntilConsumerExists(ctx aws.Context, input *kinesis.Des
 			req, _ := a.client.DescribeStreamConsumerRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
+
 			return req, nil
 		},
 	}
@@ -299,6 +301,7 @@ func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, err
 	}
 
 	k := kinesis.New(sess)
+
 	return k, nil
 }
 
@@ -313,6 +316,7 @@ func (a *AWSKinesis) parseMetadata(metadata bindings.Metadata) (*kinesisMetadata
 	if err != nil {
 		return nil, err
 	}
+
 	return &m, nil
 }
 

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -9,14 +9,12 @@ import (
 	"bytes"
 	"encoding/json"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/google/uuid"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
+	"github.com/google/uuid"
 )
 
 // AWSS3 is a binding for an AWS S3 storage bucket
@@ -51,6 +49,7 @@ func (s *AWSS3) Init(metadata bindings.Metadata) error {
 	}
 	s.metadata = m
 	s.uploader = uploader
+
 	return nil
 }
 
@@ -73,6 +72,7 @@ func (s *AWSS3) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, e
 		Key:    aws.String(key),
 		Body:   r,
 	})
+
 	return nil, err
 }
 
@@ -87,6 +87,7 @@ func (s *AWSS3) parseMetadata(metadata bindings.Metadata) (*s3Metadata, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &m, nil
 }
 
@@ -97,5 +98,6 @@ func (s *AWSS3) getClient(metadata *s3Metadata) (*s3manager.Uploader, error) {
 	}
 
 	uploader := s3manager.NewUploader(sess)
+
 	return uploader, nil
 }

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -9,12 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
-	"github.com/dapr/dapr/pkg/logger"
-
 	"github.com/aws/aws-sdk-go/service/sns"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 // AWSSNS is an AWS SNS binding
@@ -55,6 +53,7 @@ func (a *AWSSNS) Init(metadata bindings.Metadata) error {
 	}
 	a.client = client
 	a.topicARN = m.TopicArn
+
 	return nil
 }
 
@@ -69,6 +68,7 @@ func (a *AWSSNS) parseMetadata(metadata bindings.Metadata) (*snsMetadata, error)
 	if err != nil {
 		return nil, err
 	}
+
 	return &m, nil
 }
 
@@ -78,6 +78,7 @@ func (a *AWSSNS) getClient(metadata *snsMetadata) (*sns.SNS, error) {
 		return nil, err
 	}
 	c := sns.New(sess)
+
 	return c, nil
 }
 
@@ -105,5 +106,6 @@ func (a *AWSSNS) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, 
 	if err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -59,6 +59,7 @@ func (a *AWSSQS) Init(metadata bindings.Metadata) error {
 
 	a.QueueURL = resultURL.QueueUrl
 	a.Client = client
+
 	return nil
 }
 
@@ -72,6 +73,7 @@ func (a *AWSSQS) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, 
 		MessageBody: &msgBody,
 		QueueUrl:    a.QueueURL,
 	})
+
 	return nil, err
 }
 
@@ -125,6 +127,7 @@ func (a *AWSSQS) parseSQSMetadata(metadata bindings.Metadata) (*sqsMetadata, err
 	if err != nil {
 		return nil, err
 	}
+
 	return &m, nil
 }
 

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -14,11 +14,10 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/dapr/dapr/pkg/logger"
-	"github.com/google/uuid"
-
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/logger"
+	"github.com/google/uuid"
 )
 
 const (
@@ -80,6 +79,7 @@ func (a *AzureBlobStorage) Init(metadata bindings.Metadata) error {
 	// Don't return error, container might already exist
 	a.logger.Debugf("error creating container: %s", err)
 	a.containerURL = containerURL
+
 	return nil
 }
 
@@ -99,6 +99,7 @@ func (a *AzureBlobStorage) parseMetadata(metadata bindings.Metadata) (*blobStora
 	if m.GetBlobRetryCount == 0 {
 		m.GetBlobRetryCount = defaultGetBlobRetryCount
 	}
+
 	return &m, nil
 }
 
@@ -190,6 +191,7 @@ func (a *AzureBlobStorage) get(blobURL azblob.BlockBlobURL, req *bindings.Invoke
 	if err != nil {
 		return nil, fmt.Errorf("error reading az blob body: %s", err)
 	}
+
 	return &bindings.InvokeResponse{
 		Data: b.Bytes(),
 	}, nil
@@ -210,6 +212,8 @@ func (a *AzureBlobStorage) Invoke(req *bindings.InvokeRequest) (*bindings.Invoke
 		return a.create(blobURL, req)
 	case bindings.GetOperation:
 		return a.get(blobURL, req)
+	case bindings.DeleteOperation, bindings.ListOperation:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("unsupported operation %s", req.Operation)
 	}

--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -79,6 +79,7 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 
 	c.collection = &colls[0]
 	c.client = client
+
 	return nil
 }
 
@@ -94,6 +95,7 @@ func (c *CosmosDB) parseMetadata(metadata bindings.Metadata) (*cosmosDBCredentia
 	if err != nil {
 		return nil, err
 	}
+
 	return &creds, nil
 }
 

--- a/bindings/azure/cosmosdb/cosmosdb_test.go
+++ b/bindings/azure/cosmosdb/cosmosdb_test.go
@@ -58,7 +58,7 @@ func TestPartitionKeyValue(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "earth", val)
 
-	//Invalid nested partition key
+	// Invalid nested partition key
 	_, err = cosmosDB.getPartitionKeyValue("address.notexists", obj)
 	assert.NotNil(t, err)
 

--- a/bindings/azure/eventgrid/eventgrid.go
+++ b/bindings/azure/eventgrid/eventgrid.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventgrid/mgmt/2020-04-01-preview/eventgrid"
@@ -115,6 +114,7 @@ func (a *AzureEventGrid) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRe
 	err := a.ensureOutputBindingMetadata()
 	if err != nil {
 		a.logger.Error(err.Error())
+
 		return nil, err
 	}
 
@@ -133,12 +133,14 @@ func (a *AzureEventGrid) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRe
 	err = client.Do(request, response)
 	if err != nil {
 		a.logger.Error(err.Error())
+
 		return nil, err
 	}
 
 	if response.StatusCode() != fasthttp.StatusOK {
 		body := response.Body()
 		a.logger.Error(string(body))
+
 		return nil, errors.New(string(body))
 	}
 
@@ -174,10 +176,12 @@ func (a *AzureEventGrid) ensureInputBindingMetadata() error {
 func (a *AzureEventGrid) ensureOutputBindingMetadata() error {
 	if a.metadata.AccessKey == "" {
 		msg := fmt.Sprintf("metadata field 'AccessKey' is empty in EventGrid binding (%s)", a.metadata.Name)
+
 		return errors.New(msg)
 	}
 	if a.metadata.TopicEndpoint == "" {
 		msg := fmt.Sprintf("metadata field 'TopicEndpoint' is empty in EventGrid binding (%s)", a.metadata.Name)
+
 		return errors.New(msg)
 	}
 
@@ -205,6 +209,7 @@ func (a *AzureEventGrid) parseMetadata(metadata bindings.Metadata) (*azureEventG
 	if eventGridMetadata.EventSubscriptionName == "" {
 		eventGridMetadata.EventSubscriptionName = metadata.Name
 	}
+
 	return &eventGridMetadata, nil
 }
 
@@ -243,6 +248,7 @@ func (a *AzureEventGrid) createSubscription() error {
 		if err != nil {
 			return err
 		}
+
 		return errors.New(string(bodyBytes))
 	}
 

--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -91,6 +91,7 @@ func (a *AzureEventHubs) Init(metadata bindings.Metadata) error {
 	}
 
 	a.hub = hub
+
 	return nil
 }
 
@@ -203,6 +204,7 @@ func (a *AzureEventHubs) RegisterPartitionedEventProcessor(handler func(*binding
 				Data: event.Data,
 			})
 		}
+
 		return nil
 	}
 
@@ -233,6 +235,7 @@ func contains(arr []string, str string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -250,7 +253,6 @@ func (a *AzureEventHubs) RegisterEventProcessor(handler func(*bindings.ReadRespo
 	}
 
 	processor, err := eph.NewFromConnectionString(context.Background(), a.metadata.connectionString, leaserCheckpointer, leaserCheckpointer, eph.WithNoBanner(), eph.WithConsumerGroup(a.metadata.consumerGroup))
-
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/eventhubs/eventhubs_test.go
+++ b/bindings/azure/eventhubs/eventhubs_test.go
@@ -58,7 +58,8 @@ func TestParseMetadata(t *testing.T) {
 			"missing storageContainerName",
 			map[string]string{consumerGroup: "fake", connectionString: "fake", storageAccountName: "name", storageAccountKey: "key"},
 			missingStorageContainerNameErrorMsg,
-		}}
+		},
+	}
 
 	for _, c := range invalidConfigTestCases {
 		t.Run(c.name, func(t *testing.T) {

--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -69,6 +69,7 @@ func (a *AzureServiceBusQueues) Init(metadata bindings.Metadata) error {
 	for _, q := range queues {
 		if q.Name == a.metadata.QueueName {
 			entity = q
+
 			break
 		}
 	}
@@ -97,6 +98,7 @@ func (a *AzureServiceBusQueues) Init(metadata bindings.Metadata) error {
 		return err
 	}
 	a.client = client
+
 	return nil
 }
 
@@ -164,11 +166,13 @@ func (a *AzureServiceBusQueues) Read(handler func(*bindings.ReadResponse) error)
 		if err == nil {
 			return msg.Complete(ctx)
 		}
+
 		return msg.Abandon(ctx)
 	}
 
 	if err := a.client.Receive(context.Background(), sbHandler); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/bindings/azure/signalr/signalr.go
+++ b/bindings/azure/signalr/signalr.go
@@ -7,6 +7,7 @@ package signalr
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -119,7 +120,7 @@ func (s *SignalR) resolveAPIURL(req *bindings.InvokeRequest) (string, error) {
 }
 
 func (s *SignalR) sendMessageToSignalR(url string, token string, data []byte) error {
-	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	httpReq, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/signalr/signalr_test.go
+++ b/bindings/azure/signalr/signalr_test.go
@@ -160,6 +160,7 @@ func (t *mockTransport) reset() {
 func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	atomic.AddInt32(&t.requestCount, 1)
 	t.request = req
+
 	return t.response, t.errToReturn
 }
 

--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -62,6 +62,7 @@ func (d *AzureQueueHelper) Init(accountName string, accountKey string, queueName
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -75,6 +76,7 @@ func (d *AzureQueueHelper) Write(data []byte, ttl *time.Duration) error {
 		ttl = &ttlToUse
 	}
 	_, err := messagesURL.Enqueue(ctx, s, time.Second*0, *ttl)
+
 	return err
 }
 
@@ -87,6 +89,7 @@ func (d *AzureQueueHelper) Read(ctx context.Context, consumer *consumer) error {
 	if res.NumMessages() == 0 {
 		// Queue was empty so back off by 10 seconds before trying again
 		time.Sleep(10 * time.Second)
+
 		return nil
 	}
 	mt := res.Message(0).Text
@@ -116,6 +119,7 @@ func (d *AzureQueueHelper) Read(ctx context.Context, consumer *consumer) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -165,6 +169,7 @@ func (a *AzureStorageQueues) Init(metadata bindings.Metadata) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -210,6 +215,7 @@ func (a *AzureStorageQueues) Invoke(req *bindings.InvokeRequest) (*bindings.Invo
 	if err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }
 

--- a/bindings/azure/storagequeues/storagequeues_test.go
+++ b/bindings/azure/storagequeues/storagequeues_test.go
@@ -24,11 +24,13 @@ type MockHelper struct {
 
 func (m *MockHelper) Init(accountName string, accountKey string, queueName string, decodeBase64 bool) error {
 	retvals := m.Called(accountName, accountKey, queueName, decodeBase64)
+
 	return retvals.Error(0)
 }
 
 func (m *MockHelper) Write(data []byte, ttl *time.Duration) error {
 	retvals := m.Called(data, ttl)
+
 	return retvals.Error(0)
 }
 
@@ -141,9 +143,10 @@ func TestReadQueue(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	var handler = func(data *bindings.ReadResponse) error {
+	handler := func(data *bindings.ReadResponse) error {
 		s := string(data.Data)
 		assert.Equal(t, s, "This is my message")
+
 		return nil
 	}
 
@@ -175,9 +178,10 @@ func TestReadQueueDecode(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	var handler = func(data *bindings.ReadResponse) error {
+	handler := func(data *bindings.ReadResponse) error {
 		s := string(data.Data)
 		assert.Equal(t, s, "This is my message")
+
 		return nil
 	}
 
@@ -231,9 +235,10 @@ func TestReadQueueNoMessage(t *testing.T) {
 	err := a.Init(m)
 	assert.Nil(t, err)
 
-	var handler = func(data *bindings.ReadResponse) error {
+	handler := func(data *bindings.ReadResponse) error {
 		s := string(data.Data)
 		assert.Equal(t, s, "This is my message")
+
 		return nil
 	}
 

--- a/bindings/cron/cron.go
+++ b/bindings/cron/cron.go
@@ -50,6 +50,7 @@ func (b *Binding) Init(metadata bindings.Metadata) error {
 		return errors.Wrapf(err, "invalid schedule format: %s", s)
 	}
 	b.schedule = s
+
 	return nil
 }
 
@@ -73,6 +74,7 @@ func (b *Binding) Read(handler func(*bindings.ReadResponse) error) error {
 	<-b.stopCh
 	b.logger.Debugf("stopping schedule: %s", b.schedule)
 	c.Stop()
+
 	return nil
 }
 
@@ -84,6 +86,7 @@ func (b *Binding) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse,
 			req.Operation, bindings.DeleteOperation)
 	}
 	b.stopCh <- true
+
 	return &bindings.InvokeResponse{
 		Metadata: map[string]string{
 			"schedule":    b.schedule,

--- a/bindings/cron/cron_test.go
+++ b/bindings/cron/cron_test.go
@@ -19,6 +19,7 @@ func getTestMetadata(schedule string) bindings.Metadata {
 	m.Properties = map[string]string{
 		"schedule": schedule,
 	}
+
 	return m
 }
 
@@ -27,6 +28,7 @@ func getNewCron() *Binding {
 	if os.Getenv("DEBUG") != "" {
 		l.SetOutputLevel(logger.DebugLevel)
 	}
+
 	return NewCron(l)
 }
 
@@ -70,6 +72,7 @@ func TestCronReadWithDeleteInvoke(t *testing.T) {
 			assert.Truef(t, exists, "Response metadata doesn't include the expected 'schedule' key")
 			assert.Equal(t, schedule, scheduleVal)
 		}
+
 		return nil
 	})
 	assert.NoErrorf(t, err, "error on read")

--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -63,6 +63,7 @@ func (g *GCPStorage) Init(metadata bindings.Metadata) error {
 
 	g.metadata = gm
 	g.client = client
+
 	return nil
 }
 
@@ -71,6 +72,7 @@ func (g *GCPStorage) parseMetadata(metadata bindings.Metadata) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return b, nil
 }
 
@@ -90,5 +92,6 @@ func (g *GCPStorage) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespon
 	if _, err := h.Write(req.Data); err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }

--- a/bindings/gcp/bucket/bucket_test.go
+++ b/bindings/gcp/bucket/bucket_test.go
@@ -16,8 +16,10 @@ import (
 
 func TestInit(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"auth_provider_x509_cert_url": "a", "auth_uri": "a", "Bucket": "a", "client_x509_cert_url": "a", "client_email": "a", "client_id": "a", "private_key": "a",
-		"private_key_id": "a", "project_id": "a", "token_uri": "a", "type": "a"}
+	m.Properties = map[string]string{
+		"auth_provider_x509_cert_url": "a", "auth_uri": "a", "Bucket": "a", "client_x509_cert_url": "a", "client_email": "a", "client_id": "a", "private_key": "a",
+		"private_key_id": "a", "project_id": "a", "token_uri": "a", "type": "a",
+	}
 	gs := GCPStorage{logger: logger.NewLogger("test")}
 	b, err := gs.parseMetadata(m)
 	assert.Nil(t, err)

--- a/bindings/gcp/pubsub/pubsub.go
+++ b/bindings/gcp/pubsub/pubsub.go
@@ -70,11 +70,13 @@ func (g *GCPPubSub) Init(metadata bindings.Metadata) error {
 
 	g.client = pubsubClient
 	g.metadata = &pubsubMeta
+
 	return nil
 }
 
 func (g *GCPPubSub) parseMetadata(metadata bindings.Metadata) ([]byte, error) {
 	b, err := json.Marshal(metadata.Properties)
+
 	return b, err
 }
 
@@ -89,6 +91,7 @@ func (g *GCPPubSub) Read(handler func(*bindings.ReadResponse) error) error {
 			m.Ack()
 		}
 	})
+
 	return err
 }
 
@@ -107,5 +110,6 @@ func (g *GCPPubSub) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespons
 	_, err := t.Publish(ctx, &pubsub.Message{
 		Data: req.Data,
 	}).Get(ctx)
+
 	return nil, err
 }

--- a/bindings/gcp/pubsub/pubsub_test.go
+++ b/bindings/gcp/pubsub/pubsub_test.go
@@ -16,8 +16,10 @@ import (
 
 func TestInit(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"auth_provider_x509_cert_url": "https://auth", "auth_uri": "https://auth", "client_x509_cert_url": "https://cert", "client_email": "test@test.com", "client_id": "id", "private_key": "****",
-		"private_key_id": "key_id", "project_id": "project1", "token_uri": "https://token", "type": "serviceaccount", "topic": "t1", "subscription": "s1"}
+	m.Properties = map[string]string{
+		"auth_provider_x509_cert_url": "https://auth", "auth_uri": "https://auth", "client_x509_cert_url": "https://cert", "client_email": "test@test.com", "client_id": "id", "private_key": "****",
+		"private_key_id": "key_id", "project_id": "project1", "token_uri": "https://token", "type": "serviceaccount", "topic": "t1", "subscription": "s1",
+	}
 	ps := GCPPubSub{logger: logger.NewLogger("test")}
 	b, err := ps.parseMetadata(m)
 	assert.Nil(t, err)

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -48,11 +48,13 @@ func (h *HTTPSource) Init(metadata bindings.Metadata) error {
 	}
 
 	h.metadata = m
+
 	return nil
 }
 
 func (h *HTTPSource) get(url string) ([]byte, error) {
 	client := http.Client{Timeout: time.Second * 60}
+	// nolint: noctx
 	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
@@ -66,6 +68,7 @@ func (h *HTTPSource) get(url string) ([]byte, error) {
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}
+
 	return b, nil
 }
 
@@ -78,6 +81,7 @@ func (h *HTTPSource) Read(handler func(*bindings.ReadResponse) error) error {
 	handler(&bindings.ReadResponse{
 		Data: b,
 	})
+
 	return nil
 }
 
@@ -87,6 +91,7 @@ func (h *HTTPSource) Operations() []bindings.OperationKind {
 
 func (h *HTTPSource) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	client := http.Client{Timeout: time.Second * 5}
+	// nolint: noctx
 	resp, err := client.Post(h.metadata.URL, "application/json; charset=utf-8", bytes.NewBuffer(req.Data))
 	if err != nil {
 		return nil, err
@@ -94,5 +99,6 @@ func (h *HTTPSource) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespon
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}
+
 	return nil, nil
 }

--- a/bindings/influx/influx.go
+++ b/bindings/influx/influx.go
@@ -64,6 +64,7 @@ func (i *Influx) Init(metadata bindings.Metadata) error {
 	client := influxdb2.NewClient(i.metadata.URL, i.metadata.Token)
 	i.client = client
 	i.writeAPI = i.client.WriteAPIBlocking(i.metadata.Org, i.metadata.Bucket)
+
 	return nil
 }
 
@@ -79,6 +80,7 @@ func (i *Influx) getInfluxMetadata(metadata bindings.Metadata) (*influxMetadata,
 	if err != nil {
 		return nil, err
 	}
+
 	return &iMetadata, nil
 }
 
@@ -103,5 +105,6 @@ func (i *Influx) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, 
 		return nil, errors.New("Influx Error: Cannot write point")
 	}
 	i.client.Close()
+
 	return nil, nil
 }

--- a/bindings/kafka/kafka.go
+++ b/bindings/kafka/kafka.go
@@ -64,11 +64,13 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 			}
 		}
 	}
+
 	return nil
 }
 
 func (consumer *consumer) Setup(sarama.ConsumerGroupSession) error {
 	close(consumer.ready)
+
 	return nil
 }
 
@@ -96,11 +98,12 @@ func (k *Kafka) Init(metadata bindings.Metadata) error {
 	k.consumerGroup = meta.ConsumerGroup
 	k.authRequired = meta.AuthRequired
 
-	//ignore SASL properties if authRequired is false
+	// ignore SASL properties if authRequired is false
 	if meta.AuthRequired {
 		k.saslUsername = meta.SaslUsername
 		k.saslPassword = meta.SaslPassword
 	}
+
 	return nil
 }
 
@@ -146,13 +149,12 @@ func (k *Kafka) getKafkaMetadata(metadata bindings.Metadata) (*kafkaMetadata, er
 		return nil, errors.New("kafka error: 'authRequired' attribute was empty")
 	}
 	validAuthRequired, err := strconv.ParseBool(val)
-
 	if err != nil {
 		return nil, errors.New("kafka error: invalid value for 'authRequired' attribute")
 	}
 	meta.AuthRequired = validAuthRequired
 
-	//ignore SASL properties if authRequired is false
+	// ignore SASL properties if authRequired is false
 	if meta.AuthRequired {
 		if val, ok := metadata.Properties["saslUsername"]; ok && val != "" {
 			meta.SaslUsername = val
@@ -166,6 +168,7 @@ func (k *Kafka) getKafkaMetadata(metadata bindings.Metadata) (*kafkaMetadata, er
 			return nil, errors.New("kafka error: missing SASL Password")
 		}
 	}
+
 	return &meta, nil
 }
 
@@ -176,7 +179,7 @@ func (k *Kafka) getSyncProducer(meta *kafkaMetadata) (sarama.SyncProducer, error
 	config.Producer.Return.Successes = true
 	config.Version = sarama.V1_0_0_0
 
-	//ignore SASL properties if authRequired is false
+	// ignore SASL properties if authRequired is false
 	if meta.AuthRequired {
 		updateAuthInfo(config, meta.SaslUsername, meta.SaslPassword)
 	}
@@ -185,13 +188,14 @@ func (k *Kafka) getSyncProducer(meta *kafkaMetadata) (sarama.SyncProducer, error
 	if err != nil {
 		return nil, err
 	}
+
 	return producer, nil
 }
 
 func (k *Kafka) Read(handler func(*bindings.ReadResponse) error) error {
 	config := sarama.NewConfig()
 	config.Version = sarama.V1_0_0_0
-	//ignore SASL properties if authRequired is false
+	// ignore SASL properties if authRequired is false
 	if k.authRequired {
 		updateAuthInfo(config, k.saslUsername, k.saslPassword)
 	}
@@ -233,12 +237,14 @@ func (k *Kafka) Read(handler func(*bindings.ReadResponse) error) error {
 	if err = client.Close(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
 func (consumer *consumer) Cleanup(sarama.ConsumerGroupSession) error {
 	return nil
 }
+
 func updateAuthInfo(config *sarama.Config, saslUsername, saslPassword string) {
 	config.Net.SASL.Enable = true
 	config.Net.SASL.User = saslUsername
@@ -246,8 +252,9 @@ func updateAuthInfo(config *sarama.Config, saslUsername, saslPassword string) {
 	config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 
 	config.Net.TLS.Enable = true
+	// nolint: gosec
 	config.Net.TLS.Config = &tls.Config{
-		//InsecureSkipVerify: true,
+		// InsecureSkipVerify: true,
 		ClientAuth: 0,
 	}
 }

--- a/bindings/kubernetes/kubernetes.go
+++ b/bindings/kubernetes/kubernetes.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	kubeclient "github.com/dapr/components-contrib/authentication/kubernetes"
-
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
 	v1 "k8s.io/api/core/v1"
@@ -50,6 +49,7 @@ func (k *kubernetesInput) Init(metadata bindings.Metadata) error {
 		return err
 	}
 	k.kubeClient = client
+
 	return k.parseMetadata(metadata)
 }
 
@@ -68,6 +68,7 @@ func (k *kubernetesInput) parseMetadata(metadata bindings.Metadata) error {
 			k.resyncPeriodInSec = time.Second * time.Duration(intval)
 		}
 	}
+
 	return nil
 }
 
@@ -139,5 +140,6 @@ func (k *kubernetesInput) Read(handler func(*bindings.ReadResponse) error) error
 			close(stopCh)
 		}
 	}
+
 	return nil
 }

--- a/bindings/mqtt/mqtt.go
+++ b/bindings/mqtt/mqtt.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
-
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/google/uuid"
 )
@@ -66,6 +65,7 @@ func (m *MQTT) Init(metadata bindings.Metadata) error {
 		return err
 	}
 	m.client = client
+
 	return nil
 }
 
@@ -80,6 +80,7 @@ func (m *MQTT) getMQTTMetadata(metadata bindings.Metadata) (*mqttMetadata, error
 	if err != nil {
 		return nil, err
 	}
+
 	return &mMetadata, nil
 }
 
@@ -90,6 +91,7 @@ func (m *MQTT) Operations() []bindings.OperationKind {
 func (m *MQTT) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	m.client.Publish(m.metadata.Topic, 0, false, string(req.Data))
 	m.client.Disconnect(0)
+
 	return nil, nil
 }
 
@@ -103,6 +105,7 @@ func (m *MQTT) Read(handler func(*bindings.ReadResponse) error) error {
 		})
 	})
 	<-c
+
 	return nil
 }
 
@@ -115,6 +118,7 @@ func (m *MQTT) connect(clientID string, uri *url.URL) (mqtt.Client, error) {
 	if err := token.Error(); err != nil {
 		return nil, err
 	}
+
 	return client, nil
 }
 
@@ -125,5 +129,6 @@ func (m *MQTT) createClientOptions(clientID string, uri *url.URL) *mqtt.ClientOp
 	password, _ := uri.User.Password()
 	opts.SetPassword(password)
 	opts.SetClientID(clientID)
+
 	return opts
 }

--- a/bindings/postgres/postgres.go
+++ b/bindings/postgres/postgres.go
@@ -13,9 +13,8 @@ import (
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
-	"github.com/pkg/errors"
-
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
 )
 
 // List of operations.
@@ -78,6 +77,7 @@ func (p *Postgres) Invoke(req *bindings.InvokeRequest) (resp *bindings.InvokeRes
 
 	if req.Operation == closeOperation {
 		p.db.Close()
+
 		return nil, nil
 	}
 
@@ -100,7 +100,7 @@ func (p *Postgres) Invoke(req *bindings.InvokeRequest) (resp *bindings.InvokeRes
 		},
 	}
 
-	switch req.Operation {
+	switch req.Operation { // nolint: exhaustive
 	case execOperation:
 		r, err := p.exec(sql)
 		if err != nil {
@@ -149,6 +149,7 @@ func (p *Postgres) query(sql string) (result []byte, err error) {
 	if result, err = json.Marshal(rs); err != nil {
 		err = errors.Wrap(err, "error serializing results")
 	}
+
 	return
 }
 
@@ -161,5 +162,6 @@ func (p *Postgres) exec(sql string) (result int64, err error) {
 	}
 
 	result = res.RowsAffected()
+
 	return
 }

--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -162,6 +162,7 @@ func (r *RabbitMQ) parseMetadata(metadata bindings.Metadata) error {
 	}
 
 	r.metadata = m
+
 	return nil
 }
 
@@ -204,5 +205,6 @@ func (r *RabbitMQ) Read(handler func(*bindings.ReadResponse) error) error {
 	}()
 
 	<-forever
+
 	return nil
 }

--- a/bindings/redis/redis.go
+++ b/bindings/redis/redis.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
-
 	redis "github.com/go-redis/redis/v7"
 )
 
@@ -129,7 +128,9 @@ func (r *Redis) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, e
 		if err != nil {
 			return nil, err
 		}
+
 		return nil, nil
 	}
+
 	return nil, errors.New("redis binding: missing key on write request metadata")
 }

--- a/bindings/rethinkdb/statechange/statechange.go
+++ b/bindings/rethinkdb/statechange/statechange.go
@@ -75,6 +75,7 @@ func (b *Binding) Read(handler func(*bindings.ReadResponse) error) error {
 			ok := cursor.Next(&change)
 			if !ok {
 				b.logger.Errorf("error detecting change: %v", cursor.Err())
+
 				break
 			}
 
@@ -95,6 +96,7 @@ func (b *Binding) Read(handler func(*bindings.ReadResponse) error) error {
 
 			if err := handler(resp); err != nil {
 				b.logger.Errorf("error invoking change handler: %v", err)
+
 				continue
 			}
 		}
@@ -103,6 +105,7 @@ func (b *Binding) Read(handler func(*bindings.ReadResponse) error) error {
 	done := <-b.stopCh
 	b.logger.Errorf("done: %b", done)
 	defer cursor.Close()
+
 	return nil
 }
 
@@ -110,69 +113,69 @@ func metadataToConfig(cfg map[string]string, logger logger.Logger) (StateConfig,
 	c := StateConfig{}
 	for k, v := range cfg {
 		switch k {
-		case "address": //string
+		case "address": // string
 			c.Address = v
 		case "addresses": // []string
 			c.Addresses = strings.Split(v, ",")
-		case "database": //string
+		case "database": // string
 			c.Database = v
-		case "username": //string
+		case "username": // string
 			c.Username = v
-		case "password": //string
+		case "password": // string
 			c.Password = v
-		case "authkey": //string
+		case "authkey": // string
 			c.AuthKey = v
-		case "table": //string
+		case "table": // string
 			c.Table = v
-		case "timeout": //time.Duration
+		case "timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid timeout format: %v", v)
 			}
 			c.Timeout = d
-		case "write_timeout": //time.Duration
+		case "write_timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid write timeout format: %v", v)
 			}
 			c.WriteTimeout = d
-		case "read_timeout": //time.Duration
+		case "read_timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid read timeout format: %v", v)
 			}
 			c.ReadTimeout = d
-		case "keep_alive_timeout": //time.Duration
+		case "keep_alive_timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid keep alive timeout format: %v", v)
 			}
 			c.KeepAlivePeriod = d
-		case "initial_cap": //int
+		case "initial_cap": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid keep initial cap format: %v", v)
 			}
 			c.InitialCap = i
-		case "max_open": //int
+		case "max_open": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid keep max open format: %v", v)
 			}
 			c.MaxOpen = i
-		case "discover_hosts": //bool
+		case "discover_hosts": // bool
 			b, err := strconv.ParseBool(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid discover hosts format: %v", v)
 			}
 			c.DiscoverHosts = b
-		case "use-open-tracing": //bool
+		case "use-open-tracing": // bool
 			b, err := strconv.ParseBool(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid use open tracing format: %v", v)
 			}
 			c.UseOpentracing = b
-		case "max_idle": //int
+		case "max_idle": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				return c, errors.Wrapf(err, "invalid keep max idle format: %v", v)

--- a/bindings/rethinkdb/statechange/statechange_test.go
+++ b/bindings/rethinkdb/statechange/statechange_test.go
@@ -30,6 +30,7 @@ func getNewRethinkActorBinding() *Binding {
 	if os.Getenv("DEBUG") != "" {
 		l.SetOutputLevel(logger.DebugLevel)
 	}
+
 	return NewRethinkDBStateChangeBinding(l)
 }
 
@@ -66,6 +67,7 @@ func TestBinding(t *testing.T) {
 		err = b.Read(func(res *bindings.ReadResponse) error {
 			assert.NotNil(t, res)
 			t.Logf("state change event:\n%s", string(res.Data))
+
 			return nil
 		})
 		assert.NoErrorf(t, err, "error on read")

--- a/bindings/twilio/sendgrid/sendgrid.go
+++ b/bindings/twilio/sendgrid/sendgrid.go
@@ -79,6 +79,7 @@ func (sg *SendGrid) Init(metadata bindings.Metadata) error {
 
 	// Um, yeah that's about it!
 	sg.metadata = meta
+
 	return nil
 }
 
@@ -182,5 +183,6 @@ func (sg *SendGrid) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespons
 	}
 
 	sg.logger.Info("sent email with SendGrid")
+
 	return nil, nil
 }

--- a/bindings/twilio/sms/sms.go
+++ b/bindings/twilio/sms/sms.go
@@ -1,6 +1,7 @@
 package sms
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -96,7 +97,7 @@ func (t *SMS) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, err
 	vDr := *strings.NewReader(v.Encode())
 
 	twilioURL := fmt.Sprintf("%s%s/Messages.json", twilioURLBase, t.metadata.accountSid)
-	httpReq, err := http.NewRequest("POST", twilioURL, &vDr)
+	httpReq, err := http.NewRequestWithContext(context.Background(), "POST", twilioURL, &vDr)
 	if err != nil {
 		return nil, err
 	}
@@ -112,5 +113,6 @@ func (t *SMS) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, err
 	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
 		return nil, fmt.Errorf("error from Twilio: %s", resp.Status)
 	}
+
 	return nil, nil
 }

--- a/bindings/twilio/sms/sms_test.go
+++ b/bindings/twilio/sms/sms_test.go
@@ -33,6 +33,7 @@ func (t *mockTransport) reset() {
 func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	atomic.AddInt32(&t.requestCount, 1)
 	t.request = req
+
 	return t.response, t.errToReturn
 }
 
@@ -46,8 +47,10 @@ func TestInit(t *testing.T) {
 
 func TestParseDuration(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"toNumber": "toNumber", "fromNumber": "fromNumber",
-		"accountSid": "accountSid", "authToken": "authToken", "timeout": "badtimeout"}
+	m.Properties = map[string]string{
+		"toNumber": "toNumber", "fromNumber": "fromNumber",
+		"accountSid": "accountSid", "authToken": "authToken", "timeout": "badtimeout",
+	}
 	tw := NewSMS(logger.NewLogger("test"))
 	err := tw.Init(m)
 	assert.NotNil(t, err)
@@ -58,8 +61,10 @@ func TestWriteShouldSucceed(t *testing.T) {
 		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
 	}
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"toNumber": "toNumber", "fromNumber": "fromNumber",
-		"accountSid": "accountSid", "authToken": "authToken"}
+	m.Properties = map[string]string{
+		"toNumber": "toNumber", "fromNumber": "fromNumber",
+		"accountSid": "accountSid", "authToken": "authToken",
+	}
 	tw := NewSMS(logger.NewLogger("test"))
 	tw.httpClient = &http.Client{
 		Transport: httpTransport,
@@ -93,8 +98,10 @@ func TestWriteShouldFail(t *testing.T) {
 		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
 	}
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"fromNumber": "fromNumber",
-		"accountSid": "accountSid", "authToken": "authToken"}
+	m.Properties = map[string]string{
+		"fromNumber": "fromNumber",
+		"accountSid": "accountSid", "authToken": "authToken",
+	}
 	tw := NewSMS(logger.NewLogger("test"))
 	tw.httpClient = &http.Client{
 		Transport: httpTransport,

--- a/bindings/twitter/twitter.go
+++ b/bindings/twitter/twitter.go
@@ -16,10 +16,9 @@ import (
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/logger"
-	"github.com/pkg/errors"
-
 	"github.com/dghubble/go-twitter/twitter"
 	"github.com/dghubble/oauth1"
+	"github.com/pkg/errors"
 )
 
 // Binding represents Twitter input/output binding
@@ -67,6 +66,7 @@ func (t *Binding) Init(metadata bindings.Metadata) error {
 	httpClient := config.Client(oauth1.NoContext, token)
 
 	t.client = twitter.NewClient(httpClient)
+
 	return nil
 }
 
@@ -87,6 +87,7 @@ func (t *Binding) Read(handler func(*bindings.ReadResponse) error) error {
 		data, marshalErr := json.Marshal(tweet)
 		if marshalErr != nil {
 			t.logger.Errorf("error marshaling tweet: %+v", tweet)
+
 			return
 		}
 		handler(&bindings.ReadResponse{
@@ -139,6 +140,7 @@ func (t *Binding) Read(handler func(*bindings.ReadResponse) error) error {
 			done = true
 		}
 	}
+
 	return nil
 }
 
@@ -199,6 +201,7 @@ func (t *Binding) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse,
 	data, marshalErr := json.Marshal(search.Statuses)
 	if marshalErr != nil {
 		t.logger.Errorf("error marshaling tweet: %v", marshalErr)
+
 		return nil, errors.Wrapf(err, "error parsing response from: %+v", sq)
 	}
 

--- a/bindings/twitter/twitter_test.go
+++ b/bindings/twitter/twitter_test.go
@@ -31,6 +31,7 @@ func getTestMetadata() bindings.Metadata {
 		"accessToken":    testTwitterAccessToken,
 		"accessSecret":   testTwitterAccessSecret,
 	}
+
 	return m
 }
 
@@ -62,6 +63,7 @@ func TestReadError(t *testing.T) {
 	tw.Read(func(res *bindings.ReadResponse) error {
 		t.Logf("result: %+v", res)
 		assert.NotNilf(t, err, "no error on read with invalid credentials")
+
 		return nil
 	})
 }
@@ -89,6 +91,7 @@ func TestReed(t *testing.T) {
 		json.Unmarshal(res.Data, &tweet)
 		assert.NotEmpty(t, tweet.IDStr, "tweet should have an ID")
 		os.Exit(0)
+
 		return nil
 	})
 	assert.Nilf(t, err, "error on read")

--- a/exporters/native/native_exporter.go
+++ b/exporters/native/native_exporter.go
@@ -51,6 +51,7 @@ func (l *Exporter) Init(daprID string, hostAddress string, metadata exporters.Me
 
 	trace.RegisterExporter(l.traceExporter)
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
 	return nil
 }
 
@@ -65,6 +66,7 @@ func (l *Exporter) getNativeMetadata(metadata exporters.Metadata) (*nativeExport
 	if err != nil {
 		return nil, err
 	}
+
 	return &nExporterMetadata, nil
 }
 

--- a/exporters/stringexporter/string_exporter.go
+++ b/exporters/stringexporter/string_exporter.go
@@ -39,6 +39,7 @@ func (se *Exporter) Init(daprID string, hostAddress string, metadata exporters.M
 	se.Buffer = metadata.Buffer
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	trace.RegisterExporter(se)
+
 	return nil
 }
 

--- a/exporters/zipkin/zipkin_exporter.go
+++ b/exporters/zipkin/zipkin_exporter.go
@@ -54,6 +54,7 @@ func (z *Exporter) Init(daprID string, hostAddress string, metadata exporters.Me
 	z.traceExporter = zipkin.NewExporter(reporter, localEndpoint)
 	trace.RegisterExporter(z.traceExporter)
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
 	return nil
 }
 
@@ -68,6 +69,7 @@ func (z *Exporter) getZipkinMetadata(metadata exporters.Metadata) (*zipkinMetada
 	if err != nil {
 		return nil, err
 	}
+
 	return &zipkinMeta, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/gocql/gocql v0.0.0-20191018090344-07ace3bab0f8
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.3
+	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/grandcat/zeroconf v0.0.0-20190424104450-85eadb44205c
 	github.com/hashicorp/consul/api v1.2.0
@@ -74,9 +75,10 @@ require (
 	go.etcd.io/etcd v3.3.17+incompatible
 	go.mongodb.org/mongo-driver v1.1.2
 	go.opencensus.io v0.22.3
-	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
-	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6 // indirect
 	google.golang.org/api v0.15.0
 	google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150
 	google.golang.org/grpc v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -837,6 +839,7 @@ github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3Ifn
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible h1:Q4//iY4pNF6yPLZIigmvcl7k/bPgrcTPIFIcmawg5bI=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb h1:ZkM6LRnq40pR1Ox0hTHlnpkcOTuFIDQpZ1IN8rKKhX0=
 github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -885,8 +888,8 @@ golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200206161412-a0c6ece9d31a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
-golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -911,6 +914,8 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -940,8 +945,8 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
-golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -955,6 +960,8 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180828065106-d99a578cf41b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1030,9 +1037,12 @@ golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c h1:2EA2K0k9bcvvEDlqD8xdlOhCOqq+O/p9Voqi4x9W1YU=
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6 h1:qKpj8TpV+LEhel7H/fR788J+KvhWZ3o3V6N2fU/iuLU=
+golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/middleware/http/bearer/bearer_middleware.go
+++ b/middleware/http/bearer/bearer_middleware.go
@@ -6,9 +6,8 @@
 package bearer
 
 import (
-	"encoding/json"
-
 	"context"
+	"encoding/json"
 	"strings"
 
 	oidc "github.com/coreos/go-oidc"
@@ -40,7 +39,6 @@ const (
 // GetHandler retruns the HTTP handler provided by the middleware
 func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(h fasthttp.RequestHandler) fasthttp.RequestHandler, error) {
 	meta, err := m.getNativeMetadata(metadata)
-
 	if err != nil {
 		return nil, err
 	}
@@ -59,12 +57,14 @@ func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(h fasthttp.R
 			authHeader := string(ctx.Request.Header.Peek(fasthttp.HeaderAuthorization))
 			if !strings.HasPrefix(strings.ToLower(authHeader), bearerPrefix) {
 				ctx.Error(fasthttp.StatusMessage(fasthttp.StatusUnauthorized), fasthttp.StatusUnauthorized)
+
 				return
 			}
 			rawToken := authHeader[bearerPrefixLength:]
 			_, err := verifier.Verify(ctx, rawToken)
 			if err != nil {
 				ctx.Error(fasthttp.StatusMessage(fasthttp.StatusUnauthorized), fasthttp.StatusUnauthorized)
+
 				return
 			}
 
@@ -84,5 +84,6 @@ func (m *Middleware) getNativeMetadata(metadata middleware.Metadata) (*bearerMid
 	if err != nil {
 		return nil, err
 	}
+
 	return &middlewareMetadata, nil
 }

--- a/middleware/http/nethttpadaptor/nethttpadaptor.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor.go
@@ -22,6 +22,7 @@ func NewNetHTTPHandlerFunc(logger logger.Logger, h fasthttp.RequestHandler) http
 			reqBody, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				logger.Errorf("error reading request body, %+v", err)
+
 				return
 			}
 			c.Request.SetBody(reqBody)

--- a/middleware/http/nethttpadaptor/nethttpadaptor_test.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor_test.go
@@ -1,6 +1,7 @@
 package nethttpadaptor
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -111,6 +112,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			"Body is handled",
 			func() *http.Request {
 				body := strings.NewReader("test body!")
+
 				return httptest.NewRequest("GET", "http://localhost:8080/test/sub", body)
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -137,6 +139,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 				req.Header.Add("testHeaderKey1", "testHeaderValue1")
 				req.Header.Add("testHeaderKey2", "testHeaderValue2")
 				req.Header.Add("testHeaderKey3", "testHeaderValue3")
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -167,6 +170,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 				req.Header.Add("testHeaderKey1", "testHeaderValue1")
 				req.Header.Add("testHeaderKey1", "testHeaderValue2")
 				req.Header.Add("testHeaderKey1", "testHeaderValue3")
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -208,6 +212,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			func() *http.Request {
 				req := httptest.NewRequest("GET", "https://localhost:8080", nil)
 				req.Header.Add("Content-Type", "application/json")
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -221,6 +226,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			func() *http.Request {
 				req := httptest.NewRequest("GET", "https://localhost:8080", nil)
 				req.Header.Add("Content-Type", "multipart/form-data; boundary=test-boundary")
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -234,6 +240,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			func() *http.Request {
 				req := httptest.NewRequest("GET", "https://localhost:8080", nil)
 				req.Header.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36")
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -247,6 +254,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			func() *http.Request {
 				req := httptest.NewRequest("GET", "https://localhost:8080", nil)
 				req.Header.Add("Referer", "testReferer")
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -260,6 +268,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			func() *http.Request {
 				req := httptest.NewRequest("GET", "https://localhost:8080", nil)
 				req.Header.Add("Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l") // b64(aladdin:opensesame)
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -279,6 +288,7 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 			func() *http.Request {
 				req := httptest.NewRequest("GET", "https://localhost:8080", nil)
 				req.RemoteAddr = "1.1.1.1"
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -290,7 +300,8 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 		{
 			"nil body is handled",
 			func() *http.Request {
-				req, _ := http.NewRequest("GET", "https://localhost:8080", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://localhost:8080", nil)
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
@@ -302,7 +313,8 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 		{
 			"proto headers are handled",
 			func() *http.Request {
-				req, _ := http.NewRequest("GET", "https://localhost:8080", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://localhost:8080", nil)
+
 				return req
 			},
 			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {

--- a/middleware/http/oauth2/oauth2_middleware.go
+++ b/middleware/http/oauth2/oauth2_middleware.go
@@ -6,10 +6,9 @@
 package oauth2
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
-
-	"context"
 
 	"github.com/dapr/components-contrib/middleware"
 	"github.com/fasthttp-contrib/sessions"
@@ -68,6 +67,7 @@ func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(h fasthttp.R
 			if session.GetString(meta.AuthHeaderName) != "" {
 				ctx.Request.Header.Add(meta.AuthHeaderName, session.GetString(meta.AuthHeaderName))
 				h(ctx)
+
 				return
 			}
 			state := string(ctx.FormValue(stateParam))
@@ -113,5 +113,6 @@ func (m *Middleware) getNativeMetadata(metadata middleware.Metadata) (*oAuth2Mid
 	if err != nil {
 		return nil, err
 	}
+
 	return &middlewareMetadata, nil
 }

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
@@ -9,10 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dapr/components-contrib/middleware"
 	mock "github.com/dapr/components-contrib/middleware/http/oauth2clientcredentials/mocks"
 	"github.com/dapr/dapr/pkg/logger"
-
-	"github.com/dapr/components-contrib/middleware"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/middleware/http/opa/middleware_test.go
+++ b/middleware/http/opa/middleware_test.go
@@ -203,6 +203,7 @@ func TestOpaPolicy(t *testing.T) {
 
 			if test.shouldHandlerError {
 				require.Error(t, err)
+
 				return
 			}
 
@@ -217,6 +218,7 @@ func TestOpaPolicy(t *testing.T) {
 			if test.shouldRegoError {
 				assert.Equal(t, 403, reqCtx.Response.StatusCode())
 				assert.Equal(t, "true", string(reqCtx.Response.Header.Peek(opaErrorHeaderKey)))
+
 				return
 			}
 

--- a/middleware/http/ratelimit/ratelimit_middleware.go
+++ b/middleware/http/ratelimit/ratelimit_middleware.go
@@ -51,6 +51,7 @@ func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(h fasthttp.R
 	return func(h fasthttp.RequestHandler) fasthttp.RequestHandler {
 		limitHandler := tollbooth.LimitFuncHandler(limiter, nethttpadaptor.NewNetHTTPHandlerFunc(m.logger, h))
 		wrappedHandler := fasthttpadaptor.NewFastHTTPHandlerFunc(limitHandler.ServeHTTP)
+
 		return func(ctx *fasthttp.RequestCtx) {
 			wrappedHandler(ctx)
 		}

--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -37,7 +37,7 @@ func (m *resolver) Init(metadata nameresolution.Metadata) error {
 	var hostAddress string
 	var ok bool
 
-	var props = metadata.Properties
+	props := metadata.Properties
 
 	if id, ok = props[nameresolution.MDNSInstanceName]; !ok {
 		return errors.New("name is missing")
@@ -83,6 +83,7 @@ func (m *resolver) registerMDNS(id string, ips []string, port int) error {
 		if err != nil {
 			started <- false
 			m.logger.Errorf("error from zeroconf register: %s", err)
+
 			return
 		}
 		started <- true
@@ -96,6 +97,7 @@ func (m *resolver) registerMDNS(id string, ips []string, port int) error {
 	}()
 
 	<-started
+
 	return err
 }
 
@@ -127,6 +129,7 @@ func (m *resolver) ResolveID(req nameresolution.ResolveRequest) (string, error) 
 
 					// cancel timeout because it found the service
 					cancel()
+
 					return
 				}
 			}
@@ -136,6 +139,7 @@ func (m *resolver) ResolveID(req nameresolution.ResolveRequest) (string, error) 
 	if err = resolver.Browse(ctx, req.ID, "local.", entries); err != nil {
 		// cancel context
 		cancel()
+
 		return "", fmt.Errorf("failed to browse: %s", err.Error())
 	}
 

--- a/nameresolution/mdns/mdns_test.go
+++ b/nameresolution/mdns/mdns_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		missingProp string
 		props       map[string]string
 	}{

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -8,14 +8,12 @@ import (
 	"strconv"
 	"strings"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/dapr/dapr/pkg/logger"
-
 	sns "github.com/aws/aws-sdk-go/service/sns"
 	sqs "github.com/aws/aws-sdk-go/service/sqs"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 type snsSqs struct {
@@ -73,10 +71,10 @@ func NewSnsSqs(l logger.Logger) pubsub.PubSub {
 
 func parseInt64(input string, propertyName string) (int64, error) {
 	number, err := strconv.Atoi(input)
-
 	if err != nil {
 		return -1, fmt.Errorf("parsing %s failed with: %v", propertyName, err)
 	}
+
 	return int64(number), nil
 }
 
@@ -85,6 +83,7 @@ func parseInt64(input string, propertyName string) (int64, error) {
 func nameToHash(name string) string {
 	h := sha256.New()
 	h.Write([]byte(name))
+
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
@@ -131,7 +130,6 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 		md.messageVisibilityTimeout = 10
 	} else {
 		timeout, err := parseInt64(val, "messageVisibilityTimeout")
-
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +145,6 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 		md.messageRetryLimit = 10
 	} else {
 		retryLimit, err := parseInt64(val, "messageRetryLimit")
-
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +160,6 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 		md.messageWaitTimeSeconds = 1
 	} else {
 		waitTime, err := parseInt64(val, "messageWaitTimeSeconds")
-
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +175,6 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 		md.messageMaxNumber = 10
 	} else {
 		maxNumber, err := parseInt64(val, "messageMaxNumber")
-
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +193,6 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 
 func (s *snsSqs) Init(metadata pubsub.Metadata) error {
 	md, err := s.getSnsSqsMetatdata(metadata)
-
 	if err != nil {
 		return err
 	}
@@ -217,6 +211,7 @@ func (s *snsSqs) Init(metadata pubsub.Metadata) error {
 	}
 	s.snsClient = sns.New(sess)
 	s.sqsClient = sqs.New(sess)
+
 	return nil
 }
 
@@ -226,7 +221,6 @@ func (s *snsSqs) createTopic(topic string) (string, string, error) {
 		Name: aws.String(hashedName),
 		Tags: []*sns.Tag{{Key: aws.String(awsSnsTopicNameKey), Value: aws.String(topic)}},
 	})
-
 	if err != nil {
 		return "", "", err
 	}
@@ -241,15 +235,16 @@ func (s *snsSqs) getOrCreateTopic(topic string) (string, error) {
 
 	if ok {
 		s.logger.Debugf("Found existing topic ARN for topic %s: %s", topic, topicArn)
+
 		return topicArn, nil
 	}
 
 	s.logger.Debugf("No topic ARN found for %s\n Creating topic instead.", topic)
 
 	topicArn, hashedName, err := s.createTopic(topic)
-
 	if err != nil {
 		s.logger.Errorf("error creating new topic %s: %v", topic, err)
+
 		return "", err
 	}
 
@@ -265,7 +260,6 @@ func (s *snsSqs) createQueue(queueName string) (*sqsQueueInfo, error) {
 		QueueName: aws.String(nameToHash(queueName)),
 		Tags:      map[string]*string{awsSqsQueueNameKey: aws.String(queueName)},
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +268,6 @@ func (s *snsSqs) createQueue(queueName string) (*sqsQueueInfo, error) {
 		AttributeNames: []*string{aws.String("QueueArn")},
 		QueueUrl:       createQueueResponse.QueueUrl,
 	})
-
 	if err != nil {
 		s.logger.Errorf("error fetching queue attributes for %s: %v", queueName, err)
 	}
@@ -309,15 +302,16 @@ func (s *snsSqs) getOrCreateQueue(queueName string) (*sqsQueueInfo, error) {
 
 	if ok {
 		s.logger.Debugf("Found queue arn for %s: %s", queueName, queueArn)
+
 		return queueArn, nil
 	}
 	// creating queues is idempotent, the names serve as unique keys among a given region
 	s.logger.Debugf("No queue arn found for %s\nCreating queue", queueName)
 
 	queueInfo, err := s.createQueue(queueName)
-
 	if err != nil {
 		s.logger.Errorf("Error creating queue %s: %v", queueName, err)
+
 		return nil, err
 	}
 
@@ -328,7 +322,6 @@ func (s *snsSqs) getOrCreateQueue(queueName string) (*sqsQueueInfo, error) {
 
 func (s *snsSqs) Publish(req *pubsub.PublishRequest) error {
 	topicArn, err := s.getOrCreateTopic(req.Topic)
-
 	if err != nil {
 		s.logger.Errorf("error getting topic ARN for %s: %v", req.Topic, err)
 	}
@@ -341,6 +334,7 @@ func (s *snsSqs) Publish(req *pubsub.PublishRequest) error {
 
 	if err != nil {
 		s.logger.Errorf("error publishing topic %s with topic ARN %s: %v", req.Topic, topicArn, err)
+
 		return err
 	}
 
@@ -375,7 +369,6 @@ func (s *snsSqs) handleMessage(message *sqs.Message, queueInfo *sqsQueueInfo, ha
 	}
 
 	recvCountInt, err := strconv.ParseInt(*recvCount, 10, 32)
-
 	if err != nil {
 		return fmt.Errorf("error parsing ApproximateReceiveCount from message: %v", message)
 	}
@@ -427,15 +420,16 @@ func (s *snsSqs) consumeSubscription(queueInfo *sqsQueueInfo, handler func(msg *
 				VisibilityTimeout:   aws.Int64(s.metadata.messageVisibilityTimeout),
 				WaitTimeSeconds:     aws.Int64(s.metadata.messageWaitTimeSeconds),
 			})
-
 			if err != nil {
 				s.logger.Errorf("error consuming topic: %v", err)
+
 				continue
 			}
 
 			// retry receiving messages
 			if len(messageResponse.Messages) < 1 {
 				s.logger.Debug("No messages received, requesting again")
+
 				continue
 			}
 
@@ -456,17 +450,17 @@ func (s *snsSqs) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubsub
 	// these should be idempotent
 	// queues should not be created if they exist
 	topicArn, err := s.getOrCreateTopic(req.Topic)
-
 	if err != nil {
 		s.logger.Errorf("error getting topic ARN for %s: %v", req.Topic, err)
+
 		return err
 	}
 
 	// this is the ID of the application, it is supplied via runtime as "consumerID"
 	queueInfo, err := s.getOrCreateQueue(s.metadata.sqsQueueName)
-
 	if err != nil {
 		s.logger.Errorf("error retrieving SQS queue: %v", err)
+
 		return err
 	}
 
@@ -478,9 +472,9 @@ func (s *snsSqs) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubsub
 		ReturnSubscriptionArn: nil,
 		TopicArn:              &topicArn,
 	})
-
 	if err != nil {
 		s.logger.Errorf("error subscribing to topic %s: %v", req.Topic, err)
+
 		return err
 	}
 

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -103,12 +103,12 @@ func (aeh *AzureEventHubs) Init(metadata pubsub.Metadata) error {
 	}
 	aeh.metadata = m
 	hub, err := eventhub.NewHubFromConnectionString(aeh.metadata.connectionString)
-
 	if err != nil {
 		return fmt.Errorf("unable to connect to azure event hubs: %v", err)
 	}
 
 	aeh.hub = hub
+
 	return nil
 }
 
@@ -118,6 +118,7 @@ func (aeh *AzureEventHubs) Publish(req *pubsub.PublishRequest) error {
 	if err != nil {
 		return fmt.Errorf("error from publish: %s", err)
 	}
+
 	return nil
 }
 
@@ -134,7 +135,6 @@ func (aeh *AzureEventHubs) Subscribe(req pubsub.SubscribeRequest, handler func(m
 	}
 
 	processor, err := eph.NewFromConnectionString(context.Background(), aeh.metadata.connectionString, leaserCheckpointer, leaserCheckpointer, eph.WithNoBanner(), eph.WithConsumerGroup(aeh.metadata.consumerGroup))
-
 	if err != nil {
 		return err
 	}

--- a/pubsub/azure/eventhubs/eventhubs_test.go
+++ b/pubsub/azure/eventhubs/eventhubs_test.go
@@ -57,7 +57,8 @@ func TestParseEventHubsMetadata(t *testing.T) {
 			"missing storageContainerName",
 			map[string]string{"consumerID": "fake", "connectionString": "fake", "storageAccountName": "name", "storageAccountKey": "key"},
 			missingStorageContainerNameErrorMsg,
-		}}
+		},
+	}
 
 	for _, c := range invalidConfigTestCases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -202,6 +202,7 @@ func (a *azureServiceBus) Init(metadata pubsub.Metadata) error {
 	}
 
 	a.topicManager = a.namespace.NewTopicManager()
+
 	return nil
 }
 
@@ -226,6 +227,7 @@ func (a *azureServiceBus) Publish(req *pubsub.PublishRequest) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -258,6 +260,7 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, appHandler func
 				select {
 				case <-reconnCtx.Done():
 					a.logger.Debugf("Reconnect context for topic %s is done", req.Topic)
+
 					return
 				case <-time.After(2 * time.Minute):
 					attempts := readAttemptsStale()
@@ -274,6 +277,7 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, appHandler func
 			topic, err := a.namespace.NewTopic(req.Topic)
 			if err != nil {
 				a.logger.Errorf("%s could not instantiate topic %s, %s", errorMessagePrefix, req.Topic, err)
+
 				return
 			}
 
@@ -284,6 +288,7 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, appHandler func
 			subEntity, err := topic.NewSubscription(subID, opts...)
 			if err != nil {
 				a.logger.Errorf("%s could not instantiate subscription %s for topic %s", errorMessagePrefix, subID, req.Topic)
+
 				return
 			}
 			sub := newSubscription(req.Topic, subEntity, a.metadata.MaxConcurrentHandlers, a.logger)
@@ -310,6 +315,7 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, appHandler func
 			attempts := readAttemptsStale()
 			if attempts == 0 {
 				a.logger.Errorf("Subscription to topic %s lost connection, unable to recover after %d attempts", sub.topic, maxReconnAttempts)
+
 				return
 			}
 
@@ -334,6 +340,7 @@ func (a *azureServiceBus) ensureTopic(topic string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -359,6 +366,7 @@ func (a *azureServiceBus) ensureSubscription(name string, topic string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -373,6 +381,7 @@ func (a *azureServiceBus) getTopicEntity(topic string) (*azservicebus.TopicEntit
 	if err != nil && !azservicebus.IsErrNotFound(err) {
 		return nil, fmt.Errorf("%s could not get topic %s, %s", errorMessagePrefix, topic, err)
 	}
+
 	return topicEntity, nil
 }
 
@@ -383,6 +392,7 @@ func (a *azureServiceBus) createTopicEntity(topic string) error {
 	if err != nil {
 		return fmt.Errorf("%s could not put topic %s, %s", errorMessagePrefix, topic, err)
 	}
+
 	return nil
 }
 
@@ -393,6 +403,7 @@ func (a *azureServiceBus) getSubscriptionEntity(mgr *azservicebus.SubscriptionMa
 	if err != nil && !azservicebus.IsErrNotFound(err) {
 		return nil, fmt.Errorf("%s could not get subscription %s, %s", errorMessagePrefix, subscription, err)
 	}
+
 	return entity, nil
 }
 
@@ -409,6 +420,7 @@ func (a *azureServiceBus) createSubscriptionEntity(mgr *azservicebus.Subscriptio
 	if err != nil {
 		return fmt.Errorf("%s could not put subscription %s, %s", errorMessagePrefix, subscription, err)
 	}
+
 	return nil
 }
 
@@ -426,6 +438,7 @@ func (a *azureServiceBus) createSubscriptionManagementOptions() ([]azservicebus.
 	if a.metadata.AutoDeleteOnIdleInSec != nil {
 		opts = append(opts, subscriptionManagementOptionsWithAutoDeleteOnIdle(a.metadata.AutoDeleteOnIdleInSec))
 	}
+
 	return opts, nil
 }
 
@@ -433,6 +446,7 @@ func subscriptionManagementOptionsWithMaxDeliveryCount(maxDeliveryCount *int) az
 	return func(d *azservicebus.SubscriptionDescription) error {
 		mdc := int32(*maxDeliveryCount)
 		d.MaxDeliveryCount = &mdc
+
 		return nil
 	}
 }
@@ -441,6 +455,7 @@ func subscriptionManagementOptionsWithAutoDeleteOnIdle(durationInSec *int) azser
 	return func(d *azservicebus.SubscriptionDescription) error {
 		duration := fmt.Sprintf("PT%dS", *durationInSec)
 		d.AutoDeleteOnIdle = &duration
+
 		return nil
 	}
 }
@@ -449,6 +464,7 @@ func subscriptionManagementOptionsWithDefaultMessageTimeToLive(durationInSec *in
 	return func(d *azservicebus.SubscriptionDescription) error {
 		duration := fmt.Sprintf("PT%dS", *durationInSec)
 		d.DefaultMessageTimeToLive = &duration
+
 		return nil
 	}
 }
@@ -457,6 +473,7 @@ func subscriptionManagementOptionsWithLockDuration(durationInSec *int) azservice
 	return func(d *azservicebus.SubscriptionDescription) error {
 		duration := fmt.Sprintf("PT%dS", *durationInSec)
 		d.LockDuration = &duration
+
 		return nil
 	}
 }

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -8,9 +8,8 @@ package servicebus
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pubsub/azure/servicebus/subscription.go
+++ b/pubsub/azure/servicebus/subscription.go
@@ -55,12 +55,14 @@ func (s *subscription) ReceiveAndBlock(ctx context.Context, appHandler func(msg 
 		shouldRenewLocks := lockRenewalInSec > 0
 		if !shouldRenewLocks {
 			s.logger.Debugf("Lock renewal for topic %s disabled", s.topic)
+
 			return
 		}
 		for {
 			select {
 			case <-ctx.Done():
 				s.logger.Debugf("Lock renewal context for topic %s done", s.topic)
+
 				return
 			case <-time.After(time.Second * time.Duration(lockRenewalInSec)):
 				s.tryRenewLocks()
@@ -82,6 +84,7 @@ func (s *subscription) ReceiveAndBlock(ctx context.Context, appHandler func(msg 
 			select {
 			case <-ctx.Done():
 				s.logger.Debugf("Receive context for topic %s done", s.topic)
+
 				return ctx.Err()
 			case <-time.After(time.Second * time.Duration(maxActiveMessagesRecoveryInSec)):
 				continue
@@ -152,6 +155,7 @@ func (s *subscription) asyncWrapper(handlerFunc azservicebus.HandlerFunc) azserv
 				select {
 				case <-ctx.Done():
 					s.logger.Debugf("Message context done for %s on topic %s", msg.ID, s.topic)
+
 					return
 				case <-s.handlerChan: // Take or wait on a free handler before getting a new message
 					s.logger.Debugf("Taken message handler for %s on topic %s", msg.ID, s.topic)
@@ -169,6 +173,7 @@ func (s *subscription) asyncWrapper(handlerFunc azservicebus.HandlerFunc) azserv
 				s.logger.Errorf("%s error handling message %s on topic '%s', %s", errorMessagePrefix, msg.ID, s.topic, err)
 			}
 		}()
+
 		return nil
 	}
 }
@@ -179,6 +184,7 @@ func (s *subscription) tryRenewLocks() {
 	s.mu.RUnlock()
 	if activeMessageLen == 0 {
 		s.logger.Debugf("No active messages require lock renewal for topic %s", s.topic)
+
 		return
 	}
 
@@ -203,16 +209,19 @@ func (s *subscription) receiveMessage(ctx context.Context, handler azservicebus.
 	if err := s.entity.ReceiveOne(ctx, handler); err != nil {
 		return fmt.Errorf("%s error receiving message on topic %s, %s", errorMessagePrefix, s.topic, err)
 	}
+
 	return nil
 }
 
 func (s *subscription) abandonMessage(ctx context.Context, m *azservicebus.Message) error {
 	s.logger.Debugf("Abandoning message %s on topic %s", m.ID, s.topic)
+
 	return m.Abandon(ctx)
 }
 
 func (s *subscription) completeMessage(ctx context.Context, m *azservicebus.Message) error {
 	s.logger.Debugf("Completing message %s on topic %s", m.ID, s.topic)
+
 	return m.Complete(ctx)
 }
 

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -15,7 +15,7 @@ const (
 	DefaultCloudEventType = "com.dapr.event.sent"
 	// CloudEventsSpecVersion is the specversion used by Dapr for the cloud events implementation
 	CloudEventsSpecVersion = "1.0"
-	//ContentType is the Cloud Events HTTP content type
+	// ContentType is the Cloud Events HTTP content type
 	ContentType = "application/cloudevents+json"
 	// DefaultCloudEventSource is the default event source
 	DefaultCloudEventSource = "Dapr"
@@ -111,5 +111,6 @@ func getStrVal(m map[string]interface{}, key string) string {
 			return s
 		}
 	}
+
 	return ""
 }

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -55,15 +55,17 @@ func (g *GCPPubSub) Init(meta pubsub.Metadata) error {
 
 	g.client = pubsubClient
 	g.metadata = &pubsubMeta
+
 	return nil
 }
 
 func (g *GCPPubSub) parseMetadata(metadata pubsub.Metadata) ([]byte, error) {
 	b, err := json.Marshal(metadata.Properties)
+
 	return b, err
 }
 
-//Publish the topic to GCP Pubsub
+// Publish the topic to GCP Pubsub
 func (g *GCPPubSub) Publish(req *pubsub.PublishRequest) error {
 	if !g.metadata.DisableEntityManagement {
 		err := g.ensureTopic(req.Topic)
@@ -100,6 +102,7 @@ func (g *GCPPubSub) Subscribe(req pubsub.SubscribeRequest, daprHandler func(msg 
 	sub := g.getSubscription(g.metadata.ConsumerID)
 
 	go g.handleSubscriptionMessages(topic, sub, daprHandler)
+
 	return nil
 }
 
@@ -116,6 +119,7 @@ func (g *GCPPubSub) handleSubscriptionMessages(topic *gcppubsub.Topic, sub *gcpp
 			m.Ack()
 		}
 	})
+
 	return err
 }
 
@@ -125,6 +129,7 @@ func (g *GCPPubSub) ensureTopic(topic string) error {
 	if !exists {
 		_, err = g.client.CreateTopic(context.Background(), topic)
 	}
+
 	return err
 }
 
@@ -144,6 +149,7 @@ func (g *GCPPubSub) ensureSubscription(subscription string, topic string) error 
 		_, subErr = g.client.CreateSubscription(context.Background(), g.metadata.ConsumerID,
 			gcppubsub.SubscriptionConfig{Topic: g.getTopic(topic)})
 	}
+
 	return subErr
 }
 

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -4,16 +4,17 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInit(t *testing.T) {
 	m := pubsub.Metadata{}
-	m.Properties = map[string]string{"auth_provider_x509_cert_url": "https://auth", "auth_uri": "https://auth", "client_x509_cert_url": "https://cert", "client_email": "test@test.com", "client_id": "id", "private_key": "****",
-		"private_key_id": "key_id", "project_id": "project1", "token_uri": "https://token", "type": "serviceaccount"}
+	m.Properties = map[string]string{
+		"auth_provider_x509_cert_url": "https://auth", "auth_uri": "https://auth", "client_x509_cert_url": "https://cert", "client_email": "test@test.com", "client_id": "id", "private_key": "****",
+		"private_key_id": "key_id", "project_id": "project1", "token_uri": "https://token", "type": "serviceaccount",
+	}
 	ps := GCPPubSub{logger: logger.NewLogger("test")}
 	b, err := ps.parseMetadata(m)
 	assert.Nil(t, err)

--- a/pubsub/hazelcast/hazelcast.go
+++ b/pubsub/hazelcast/hazelcast.go
@@ -32,6 +32,7 @@ func parseHazelcastMetadata(meta pubsub.Metadata) (metadata, error) {
 	} else {
 		return m, errors.New("hazelcast error: missing hazelcast servers")
 	}
+
 	return m, nil
 }
 
@@ -91,6 +92,7 @@ func (l *hazelcastMessageListener) OnMessage(message hazelcastCore.Message) erro
 	if !ok {
 		return errors.New("hazelcast error: cannot cast message to byte array")
 	}
+
 	return l.handleMessageObject(msg)
 }
 
@@ -99,5 +101,6 @@ func (l *hazelcastMessageListener) handleMessageObject(message []byte) error {
 		Data:  message,
 		Topic: l.topicName,
 	}
+
 	return l.pubsubHandler(pubsubMsg)
 }

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -114,6 +114,7 @@ func (k *Kafka) Init(metadata pubsub.Metadata) error {
 	k.topics = make(map[string]bool)
 
 	k.logger.Debug("Kafka message bus initialization complete")
+
 	return nil
 }
 
@@ -154,7 +155,6 @@ func (k *Kafka) closeSubscripionResources() {
 	if k.cg != nil {
 		k.cancel()
 		err := k.cg.Close()
-
 		if err != nil {
 			k.logger.Errorf("Error closing consumer group: %v", err)
 		}
@@ -175,7 +175,6 @@ func (k *Kafka) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubsub.
 	k.closeSubscripionResources()
 
 	cg, err := sarama.NewConsumerGroup(k.brokers, k.consumerGroup, k.config)
-
 	if err != nil {
 		return err
 	}
@@ -195,7 +194,6 @@ func (k *Kafka) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubsub.
 		defer func() {
 			k.logger.Debugf("Closing ConsumerGroup for topics: %v", topics)
 			err := k.cg.Close()
-
 			if err != nil {
 				k.logger.Errorf("Error closing consumer group: %v", err)
 			}
@@ -219,6 +217,7 @@ func (k *Kafka) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubsub.
 	}()
 
 	<-ready
+
 	return nil
 }
 
@@ -245,13 +244,12 @@ func (k *Kafka) getKafkaMetadata(metadata pubsub.Metadata) (*kafkaMetadata, erro
 		return nil, errors.New("kafka error: 'authRequired' attribute was empty")
 	}
 	validAuthRequired, err := strconv.ParseBool(val)
-
 	if err != nil {
 		return nil, errors.New("kafka error: invalid value for 'authRequired' attribute")
 	}
 	meta.AuthRequired = validAuthRequired
 
-	//ignore SASL properties if authRequired is false
+	// ignore SASL properties if authRequired is false
 	if meta.AuthRequired {
 		if val, ok := metadata.Properties["saslUsername"]; ok && val != "" {
 			meta.SaslUsername = val
@@ -283,6 +281,7 @@ func (k *Kafka) getSyncProducer(meta *kafkaMetadata) (sarama.SyncProducer, error
 	if err != nil {
 		return nil, err
 	}
+
 	return producer, nil
 }
 
@@ -293,8 +292,9 @@ func updateAuthInfo(config *sarama.Config, saslUsername, saslPassword string) {
 	config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 
 	config.Net.TLS.Enable = true
+	// nolint: gosec
 	config.Net.TLS.Config = &tls.Config{
-		//InsecureSkipVerify: true,
+		// InsecureSkipVerify: true,
 		ClientAuth: 0,
 	}
 }

--- a/pubsub/kafka/kafka_test.go
+++ b/pubsub/kafka/kafka_test.go
@@ -8,9 +8,8 @@ package kafka
 import (
 	"testing"
 
-	"github.com/dapr/dapr/pkg/logger"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -15,11 +15,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/logger"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/google/uuid"
 )
 
 const (
@@ -61,6 +60,7 @@ func NewMQTTPubSub(logger logger.Logger) pubsub.PubSub {
 // isValidPEM validates the provided input has PEM formatted block.
 func isValidPEM(val string) bool {
 	block, _ := pem.Decode([]byte(val))
+
 	return block != nil
 }
 
@@ -148,6 +148,7 @@ func (m *mqttPubSub) Init(metadata pubsub.Metadata) error {
 	m.topics = make(map[string]byte)
 
 	m.logger.Debug("mqtt message bus initialization complete")
+
 	return nil
 }
 
@@ -159,6 +160,7 @@ func (m *mqttPubSub) Publish(req *pubsub.PublishRequest) error {
 	if !token.WaitTimeout(defaultWait) || token.Error() != nil {
 		return fmt.Errorf("mqtt error from publish: %v", token.Error())
 	}
+
 	return nil
 }
 
@@ -215,6 +217,7 @@ func (m *mqttPubSub) connect(clientID string) (mqtt.Client, error) {
 	if err := token.Error(); err != nil {
 		return nil, err
 	}
+
 	return client, nil
 }
 
@@ -225,6 +228,7 @@ func (m *mqttPubSub) newTLSConfig() *tls.Config {
 		cert, err := tls.X509KeyPair([]byte(m.metadata.clientCert), []byte(m.metadata.clientKey))
 		if err != nil {
 			m.logger.Warnf("unable to load client certificate and key pair. Err: %v", err)
+
 			return tlsConfig
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
@@ -250,5 +254,6 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 	opts.SetPassword(password)
 	// tls config
 	opts.SetTLSConfig(m.newTLSConfig())
+
 	return opts
 }

--- a/pubsub/nats/nats.go
+++ b/pubsub/nats/nats.go
@@ -62,6 +62,7 @@ func (n *natsPubSub) Init(metadata pubsub.Metadata) error {
 	n.logger.Debugf("connected to nats at %s", m.natsURL)
 
 	n.natsConn = natsConn
+
 	return nil
 }
 
@@ -70,6 +71,7 @@ func (n *natsPubSub) Publish(req *pubsub.PublishRequest) error {
 	if err != nil {
 		return fmt.Errorf("nats: error from publish: %s", err)
 	}
+
 	return nil
 }
 

--- a/pubsub/nats/nats_test.go
+++ b/pubsub/nats/nats_test.go
@@ -9,9 +9,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNATSMetadata(t *testing.T) {

--- a/pubsub/natsstreaming/natsstreaming.go
+++ b/pubsub/natsstreaming/natsstreaming.go
@@ -50,7 +50,7 @@ const (
 )
 
 const (
-	consumerID       = "consumerID" //passed in by Dapr runtime
+	consumerID       = "consumerID" // passed in by Dapr runtime
 	subscriptionType = "subscriptionType"
 )
 
@@ -167,6 +167,7 @@ func (n *natsStreamingPubSub) Init(metadata pubsub.Metadata) error {
 	n.logger.Debugf("connected to natsstreaming at %s", m.natsURL)
 
 	n.natStreamingConn = natStreamingConn
+
 	return nil
 }
 
@@ -175,6 +176,7 @@ func (n *natsStreamingPubSub) Publish(req *pubsub.PublishRequest) error {
 	if err != nil {
 		return fmt.Errorf("nats-streaming: error from publish: %s", err)
 	}
+
 	return nil
 }
 
@@ -220,13 +222,13 @@ func (n *natsStreamingPubSub) subscriptionOptions() ([]stan.SubscriptionOption, 
 	switch {
 	case n.metadata.deliverNew == deliverNewTrue:
 		options = append(options, stan.StartAt(pb.StartPosition_NewOnly))
-	case n.metadata.startAtSequence >= 1: //messages index start from 1, this is a valid check
+	case n.metadata.startAtSequence >= 1: // messages index start from 1, this is a valid check
 		options = append(options, stan.StartAtSequence(n.metadata.startAtSequence))
 	case n.metadata.startWithLastReceived == startWithLastReceivedTrue:
 		options = append(options, stan.StartWithLastReceived())
 	case n.metadata.deliverAll == deliverAllTrue:
 		options = append(options, stan.DeliverAllAvailable())
-	case n.metadata.startAtTimeDelta > (1 * time.Nanosecond): //as long as its a valid time.Duration
+	case n.metadata.startAtTimeDelta > (1 * time.Nanosecond): // as long as its a valid time.Duration
 		options = append(options, stan.StartAtTimeDelta(n.metadata.startAtTimeDelta))
 	case n.metadata.startAtTime != "":
 		if n.metadata.startAtTimeFormat != "" {

--- a/pubsub/natsstreaming/natsstreaming_test.go
+++ b/pubsub/natsstreaming/natsstreaming_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNATSStreamingForMetadataMandatoryOptionsMissing(t *testing.T) {
@@ -127,50 +126,65 @@ func TestParseNATSStreamingMetadataForValidSubscriptionOptions(t *testing.T) {
 
 	tests := []test{
 
-		{"using startWithLastReceived", map[string]string{
-			natsURL:                "nats://foo.bar:4222",
-			natsStreamingClusterID: "testcluster",
-			consumerID:             "consumer1",
-			subscriptionType:       "topic",
-			startWithLastReceived:  "true",
+		{
+			"using startWithLastReceived",
+			map[string]string{
+				natsURL:                "nats://foo.bar:4222",
+				natsStreamingClusterID: "testcluster",
+				consumerID:             "consumer1",
+				subscriptionType:       "topic",
+				startWithLastReceived:  "true",
+			},
+			"startWithLastReceived", "true",
 		},
-			"startWithLastReceived", "true"},
 
-		{"using deliverAll", map[string]string{
-			natsURL:                "nats://foo.bar:4222",
-			natsStreamingClusterID: "testcluster",
-			consumerID:             "consumer1",
-			subscriptionType:       "topic",
-			deliverAll:             "true",
+		{
+			"using deliverAll",
+			map[string]string{
+				natsURL:                "nats://foo.bar:4222",
+				natsStreamingClusterID: "testcluster",
+				consumerID:             "consumer1",
+				subscriptionType:       "topic",
+				deliverAll:             "true",
+			},
+			"deliverAll", "true",
 		},
-			"deliverAll", "true"},
 
-		{"using deliverNew", map[string]string{
-			natsURL:                "nats://foo.bar:4222",
-			natsStreamingClusterID: "testcluster",
-			consumerID:             "consumer1",
-			subscriptionType:       "topic",
-			deliverNew:             "true",
+		{
+			"using deliverNew",
+			map[string]string{
+				natsURL:                "nats://foo.bar:4222",
+				natsStreamingClusterID: "testcluster",
+				consumerID:             "consumer1",
+				subscriptionType:       "topic",
+				deliverNew:             "true",
+			},
+			"deliverNew", "true",
 		},
-			"deliverNew", "true"},
 
-		{"using startAtSequence", map[string]string{
-			natsURL:                "nats://foo.bar:4222",
-			natsStreamingClusterID: "testcluster",
-			consumerID:             "consumer1",
-			subscriptionType:       "topic",
-			startAtSequence:        "42",
+		{
+			"using startAtSequence",
+			map[string]string{
+				natsURL:                "nats://foo.bar:4222",
+				natsStreamingClusterID: "testcluster",
+				consumerID:             "consumer1",
+				subscriptionType:       "topic",
+				startAtSequence:        "42",
+			},
+			"startAtSequence", "42",
 		},
-			"startAtSequence", "42"},
 
-		{"using startAtTimeDelta", map[string]string{
-			natsURL:                "nats://foo.bar:4222",
-			natsStreamingClusterID: "testcluster",
-			consumerID:             "consumer1",
-			subscriptionType:       "topic",
-			startAtTimeDelta:       "1h",
+		{
+			"using startAtTimeDelta",
+			map[string]string{
+				natsURL:                "nats://foo.bar:4222",
+				natsStreamingClusterID: "testcluster",
+				consumerID:             "consumer1",
+				subscriptionType:       "topic",
+				startAtTimeDelta:       "1h",
+			},
+			"startAtTimeDelta", "1h",
 		},
-			"startAtTimeDelta", "1h"},
 	}
 
 	for _, _test := range tests {
@@ -196,6 +210,7 @@ func TestParseNATSStreamingMetadataForValidSubscriptionOptions(t *testing.T) {
 		})
 	}
 }
+
 func TestParseNATSStreamingMetadata(t *testing.T) {
 	t.Run("mandatory metadata provided", func(t *testing.T) {
 		fakeProperties := map[string]string{
@@ -262,9 +277,9 @@ func TestParseNATSStreamingMetadata(t *testing.T) {
 		assert.NotEmpty(t, m.subscriptionType)
 		assert.NotEmpty(t, m.natsQueueGroupName)
 		assert.NotEmpty(t, m.startAtSequence)
-		//startWithLastReceived ignored
+		// startWithLastReceived ignored
 		assert.Empty(t, m.startWithLastReceived)
-		//deliverAll will be ignored
+		// deliverAll will be ignored
 		assert.Empty(t, m.deliverAll)
 
 		assert.Equal(t, fakeProperties[natsURL], m.natsURL)
@@ -330,7 +345,7 @@ func TestSubscriptionOptionsForInvalidOptions(t *testing.T) {
 }
 
 func TestSubscriptionOptions(t *testing.T) {
-	//general
+	// general
 	t.Run("manual ACK option is present by default", func(t *testing.T) {
 		natsStreaming := natsStreamingPubSub{metadata: metadata{}}
 		opts, err := natsStreaming.subscriptionOptions()

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -8,9 +8,8 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/dapr/dapr/pkg/logger"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -66,6 +65,7 @@ func (p *Pulsar) Init(metadata pubsub.Metadata) error {
 
 	p.client = client
 	p.metadata = *m
+
 	return nil
 }
 

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -3,9 +3,8 @@ package pulsar
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParsePulsarMetadata(t *testing.T) {

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -17,7 +17,7 @@ func getFakeProperties() map[string]string {
 }
 
 func TestCreateMetadata(t *testing.T) {
-	var booleanFlagTests = []struct {
+	booleanFlagTests := []struct {
 		in       string
 		expected bool
 	}{
@@ -82,7 +82,7 @@ func TestCreateMetadata(t *testing.T) {
 		assert.Empty(t, m.consumerID)
 	})
 
-	var invalidDeliveryModes = []string{"3", "10", "-1"}
+	invalidDeliveryModes := []string{"3", "10", "-1"}
 
 	for _, deliveryMode := range invalidDeliveryModes {
 		t.Run(fmt.Sprintf("deliveryMode value=%s", deliveryMode), func(t *testing.T) {

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -57,6 +57,7 @@ func (r *rabbitMQ) Init(metadata pubsub.Metadata) error {
 
 	r.connection = conn
 	r.channel = ch
+
 	return nil
 }
 
@@ -110,7 +111,6 @@ func (r *rabbitMQ) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubs
 		false, // noWait
 		nil,
 	)
-
 	if err != nil {
 		return err
 	}

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -12,9 +12,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/dapr/dapr/pkg/logger"
-
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/logger"
 	"github.com/go-redis/redis/v7"
 )
 
@@ -96,6 +95,7 @@ func (r *redisStreams) Init(metadata pubsub.Metadata) error {
 	}
 
 	r.client = client
+
 	return nil
 }
 
@@ -117,6 +117,7 @@ func (r *redisStreams) Subscribe(req pubsub.SubscribeRequest, handler func(msg *
 		r.logger.Warnf("redis streams: %s", err)
 	}
 	go r.beginReadingFromStream(req.Topic, r.metadata.consumerID, handler)
+
 	return nil
 }
 
@@ -163,11 +164,12 @@ func (r *redisStreams) beginReadingFromStream(stream, consumerID string, handler
 		streams, err := r.readFromStream(stream, consumerID, start)
 		if err != nil {
 			r.logger.Errorf("redis streams: error reading from stream %s: %s", stream, err)
+
 			return
 		}
 		r.processStreams(consumerID, streams, handler)
 
-		//continue with new non received items
+		// continue with new non received items
 		start = ">"
 	}
 }

--- a/pubsub/redis/redis_test.go
+++ b/pubsub/redis/redis_test.go
@@ -11,11 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v7"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/logger"
+	"github.com/go-redis/redis/v7"
+	"github.com/stretchr/testify/assert"
 )
 
 func getFakeProperties() map[string]string {
@@ -136,5 +135,6 @@ func generateRedisStreamTestData(topicCount, messageCount int, data string) []re
 			Messages: xmessageArray,
 		}
 	}
+
 	return redisStreams
 }

--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -9,13 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
-	"github.com/dapr/dapr/pkg/logger"
-
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -52,6 +50,7 @@ func (s *smSecretStore) Init(metadata secretstores.Metadata) error {
 		return err
 	}
 	s.client = client
+
 	return nil
 }
 
@@ -71,7 +70,6 @@ func (s *smSecretStore) GetSecret(req secretstores.GetSecretRequest) (secretstor
 		VersionId:    versionID,
 		VersionStage: versionStage,
 	})
-
 	if err != nil {
 		return secretstores.GetSecretResponse{Data: nil}, fmt.Errorf("couldn't get secret: %s", err)
 	}
@@ -82,6 +80,7 @@ func (s *smSecretStore) GetSecret(req secretstores.GetSecretRequest) (secretstor
 	if output.Name != nil && output.SecretString != nil {
 		resp.Data[*output.Name] = *output.SecretString
 	}
+
 	return resp, nil
 }
 
@@ -90,6 +89,7 @@ func (s *smSecretStore) getClient(metadata *secretManagerMetaData) (*secretsmana
 	if err != nil {
 		return nil, err
 	}
+
 	return secretsmanager.New(sess), nil
 }
 
@@ -104,5 +104,6 @@ func (s *smSecretStore) getSecretManagerMetadata(spec secretstores.Metadata) (*s
 	if err != nil {
 		return nil, err
 	}
+
 	return &meta, nil
 }

--- a/secretstores/aws/secretmanager/secretmanager_test.go
+++ b/secretstores/aws/secretmanager/secretmanager_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
-
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +51,7 @@ func TestGetSecret(t *testing.T) {
 						assert.Nil(t, input.VersionId)
 						assert.Nil(t, input.VersionStage)
 						secret := secretValue
+
 						return &secretsmanager.GetSecretValueOutput{
 							Name:         input.SecretId,
 							SecretString: &secret,
@@ -75,6 +75,7 @@ func TestGetSecret(t *testing.T) {
 					GetSecretValueFn: func(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 						assert.NotNil(t, input.VersionId)
 						secret := secretValue
+
 						return &secretsmanager.GetSecretValueOutput{
 							Name:         input.SecretId,
 							SecretString: &secret,
@@ -100,6 +101,7 @@ func TestGetSecret(t *testing.T) {
 					GetSecretValueFn: func(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 						assert.NotNil(t, input.VersionStage)
 						secret := secretValue
+
 						return &secretsmanager.GetSecretValueOutput{
 							Name:         input.SecretId,
 							SecretString: &secret,

--- a/secretstores/azure/keyvault/authutils.go
+++ b/secretstores/azure/keyvault/authutils.go
@@ -72,6 +72,7 @@ func (c CertConfig) Authorizer() (autorest.Authorizer, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get oauth token from certificate auth: %v", err)
 		}
+
 		return autorest.NewBearerAuthorizer(spToken), nil
 	}
 
@@ -89,6 +90,7 @@ func (c CertConfig) ServicePrincipalTokenByCertBytes() (*adal.ServicePrincipalTo
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode pkcs12 certificate while creating spt: %v", err)
 	}
+
 	return adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, c.ClientID, certificate, rsaPrivateKey, c.Resource)
 }
 
@@ -110,6 +112,7 @@ func (s EnvironmentSettings) GetMSI() MSIConfig {
 	config := NewMSIConfig()
 	config.Resource = azure.PublicCloud.ResourceIdentifiers.KeyVault
 	config.ClientID = s.Values[componentSPNClientID]
+
 	return config
 }
 

--- a/secretstores/azure/keyvault/authutils_test.go
+++ b/secretstores/azure/keyvault/authutils_test.go
@@ -183,5 +183,6 @@ func TestAuthorizorWithMSIAndUserAssignedID(t *testing.T) {
 
 func getTestCert() []byte {
 	certBytes, _ := base64.StdEncoding.DecodeString(testCert)
+
 	return certBytes
 }

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -9,10 +9,9 @@ import (
 	"context"
 	"fmt"
 
+	kv "github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/dapr/pkg/logger"
-
-	kv "github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
 )
 
 // Keyvault secret store component metadata properties

--- a/secretstores/gcp/cloudkms/cloudkms.go
+++ b/secretstores/gcp/cloudkms/cloudkms.go
@@ -65,13 +65,11 @@ func (c *cloudkmsSecretStore) Init(metadata secretstores.Metadata) error {
 	clientOptions := option.WithCredentialsJSON(b)
 	ctx := context.Background()
 	cloudkmsClient, err := cloudkms.NewKeyManagementClient(ctx, clientOptions)
-
 	if err != nil {
 		return fmt.Errorf("error creating cloudkms client: %s", err)
 	}
 
 	storageClient, err := storage.NewClient(ctx, clientOptions)
-
 	if err != nil {
 		return fmt.Errorf("error creating cloud storage client: %s", err)
 	}
@@ -79,6 +77,7 @@ func (c *cloudkmsSecretStore) Init(metadata secretstores.Metadata) error {
 	c.cloudkmsclient = cloudkmsClient
 	c.storageclient = storageClient
 	c.metadata = &cloudkmsMeta
+
 	return nil
 }
 
@@ -111,10 +110,9 @@ func (c *cloudkmsSecretStore) GetSecret(req secretstores.GetSecretRequest) (secr
 
 func (c *cloudkmsSecretStore) getCipherTextFromSecretObject(gcpStorageBucket string, secretObject string) ([]byte, error) {
 	ctx := context.Background()
-	var client = c.storageclient
+	client := c.storageclient
 
 	rc, err := client.Bucket(gcpStorageBucket).Object(secretObject).NewReader(ctx)
-
 	if err != nil {
 		return nil, fmt.Errorf("creation of read client failed: %s", err)
 	}
@@ -122,7 +120,6 @@ func (c *cloudkmsSecretStore) getCipherTextFromSecretObject(gcpStorageBucket str
 	defer rc.Close()
 
 	data, err := ioutil.ReadAll(rc)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed while reading secret file: %s", err)
 	}
@@ -139,7 +136,6 @@ func (c *cloudkmsSecretStore) decryptSymmetric(name string, ciphertext []byte) (
 	}
 
 	resp, err := c.cloudkmsclient.Decrypt(ctx, req)
-
 	if err != nil {
 		return nil, fmt.Errorf("decrypt: %v", err)
 	}
@@ -149,5 +145,6 @@ func (c *cloudkmsSecretStore) decryptSymmetric(name string, ciphertext []byte) (
 
 func (c *cloudkmsSecretStore) parseMetadata(metadata secretstores.Metadata) ([]byte, error) {
 	b, err := json.Marshal(metadata.Properties)
+
 	return b, err
 }

--- a/secretstores/gcp/secretmanager/secretmanager.go
+++ b/secretstores/gcp/secretmanager/secretmanager.go
@@ -100,6 +100,7 @@ func (s *Store) GetSecret(req secretstores.GetSecretRequest) (secretstores.GetSe
 	if err != nil {
 		return res, fmt.Errorf("failed to access secret version: %v", err)
 	}
+
 	return secretstores.GetSecretResponse{Data: map[string]string{req.Name: string(result.Payload.Data)}}, nil
 }
 
@@ -127,5 +128,6 @@ func (s *Store) parseSecretManagerMetadata(metadataRaw secretstores.Metadata) (*
 	if meta.ClientEmail == "" {
 		return nil, fmt.Errorf("missing property `client_email` in metadata")
 	}
+
 	return &meta, nil
 }

--- a/secretstores/kubernetes/kubernetes.go
+++ b/secretstores/kubernetes/kubernetes.go
@@ -32,6 +32,7 @@ func (k *kubernetesSecretStore) Init(metadata secretstores.Metadata) error {
 		return err
 	}
 	k.kubeClient = client
+
 	return nil
 }
 
@@ -53,6 +54,7 @@ func (k *kubernetesSecretStore) GetSecret(req secretstores.GetSecretRequest) (se
 	for k, v := range secret.Data {
 		resp.Data[k] = string(v)
 	}
+
 	return resp, nil
 }
 
@@ -60,5 +62,6 @@ func (k *kubernetesSecretStore) getNamespaceFromMetadata(metadata map[string]str
 	if val, ok := metadata["namespace"]; ok && val != "" {
 		return val, nil
 	}
+
 	return "", errors.New("namespace is missing on metadata")
 }

--- a/secretstores/local/file/filestore.go
+++ b/secretstores/local/file/filestore.go
@@ -90,6 +90,7 @@ func (j *localSecretStore) visitJSONObject(jsonConfig map[string]interface{}) er
 		}
 		j.exitContext()
 	}
+
 	return nil
 }
 
@@ -120,6 +121,7 @@ func (j *localSecretStore) visitArray(array []interface{}) error {
 		}
 		j.exitContext()
 	}
+
 	return nil
 }
 
@@ -165,6 +167,7 @@ func (j *localSecretStore) getLocalSecretStoreMetadata(spec secretstores.Metadat
 	if meta.SecretsFile == "" {
 		return nil, fmt.Errorf("missing local secrets file in metadata")
 	}
+
 	return &meta, nil
 }
 

--- a/secretstores/local/file/filestore_test.go
+++ b/secretstores/local/file/filestore_test.go
@@ -53,6 +53,7 @@ func TestGetSecret(t *testing.T) {
 		readLocalFileFn: func(secretsFile string) (map[string]interface{}, error) {
 			secrets := make(map[string]interface{})
 			secrets["secret"] = secretValue
+
 			return secrets, nil
 		},
 	}

--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -6,18 +6,16 @@
 package aerospike
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
-
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
-
-	"encoding/json"
 	"strconv"
 	"strings"
 
 	as "github.com/aerospike/aerospike-client-go"
 	"github.com/aerospike/aerospike-client-go/types"
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -28,9 +26,11 @@ const (
 	set       = "set" // optional
 )
 
-var errMissingHosts = errors.New("aerospike: value for 'hosts' missing")
-var errInvalidHosts = errors.New("aerospike: invalid value for hosts")
-var errInvalidETag = errors.New("aerospike: invalid ETag value")
+var (
+	errMissingHosts = errors.New("aerospike: value for 'hosts' missing")
+	errInvalidHosts = errors.New("aerospike: invalid value for hosts")
+	errInvalidETag  = errors.New("aerospike: invalid ETag value")
+)
 
 // Aerospike is a state store
 type Aerospike struct {
@@ -132,6 +132,7 @@ func (aspike *Aerospike) Set(req *state.SetRequest) error {
 	if err != nil {
 		return fmt.Errorf("aerospike: failed to save value for key %s - %v", req.Key, err)
 	}
+
 	return nil
 }
 
@@ -143,13 +144,13 @@ func (aspike *Aerospike) BulkSet(req []state.SetRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
 // Get retrieves state from Aerospike with a key
 func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	asKey, err := as.NewKey(aspike.namespace, aspike.set, req.Key)
-
 	if err != nil {
 		return nil, err
 	}
@@ -165,10 +166,10 @@ func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) 
 		if err == types.ErrKeyNotFound {
 			return &state.GetResponse{}, nil
 		}
+
 		return nil, fmt.Errorf("aerospike: failed to get value for key %s - %v", req.Key, err)
 	}
 	value, err := aspike.json.Marshal(record.Bins)
-
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +215,7 @@ func (aspike *Aerospike) Delete(req *state.DeleteRequest) error {
 	if err != nil {
 		return fmt.Errorf("aerospike: failed to delete key %s - %v", req.Key, err)
 	}
+
 	return nil
 }
 
@@ -225,6 +227,7 @@ func (aspike *Aerospike) BulkDelete(req []state.DeleteRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -241,6 +244,7 @@ func parseHosts(hostsMeta string) ([]*as.Host, error) {
 		}
 		hostPorts = append(hostPorts, as.NewHost(host, int(port)))
 	}
+
 	return hostPorts, nil
 }
 
@@ -249,5 +253,6 @@ func convertETag(eTag string) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return uint32(i), nil
 }

--- a/state/aerospike/aerospike_test.go
+++ b/state/aerospike/aerospike_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/dapr/components-contrib/state"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,6 +74,7 @@ func TestValidateMetadataForInvalidInputs(t *testing.T) {
 		})
 	}
 }
+
 func TestParseHostsForValidInputs(t *testing.T) {
 	type testCase struct {
 		name      string

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -4,15 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	aws_auth "github.com/dapr/components-contrib/authentication/aws"
-
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	jsoniterator "github.com/json-iterator/go"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	aws_auth "github.com/dapr/components-contrib/authentication/aws"
 	"github.com/dapr/components-contrib/state"
+	jsoniterator "github.com/json-iterator/go"
 )
 
 // StateStore is a DynamoDB state store
@@ -49,6 +47,7 @@ func (d *StateStore) Init(metadata state.Metadata) error {
 
 	d.client = client
 	d.table = meta.Table
+
 	return nil
 }
 
@@ -77,6 +76,7 @@ func (d *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if err = dynamodbattribute.Unmarshal(result.Item["value"], &output); err != nil {
 		return nil, err
 	}
+
 	return &state.GetResponse{
 		Data: []byte(output),
 	}, nil
@@ -104,6 +104,7 @@ func (d *StateStore) Set(req *state.SetRequest) error {
 	}
 
 	_, e := d.client.PutItem(input)
+
 	return e
 }
 
@@ -139,6 +140,7 @@ func (d *StateStore) BulkSet(req []state.SetRequest) error {
 	_, e := d.client.BatchWriteItem(&dynamodb.BatchWriteItemInput{
 		RequestItems: requestItems,
 	})
+
 	return e
 }
 
@@ -153,6 +155,7 @@ func (d *StateStore) Delete(req *state.DeleteRequest) error {
 		TableName: aws.String(d.table),
 	}
 	_, err := d.client.DeleteItem(input)
+
 	return err
 }
 
@@ -179,6 +182,7 @@ func (d *StateStore) BulkDelete(req []state.DeleteRequest) error {
 	_, e := d.client.BatchWriteItem(&dynamodb.BatchWriteItemInput{
 		RequestItems: requestItems,
 	})
+
 	return e
 }
 
@@ -207,6 +211,7 @@ func (d *StateStore) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, 
 		return nil, err
 	}
 	c := dynamodb.New(sess)
+
 	return c, nil
 }
 

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/dapr/components-contrib/state"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -175,7 +174,9 @@ func TestSet(t *testing.T) {
 						},
 						"value": {
 							S: aws.String(`{"Value":"value"}`),
-						}}, input.Item)
+						},
+					}, input.Item)
+
 					return &dynamodb.PutItemOutput{
 						Attributes: map[string]*dynamodb.AttributeValue{
 							"key": {
@@ -252,6 +253,7 @@ func TestBulkSet(t *testing.T) {
 						},
 					}
 					assert.Equal(t, expected, input.RequestItems)
+
 					return &dynamodb.BatchWriteItemOutput{
 						UnprocessedItems: map[string][]*dynamodb.WriteRequest{},
 					}, nil
@@ -311,6 +313,7 @@ func TestDelete(t *testing.T) {
 							S: aws.String(req.Key),
 						},
 					}, input.Key)
+
 					return nil, nil
 				},
 			},
@@ -363,6 +366,7 @@ func TestBulkDelete(t *testing.T) {
 						},
 					}
 					assert.Equal(t, expected, input.RequestItems)
+
 					return &dynamodb.BatchWriteItemOutput{
 						UnprocessedItems: map[string][]*dynamodb.WriteRequest{},
 					}, nil

--- a/state/azure/blobstorage/blobstorage.go
+++ b/state/azure/blobstorage/blobstorage.go
@@ -91,18 +91,20 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 // Delete the state
 func (r *StateStore) Delete(req *state.DeleteRequest) error {
 	r.logger.Debugf("delete %s", req.Key)
+
 	return r.deleteFile(req)
 }
 
 // BulkDelete the state
 func (r *StateStore) BulkDelete(req []state.DeleteRequest) error {
 	r.logger.Debugf("bulk delete %v key(s)", len(req))
-	for _, s := range req {
-		err := r.Delete(&s)
+	for i := range req {
+		err := r.Delete(&req[i])
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -129,6 +131,7 @@ func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 // Set the state
 func (r *StateStore) Set(req *state.SetRequest) error {
 	r.logger.Debugf("saving %s", req.Key)
+
 	return r.writeFile(req)
 }
 
@@ -136,8 +139,8 @@ func (r *StateStore) Set(req *state.SetRequest) error {
 func (r *StateStore) BulkSet(req []state.SetRequest) error {
 	r.logger.Debugf("bulk set %v key(s)", len(req))
 
-	for _, s := range req {
-		err := r.Set(&s)
+	for i := range req {
+		err := r.Set(&req[i])
 		if err != nil {
 			return err
 		}
@@ -184,6 +187,7 @@ func (r *StateStore) readFile(req *state.GetRequest) ([]byte, string, error) {
 	resp, err := blobURL.Download(context.Background(), 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
 	if err != nil {
 		r.logger.Debugf("download file %s, err %s", req.Key, err)
+
 		return nil, "", err
 	}
 
@@ -193,8 +197,10 @@ func (r *StateStore) readFile(req *state.GetRequest) ([]byte, string, error) {
 
 	if err != nil {
 		r.logger.Debugf("read file %s, err %s", req.Key, err)
+
 		return nil, "", err
 	}
+
 	return data.Bytes(), string(resp.ETag()), nil
 }
 
@@ -212,9 +218,9 @@ func (r *StateStore) writeFile(req *state.SetRequest) error {
 		Metadata:         req.Metadata,
 		AccessConditions: accessConditions,
 	})
-
 	if err != nil {
 		r.logger.Debugf("write file %s, err %s", req.Key, err)
+
 		return err
 	}
 
@@ -230,11 +236,12 @@ func (r *StateStore) deleteFile(req *state.DeleteRequest) error {
 	}
 
 	_, err := blobURL.Delete(context.Background(), azblob.DeleteSnapshotsOptionNone, accessConditions)
-
 	if err != nil {
 		r.logger.Debugf("delete file %s, err %s", req.Key, err)
+
 		return err
 	}
+
 	return nil
 }
 
@@ -243,6 +250,7 @@ func getFileName(key string) string {
 	if len(pr) != 2 {
 		return pr[0]
 	}
+
 	return pr[1]
 }
 
@@ -254,10 +262,12 @@ func (r *StateStore) marshal(req *state.SetRequest) []byte {
 	} else {
 		v, _ = jsoniter.MarshalToString(req.Value)
 	}
+
 	return []byte(v)
 }
 
 func isNotFoundError(err error) bool {
 	azureError, ok := err.(azblob.StorageError)
+
 	return ok && azureError.ServiceCode() == azblob.ServiceCodeBlobNotFound
 }

--- a/state/cassandra/cassandra.go
+++ b/state/cassandra/cassandra.go
@@ -91,6 +91,7 @@ func (c *Cassandra) Init(metadata state.Metadata) error {
 	}
 
 	c.table = fmt.Sprintf("%s.%s", meta.keyspace, meta.table)
+
 	return nil
 }
 
@@ -115,6 +116,7 @@ func (c *Cassandra) createClusterConfig(metadata *cassandraMetadata) (*gocql.Clu
 	}
 
 	clusterConfig.Consistency = cons
+
 	return clusterConfig, nil
 }
 
@@ -141,6 +143,7 @@ func (c *Cassandra) getConsistency(consistency string) (gocql.Consistency, error
 	case "":
 		return defaultConsistency, nil
 	}
+
 	return 0, fmt.Errorf("consistency mode %s not found", consistency)
 }
 
@@ -252,6 +255,7 @@ func (c *Cassandra) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if len(results) == 0 {
 		return &state.GetResponse{}, nil
 	}
+
 	return &state.GetResponse{
 		Data: results[0]["value"].([]byte),
 	}, nil
@@ -295,6 +299,7 @@ func (c *Cassandra) createSession(consistency gocql.Consistency) (*gocql.Session
 	}
 
 	session.SetConsistency(consistency)
+
 	return session, nil
 }
 
@@ -306,5 +311,6 @@ func (c *Cassandra) BulkSet(req []state.SetRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/state/cloudstate/cloudstate_crdt.go
+++ b/state/cloudstate/cloudstate_crdt.go
@@ -259,6 +259,7 @@ func (c *CRDT) Init(metadata state.Metadata) error {
 
 	c.metadata = m
 	go c.startServer()
+
 	return nil
 }
 
@@ -273,6 +274,7 @@ func (c *CRDT) startServer() error {
 	if err := s.Serve(lis); err != nil {
 		c.logger.Fatalf("failed to serve: %v", err)
 	}
+
 	return nil
 }
 
@@ -298,6 +300,7 @@ func (c *CRDT) Discover(ctx context.Context, in *pb.ProxyInfo) (*pb.EntitySpec, 
 
 func (c *CRDT) ReportError(ctx context.Context, in *pb.UserFunctionError) (*empty.Empty, error) {
 	c.logger.Errorf("error from CloudState: %s", in.GetMessage())
+
 	return &empty.Empty{}, nil
 }
 
@@ -314,6 +317,7 @@ func (c *CRDT) Handle(srv pb.Crdt_HandleServer) error {
 		if err != nil {
 			c.logger.Debugf("error from src.Recv(): %s", err)
 			srv.Context().Done()
+
 			return err
 		}
 
@@ -391,6 +395,7 @@ func (c *CRDT) Handle(srv pb.Crdt_HandleServer) error {
 					err := ptypes.UnmarshalAny(vAny, &saveState)
 					if err != nil {
 						c.logger.Error(err)
+
 						break
 					}
 
@@ -442,6 +447,7 @@ func (c *CRDT) Handle(srv pb.Crdt_HandleServer) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -457,6 +463,7 @@ func (c *CRDT) createConnectionOnce() error {
 			c.connection = conn
 		}
 	})
+
 	return connError
 }
 
@@ -477,6 +484,7 @@ func (c *CRDT) parseMetadata(metadata state.Metadata) (*crdtMetadata, error) {
 	} else {
 		return nil, fmt.Errorf("serverPort field required")
 	}
+
 	return &m, nil
 }
 
@@ -506,6 +514,7 @@ func (c *CRDT) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if resp.Data != nil {
 		stateResp.Data = resp.Data.Value
 	}
+
 	return stateResp, nil
 }
 
@@ -524,6 +533,7 @@ func (c *CRDT) Delete(req *state.DeleteRequest) error {
 		Key:  req.Key,
 		Etag: req.ETag,
 	})
+
 	return err
 }
 
@@ -540,6 +550,7 @@ func (c *CRDT) BulkDelete(req []state.DeleteRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -569,6 +580,7 @@ func (c *CRDT) Set(req *state.SetRequest) error {
 			Value: bt,
 		},
 	})
+
 	return err
 }
 
@@ -585,5 +597,6 @@ func (c *CRDT) BulkSet(req []state.SetRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/state/couchbase/couchbase_test.go
+++ b/state/couchbase/couchbase_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 
 	"github.com/dapr/components-contrib/state"
-	"gopkg.in/couchbase/gocb.v1"
-
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 func TestValidateMetadata(t *testing.T) {

--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -20,11 +20,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-const defaultOperationTimeout = 10 * time.Second
-const defaultSeparator = ","
+const (
+	defaultOperationTimeout = 10 * time.Second
+	defaultSeparator        = ","
+)
 
-var errMissingEndpoints = errors.New("endpoints are required")
-var errInvalidDialTimeout = errors.New("DialTimeout is invalid")
+var (
+	errMissingEndpoints   = errors.New("endpoints are required")
+	errInvalidDialTimeout = errors.New("DialTimeout is invalid")
+)
 
 // ETCD is a state store
 type ETCD struct {
@@ -157,7 +161,7 @@ func (r *ETCD) Delete(req *state.DeleteRequest) error {
 	defer cancelFn()
 
 	version := req.ETag
-	//honor client etag
+	// honor client etag
 	if version != "" {
 		txn := r.client.KV.Txn(ctx)
 		_, err = txn.If(clientv3.Compare(clientv3.Version(req.Key), "=", version)).Then(clientv3.OpDelete(req.Key)).Commit()
@@ -201,7 +205,7 @@ func (r *ETCD) Set(req *state.SetRequest) error {
 	}
 
 	version := req.ETag
-	//honor client etag
+	// honor client etag
 	if version != "" {
 		txn := r.client.KV.Txn(ctx)
 		_, err = txn.If(clientv3.Compare(clientv3.Version(req.Key), "=", version)).Then(clientv3.OpPut(req.Key, vStr)).Commit()
@@ -212,6 +216,7 @@ func (r *ETCD) Set(req *state.SetRequest) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -70,6 +70,7 @@ func (f *Firestore) Init(metadata state.Metadata) error {
 
 	f.client = client
 	f.entityKind = meta.EntityKind
+
 	return nil
 }
 
@@ -117,6 +118,7 @@ func (f *Firestore) setValue(req *state.SetRequest) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -133,6 +135,7 @@ func (f *Firestore) BulkSet(req []state.SetRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -141,10 +144,10 @@ func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
 	key := datastore.NameKey(f.entityKind, req.Key, nil)
 
 	err := f.client.Delete(ctx, key)
-
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -161,6 +164,7 @@ func (f *Firestore) BulkDelete(req []state.DeleteRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -168,9 +172,10 @@ func getFirestoreMetadata(metadata state.Metadata) (*firestoreMetadata, error) {
 	meta := firestoreMetadata{
 		EntityKind: defaultEntityKind,
 	}
-	var requiredMetaProperties = []string{
+	requiredMetaProperties := []string{
 		"type", "project_id", "private_key_id", "private_key", "client_email", "client_id",
-		"auth_uri", "token_uri", "auth_provider_x509_cert_url", "client_x509_cert_url"}
+		"auth_uri", "token_uri", "auth_provider_x509_cert_url", "client_x509_cert_url",
+	}
 
 	for _, k := range requiredMetaProperties {
 		if val, ok := metadata.Properties[k]; !ok || len(val) < 1 {

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -117,8 +117,8 @@ func (c *Consul) Set(req *state.SetRequest) error {
 
 	_, err := c.client.KV().Put(&api.KVPair{
 		Key:   keyWithPath,
-		Value: reqValByte}, nil)
-
+		Value: reqValByte,
+	}, nil)
 	if err != nil {
 		return fmt.Errorf("couldn't set key %s: %s", keyWithPath, err)
 	}

--- a/state/hazelcast/hazelcast.go
+++ b/state/hazelcast/hazelcast.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
+	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	jsoniter "github.com/json-iterator/go"
-
-	"github.com/dapr/components-contrib/state"
-	"github.com/hazelcast/hazelcast-go-client"
 )
 
 const (
@@ -18,7 +17,7 @@ const (
 	hazelcastMap     = "hazelcastMap"
 )
 
-//Hazelcast state store
+// Hazelcast state store
 type Hazelcast struct {
 	hzMap  core.Map
 	json   jsoniter.API
@@ -64,10 +63,11 @@ func (store *Hazelcast) Init(metadata state.Metadata) error {
 	if err != nil {
 		return fmt.Errorf("hazelcast error: %v", err)
 	}
+
 	return nil
 }
 
-//Set stores value for a key to Hazelcast
+// Set stores value for a key to Hazelcast
 func (store *Hazelcast) Set(req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req)
 	if err != nil {
@@ -89,6 +89,7 @@ func (store *Hazelcast) Set(req *state.SetRequest) error {
 	if err != nil {
 		return fmt.Errorf("hazelcast error: failed to set key %s: %s", req.Key, err)
 	}
+
 	return nil
 }
 
@@ -111,12 +112,11 @@ func (store *Hazelcast) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		return nil, fmt.Errorf("hazelcast error: failed to get value for %s: %s", req.Key, err)
 	}
 
-	//HZ Get API returns nil response if key does not exist in the map
+	// HZ Get API returns nil response if key does not exist in the map
 	if resp == nil {
 		return &state.GetResponse{}, nil
 	}
 	value, err := store.json.Marshal(&resp)
-
 	if err != nil {
 		return nil, fmt.Errorf("hazelcast error: %v", err)
 	}
@@ -136,6 +136,7 @@ func (store *Hazelcast) Delete(req *state.DeleteRequest) error {
 	if err != nil {
 		return fmt.Errorf("hazelcast error: failed to delete key - %s", req.Key)
 	}
+
 	return nil
 }
 
@@ -147,5 +148,6 @@ func (store *Hazelcast) BulkDelete(req []state.DeleteRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -97,7 +97,6 @@ func (m *Memcached) setValue(req *state.SetRequest) error {
 	var bt []byte
 	bt, _ = utils.Marshal(req.Value, m.json.Marshal)
 	err := m.client.Set(&memcache.Item{Key: req.Key, Value: bt})
-
 	if err != nil {
 		return fmt.Errorf("failed to set key %s: %s", req.Key, err)
 	}
@@ -110,6 +109,7 @@ func (m *Memcached) Delete(req *state.DeleteRequest) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -120,6 +120,7 @@ func (m *Memcached) BulkDelete(req []state.DeleteRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -130,6 +131,7 @@ func (m *Memcached) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		if errors.Is(err, memcache.ErrCacheMiss) {
 			return &state.GetResponse{}, nil
 		}
+
 		return &state.GetResponse{}, err
 	}
 
@@ -149,5 +151,6 @@ func (m *Memcached) BulkSet(req []state.SetRequest) error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -14,11 +14,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
 	json "github.com/json-iterator/go"
-
-	"github.com/dapr/components-contrib/state"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -92,7 +90,6 @@ func (m *MongoDB) Init(metadata state.Metadata) error {
 	m.operationTimeout = meta.operationTimeout
 
 	client, err := getMongoDBClient(meta)
-
 	if err != nil {
 		return fmt.Errorf("error in creating mongodb client: %s", err)
 	}
@@ -105,14 +102,12 @@ func (m *MongoDB) Init(metadata state.Metadata) error {
 
 	// get the write concern
 	wc, err := getWriteConcernObject(meta.writeconcern)
-
 	if err != nil {
 		return fmt.Errorf("error in getting write concern object: %s", err)
 	}
 
 	// get the read concern
 	rc, err := getReadConcernObject(meta.readconcern)
-
 	if err != nil {
 		return fmt.Errorf("error in getting read concern object: %s", err)
 	}
@@ -131,7 +126,6 @@ func (m *MongoDB) Set(req *state.SetRequest) error {
 	defer cancel()
 
 	err := m.setInternal(ctx, req)
-
 	if err != nil {
 		return err
 	}
@@ -152,7 +146,6 @@ func (m *MongoDB) setInternal(ctx context.Context, req *state.SetRequest) error 
 	filter := bson.M{id: req.Key}
 	update := bson.M{"$set": bson.M{id: req.Key, value: vStr}}
 	_, err := m.collection.UpdateOne(ctx, filter, update, options.Update().SetUpsert(true))
-
 	if err != nil {
 		return err
 	}
@@ -169,7 +162,6 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	filter := bson.M{id: req.Key}
 	err := m.collection.FindOne(ctx, filter).Decode(&result)
-
 	if err != nil {
 		return &state.GetResponse{}, err
 	}
@@ -199,7 +191,6 @@ func (m *MongoDB) Delete(req *state.DeleteRequest) error {
 	defer cancel()
 
 	err := m.deleteInternal(ctx, req)
-
 	if err != nil {
 		return err
 	}
@@ -210,7 +201,6 @@ func (m *MongoDB) Delete(req *state.DeleteRequest) error {
 func (m *MongoDB) deleteInternal(ctx context.Context, req *state.DeleteRequest) error {
 	filter := bson.M{id: req.Key}
 	_, err := m.collection.DeleteOne(ctx, filter)
-
 	if err != nil {
 		return err
 	}
@@ -244,6 +234,7 @@ func (m *MongoDB) Multi(request *state.TransactionalStateRequest) error {
 
 	sess.WithTransaction(context.Background(), func(sessCtx mongo.SessionContext) (interface{}, error) {
 		err = m.doTransaction(sessCtx, request.Operations)
+
 		return nil, err
 	}, txnOpts)
 
@@ -263,6 +254,7 @@ func (m *MongoDB) doTransaction(sessCtx mongo.SessionContext, operations []state
 
 		if err != nil {
 			sessCtx.AbortTransaction(sessCtx)
+
 			return fmt.Errorf("error during transaction, aborting the transaction: %s", err)
 		}
 	}
@@ -274,6 +266,7 @@ func getMongoURI(metadata *mongoDBMetadata) string {
 	if metadata.username != "" && metadata.password != "" {
 		return fmt.Sprintf(connectionURIFormatWithAuthentication, metadata.username, metadata.password, metadata.host, metadata.databaseName, metadata.params)
 	}
+
 	return fmt.Sprintf(connectionURIFormat, metadata.host, metadata.databaseName, metadata.params)
 }
 
@@ -288,7 +281,6 @@ func getMongoDBClient(metadata *mongoDBMetadata) (*mongo.Client, error) {
 	defer cancel()
 
 	client, err := mongo.Connect(ctx, clientOptions)
-
 	if err != nil {
 		return nil, err
 	}

--- a/state/postgresql/postgresql.go
+++ b/state/postgresql/postgresql.go
@@ -21,6 +21,7 @@ type PostgreSQL struct {
 // NewPostgreSQLStateStore creates a new instance of PostgreSQL state store
 func NewPostgreSQLStateStore(logger logger.Logger) *PostgreSQL {
 	dba := newPostgresDBAccess(logger)
+
 	return newPostgreSQLStateStore(logger, dba)
 }
 

--- a/state/postgresql/postgresql_integration_test.go
+++ b/state/postgresql/postgresql_integration_test.go
@@ -133,7 +133,6 @@ func TestPostgreSQLIntegration(t *testing.T) {
 // setGetUpdateDeleteOneItem validates setting one item, getting it, and deleting it.
 func setGetUpdateDeleteOneItem(t *testing.T, pgs *PostgreSQL) {
 	key := randomKey()
-	//value := `{"something": "DKbLaZwrlCAZ"}`
 	value := &fakeItem{Color: "yellow"}
 
 	setItem(t, pgs, key, value, "")
@@ -526,6 +525,7 @@ func getItem(t *testing.T, pgs *PostgreSQL, key string) (*state.GetResponse, *fa
 	assert.NotNil(t, response)
 	outputObject := &fakeItem{}
 	_ = json.Unmarshal(response.Data, outputObject)
+
 	return response, outputObject
 }
 
@@ -550,6 +550,7 @@ func storeItemExists(t *testing.T, key string) bool {
 	statement := fmt.Sprintf(`SELECT EXISTS (SELECT FROM %s WHERE key = $1)`, tableName)
 	err = db.QueryRow(statement, key).Scan(&exists)
 	assert.Nil(t, err)
+
 	return exists
 }
 
@@ -560,6 +561,7 @@ func getRowData(t *testing.T, key string) (returnValue string, insertdate sql.Nu
 
 	err = db.QueryRow(fmt.Sprintf("SELECT value, insertdate, updatedate FROM %s WHERE key = $1", tableName), key).Scan(&returnValue, &insertdate, &updatedate)
 	assert.Nil(t, err)
+
 	return returnValue, insertdate, updatedate
 }
 

--- a/state/postgresql/postgresql_test.go
+++ b/state/postgresql/postgresql_test.go
@@ -26,16 +26,19 @@ type fakeDBaccess struct {
 
 func (m *fakeDBaccess) Init(metadata state.Metadata) error {
 	m.initExecuted = true
+
 	return nil
 }
 
 func (m *fakeDBaccess) Set(req *state.SetRequest) error {
 	m.setExecuted = true
+
 	return nil
 }
 
 func (m *fakeDBaccess) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	m.getExecuted = true
+
 	return nil, nil
 }
 
@@ -164,6 +167,7 @@ func createDeleteRequest() state.DeleteRequest {
 func createPostgreSQLWithFake(t *testing.T) (*PostgreSQL, *fakeDBaccess) {
 	pgs := createPostgreSQL(t)
 	fake := pgs.dbaccess.(*fakeDBaccess)
+
 	return pgs, fake
 }
 

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -17,10 +17,8 @@ import (
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
-
-	jsoniter "github.com/json-iterator/go"
-
 	redis "github.com/go-redis/redis/v7"
+	jsoniter "github.com/json-iterator/go"
 )
 
 const (
@@ -204,6 +202,7 @@ func (r *StateStore) parseConnectedSlaves(res string) int {
 	for _, info := range infos {
 		if strings.Contains(info, connectedSlavesReplicas) {
 			parsedReplicas, _ := strconv.ParseUint(info[len(connectedSlavesReplicas):], 10, 32)
+
 			return int(parsedReplicas)
 		}
 	}
@@ -216,7 +215,6 @@ func (r *StateStore) deleteValue(req *state.DeleteRequest) error {
 		req.ETag = "0"
 	}
 	_, err := r.client.DoContext(context.Background(), "EVAL", delQuery, 1, req.Key, req.ETag).Result()
-
 	if err != nil {
 		return fmt.Errorf("failed to delete key '%s' due to ETag mismatch", req.Key)
 	}
@@ -230,6 +228,7 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 	if err != nil {
 		return err
 	}
+
 	return state.DeleteWithOptions(r.deleteValue, req)
 }
 
@@ -256,6 +255,7 @@ func (r *StateStore) directGet(req *state.GetRequest) (*state.GetResponse, error
 	}
 
 	s, _ := strconv.Unquote(fmt.Sprintf("%q", res))
+
 	return &state.GetResponse{
 		Data: []byte(s),
 	}, nil
@@ -279,6 +279,7 @@ func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &state.GetResponse{
 		Data: []byte(data),
 		ETag: version,
@@ -351,6 +352,7 @@ func (r *StateStore) Multi(request *state.TransactionalStateRequest) error {
 	}
 
 	_, err := pipe.Exec()
+
 	return err
 }
 
@@ -371,6 +373,7 @@ func (r *StateStore) getKeyVersion(vals []interface{}) (data string, version str
 	if !seenData || !seenVersion {
 		return "", "", errors.New("required hash field 'data' or 'version' was not found")
 	}
+
 	return data, version, nil
 }
 
@@ -382,5 +385,6 @@ func (r *StateStore) parseETag(req *state.SetRequest) (int, error) {
 	if err != nil {
 		return -1, err
 	}
+
 	return ver, nil
 }

--- a/state/redis/redis_test.go
+++ b/state/redis/redis_test.go
@@ -12,10 +12,9 @@ import (
 	miniredis "github.com/alicebob/miniredis/v2"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-	"github.com/stretchr/testify/assert"
-
 	redis "github.com/go-redis/redis/v7"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetKeyVersion(t *testing.T) {
@@ -215,5 +214,6 @@ func setupMiniredis() (*miniredis.Miniredis, *redis.Client) {
 		Addr: s.Addr(),
 		DB:   defaultDB,
 	}
+
 	return s, redis.NewClient(opts)
 }

--- a/state/request_options.go
+++ b/state/request_options.go
@@ -39,6 +39,7 @@ func CheckRequestOptions(options interface{}) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -46,6 +47,7 @@ func validateConcurrencyOption(c string) error {
 	if c != "" && c != FirstWrite && c != LastWrite {
 		return fmt.Errorf("unrecognized concurrency model '%s'", c)
 	}
+
 	return nil
 }
 
@@ -53,6 +55,7 @@ func validateConsistencyOption(c string) error {
 	if c != "" && c != Strong && c != Eventual {
 		return fmt.Errorf("unrecognized consistency model '%s'", c)
 	}
+
 	return nil
 }
 

--- a/state/request_options_test.go
+++ b/state/request_options_test.go
@@ -17,6 +17,7 @@ func TestSetRequestWithOptions(t *testing.T) {
 		counter := 0
 		SetWithOptions(func(req *SetRequest) error {
 			counter++
+
 			return nil
 		}, &SetRequest{})
 		assert.Equal(t, 1, counter, "should execute only once")
@@ -26,6 +27,7 @@ func TestSetRequestWithOptions(t *testing.T) {
 		counter := 0
 		SetWithOptions(func(req *SetRequest) error {
 			counter++
+
 			return nil
 		}, &SetRequest{
 			Options: SetStateOption{},

--- a/state/requests.go
+++ b/state/requests.go
@@ -14,7 +14,7 @@ type GetRequest struct {
 
 // GetStateOption controls how a state store reacts to a get request
 type GetStateOption struct {
-	Consistency string `json:"consistency"` //"eventual, strong"
+	Consistency string `json:"consistency"` // "eventual, strong"
 }
 
 // DeleteRequest is the object describing a delete state request
@@ -37,8 +37,8 @@ func (r DeleteRequest) GetMetadata() map[string]string {
 
 // DeleteStateOption controls how a state store reacts to a delete request
 type DeleteStateOption struct {
-	Concurrency string `json:"concurrency,omitempty"` //"concurrency"
-	Consistency string `json:"consistency"`           //"eventual, strong"
+	Concurrency string `json:"concurrency,omitempty"` // "concurrency"
+	Consistency string `json:"consistency"`           // "eventual, strong"
 }
 
 // SetRequest is the object describing an upsert request
@@ -62,8 +62,8 @@ func (r SetRequest) GetMetadata() map[string]string {
 
 // SetStateOption controls how a state store reacts to a set request
 type SetStateOption struct {
-	Concurrency string `json:"concurrency,omitempty"` //first-write, last-write
-	Consistency string `json:"consistency"`           //"eventual, strong"
+	Concurrency string `json:"concurrency,omitempty"` // first-write, last-write
+	Consistency string `json:"consistency"`           // "eventual, strong"
 }
 
 // OperationType describes a CRUD operation performed against a state store

--- a/state/rethinkdb/rethinkdb.go
+++ b/state/rethinkdb/rethinkdb.go
@@ -125,6 +125,7 @@ func tableExists(arr []string, table string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -164,6 +165,7 @@ func (s *RethinkDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		}
 		resp.Data = data
 	}
+
 	return resp, nil
 }
 
@@ -172,6 +174,7 @@ func (s *RethinkDB) Set(req *state.SetRequest) error {
 	if req == nil || req.Key == "" || req.Value == nil {
 		return errors.New("invalid state request, key and value required")
 	}
+
 	return s.BulkSet([]state.SetRequest{*req})
 }
 
@@ -209,6 +212,7 @@ func (s *RethinkDB) archive(changes []r.ChangeResponse) error {
 			record, ok := c.NewValue.(map[string]interface{})
 			if !ok {
 				s.logger.Infof("invalid state DB change type: %T", c.NewValue)
+
 				continue
 			}
 			list = append(list, record)
@@ -220,6 +224,7 @@ func (s *RethinkDB) archive(changes []r.ChangeResponse) error {
 			return errors.Wrap(err, "error archiving records to the database")
 		}
 	}
+
 	return nil
 }
 
@@ -228,6 +233,7 @@ func (s *RethinkDB) Delete(req *state.DeleteRequest) error {
 	if req == nil || req.Key == "" {
 		return errors.New("invalid request, missing key")
 	}
+
 	return s.BulkDelete([]state.DeleteRequest{*req})
 }
 
@@ -243,6 +249,7 @@ func (s *RethinkDB) BulkDelete(req []state.DeleteRequest) error {
 		return errors.Wrap(err, "error deleting record from the database")
 	}
 	defer c.Close()
+
 	return nil
 }
 
@@ -291,75 +298,75 @@ func metadataToConfig(cfg map[string]string, logger logger.Logger) (*stateConfig
 	// runtime
 	for k, v := range cfg {
 		switch k {
-		case "table": //string
+		case "table": // string
 			c.Table = v
-		case "address": //string
+		case "address": // string
 			c.Address = v
 		case "addresses": // []string
 			c.Addresses = strings.Split(v, ",")
-		case "database": //string
+		case "database": // string
 			c.Database = v
-		case "username": //string
+		case "username": // string
 			c.Username = v
-		case "password": //string
+		case "password": // string
 			c.Password = v
-		case "authkey": //string
+		case "authkey": // string
 			c.AuthKey = v
-		case "timeout": //time.Duration
+		case "timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid timeout format: %v", v)
 			}
 			c.Timeout = d
-		case "write_timeout": //time.Duration
+		case "write_timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid write timeout format: %v", v)
 			}
 			c.WriteTimeout = d
-		case "read_timeout": //time.Duration
+		case "read_timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid read timeout format: %v", v)
 			}
 			c.ReadTimeout = d
-		case "keep_alive_timeout": //time.Duration
+		case "keep_alive_timeout": // time.Duration
 			d, err := time.ParseDuration(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid keep alive timeout format: %v", v)
 			}
 			c.KeepAlivePeriod = d
-		case "initial_cap": //int
+		case "initial_cap": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid keep initial cap format: %v", v)
 			}
 			c.InitialCap = i
-		case "max_open": //int
+		case "max_open": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid keep max open format: %v", v)
 			}
 			c.MaxOpen = i
-		case "discover_hosts": //bool
+		case "discover_hosts": // bool
 			b, err := strconv.ParseBool(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid discover hosts format: %v", v)
 			}
 			c.DiscoverHosts = b
-		case "use-open-tracing": //bool
+		case "use-open-tracing": // bool
 			b, err := strconv.ParseBool(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid use open tracing format: %v", v)
 			}
 			c.UseOpentracing = b
-		case "archive": //bool
+		case "archive": // bool
 			b, err := strconv.ParseBool(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid use open tracing format: %v", v)
 			}
 			c.Archive = b
-		case "max_idle": //int
+		case "max_idle": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid keep max idle format: %v", v)

--- a/state/rethinkdb/rethinkdb_test.go
+++ b/state/rethinkdb/rethinkdb_test.go
@@ -226,13 +226,15 @@ func TestRethinkDBStateStoreMulti(t *testing.T) {
 					Operation: state.Upsert,
 					Request: state.SetRequest{
 						Key:   fmt.Sprintf(recordIDFormat, 0),
-						Value: d2},
+						Value: d2,
+					},
 				},
 				{
 					Operation: state.Upsert,
 					Request: state.SetRequest{
 						Key:   fmt.Sprintf(recordIDFormat, 1),
-						Value: d2},
+						Value: d2,
+					},
 				},
 				{
 					Operation: state.Delete,

--- a/state/sqlserver/migration.go
+++ b/state/sqlserver/migration.go
@@ -50,6 +50,7 @@ func (m *migration) executeMigrations() (migrationResult, error) {
 	r.bulkDeleteProcFullName = fmt.Sprintf("[%s].%s", m.store.schema, r.bulkDeleteProcName)
 	r.upsertProcFullName = fmt.Sprintf("[%s].%s", m.store.schema, r.upsertProcName)
 
+	// nolint: exhaustive
 	switch m.store.keyType {
 	case StringKeyType:
 		r.pkColumnType = fmt.Sprintf("NVARCHAR(%d)", m.store.keyLength)
@@ -157,6 +158,7 @@ func (m *migration) ensureTableExists(db *sql.DB, r migrationResult) error {
 	tsql += `
 		[RowVersion] 	ROWVERSION NOT NULL)
 	`
+
 	return runCommand(tsql, db)
 }
 

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -44,10 +44,10 @@ const (
 	// UUIDKeyType defines a key of type UUID/GUID
 	UUIDKeyType KeyType = "uuid"
 
-	//IntegerKeyType defines a key of type integer
+	// IntegerKeyType defines a key of type integer
 	IntegerKeyType KeyType = "integer"
 
-	//InvalidKeyType defines an invalid key type
+	// InvalidKeyType defines an invalid key type
 	InvalidKeyType KeyType = "invalid"
 )
 
@@ -111,6 +111,7 @@ func isValidSQLName(s string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -120,6 +121,7 @@ func isValidIndexedPropertyName(s string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -129,6 +131,7 @@ func isValidIndexedPropertyType(s string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -297,6 +300,7 @@ func (s *SQLServer) executeMulti(sets []state.SetRequest, deletes []state.Delete
 		err = s.executeBulkDelete(tx, deletes)
 		if err != nil {
 			tx.Rollback()
+
 			return err
 		}
 	}
@@ -306,6 +310,7 @@ func (s *SQLServer) executeMulti(sets []state.SetRequest, deletes []state.Delete
 			err = s.executeSet(tx, &sets[i])
 			if err != nil {
 				tx.Rollback()
+
 				return err
 			}
 		}
@@ -362,6 +367,7 @@ func (s *SQLServer) BulkDelete(req []state.DeleteRequest) error {
 	err = s.executeBulkDelete(tx, req)
 	if err != nil {
 		tx.Rollback()
+
 		return err
 	}
 
@@ -401,6 +407,7 @@ func (s *SQLServer) executeBulkDelete(db dbExecutor, req []state.DeleteRequest) 
 
 	if int(rows) != len(req) {
 		err = fmt.Errorf("delete affected only %d rows, expected %d", rows, len(req))
+
 		return err
 	}
 
@@ -410,7 +417,6 @@ func (s *SQLServer) executeBulkDelete(db dbExecutor, req []state.DeleteRequest) 
 // Get returns an entity from store
 func (s *SQLServer) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	rows, err := s.db.Query(s.getCommand, sql.Named(keyColumnName, req.Key))
-
 	if err != nil {
 		return nil, err
 	}
@@ -494,10 +500,12 @@ func (s *SQLServer) BulkSet(req []state.SetRequest) error {
 		err = s.executeSet(tx, &req[i])
 		if err != nil {
 			tx.Rollback()
+
 			return err
 		}
 	}
 
 	err = tx.Commit()
+
 	return err
 }

--- a/state/sqlserver/sqlserver_integration_test.go
+++ b/state/sqlserver/sqlserver_integration_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-
 	uuid "github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -92,6 +91,7 @@ func TestIntegrationCases(t *testing.T) {
 func getUniqueDBSchema() string {
 	uuid := uuid.New().String()
 	uuid = strings.ReplaceAll(uuid, "-", "")
+
 	return fmt.Sprintf("v%s", uuid)
 }
 
@@ -203,6 +203,7 @@ type numbericKeyGenerator struct {
 
 func (n *numbericKeyGenerator) NextKey() string {
 	val := atomic.AddInt32(&n.seed, 1)
+
 	return strconv.Itoa(int(val))
 }
 
@@ -422,7 +423,8 @@ func testMultiOperations(t *testing.T) {
 					Operations: []state.TransactionalStateOperation{
 						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: toDelete.etag}},
 						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: toModify.etag}},
-					}})
+					},
+				})
 				assert.Nil(t, err)
 				assertLoadedUserIsEqual(t, store, modified.ID, modified)
 				assertUserDoesNotExist(t, store, toDelete.ID)
@@ -441,7 +443,8 @@ func testMultiOperations(t *testing.T) {
 					Operations: []state.TransactionalStateOperation{
 						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: invalidEtag}},
 						{Operation: state.Upsert, Request: state.SetRequest{Key: toInsert.ID, Value: toInsert}},
-					}})
+					},
+				})
 
 				assert.NotNil(t, err)
 				assertUserDoesNotExist(t, store, toInsert.ID)
@@ -460,7 +463,8 @@ func testMultiOperations(t *testing.T) {
 					Operations: []state.TransactionalStateOperation{
 						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID, ETag: invalidEtag}},
 						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified}},
-					}})
+					},
+				})
 				assert.NotNil(t, err)
 				assertLoadedUserIsEqual(t, store, toDelete.ID, toDelete.user)
 				assertLoadedUserIsEqual(t, store, toModify.ID, toModify.user)
@@ -478,7 +482,8 @@ func testMultiOperations(t *testing.T) {
 					Operations: []state.TransactionalStateOperation{
 						{Operation: state.Delete, Request: state.DeleteRequest{Key: toDelete.ID}},
 						{Operation: state.Upsert, Request: state.SetRequest{Key: modified.ID, Value: modified, ETag: invalidEtag}},
-					}})
+					},
+				})
 
 				assert.NotNil(t, err)
 				assertLoadedUserIsEqual(t, store, toDelete.ID, toDelete.user)
@@ -715,7 +720,7 @@ func testInsertAndUpdateSetRecordDates(t *testing.T) {
 		assert.Nil(t, localErr)
 
 		assert.True(t, insertDate.Valid)
-		var insertDiff = float64(time.Now().UTC().Sub(insertDate.Time).Milliseconds())
+		insertDiff := float64(time.Now().UTC().Sub(insertDate.Time).Milliseconds())
 		assert.LessOrEqual(t, math.Abs(insertDiff), maxDiffInMs)
 		assert.False(t, updateDate.Valid)
 
@@ -737,7 +742,7 @@ func testInsertAndUpdateSetRecordDates(t *testing.T) {
 		assert.Equal(t, originalInsertTime, insertDate.Time)
 
 		assert.True(t, updateDate.Valid)
-		var updateDiff = float64(time.Now().UTC().Sub(updateDate.Time).Milliseconds())
+		updateDiff := float64(time.Now().UTC().Sub(updateDate.Time).Milliseconds())
 		assert.LessOrEqual(t, math.Abs(updateDiff), maxDiffInMs)
 	})
 }

--- a/state/sqlserver/sqlserver_test.go
+++ b/state/sqlserver/sqlserver_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,6 +22,7 @@ type mockMigrator struct {
 
 func (m *mockMigrator) executeMigrations() (migrationResult, error) {
 	r := migrationResult{}
+
 	return r, nil
 }
 

--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -19,13 +19,16 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 )
 
-const defaultMaxBufferSize = 1024 * 1024
-const defaultMaxConnBufferSize = 1024 * 1024
+const (
+	anyVersion               = -1
+	defaultMaxBufferSize     = 1024 * 1024
+	defaultMaxConnBufferSize = 1024 * 1024
+)
 
-const anyVersion = -1
-
-var errMissingServers = errors.New("servers are required")
-var errInvalidSessionTimeout = errors.New("sessionTimeout is invalid")
+var (
+	errMissingServers        = errors.New("servers are required")
+	errInvalidSessionTimeout = errors.New("sessionTimeout is invalid")
+)
 
 type properties struct {
 	Servers           string `json:"servers"`
@@ -109,8 +112,10 @@ type StateStore struct {
 	logger logger.Logger
 }
 
-var _ Conn = (*zk.Conn)(nil)
-var _ state.Store = (*StateStore)(nil)
+var (
+	_ Conn        = (*zk.Conn)(nil)
+	_ state.Store = (*StateStore)(nil)
+)
 
 // NewZookeeperStateStore returns a new Zookeeper state store
 func NewZookeeperStateStore(logger logger.Logger) *StateStore {
@@ -139,11 +144,11 @@ func (s *StateStore) Init(metadata state.Metadata) (err error) {
 // Get retrieves state from Zookeeper with a key
 func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	value, stat, err := s.conn.Get(s.prefixedKey(req.Key))
-
 	if err != nil {
 		if errors.Is(err, zk.ErrNoNode) {
 			return &state.GetResponse{}, nil
 		}
+
 		return nil, err
 	}
 
@@ -165,6 +170,7 @@ func (s *StateStore) Delete(req *state.DeleteRequest) error {
 		if errors.Is(err, zk.ErrNoNode) {
 			return nil
 		}
+
 		return err
 	}, req)
 }
@@ -239,6 +245,7 @@ func (s *StateStore) BulkSet(reqs []state.SetRequest) error {
 				if errors.Is(res.Error, zk.ErrNoNode) {
 					if req, ok := ops[i].(*zk.SetDataRequest); ok {
 						retry = append(retry, s.newCreateRequest(req))
+
 						continue
 					}
 				}
@@ -321,6 +328,7 @@ func (s *StateStore) parseETag(etag string) int32 {
 			return int32(version)
 		}
 	}
+
 	return anyVersion
 }
 


### PR DESCRIPTION
# Description

Upgrade golang linter to v1.31 and switch to using golangci-lint.

## Issue reference

closes https://github.com/dapr/components-contrib/issues/439

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
