### PR TITLE
Add close method to pub/sub

### DIFF
--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -24,12 +24,13 @@ type snsSqs struct {
 	// key is the hashed topic name, value is the actual topic name
 	topicHash map[string]string
 	// key is the topic name, value holds the ARN of the queue and its url
-	queues    map[string]*sqsQueueInfo
-	awsAcctID string
-	snsClient *sns.SNS
-	sqsClient *sqs.SQS
-	metadata  *snsSqsMetadata
-	logger    logger.Logger
+	queues        map[string]*sqsQueueInfo
+	awsAcctID     string
+	snsClient     *sns.SNS
+	sqsClient     *sqs.SQS
+	metadata      *snsSqsMetadata
+	logger        logger.Logger
+	subscriptions []*string
 }
 
 type sqsQueueInfo struct {
@@ -68,7 +69,7 @@ const (
 )
 
 func NewSnsSqs(l logger.Logger) pubsub.PubSub {
-	return &snsSqs{logger: l}
+	return &snsSqs{logger: l, subscriptions: []*string{}}
 }
 
 func parseInt64(input string, propertyName string) (int64, error) {
@@ -478,15 +479,24 @@ func (s *snsSqs) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pubsub
 		ReturnSubscriptionArn: nil,
 		TopicArn:              &topicArn,
 	})
-
 	if err != nil {
 		s.logger.Errorf("error subscribing to topic %s: %v", req.Topic, err)
 		return err
 	}
 
+	s.subscriptions = append(s.subscriptions, subscribeOutput.SubscriptionArn)
 	s.logger.Debugf("Subscribed to topic %s: %v", req.Topic, subscribeOutput)
 
 	s.consumeSubscription(queueInfo, handler)
 
+	return nil
+}
+
+func (s *snsSqs) Close() error {
+	for _, sub := range s.subscriptions {
+		s.snsClient.Unsubscribe(&sns.UnsubscribeInput{
+			SubscriptionArn: sub,
+		})
+	}
 	return nil
 }

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -493,5 +493,6 @@ func (s *snsSqs) Close() error {
 			SubscriptionArn: sub,
 		})
 	}
+
 	return nil
 }

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -448,6 +448,7 @@ func (a *azureServiceBus) Close() error {
 	for _, s := range a.subscriptions {
 		s.close(context.TODO())
 	}
+
 	return nil
 }
 

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -51,16 +51,18 @@ const (
 type handler = struct{}
 
 type azureServiceBus struct {
-	metadata     metadata
-	namespace    *azservicebus.Namespace
-	topicManager *azservicebus.TopicManager
-	logger       logger.Logger
+	metadata      metadata
+	namespace     *azservicebus.Namespace
+	topicManager  *azservicebus.TopicManager
+	logger        logger.Logger
+	subscriptions []*subscription
 }
 
 // NewAzureServiceBus returns a new Azure ServiceBus pub-sub implementation
 func NewAzureServiceBus(logger logger.Logger) pubsub.PubSub {
 	return &azureServiceBus{
-		logger: logger,
+		logger:        logger,
+		subscriptions: []*subscription{},
 	}
 }
 
@@ -287,7 +289,7 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, appHandler func
 				return
 			}
 			sub := newSubscription(req.Topic, subEntity, a.metadata.MaxConcurrentHandlers, a.logger)
-
+			a.subscriptions = append(a.subscriptions, sub)
 			// ReceiveAndBlock will only return with an error
 			// that it cannot handle internally. The subscription
 			// connection is closed when this method returns.
@@ -427,6 +429,13 @@ func (a *azureServiceBus) createSubscriptionManagementOptions() ([]azservicebus.
 		opts = append(opts, subscriptionManagementOptionsWithAutoDeleteOnIdle(a.metadata.AutoDeleteOnIdleInSec))
 	}
 	return opts, nil
+}
+
+func (a *azureServiceBus) Close() error {
+	for _, s := range a.subscriptions {
+		s.close(context.TODO())
+	}
+	return nil
 }
 
 func subscriptionManagementOptionsWithMaxDeliveryCount(maxDeliveryCount *int) azservicebus.SubscriptionManagementOption {

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -150,3 +150,7 @@ func (g *GCPPubSub) ensureSubscription(subscription string, topic string) error 
 func (g *GCPPubSub) getSubscription(subscription string) *gcppubsub.Subscription {
 	return g.client.Subscription(subscription)
 }
+
+func (g *GCPPubSub) Close() error {
+	return g.client.Close()
+}

--- a/pubsub/hazelcast/hazelcast.go
+++ b/pubsub/hazelcast/hazelcast.go
@@ -84,6 +84,7 @@ func (p *Hazelcast) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pub
 
 func (p *Hazelcast) Close() error {
 	p.client.Shutdown()
+
 	return nil
 }
 

--- a/pubsub/hazelcast/hazelcast.go
+++ b/pubsub/hazelcast/hazelcast.go
@@ -81,6 +81,11 @@ func (p *Hazelcast) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pub
 	return nil
 }
 
+func (p *Hazelcast) Close() error {
+	p.client.Shutdown()
+	return nil
+}
+
 type hazelcastMessageListener struct {
 	topicName     string
 	pubsubHandler func(msg *pubsub.NewMessage) error

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -301,5 +301,6 @@ func updateAuthInfo(config *sarama.Config, saslUsername, saslPassword string) {
 
 func (k *Kafka) Close() error {
 	k.closeSubscripionResources()
+
 	return k.producer.Close()
 }

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -298,3 +298,8 @@ func updateAuthInfo(config *sarama.Config, saslUsername, saslPassword string) {
 		ClientAuth: 0,
 	}
 }
+
+func (k *Kafka) Close() error {
+	k.closeSubscripionResources()
+	return k.producer.Close()
+}

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -252,3 +252,9 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 	opts.SetTLSConfig(m.newTLSConfig())
 	return opts
 }
+
+func (m *mqttPubSub) Close() error {
+	m.consumer.Disconnect(0)
+	m.producer.Disconnect(0)
+	return nil
+}

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -261,5 +261,6 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 func (m *mqttPubSub) Close() error {
 	m.consumer.Disconnect(0)
 	m.producer.Disconnect(0)
+
 	return nil
 }

--- a/pubsub/nats/nats.go
+++ b/pubsub/nats/nats.go
@@ -84,3 +84,8 @@ func (n *natsPubSub) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pu
 
 	return nil
 }
+
+func (n *natsPubSub) Close() error {
+	n.natsConn.Close()
+	return nil
+}

--- a/pubsub/nats/nats.go
+++ b/pubsub/nats/nats.go
@@ -89,5 +89,6 @@ func (n *natsPubSub) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pu
 
 func (n *natsPubSub) Close() error {
 	n.natsConn.Close()
+
 	return nil
 }

--- a/pubsub/natsstreaming/natsstreaming.go
+++ b/pubsub/natsstreaming/natsstreaming.go
@@ -257,3 +257,7 @@ func genRandomString(n int) string {
 
 	return clientID
 }
+
+func (n *natsStreamingPubSub) Close() error {
+	return n.natStreamingConn.Close()
+}

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -10,4 +10,5 @@ type PubSub interface {
 	Init(metadata Metadata) error
 	Publish(req *PublishRequest) error
 	Subscribe(req SubscribeRequest, handler func(msg *NewMessage) error) error
+	Close() error
 }

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -129,5 +129,6 @@ func (p *Pulsar) HandleMessage(m pulsar.ConsumerMessage, topic string, handler f
 
 func (p *Pulsar) Close() error {
 	p.client.Close()
+
 	return nil
 }

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -126,3 +126,8 @@ func (p *Pulsar) HandleMessage(m pulsar.ConsumerMessage, topic string, handler f
 		m.Ack(m.Message)
 	}
 }
+
+func (p *Pulsar) Close() error {
+	p.client.Close()
+	return nil
+}

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -169,3 +169,7 @@ func (r *rabbitMQ) ensureExchangeDeclared(exchange string) error {
 
 	return nil
 }
+
+func (r *rabbitMQ) Close() error {
+	return r.connection.Close()
+}

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -171,3 +171,7 @@ func (r *redisStreams) beginReadingFromStream(stream, consumerID string, handler
 		start = ">"
 	}
 }
+
+func (r *redisStreams) Close() error {
+	return r.client.Close()
+}


### PR DESCRIPTION
As Pub/Sub components encapsulate the lifecycle management of their subscriptions, it's beneficial to provide consumers the ability to explicitly close an implementation and thereby all of it's underlying connections and/or subscriptions.

This issue participates in closing https://github.com/dapr/dapr/issues/1172.