### PR TITLE
Key Vault Secret Store now reads the secret version from metadata (Fixing #522)

### DIFF
--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -24,6 +24,7 @@ const (
 	componentSPNClientID            = "spnClientId"
 	componentSPNTenantID            = "spnTenantId"
 	componentVaultName              = "vaultName"
+	VersionID                       = "version_id"
 )
 
 type keyvaultSecretStore struct {
@@ -60,7 +61,12 @@ func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
 
 // GetSecret retrieves a secret using a key and returns a map of decrypted string/string values
 func (k *keyvaultSecretStore) GetSecret(req secretstores.GetSecretRequest) (secretstores.GetSecretResponse, error) {
-	secretResp, err := k.vaultClient.GetSecret(context.Background(), k.getVaultURI(), req.Name, "")
+	versionID := ""
+	if value, ok := req.Metadata[VersionID]; ok {
+		versionID = value
+	}
+
+	secretResp, err := k.vaultClient.GetSecret(context.Background(), k.getVaultURI(), req.Name, versionID)
 	if err != nil {
 		return secretstores.GetSecretResponse{}, err
 	}


### PR DESCRIPTION
# Description

Azure Key Vault Secret Store now reads the secret version from metadata, if provided

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #522

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
