### PR TITLE
Various AWS improvements

### DIFF
--- a/authentication/aws/aws.go
+++ b/authentication/aws/aws.go
@@ -6,14 +6,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
-func GetClient(accessKey string, secretKey string, region string, endpoint string) (*session.Session, error) {
+func GetClient(accessKey string, secretKey string, sessionToken string, region string, endpoint string) (*session.Session, error) {
 	awsConfig := aws.NewConfig()
 
 	if region != "" {
 		awsConfig = awsConfig.WithRegion(region)
 	}
+
 	if accessKey != "" && secretKey != "" {
-		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(accessKey, secretKey, ""))
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(accessKey, secretKey, sessionToken))
 	}
 
 	if endpoint != "" {

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -24,12 +24,12 @@ type DynamoDB struct {
 }
 
 type dynamoDBMetadata struct {
-	Region        string `json:"region"`
-	Endpoint      string `json:"endpoint"`
-	AccessKey     string `json:"accessKey"`
-	SecretKey     string `json:"secretKey"`
-	SessionToken  string `json:"sessionToken"`
-	Table         string `json:"table"`
+	Region       string `json:"region"`
+	Endpoint     string `json:"endpoint"`
+	AccessKey    string `json:"accessKey"`
+	SecretKey    string `json:"secretKey"`
+	SessionToken string `json:"sessionToken"`
+	Table        string `json:"table"`
 }
 
 // NewDynamoDB returns a new DynamoDB instance

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -24,11 +24,12 @@ type DynamoDB struct {
 }
 
 type dynamoDBMetadata struct {
-	Region    string `json:"region"`
-	Endpoint  string `json:"endpoint"`
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
-	Table     string `json:"table"`
+	Region        string `json:"region"`
+	Endpoint      string `json:"endpoint"`
+	AccessKey     string `json:"accessKey"`
+	SecretKey     string `json:"secretKey"`
+	SessionToken  string `json:"sessionToken"`
+	Table         string `json:"table"`
 }
 
 // NewDynamoDB returns a new DynamoDB instance

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -100,7 +100,7 @@ func (d *DynamoDB) getDynamoDBMetadata(spec bindings.Metadata) (*dynamoDBMetadat
 }
 
 func (d *DynamoDB) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -104,7 +104,6 @@ func (d *DynamoDB) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, er
 	if err != nil {
 		return nil, err
 	}
-
 	c := dynamodb.New(sess)
 
 	return c, nil

--- a/bindings/aws/dynamodb/dynamodb_test.go
+++ b/bindings/aws/dynamodb/dynamodb_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"AccessKey": "a", "Region": "a", "SecretKey": "a", "Table": "a", "Endpoint": "a"}
+	m.Properties = map[string]string{
+		"AccessKey": "a", "Region": "a", "SecretKey": "a", "Table": "a", "Endpoint": "a", "SessionToken": "t",
+	}
 	dy := DynamoDB{}
 	meta, err := dy.getDynamoDBMetadata(m)
 	assert.Nil(t, err)
@@ -23,4 +25,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", meta.SecretKey)
 	assert.Equal(t, "a", meta.Table)
 	assert.Equal(t, "a", meta.Endpoint)
+	assert.Equal(t, "t", meta.SessionToken)
 }

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -48,6 +48,7 @@ type kinesisMetadata struct {
 	Endpoint            string              `json:"endpoint"`
 	AccessKey           string              `json:"accessKey"`
 	SecretKey           string              `json:"secretKey"`
+	SessionToken        string              `json:"sessionToken"`
 	KinesisConsumerMode kinesisConsumerMode `json:"mode"`
 }
 

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -296,7 +296,7 @@ func (a *AWSKinesis) waitUntilConsumerExists(ctx aws.Context, input *kinesis.Des
 }
 
 func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -300,7 +300,6 @@ func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, err
 	if err != nil {
 		return nil, err
 	}
-
 	k := kinesis.New(sess)
 
 	return k, nil

--- a/bindings/aws/kinesis/kinesis_test.go
+++ b/bindings/aws/kinesis/kinesis_test.go
@@ -22,6 +22,7 @@ func TestParseMetadata(t *testing.T) {
 		"StreamName":   "stream",
 		"Mode":         "extended",
 		"Endpoint":     "endpoint",
+		"SessionToken":  "token",
 	}
 	kinesis := AWSKinesis{}
 	meta, err := kinesis.parseMetadata(m)
@@ -32,5 +33,6 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "test", meta.ConsumerName)
 	assert.Equal(t, "stream", meta.StreamName)
 	assert.Equal(t, "endpoint", meta.Endpoint)
+	assert.Equal(t, "token", meta.SessionToken)
 	assert.Equal(t, kinesisConsumerMode("extended"), meta.KinesisConsumerMode)
 }

--- a/bindings/aws/kinesis/kinesis_test.go
+++ b/bindings/aws/kinesis/kinesis_test.go
@@ -22,7 +22,7 @@ func TestParseMetadata(t *testing.T) {
 		"StreamName":   "stream",
 		"Mode":         "extended",
 		"Endpoint":     "endpoint",
-		"SessionToken":  "token",
+		"SessionToken": "token",
 	}
 	kinesis := AWSKinesis{}
 	meta, err := kinesis.parseMetadata(m)

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -25,12 +25,12 @@ type AWSS3 struct {
 }
 
 type s3Metadata struct {
-	Region        string `json:"region"`
-	Endpoint      string `json:"endpoint"`
-	AccessKey     string `json:"accessKey"`
-	SecretKey     string `json:"secretKey"`
-	SessionToken  string `json:"sessionToken"`
-	Bucket        string `json:"bucket"`
+	Region       string `json:"region"`
+	Endpoint     string `json:"endpoint"`
+	AccessKey    string `json:"accessKey"`
+	SecretKey    string `json:"secretKey"`
+	SessionToken string `json:"sessionToken"`
+	Bucket       string `json:"bucket"`
 }
 
 // NewAWSS3 returns a new AWSS3 instance

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -25,11 +25,12 @@ type AWSS3 struct {
 }
 
 type s3Metadata struct {
-	Region    string `json:"region"`
-	Endpoint  string `json:"endpoint"`
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
-	Bucket    string `json:"bucket"`
+	Region        string `json:"region"`
+	Endpoint      string `json:"endpoint"`
+	AccessKey     string `json:"accessKey"`
+	SecretKey     string `json:"secretKey"`
+	SessionToken  string `json:"sessionToken"`
+	Bucket        string `json:"bucket"`
 }
 
 // NewAWSS3 returns a new AWSS3 instance

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -93,7 +93,7 @@ func (s *AWSS3) parseMetadata(metadata bindings.Metadata) (*s3Metadata, error) {
 }
 
 func (s *AWSS3) getClient(metadata *s3Metadata) (*s3manager.Uploader, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint"}
+	m.Properties = map[string]string{
+		"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint", "SessionToken": "token",
+	}
 	s3 := AWSS3{}
 	meta, err := s3.parseMetadata(m)
 	assert.Nil(t, err)
@@ -23,4 +25,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "secret", meta.SecretKey)
 	assert.Equal(t, "test", meta.Bucket)
 	assert.Equal(t, "endpoint", meta.Endpoint)
+	assert.Equal(t, "token", meta.SessionToken)
 }

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -24,11 +24,12 @@ type AWSSNS struct {
 }
 
 type snsMetadata struct {
-	TopicArn  string `json:"topicArn"`
-	Region    string `json:"region"`
-	Endpoint  string `json:"endpoint"`
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
+	TopicArn      string `json:"topicArn"`
+	Region        string `json:"region"`
+	Endpoint      string `json:"endpoint"`
+	AccessKey     string `json:"accessKey"`
+	SecretKey     string `json:"secretKey"`
+	SessionToken  string `json:"sessionToken"`
 }
 
 type dataPayload struct {

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -24,12 +24,12 @@ type AWSSNS struct {
 }
 
 type snsMetadata struct {
-	TopicArn      string `json:"topicArn"`
-	Region        string `json:"region"`
-	Endpoint      string `json:"endpoint"`
-	AccessKey     string `json:"accessKey"`
-	SecretKey     string `json:"secretKey"`
-	SessionToken  string `json:"sessionToken"`
+	TopicArn     string `json:"topicArn"`
+	Region       string `json:"region"`
+	Endpoint     string `json:"endpoint"`
+	AccessKey    string `json:"accessKey"`
+	SecretKey    string `json:"secretKey"`
+	SessionToken string `json:"sessionToken"`
 }
 
 type dataPayload struct {

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -74,7 +74,7 @@ func (a *AWSSNS) parseMetadata(metadata bindings.Metadata) (*snsMetadata, error)
 }
 
 func (a *AWSSNS) getClient(metadata *snsMetadata) (*sns.SNS, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sns/sns_test.go
+++ b/bindings/aws/sns/sns_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"TopicArn": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a"}
+	m.Properties = map[string]string{
+		"TopicArn": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a", "SessionToken": "t",
+		}
 	s := AWSSNS{}
 	snsM, err := s.parseMetadata(m)
 	assert.Nil(t, err)
@@ -23,4 +25,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", snsM.AccessKey)
 	assert.Equal(t, "a", snsM.SecretKey)
 	assert.Equal(t, "a", snsM.Endpoint)
+	assert.Equal(t, "t", snsM.SessionToken)
 }

--- a/bindings/aws/sns/sns_test.go
+++ b/bindings/aws/sns/sns_test.go
@@ -16,7 +16,7 @@ func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{
 		"TopicArn": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a", "SessionToken": "t",
-		}
+	}
 	s := AWSSNS{}
 	snsM, err := s.parseMetadata(m)
 	assert.Nil(t, err)

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -25,11 +25,12 @@ type AWSSQS struct {
 }
 
 type sqsMetadata struct {
-	QueueName string `json:"queueName"`
-	Region    string `json:"region"`
-	Endpoint  string `json:"endpoint"`
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
+	QueueName     string `json:"queueName"`
+	Region        string `json:"region"`
+	Endpoint      string `json:"endpoint"`
+	AccessKey     string `json:"accessKey"`
+	SecretKey     string `json:"secretKey"`
+	SessionToken  string `json:"sessionToken"`
 }
 
 // NewAWSSQS returns a new AWS SQS instance

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -25,12 +25,12 @@ type AWSSQS struct {
 }
 
 type sqsMetadata struct {
-	QueueName     string `json:"queueName"`
-	Region        string `json:"region"`
-	Endpoint      string `json:"endpoint"`
-	AccessKey     string `json:"accessKey"`
-	SecretKey     string `json:"secretKey"`
-	SessionToken  string `json:"sessionToken"`
+	QueueName    string `json:"queueName"`
+	Region       string `json:"region"`
+	Endpoint     string `json:"endpoint"`
+	AccessKey    string `json:"accessKey"`
+	SecretKey    string `json:"secretKey"`
+	SessionToken string `json:"sessionToken"`
 }
 
 // NewAWSSQS returns a new AWS SQS instance

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -133,7 +133,7 @@ func (a *AWSSQS) parseSQSMetadata(metadata bindings.Metadata) (*sqsMetadata, err
 }
 
 func (a *AWSSQS) getClient(metadata *sqsMetadata) (*sqs.SQS, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/sqs/sqs_test.go
+++ b/bindings/aws/sqs/sqs_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"QueueName": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a"}
+	m.Properties = map[string]string{
+		"QueueName": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a", "SessionToken": "t",
+	}
 	s := AWSSQS{}
 	sqsM, err := s.parseSQSMetadata(m)
 	assert.Nil(t, err)
@@ -23,4 +25,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", sqsM.AccessKey)
 	assert.Equal(t, "a", sqsM.SecretKey)
 	assert.Equal(t, "a", sqsM.Endpoint)
+	assert.Equal(t, "t", sqsM.SessionToken)
 }

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -23,7 +23,7 @@ type snsSqs struct {
 	topicHash map[string]string
 	// key is the topic name, value holds the ARN of the queue and its url
 	queues        map[string]*sqsQueueInfo
-	awsAcctID     string
+	// awsAcctID     string
 	snsClient     *sns.SNS
 	sqsClient     *sqs.SQS
 	metadata      *snsSqsMetadata

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -41,17 +41,15 @@ type snsSqsMetadata struct {
 	sqsQueueName string
 
 	// aws endpoint for the component to use.
-	awsEndpoint string
-	// aws account ID to use for SNS/SQS. Required
-	awsAccountID string
-	// aws secret corresponding to the account ID. Required
-	awsSecret string
-	// aws token to use. Required
-	awsToken string
-	// aws sessino token to use.
-	awsSessionToken string
-	// aws region in which SNS/SQS should create resources. Required
-	awsRegion string
+	Endpoint string
+	// access key to use for accessing sqs/sns
+	AccessKey string
+	// secret key to use for accessing sqs/sns
+	SecretKey string
+	// aws session token to use.
+	SessionToken string
+	// aws region in which SNS/SQS should create resources
+	Region string
 
 	// amount of time in seconds that a message is hidden from receive requests after it is sent to a subscriber. Default: 10
 	messageVisibilityTimeout int64
@@ -59,7 +57,7 @@ type snsSqsMetadata struct {
 	messageRetryLimit int64
 	// amount of time to await receipt of a message before making another request. Default: 1
 	messageWaitTimeSeconds int64
-	// maximum number of messsages to receive from the queue at a time. Default: 10, Maximum: 10
+	// maximum number of messages to receive from the queue at a time. Default: 10, Maximum: 10
 	messageMaxNumber int64
 }
 
@@ -70,6 +68,16 @@ const (
 
 func NewSnsSqs(l logger.Logger) pubsub.PubSub {
 	return &snsSqs{logger: l, subscriptions: []*string{}}
+}
+
+func getAliasedProperty(aliases []string, metadata pubsub.Metadata) (string, bool) {
+	props := metadata.Properties
+	for _, s := range aliases {
+		if val, ok := props[s]; ok {
+			return val, true
+		}
+	}
+	return "", false
 }
 
 func parseInt64(input string, propertyName string) (int64, error) {
@@ -96,45 +104,28 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 	md.sqsQueueName = metadata.Properties["consumerID"]
 	s.logger.Debugf("Setting queue name to %s", md.sqsQueueName)
 
-	if val, ok := props["awsEndpoint"]; ok {
-		md.awsEndpoint = val
+	if val, ok := getAliasedProperty([]string{"Endpoint", "endpoint"}, metadata); ok {
+		s.logger.Debugf("endpoint: %s", val)
+		md.Endpoint = val
 	}
 
-	val, ok := props["awsAccountID"]
-
-	if !ok {
-		return nil, errors.New("missing required property: awsAccountID")
+	if val, ok := getAliasedProperty([]string{"awsAccountID", "accessKey"}, metadata); ok {
+		s.logger.Debugf("AccessKey: %s", val)
+		md.AccessKey = val
 	}
 
-	md.awsAccountID = val
-
-	val, ok = props["awsSecret"]
-	if !ok {
-		return nil, errors.New("missing required property: awsSecret")
+	if val, ok := getAliasedProperty([]string{"awsSecret", "secretKey"}, metadata); ok {
+		s.logger.Debugf("awsToken: %s", val)
+		md.SecretKey = val
 	}
 
-	md.awsSecret = val
-
-	val, ok = props["awsToken"]
-	if !ok {
-		md.awsToken = ""
-	} else {
-		md.awsToken = val
+	if val, ok := getAliasedProperty([]string{"sessionToken"}, metadata); ok {
+		md.SessionToken = val
 	}
 
-	val, ok = props["awsSessionToken"]
-	if !ok {
-		md.awsSessionToken = ""
-	} else {
-		md.awsSessionToken = val
+	if val, ok := getAliasedProperty([]string{"awsRegion", "region"}, metadata); ok {
+		md.Region = val
 	}
-
-	val, ok = props["awsRegion"]
-	if !ok {
-		return nil, errors.New("missing required property: awsRegion")
-	}
-
-	md.awsRegion = val
 
 	if val, ok := props["messageVisibilityTimeout"]; !ok {
 		md.messageVisibilityTimeout = 10
@@ -214,8 +205,7 @@ func (s *snsSqs) Init(metadata pubsub.Metadata) error {
 	s.topics = make(map[string]string)
 	s.topicHash = make(map[string]string)
 	s.queues = make(map[string]*sqsQueueInfo)
-	s.awsAcctID = md.awsAccountID
-	sess, err := aws_auth.GetClient(s.awsAcctID, md.awsSecret, md.awsSessionToken, md.awsRegion, md.awsEndpoint)
+	sess, err := aws_auth.GetClient(md.AccessKey, md.SecretKey, md.SessionToken, md.Region, md.Endpoint)
 	if err != nil {
 		return err
 	}

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -48,6 +48,8 @@ type snsSqsMetadata struct {
 	awsSecret string
 	// aws token to use. Required
 	awsToken string
+	// aws sessino token to use.
+	awsSessionToken string
 	// aws region in which SNS/SQS should create resources. Required
 	awsRegion string
 
@@ -118,6 +120,13 @@ func (s *snsSqs) getSnsSqsMetatdata(metadata pubsub.Metadata) (*snsSqsMetadata, 
 		md.awsToken = ""
 	} else {
 		md.awsToken = val
+	}
+
+	val, ok = props["awsSessionToken"]
+	if !ok {
+		md.awsSessionToken = ""
+	} else {
+		md.awsSessionToken = val
 	}
 
 	val, ok = props["awsRegion"]
@@ -206,7 +215,7 @@ func (s *snsSqs) Init(metadata pubsub.Metadata) error {
 	s.topicHash = make(map[string]string)
 	s.queues = make(map[string]*sqsQueueInfo)
 	s.awsAcctID = md.awsAccountID
-	sess, err := aws_auth.GetClient(s.awsAcctID, md.awsSecret, md.awsRegion, md.awsEndpoint)
+	sess, err := aws_auth.GetClient(s.awsAcctID, md.awsSecret, md.awsSessionToken, md.awsRegion, md.awsEndpoint)
 	if err != nil {
 		return err
 	}

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -22,7 +22,7 @@ type snsSqs struct {
 	// key is the hashed topic name, value is the actual topic name
 	topicHash map[string]string
 	// key is the topic name, value holds the ARN of the queue and its url
-	queues map[string]*sqsQueueInfo
+	queues        map[string]*sqsQueueInfo
 	snsClient     *sns.SNS
 	sqsClient     *sqs.SQS
 	metadata      *snsSqsMetadata

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -22,7 +22,7 @@ type snsSqs struct {
 	// key is the hashed topic name, value is the actual topic name
 	topicHash map[string]string
 	// key is the topic name, value holds the ARN of the queue and its url
-	queues        map[string]*sqsQueueInfo
+	queues map[string]*sqsQueueInfo
 	// awsAcctID     string
 	snsClient     *sns.SNS
 	sqsClient     *sqs.SQS
@@ -77,6 +77,7 @@ func getAliasedProperty(aliases []string, metadata pubsub.Metadata) (string, boo
 			return val, true
 		}
 	}
+
 	return "", false
 }
 

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -23,7 +23,6 @@ type snsSqs struct {
 	topicHash map[string]string
 	// key is the topic name, value holds the ARN of the queue and its url
 	queues map[string]*sqsQueueInfo
-	// awsAcctID     string
 	snsClient     *sns.SNS
 	sqsClient     *sqs.SQS
 	metadata      *snsSqsMetadata

--- a/pubsub/aws/snssqs/snssqs_test.go
+++ b/pubsub/aws/snssqs/snssqs_test.go
@@ -26,26 +26,26 @@ func Test_getSnsSqsMetatdata_AllConfiguration(t *testing.T) {
 	}
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
-		"consumerID":               "consumer",
-		"awsEndpoint":              "endpoint",
-		"awsAccountID":             "acctId",
-		"awsSecret":                "secret",
-		"awsToken":                 "token",
-		"awsRegion":                "region",
-		"messageVisibilityTimeout": "2",
-		"messageRetryLimit":        "3",
-		"messageWaitTimeSeconds":   "4",
-		"messageMaxNumber":         "5",
+		"consumerID":                 "consumer",
+		"Endpoint":                   "endpoint",
+		"accessKey":                  "a",
+		"secretKey":                  "s",
+		"sessionToken":               "t",
+		"region":                     "r",
+		"messageVisibilityTimeout":   "2",
+		"messageRetryLimit":          "3",
+		"messageWaitTimeSeconds":     "4",
+		"messageMaxNumber":           "5",
 	}})
 
 	r.NoError(err)
 
 	r.Equal("consumer", md.sqsQueueName)
-	r.Equal("endpoint", md.awsEndpoint)
-	r.Equal("acctId", md.awsAccountID)
-	r.Equal("secret", md.awsSecret)
-	r.Equal("token", md.awsToken)
-	r.Equal("region", md.awsRegion)
+	r.Equal("endpoint", md.Endpoint)
+	r.Equal("a", md.AccessKey)
+	r.Equal("s", md.SecretKey)
+	r.Equal("t", md.SessionToken)
+	r.Equal("r", md.Region)
 	r.Equal(int64(2), md.messageVisibilityTimeout)
 	r.Equal(int64(3), md.messageRetryLimit)
 	r.Equal(int64(4), md.messageWaitTimeSeconds)
@@ -53,6 +53,35 @@ func Test_getSnsSqsMetatdata_AllConfiguration(t *testing.T) {
 }
 
 func Test_getSnsSqsMetatdata_defaults(t *testing.T) {
+	r := require.New(t)
+	l := logger.NewLogger("SnsSqs unit test")
+	l.SetOutputLevel(logger.DebugLevel)
+	ps := snsSqs{
+		logger: l,
+	}
+
+	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
+		"consumerID":   "c",
+		"accessKey":    "a",
+		"secretKey":    "s",
+		"region":       "r",
+	}})
+
+	r.NoError(err)
+
+	r.Equal("c", md.sqsQueueName)
+	r.Equal("", md.Endpoint)
+	r.Equal("a", md.AccessKey)
+	r.Equal("s", md.SecretKey)
+	r.Equal("", md.SessionToken)
+	r.Equal("r", md.Region)
+	r.Equal(int64(10), md.messageVisibilityTimeout)
+	r.Equal(int64(10), md.messageRetryLimit)
+	r.Equal(int64(1), md.messageWaitTimeSeconds)
+	r.Equal(int64(10), md.messageMaxNumber)
+}
+
+func Test_getSnsSqsMetatdata_legacyaliases(t *testing.T) {
 	r := require.New(t)
 	l := logger.NewLogger("SnsSqs unit test")
 	l.SetOutputLevel(logger.DebugLevel)
@@ -70,11 +99,10 @@ func Test_getSnsSqsMetatdata_defaults(t *testing.T) {
 	r.NoError(err)
 
 	r.Equal("consumer", md.sqsQueueName)
-	r.Equal("", md.awsEndpoint)
-	r.Equal("acctId", md.awsAccountID)
-	r.Equal("secret", md.awsSecret)
-	r.Equal("", md.awsToken)
-	r.Equal("region", md.awsRegion)
+	r.Equal("", md.Endpoint)
+	r.Equal("acctId", md.AccessKey)
+	r.Equal("secret", md.SecretKey)
+	r.Equal("region", md.Region)
 	r.Equal(int64(10), md.messageVisibilityTimeout)
 	r.Equal(int64(10), md.messageRetryLimit)
 	r.Equal(int64(1), md.messageWaitTimeSeconds)
@@ -91,11 +119,11 @@ func Test_getSnsSqsMetatdata_invalidMessageVisibility(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":               "consumer",
-		"awsEndpoint":              "endpoint",
-		"awsAccountID":             "acctId",
-		"awsSecret":                "secret",
+		"Endpoint":              "endpoint",
+		"AccessKey":             "acctId",
+		"SecretKey":                "secret",
 		"awsToken":                 "token",
-		"awsRegion":                "region",
+		"Region":                "region",
 		"messageVisibilityTimeout": "-100",
 	}})
 
@@ -113,11 +141,11 @@ func Test_getSnsSqsMetatdata_invalidMessageRetryLimit(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":        "consumer",
-		"awsEndpoint":       "endpoint",
-		"awsAccountID":      "acctId",
-		"awsSecret":         "secret",
+		"Endpoint":       "endpoint",
+		"AccessKey":      "acctId",
+		"SecretKey":         "secret",
 		"awsToken":          "token",
-		"awsRegion":         "region",
+		"Region":         "region",
 		"messageRetryLimit": "-100",
 	}})
 
@@ -135,11 +163,11 @@ func Test_getSnsSqsMetatdata_invalidWaitTimeSecondsTooLow(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":             "consumer",
-		"awsEndpoint":            "endpoint",
-		"awsAccountID":           "acctId",
-		"awsSecret":              "secret",
+		"Endpoint":            "endpoint",
+		"AccessKey":           "acctId",
+		"SecretKey":              "secret",
 		"awsToken":               "token",
-		"awsRegion":              "region",
+		"Region":              "region",
 		"messageWaitTimeSeconds": "0",
 	}})
 
@@ -157,11 +185,11 @@ func Test_getSnsSqsMetatdata_invalidMessageMaxNumberTooHigh(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":       "consumer",
-		"awsEndpoint":      "endpoint",
-		"awsAccountID":     "acctId",
-		"awsSecret":        "secret",
+		"Endpoint":      "endpoint",
+		"AccessKey":     "acctId",
+		"SecretKey":        "secret",
 		"awsToken":         "token",
-		"awsRegion":        "region",
+		"Region":        "region",
 		"messageMaxNumber": "100",
 	}})
 
@@ -179,11 +207,11 @@ func Test_getSnsSqsMetatdata_invalidMessageMaxNumberTooLow(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":       "consumer",
-		"awsEndpoint":      "endpoint",
-		"awsAccountID":     "acctId",
-		"awsSecret":        "secret",
+		"Endpoint":      "endpoint",
+		"AccessKey":     "acctId",
+		"SecretKey":        "secret",
 		"awsToken":         "token",
-		"awsRegion":        "region",
+		"Region":        "region",
 		"messageMaxNumber": "-100",
 	}})
 

--- a/pubsub/aws/snssqs/snssqs_test.go
+++ b/pubsub/aws/snssqs/snssqs_test.go
@@ -26,16 +26,16 @@ func Test_getSnsSqsMetatdata_AllConfiguration(t *testing.T) {
 	}
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
-		"consumerID":                 "consumer",
-		"Endpoint":                   "endpoint",
-		"accessKey":                  "a",
-		"secretKey":                  "s",
-		"sessionToken":               "t",
-		"region":                     "r",
-		"messageVisibilityTimeout":   "2",
-		"messageRetryLimit":          "3",
-		"messageWaitTimeSeconds":     "4",
-		"messageMaxNumber":           "5",
+		"consumerID":               "consumer",
+		"Endpoint":                 "endpoint",
+		"accessKey":                "a",
+		"secretKey":                "s",
+		"sessionToken":             "t",
+		"region":                   "r",
+		"messageVisibilityTimeout": "2",
+		"messageRetryLimit":        "3",
+		"messageWaitTimeSeconds":   "4",
+		"messageMaxNumber":         "5",
 	}})
 
 	r.NoError(err)
@@ -61,10 +61,10 @@ func Test_getSnsSqsMetatdata_defaults(t *testing.T) {
 	}
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
-		"consumerID":   "c",
-		"accessKey":    "a",
-		"secretKey":    "s",
-		"region":       "r",
+		"consumerID": "c",
+		"accessKey":  "a",
+		"secretKey":  "s",
+		"region":     "r",
 	}})
 
 	r.NoError(err)
@@ -119,11 +119,11 @@ func Test_getSnsSqsMetatdata_invalidMessageVisibility(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":               "consumer",
-		"Endpoint":              "endpoint",
-		"AccessKey":             "acctId",
+		"Endpoint":                 "endpoint",
+		"AccessKey":                "acctId",
 		"SecretKey":                "secret",
 		"awsToken":                 "token",
-		"Region":                "region",
+		"Region":                   "region",
 		"messageVisibilityTimeout": "-100",
 	}})
 
@@ -141,11 +141,11 @@ func Test_getSnsSqsMetatdata_invalidMessageRetryLimit(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":        "consumer",
-		"Endpoint":       "endpoint",
-		"AccessKey":      "acctId",
+		"Endpoint":          "endpoint",
+		"AccessKey":         "acctId",
 		"SecretKey":         "secret",
 		"awsToken":          "token",
-		"Region":         "region",
+		"Region":            "region",
 		"messageRetryLimit": "-100",
 	}})
 
@@ -163,11 +163,11 @@ func Test_getSnsSqsMetatdata_invalidWaitTimeSecondsTooLow(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":             "consumer",
-		"Endpoint":            "endpoint",
-		"AccessKey":           "acctId",
+		"Endpoint":               "endpoint",
+		"AccessKey":              "acctId",
 		"SecretKey":              "secret",
 		"awsToken":               "token",
-		"Region":              "region",
+		"Region":                 "region",
 		"messageWaitTimeSeconds": "0",
 	}})
 
@@ -185,11 +185,11 @@ func Test_getSnsSqsMetatdata_invalidMessageMaxNumberTooHigh(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":       "consumer",
-		"Endpoint":      "endpoint",
-		"AccessKey":     "acctId",
+		"Endpoint":         "endpoint",
+		"AccessKey":        "acctId",
 		"SecretKey":        "secret",
 		"awsToken":         "token",
-		"Region":        "region",
+		"Region":           "region",
 		"messageMaxNumber": "100",
 	}})
 
@@ -207,11 +207,11 @@ func Test_getSnsSqsMetatdata_invalidMessageMaxNumberTooLow(t *testing.T) {
 
 	md, err := ps.getSnsSqsMetatdata(pubsub.Metadata{Properties: map[string]string{
 		"consumerID":       "consumer",
-		"Endpoint":      "endpoint",
-		"AccessKey":     "acctId",
+		"Endpoint":         "endpoint",
+		"AccessKey":        "acctId",
 		"SecretKey":        "secret",
 		"awsToken":         "token",
-		"Region":        "region",
+		"Region":           "region",
 		"messageMaxNumber": "-100",
 	}})
 

--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -125,7 +125,7 @@ func (s *smSecretStore) BulkGetSecret(req secretstores.BulkGetSecretRequest) (se
 }
 
 func (s *smSecretStore) getClient(metadata *secretManagerMetaData) (*secretsmanager.SecretsManager, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, "")
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, "")
 	if err != nil {
 		return nil, err
 	}

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -206,7 +206,7 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 }
 
 func (d *StateStore) getClient(metadata *dynamoDBMetadata) (*dynamodb.DynamoDB, error) {
-	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.Region, metadata.Endpoint)
+	sess, err := aws_auth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description
- Implemented support for AWS session token (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) in the shared `authentication/aws` function
- Cleaned up the sns/sqs pubsub attributes so that its configuration attribute set matches the rest of the aws resources (created an alias lookup thing so that the old attribute names still work, added tests for that)


As far as I can see, the existing sns/sqs pubsub binding simply cannot have worked - the way it mixes account id and access key ist just... strange. In any case, this PR attempts to fix all of that so that all aws-related things can be configured in the same way. I'm not sure if the aliasing is really needed, as I strongly doubt anyone using it in its current state, but I figure it never hurts to be backwards-compatible anyway.

I've functinally tested both the `sqssns` pubsub, and a few of the bindings as well with various aws auth methods (explicit, implicit, etc), and everything now seems to work as it should.

I'll create documentation in a separate PR - I want to create a shared "aws auth" documentation page for all aws components to refer to.
## Issue reference

## Checklist
* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#934
