### PR TITLE
add BulkGet method on state store - Plan A

### DIFF
--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -29,7 +29,7 @@ type dynamoDBMetadata struct {
 }
 
 // NewDynamoDBStateStore returns a new dynamoDB state store
-func NewDynamoDBStateStore() *StateStore {
+func NewDynamoDBStateStore() state.Store {
 	return &StateStore{}
 }
 
@@ -69,7 +69,7 @@ func (d *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	if len(result.Item) == 0 {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	var output string
@@ -78,8 +78,24 @@ func (d *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: []byte(output),
 	}, nil
+}
+
+// BulkGet performs a bulks get operations
+func (d *StateStore) BulkGet(req []state.GetRequest) ([]state.GetResponse, error) {
+	// TODO: replace with dynamodb.BatchGetItem for performance
+	var response []state.GetResponse
+	for i := range req {
+		r, err := d.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
 }
 
 // Set saves a dynamoDB item

--- a/state/azure/blobstorage/blobstorage.go
+++ b/state/azure/blobstorage/blobstorage.go
@@ -49,6 +49,7 @@ const (
 
 // StateStore Type
 type StateStore struct {
+	state.DefaultBulkStore
 	containerURL azblob.ContainerURL
 	json         jsoniter.API
 
@@ -95,19 +96,6 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 	return r.deleteFile(req)
 }
 
-// BulkDelete the state
-func (r *StateStore) BulkDelete(req []state.DeleteRequest) error {
-	r.logger.Debugf("bulk delete %v key(s)", len(req))
-	for i := range req {
-		err := r.Delete(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Get the state
 func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	r.logger.Debugf("fetching %s", req.Key)
@@ -116,13 +104,14 @@ func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		r.logger.Debugf("error %s", err)
 
 		if isNotFoundError(err) {
-			return &state.GetResponse{}, nil
+			return &state.GetResponse{Key: req.Key}, nil
 		}
 
-		return &state.GetResponse{}, err
+		return &state.GetResponse{Key: req.Key}, err
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: data,
 		ETag: etag,
 	}, err
@@ -135,26 +124,14 @@ func (r *StateStore) Set(req *state.SetRequest) error {
 	return r.writeFile(req)
 }
 
-// BulkSet the state
-func (r *StateStore) BulkSet(req []state.SetRequest) error {
-	r.logger.Debugf("bulk set %v key(s)", len(req))
-
-	for i := range req {
-		err := r.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // NewAzureBlobStorageStore instance
 func NewAzureBlobStorageStore(logger logger.Logger) *StateStore {
-	return &StateStore{
+	s := &StateStore{
 		json:   jsoniter.ConfigFastest,
 		logger: logger,
 	}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 func getBlobStorageMetadata(metadata map[string]string) (*blobStorageMetadata, error) {

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -19,6 +19,7 @@ import (
 
 // StateStore is a CosmosDB state store
 type StateStore struct {
+	state.DefaultBulkStore
 	client     *documentdb.DocumentDB
 	collection *documentdb.Collection
 	db         *documentdb.Database
@@ -65,7 +66,9 @@ const (
 
 // NewCosmosDBStateStore returns a new CosmosDB state store
 func NewCosmosDBStateStore(logger logger.Logger) *StateStore {
-	return &StateStore{logger: logger}
+	s := &StateStore{logger: logger}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 // Init does metadata and connection parsing
@@ -172,7 +175,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if err != nil {
 		return nil, err
 	} else if len(items) == 0 {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	b, err := jsoniter.ConfigFastest.Marshal(&items[0].Value)
@@ -181,6 +184,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: b,
 		ETag: items[0].Etag,
 	}, nil
@@ -228,18 +232,6 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 	return nil
 }
 
-// BulkSet performs a bulk set operation
-func (c *StateStore) BulkSet(req []state.SetRequest) error {
-	for i := range req {
-		err := c.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Delete performs a delete operation
 func (c *StateStore) Delete(req *state.DeleteRequest) error {
 	err := state.CheckRequestOptions(req.Options)
@@ -279,18 +271,6 @@ func (c *StateStore) Delete(req *state.DeleteRequest) error {
 	}
 
 	return err
-}
-
-// BulkDelete performs a bulk delete operation
-func (c *StateStore) BulkDelete(req []state.DeleteRequest) error {
-	for i := range req {
-		err := c.Delete(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -51,6 +51,7 @@ const (
 )
 
 type StateStore struct {
+	state.DefaultBulkStore
 	table *storage.Table
 	json  jsoniter.API
 
@@ -97,18 +98,6 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 	return r.deleteRow(req)
 }
 
-func (r *StateStore) BulkDelete(req []state.DeleteRequest) error {
-	r.logger.Debugf("bulk delete %v key(s)", len(req))
-	for i := range req {
-		err := r.Delete(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	r.logger.Debugf("fetching %s", req.Key)
 	pk, rk := getPartitionAndRowKey(req.Key)
@@ -116,15 +105,16 @@ func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	err := entity.Get(operationTimeout, storage.FullMetadata, nil)
 	if err != nil {
 		if isNotFoundError(err) {
-			return &state.GetResponse{}, nil
+			return &state.GetResponse{Key: req.Key}, nil
 		}
 
-		return &state.GetResponse{}, err
+		return &state.GetResponse{Key: req.Key}, err
 	}
 
 	data, etag, err := r.unmarshal(entity)
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: data,
 		ETag: etag,
 	}, err
@@ -136,24 +126,13 @@ func (r *StateStore) Set(req *state.SetRequest) error {
 	return r.writeRow(req)
 }
 
-func (r *StateStore) BulkSet(req []state.SetRequest) error {
-	r.logger.Debugf("bulk set %v key(s)", len(req))
-
-	for i := range req {
-		err := r.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func NewAzureTablesStateStore(logger logger.Logger) *StateStore {
-	return &StateStore{
+	s := &StateStore{
 		json:   jsoniter.ConfigFastest,
 		logger: logger,
 	}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 func getTablesMetadata(metadata map[string]string) (*tablesMetadata, error) {

--- a/state/cassandra/cassandra.go
+++ b/state/cassandra/cassandra.go
@@ -37,6 +37,7 @@ const (
 
 // Cassandra is a state store implementation for Apache Cassandra
 type Cassandra struct {
+	state.DefaultBulkStore
 	session *gocql.Session
 	cluster *gocql.ClusterConfig
 	table   string
@@ -58,7 +59,9 @@ type cassandraMetadata struct {
 
 // NewCassandraStateStore returns a new cassandra state store
 func NewCassandraStateStore(logger logger.Logger) *Cassandra {
-	return &Cassandra{logger: logger}
+	s := &Cassandra{logger: logger}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 // Init performs metadata and connection parsing
@@ -215,18 +218,6 @@ func (c *Cassandra) Delete(req *state.DeleteRequest) error {
 	return c.session.Query("DELETE FROM ? WHERE key = ?", c.table, req.Key).Exec()
 }
 
-// BulkDelete performs a bulk delete operation
-func (c *Cassandra) BulkDelete(req []state.DeleteRequest) error {
-	for i := range req {
-		err := c.Delete(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Get retrieves state from cassandra with a key
 func (c *Cassandra) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	session := c.session
@@ -253,10 +244,11 @@ func (c *Cassandra) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	if len(results) == 0 {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: results[0]["value"].([]byte),
 	}, nil
 }
@@ -303,14 +295,3 @@ func (c *Cassandra) createSession(consistency gocql.Consistency) (*gocql.Session
 	return session, nil
 }
 
-// BulkSet performs a bulks save operation
-func (c *Cassandra) BulkSet(req []state.SetRequest) error {
-	for i := range req {
-		err := c.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}

--- a/state/cloudstate/cloudstate_crdt.go
+++ b/state/cloudstate/cloudstate_crdt.go
@@ -510,12 +510,31 @@ func (c *CRDT) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		return nil, err
 	}
 
-	stateResp := &state.GetResponse{}
+	stateResp := &state.GetResponse{Key: req.Key}
 	if resp.Data != nil {
 		stateResp.Data = resp.Data.Value
 	}
 
 	return stateResp, nil
+}
+
+// BulkGet performs a bulks get operations
+func (c *CRDT) BulkGet(req []state.GetRequest) ([]state.GetResponse, error) {
+	err := c.createConnectionOnce()
+	if err != nil {
+		return nil, err
+	}
+
+	var response []state.GetResponse
+	for i := range req {
+		r, err := c.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
 }
 
 // Delete performs a delete operation

--- a/state/couchbase/couchbase.go
+++ b/state/couchbase/couchbase.go
@@ -29,6 +29,7 @@ const (
 
 // Couchbase is a couchbase state store
 type Couchbase struct {
+	state.DefaultBulkStore
 	bucket                        *gocb.Bucket
 	bucketName                    string // TODO: having bucket name sent as part of request (get,set etc.) metadata would be more flexible
 	numReplicasDurableReplication uint
@@ -40,10 +41,12 @@ type Couchbase struct {
 
 // NewCouchbaseStateStore returns a new couchbase state store
 func NewCouchbaseStateStore(logger logger.Logger) *Couchbase {
-	return &Couchbase{
+	s := &Couchbase{
 		json:   jsoniter.ConfigFastest,
 		logger: logger,
 	}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 func validateMetadata(metadata state.Metadata) error {
@@ -168,25 +171,13 @@ func (cbs *Couchbase) Set(req *state.SetRequest) error {
 	return nil
 }
 
-// BulkSet performs a bulks save operation
-func (cbs *Couchbase) BulkSet(req []state.SetRequest) error {
-	for i := range req {
-		err := cbs.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Get retrieves state from couchbase with a key
 func (cbs *Couchbase) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	var data interface{}
 	cas, err := cbs.bucket.Get(req.Key, &data)
 	if err != nil {
 		if gocb.IsKeyNotFoundError(err) {
-			return &state.GetResponse{}, nil
+			return &state.GetResponse{Key: req.Key}, nil
 		}
 
 		return nil, fmt.Errorf("couchbase error: failed to get value for key %s - %v", req.Key, err)
@@ -197,6 +188,7 @@ func (cbs *Couchbase) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: value,
 		ETag: fmt.Sprintf("%d", cas),
 	}, nil
@@ -224,18 +216,6 @@ func (cbs *Couchbase) Delete(req *state.DeleteRequest) error {
 	}
 	if err != nil {
 		return fmt.Errorf("couchbase error: failed to delete key %s - %v", req.Key, err)
-	}
-
-	return nil
-}
-
-// BulkDelete performs a bulk delete operation
-func (cbs *Couchbase) BulkDelete(req []state.DeleteRequest) error {
-	for i := range req {
-		err := cbs.Delete(&req[i])
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -22,6 +22,7 @@ const defaultEntityKind = "DaprState"
 
 // Firestore State Store
 type Firestore struct {
+	state.DefaultBulkStore
 	client     *datastore.Client
 	entityKind string
 
@@ -47,7 +48,9 @@ type StateEntity struct {
 }
 
 func NewFirestoreStateStore(logger logger.Logger) *Firestore {
-	return &Firestore{logger: logger}
+	s := &Firestore{logger: logger}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 // Init does metadata and connection parsing
@@ -85,10 +88,11 @@ func (f *Firestore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if err != nil && !errors.Is(err, datastore.ErrNoSuchEntity) {
 		return nil, err
 	} else if errors.Is(err, datastore.ErrNoSuchEntity) {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: []byte(entity.Value),
 	}, nil
 }
@@ -127,18 +131,6 @@ func (f *Firestore) Set(req *state.SetRequest) error {
 	return state.SetWithOptions(f.setValue, req)
 }
 
-// BulkSet performs a bulk set operation
-func (f *Firestore) BulkSet(req []state.SetRequest) error {
-	for i := range req {
-		err := f.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
 	ctx := context.Background()
 	key := datastore.NameKey(f.entityKind, req.Key, nil)
@@ -154,18 +146,6 @@ func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
 // Delete performs a delete operation
 func (f *Firestore) Delete(req *state.DeleteRequest) error {
 	return state.DeleteWithOptions(f.deleteValue, req)
-}
-
-// BulkDelete performs a bulk delete operation
-func (f *Firestore) BulkDelete(req []state.DeleteRequest) error {
-	for i := range req {
-		err := f.Delete(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func getFirestoreMetadata(metadata state.Metadata) (*firestoreMetadata, error) {

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -17,6 +17,7 @@ import (
 
 // Consul is a state store implementation for HashiCorp Consul.
 type Consul struct {
+	state.DefaultBulkStore
 	client        *api.Client
 	keyPrefixPath string
 	logger        logger.Logger
@@ -32,7 +33,9 @@ type consulConfig struct {
 
 // NewConsulStateStore returns a new consul state store.
 func NewConsulStateStore(logger logger.Logger) *Consul {
-	return &Consul{logger: logger}
+	s := &Consul{logger: logger}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+	return s
 }
 
 // Init does metadata and config parsing and initializes the
@@ -94,10 +97,11 @@ func (c *Consul) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	if resp == nil {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: resp.Value,
 		ETag: queryMeta.LastContentHash,
 	}, nil
@@ -126,36 +130,12 @@ func (c *Consul) Set(req *state.SetRequest) error {
 	return nil
 }
 
-// BulkSet performs a bulk save operation
-func (c *Consul) BulkSet(req []state.SetRequest) error {
-	for i := range req {
-		err := c.Set(&req[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Delete performes a Consul KV delete operation
 func (c *Consul) Delete(req *state.DeleteRequest) error {
 	keyWithPath := fmt.Sprintf("%s/%s", c.keyPrefixPath, req.Key)
 	_, err := c.client.KV().Delete(keyWithPath, nil)
 	if err != nil {
 		return fmt.Errorf("couldn't delete key %s: %s", keyWithPath, err)
-	}
-
-	return nil
-}
-
-// BulkDelete performs a bulk delete operation
-func (c *Consul) BulkDelete(req []state.DeleteRequest) error {
-	for i := range req {
-		err := c.Delete(&req[i])
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -140,13 +140,14 @@ func (p *postgresDBAccess) Get(req *state.GetRequest) (*state.GetResponse, error
 	if err != nil {
 		// If no rows exist, return an empty response, otherwise return the error.
 		if err == sql.ErrNoRows {
-			return &state.GetResponse{}, nil
+			return &state.GetResponse{Key: req.Key}, nil
 		}
 
 		return nil, err
 	}
 
 	response := &state.GetResponse{
+		Key:      req.Key,
 		Data:     []byte(value),
 		ETag:     strconv.Itoa(etag),
 		Metadata: req.Metadata,

--- a/state/postgresql/postgresql.go
+++ b/state/postgresql/postgresql.go
@@ -54,6 +54,21 @@ func (p *PostgreSQL) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	return p.dbaccess.Get(req)
 }
 
+// BulkGet performs a bulks get operations
+func (p *PostgreSQL) BulkGet(req []state.GetRequest)  ([]state.GetResponse, error)  {
+	// TODO: replace with ExecuteMulti for performance
+	var response []state.GetResponse
+	for i := range req {
+		r, err := p.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
+}
+
 // Set adds/updates an entity on store
 func (p *PostgreSQL) Set(req *state.SetRequest) error {
 	return p.dbaccess.Set(req)

--- a/state/responses.go
+++ b/state/responses.go
@@ -7,6 +7,7 @@ package state
 
 // GetResponse is the request object for getting state
 type GetResponse struct {
+	Key      string            `json:"key"`
 	Data     []byte            `json:"data"`
 	ETag     string            `json:"etag,omitempty"`
 	Metadata map[string]string `json:"metadata"`

--- a/state/rethinkdb/rethinkdb.go
+++ b/state/rethinkdb/rethinkdb.go
@@ -141,7 +141,7 @@ func (s *RethinkDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	if c == nil || c.IsNil() {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	if c != nil {
@@ -155,6 +155,7 @@ func (s *RethinkDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	resp := &state.GetResponse{ETag: doc.Hash}
+	resp.Key = req.Key
 	b, ok := doc.Data.([]byte)
 	if ok {
 		resp.Data = b
@@ -167,6 +168,21 @@ func (s *RethinkDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	return resp, nil
+}
+
+// BulkGet performs a bulks get operations
+func (s *RethinkDB) BulkGet(req []state.GetRequest)  ([]state.GetResponse, error)  {
+	// TODO: replace with bulk get for performance
+	var response []state.GetResponse
+	for i := range req {
+		r, err := s.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
 }
 
 // Set saves a state KV item

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -428,7 +428,7 @@ func (s *SQLServer) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	defer rows.Close()
 
 	if !rows.Next() {
-		return &state.GetResponse{}, nil
+		return &state.GetResponse{Key: req.Key}, nil
 	}
 
 	var data string
@@ -441,9 +441,25 @@ func (s *SQLServer) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	etag := hex.EncodeToString(rowVersion)
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: []byte(data),
 		ETag: etag,
 	}, nil
+}
+
+// BulkGet performs a bulks get operations
+func (s *SQLServer) BulkGet(req []state.GetRequest) ([]state.GetResponse, error) {
+	// TODO: replace with bulk get for performance
+	var response []state.GetResponse
+	for i := range req {
+		r, err := s.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
 }
 
 // Set adds/updates an entity on store

--- a/state/store.go
+++ b/state/store.go
@@ -7,10 +7,66 @@ package state
 
 // Store is an interface to perform operations on store
 type Store interface {
+	BulkStore
 	Init(metadata Metadata) error
 	Delete(req *DeleteRequest) error
-	BulkDelete(req []DeleteRequest) error
 	Get(req *GetRequest) (*GetResponse, error)
 	Set(req *SetRequest) error
+}
+
+// BulkStore is an interface to perform bulk operations on store
+type BulkStore interface {
+	BulkDelete(req []DeleteRequest) error
+	BulkGet(req []GetRequest) ([]GetResponse, error)
 	BulkSet(req []SetRequest) error
+}
+
+// DefaultBulkStore is a default implementation of BulkStore
+type DefaultBulkStore struct {
+	s Store
+}
+
+// NewDefaultBulkStore build a default bulk store
+func NewDefaultBulkStore(store Store) DefaultBulkStore  {
+	defaultBulkStore := DefaultBulkStore{}
+	defaultBulkStore.s = store
+	return defaultBulkStore
+}
+
+// BulkGet performs a bulks get operations
+func (b *DefaultBulkStore) BulkGet(req []GetRequest)  ([]GetResponse, error)  {
+	var response []GetResponse
+	for i := range req {
+		r, err := b.s.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
+}
+
+// BulkSet performs a bulks save operation
+func (b *DefaultBulkStore) BulkSet(req []SetRequest) error {
+	for i := range req {
+		err := b.s.Set(&req[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BulkDelete performs a bulk delete operation
+func (b *DefaultBulkStore) BulkDelete(req []DeleteRequest) error {
+	for i := range req {
+		err := b.s.Delete(&req[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -1,0 +1,127 @@
+package state
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStore_withDefaultBulkImpl(t *testing.T) {
+	s := &Store1{}
+	s.DefaultBulkStore = NewDefaultBulkStore(s)
+	var store Store = s
+	require.Equal(t, s.count, 0)
+	require.Equal(t, s.bulkCount, 0)
+
+	store.Get(&GetRequest{})
+	store.Set(&SetRequest{})
+	store.Delete(&DeleteRequest{})
+	require.Equal(t, 3, s.count)
+	require.Equal(t, 0, s.bulkCount)
+
+	store.BulkGet([]GetRequest{GetRequest{}, GetRequest{}, GetRequest{}})
+	require.Equal(t, 3 + 3, s.count)
+	require.Equal(t, 0, s.bulkCount)
+	store.BulkSet([]SetRequest{SetRequest{}, SetRequest{}, SetRequest{}, SetRequest{}})
+	require.Equal(t, 3 + 3 +4, s.count)
+	require.Equal(t, 0, s.bulkCount)
+	store.BulkDelete([]DeleteRequest{DeleteRequest{}, DeleteRequest{}, DeleteRequest{}, DeleteRequest{}, DeleteRequest{}})
+	require.Equal(t, 3 + 3 + 4 + 5, s.count)
+	require.Equal(t, 0, s.bulkCount)
+}
+
+func TestStore_withCustomisedBulkImpl(t *testing.T) {
+	s := &Store2{}
+	var store Store = s
+	require.Equal(t, s.count, 0)
+	require.Equal(t, s.bulkCount, 0)
+
+	store.Get(&GetRequest{})
+	store.Set(&SetRequest{})
+	store.Delete(&DeleteRequest{})
+	require.Equal(t, 3, s.count)
+	require.Equal(t, 0, s.bulkCount)
+
+	store.BulkGet([]GetRequest{GetRequest{}, GetRequest{}, GetRequest{}})
+	require.Equal(t, 3, s.count)
+	require.Equal(t, 3, s.bulkCount)
+	store.BulkSet([]SetRequest{SetRequest{}, SetRequest{}, SetRequest{}, SetRequest{}})
+	require.Equal(t, 3, s.count)
+	require.Equal(t, 3 +4, s.bulkCount)
+	store.BulkDelete([]DeleteRequest{DeleteRequest{}, DeleteRequest{}, DeleteRequest{}, DeleteRequest{}, DeleteRequest{}})
+	require.Equal(t, 3, s.count)
+	require.Equal(t, 3 + 4 + 5, s.bulkCount)
+}
+
+var _ Store = &Store1{}
+var _ Store = &Store2{}
+
+// example of store which doesn't support bulk method
+type Store1 struct {
+	DefaultBulkStore
+	count int
+	bulkCount int
+}
+
+func (s *Store1) Init(metadata Metadata) error  {
+	return nil
+}
+
+func (s *Store1) Delete(req *DeleteRequest) error  {
+	s.count++
+	return nil
+}
+
+func (s *Store1) Get(req *GetRequest) (*GetResponse, error)  {
+	s.count++
+	return &GetResponse{},nil
+}
+
+func (s *Store1) Set(req *SetRequest) error  {
+	s.count++
+	return nil
+}
+
+// example of store which supports bulk method
+type Store2 struct {
+	//DefaultBulkStore
+	count int
+	bulkCount int
+}
+
+func (s *Store2) Init(metadata Metadata) error  {
+	return nil
+}
+
+func (s *Store2) Delete(req *DeleteRequest) error  {
+	s.count++
+	return nil
+}
+
+func (s *Store2) Get(req *GetRequest) (*GetResponse, error)  {
+	s.count++
+	return &GetResponse{},nil
+}
+
+func (s *Store2) Set(req *SetRequest) error  {
+	s.count++
+	return nil
+}
+
+func (s *Store2) BulkGet(req []GetRequest)  ([]GetResponse, error)  {
+	s.bulkCount = s.bulkCount + len(req)
+	return nil, nil
+}
+
+func (s *Store2) BulkSet(req []SetRequest) error {
+	s.bulkCount = s.bulkCount + len(req)
+	return nil
+}
+
+func (s *Store2) BulkDelete(req []DeleteRequest) error {
+	s.bulkCount = s.bulkCount + len(req)
+	return nil
+}
+
+
+
+

--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -146,16 +146,32 @@ func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	value, stat, err := s.conn.Get(s.prefixedKey(req.Key))
 	if err != nil {
 		if errors.Is(err, zk.ErrNoNode) {
-			return &state.GetResponse{}, nil
+			return &state.GetResponse{Key: req.Key}, nil
 		}
 
 		return nil, err
 	}
 
 	return &state.GetResponse{
+		Key:  req.Key,
 		Data: value,
 		ETag: strconv.Itoa(int(stat.Version)),
 	}, nil
+}
+
+// BulkGet performs a bulks get operations
+func (s *StateStore) BulkGet(req []state.GetRequest) ([]state.GetResponse, error) {
+	// TODO: replace with Multi for performance
+	var response []state.GetResponse
+	for i := range req {
+		r, err := s.Get(&req[i])
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, *r)
+	}
+
+	return response, nil
 }
 
 // Delete performs a delete operation

--- a/state/zookeeper/zk_test.go
+++ b/state/zookeeper/zk_test.go
@@ -81,7 +81,7 @@ func TestGet(t *testing.T) {
 		conn.EXPECT().Get("foo").Return(nil, nil, zk.ErrNoNode).Times(1)
 
 		res, err := s.Get(&state.GetRequest{Key: "foo"})
-		assert.Equal(t, &state.GetResponse{}, res, "Response must be empty")
+		assert.Equal(t, &state.GetResponse{Key: "foo"}, res, "Response must be empty")
 		assert.NoError(t, err, "Non-existent key must not be treated as error")
 	})
 }


### PR DESCRIPTION
# Description

Add BulkGet method on state store.

This is Plan A:

- Adding BulkGet method on state store
- Dapr simply calls BulkGet method of store componnent implementation
- store componnent implementation decided to do bulk get or fallback to call get one by one 

## Issue reference

https://github.com/dapr/dapr/issues/2368

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
