### PR TITLE
Add metadata to SubscribeRequest

### DIFF
--- a/pubsub/requests.go
+++ b/pubsub/requests.go
@@ -14,7 +14,8 @@ type PublishRequest struct {
 
 // SubscribeRequest is the request to subscribe to a topic
 type SubscribeRequest struct {
-	Topic string `json:"topic"`
+	Topic    string            `json:"topic"`
+	Metadata map[string]string `json:"metadata"`
 }
 
 // NewMessage is an event arriving from a message bus instance


### PR DESCRIPTION
# Description

Added a metadata field to a SubscribeRequest to allow additional data to be provided to the pubsub component.

## Issue reference

Please reference the issue this PR will close: #[Dapr/2379](https://github.com/dapr/dapr/issues/2379)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
