### PR TITLE
properly initialize logger in bindings/sqs

### DIFF
--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -34,7 +34,7 @@ type sqsMetadata struct {
 
 // NewAWSSQS returns a new AWS SQS instance
 func NewAWSSQS(logger logger.Logger) *AWSSQS {
-	return &AWSSQS{}
+	return &AWSSQS{logger: logger}
 }
 
 // Init does metadata parsing and connection creation


### PR DESCRIPTION
# Description
the sqs binding didn't correctly initialize its logger, which caused the application to crash on log writes. This fixes that.

## Issue reference
Please reference the issue this PR will close: #529

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
