### PR TITLE
Add support for prefetch

### DIFF
--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -15,8 +15,8 @@ type metadata struct {
 	autoAck          bool
 	requeueInFailure bool
 	deliveryMode     uint8 // Transient (0 or 1) or Persistent (2)
-	reconnectWait    time.Duration
 	prefetchCount    uint8 // Prefetch deactivated if 0
+	reconnectWait    time.Duration
 }
 
 // createMetadata creates a new instance from the pubsub metadata

--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -16,6 +16,7 @@ type metadata struct {
 	requeueInFailure bool
 	deliveryMode     uint8 // Transient (0 or 1) or Persistent (2)
 	reconnectWait    time.Duration
+	prefetchCount    uint8 // Prefetch deactivated if 0
 }
 
 // createMetadata creates a new instance from the pubsub metadata
@@ -68,6 +69,12 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 	if val, found := pubSubMetadata.Properties[metadataReconnectWaitSeconds]; found && val != "" {
 		if intVal, err := strconv.Atoi(val); err == nil {
 			result.reconnectWait = time.Duration(intVal) * time.Second
+		}
+	}
+
+	if val, found := pubSubMetadata.Properties[metadataprefetchCount]; found && val != "" {
+		if intVal, err := strconv.Atoi(val); err == nil {
+			result.prefetchCount = uint8(intVal)
 		}
 	}
 

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -45,6 +45,7 @@ func TestCreateMetadata(t *testing.T) {
 		assert.Equal(t, false, m.requeueInFailure)
 		assert.Equal(t, true, m.deleteWhenUnused)
 		assert.Equal(t, uint8(0), m.deliveryMode)
+		assert.Equal(t, uint8(0), m.prefetchCount)
 	})
 
 	t.Run("host is not given", func(t *testing.T) {
@@ -120,6 +121,24 @@ func TestCreateMetadata(t *testing.T) {
 		assert.Equal(t, fakeProperties[metadataHostKey], m.host)
 		assert.Equal(t, fakeProperties[metadataConsumerIDKey], m.consumerID)
 		assert.Equal(t, uint8(2), m.deliveryMode)
+	})
+
+	t.Run("prefetchCount is set", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[metadataprefetchCount] = "1"
+
+		// act
+		m, err := createMetadata(fakeMetaData)
+
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, fakeProperties[metadataHostKey], m.host)
+		assert.Equal(t, fakeProperties[metadataConsumerIDKey], m.consumerID)
+		assert.Equal(t, uint8(1), m.prefetchCount)
 	})
 
 	for _, tt := range booleanFlagTests {

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +28,7 @@ const (
 	metadataReconnectWaitSeconds = "reconnectWaitSeconds"
 
 	defaultReconnectWaitSeconds = 10
+	metadataprefetchCount       = "prefetchCount"
 )
 
 // RabbitMQ allows sending/receiving messages in pub/sub format
@@ -53,6 +55,7 @@ type rabbitMQChannelBroker interface {
 	Nack(tag uint64, multiple bool, requeue bool) error
 	Ack(tag uint64, multiple bool) error
 	ExchangeDeclare(name string, kind string, durable bool, autoDelete bool, internal bool, noWait bool, args amqp.Table) error
+	Qos(prefetchCount, prefetchSize int, global bool) error
 }
 
 // interface used to allow unit testing
@@ -80,6 +83,7 @@ func dial(host string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) 
 	if err != nil {
 		return conn, nil, err
 	}
+
 
 	return conn, ch, nil
 }
@@ -207,6 +211,14 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 	q, err := channel.QueueDeclare(queueName, true, r.metadata.deleteWhenUnused, false, false, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if r.metadata.prefetchCount > 0 {
+		r.logger.Debugf("setting prefetch count to %s", strconv.Itoa(int(r.metadata.prefetchCount)))
+		err = channel.Qos(int(r.metadata.prefetchCount), 0, false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r.logger.Debugf("%s binding queue '%s' to exchange '%s'", logMessagePrefix, q.Name, req.Topic)

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -84,7 +84,6 @@ func dial(host string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) 
 		return conn, nil, err
 	}
 
-
 	return conn, ch, nil
 }
 

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -254,6 +254,10 @@ type rabbitMQInMemoryBroker struct {
 	closeCount   int
 }
 
+func (r *rabbitMQInMemoryBroker) Qos(prefetchCount, prefetchSize int, global bool) error {
+	return nil
+}
+
 func (r *rabbitMQInMemoryBroker) Publish(exchange string, key string, mandatory bool, immediate bool, msg amqp.Publishing) error {
 	if string(msg.Body) == errorChannelConnection {
 		return errors.New(errorChannelConnection)


### PR DESCRIPTION
# Description
Adds support for the "prefetch" parameter in rabbitmq, allowing clients to only prefetch a portion of the available messages, instead of all of them.

I can do a separate PR to update rabbitmq docs according to https://v1-rc2.docs.dapr.io/operations/components/component-schema/

I'm not sure if I should just switch to intsince that's what the Qos function expects natively. I figured I'd use the same numeric format as other parameters in the same module. Happy to change that.

I'm also not sure if it should default to 0 (which disables the prefetch functionality) or 1 (which IMHO is the safe and "correct" setting). 

## Issue reference
https://github.com/dapr/components-contrib/issues/560

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
