### PR TITLE
Fallback to NAMESPACE env for get secret on K8s.

### DIFF
--- a/secretstores/kubernetes/kubernetes.go
+++ b/secretstores/kubernetes/kubernetes.go
@@ -8,6 +8,7 @@ package kubernetes
 import (
 	"context"
 	"errors"
+	"os"
 
 	kubeclient "github.com/dapr/components-contrib/authentication/kubernetes"
 	"github.com/dapr/components-contrib/secretstores"
@@ -88,5 +89,10 @@ func (k *kubernetesSecretStore) getNamespaceFromMetadata(metadata map[string]str
 		return val, nil
 	}
 
-	return "", errors.New("namespace is missing on metadata")
+	val := os.Getenv("NAMESPACE")
+	if val != "" {
+		return val, nil
+	}
+
+	return "", errors.New("namespace is missing on metadata and NAMESPACE env variable")
 }

--- a/secretstores/kubernetes/kubernetes_test.go
+++ b/secretstores/kubernetes/kubernetes_test.go
@@ -6,6 +6,7 @@
 package kubernetes
 
 import (
+	"os"
 	"testing"
 
 	"github.com/dapr/dapr/pkg/logger"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestGetNamespace(t *testing.T) {
-	t.Run("has namespace", func(t *testing.T) {
+	t.Run("has namespace metadata", func(t *testing.T) {
 		store := kubernetesSecretStore{logger: logger.NewLogger("test")}
 		namespace := "a"
 
@@ -22,11 +23,21 @@ func TestGetNamespace(t *testing.T) {
 		assert.Equal(t, namespace, ns)
 	})
 
+	t.Run("has namespace env", func(t *testing.T) {
+		store := kubernetesSecretStore{logger: logger.NewLogger("test")}
+		os.Setenv("NAMESPACE", "b")
+
+		ns, err := store.getNamespaceFromMetadata(map[string]string{})
+		assert.Nil(t, err)
+		assert.Equal(t, "b", ns)
+	})
+
 	t.Run("no namespace", func(t *testing.T) {
 		store := kubernetesSecretStore{logger: logger.NewLogger("test")}
+		os.Setenv("NAMESPACE", "")
 		_, err := store.getNamespaceFromMetadata(map[string]string{})
 
 		assert.NotNil(t, err)
-		assert.Equal(t, "namespace is missing on metadata", err.Error())
+		assert.Equal(t, "namespace is missing on metadata and NAMESPACE env variable", err.Error())
 	})
 }


### PR DESCRIPTION
# Description

Fallback to NAMESPACE env for get secret on K8s.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #563 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
