### PR TITLE
Replace content cloud event check, add settraceid

### DIFF
--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -6,6 +6,7 @@
 package pubsub
 
 import (
+	"fmt"
 	"time"
 
 	contrib_metadata "github.com/dapr/components-contrib/metadata"
@@ -24,27 +25,12 @@ const (
 	DefaultCloudEventSource = "Dapr"
 	// DefaultCloudEventDataContentType is the default content-type for the data attribute
 	DefaultCloudEventDataContentType = "text/plain"
-	DaprTraceIDField                 = "daprtraceid"
+	TraceIDField                     = "traceid"
+	expirationField                  = "expiration"
 )
 
-// CloudEventsEnvelope describes the Dapr implementation of the Cloud Events spec
-// Spec details: https://github.com/cloudevents/spec/blob/master/spec.md
-type CloudEventsEnvelope struct {
-	ID              string      `json:"id"`
-	Source          string      `json:"source"`
-	Type            string      `json:"type"`
-	SpecVersion     string      `json:"specversion"`
-	DataContentType string      `json:"datacontenttype"`
-	Data            interface{} `json:"data"`
-	Subject         string      `json:"subject"`
-	Topic           string      `json:"topic"`
-	PubsubName      string      `json:"pubsubname"`
-	Expiration      string      `json:"expiration,omitempty"`
-	DaprTraceID     string      `json:"daprtraceid"`
-}
-
-// NewCloudEventsEnvelope returns CloudEventsEnvelope from data or a new one when data content was not
-func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string, pubsubName string, dataContentType string, data []byte, traceID string) *CloudEventsEnvelope {
+// NewCloudEventsEnvelope returns a map representation of a cloudevents JSON
+func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string, pubsubName string, dataContentType string, data []byte, traceID string) map[string]interface{} {
 	// defaults
 	if id == "" {
 		id = uuid.New().String()
@@ -59,37 +45,23 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 		dataContentType = DefaultCloudEventDataContentType
 	}
 
-	// check if JSON
 	var j interface{}
 	err := jsoniter.Unmarshal(data, &j)
-	if err != nil {
-		// not JSON, return new envelope
-		return &CloudEventsEnvelope{
-			ID:              id,
-			SpecVersion:     CloudEventsSpecVersion,
-			DataContentType: dataContentType,
-			Source:          source,
-			Type:            eventType,
-			Subject:         subject,
-			Topic:           topic,
-			PubsubName:      pubsubName,
-			Data:            string(data),
-			DaprTraceID:     traceID,
-		}
+	if err == nil {
+		dataContentType = "application/json"
 	}
 
-	// content was JSON but not a valid CloudEvent, make one
-	return &CloudEventsEnvelope{
-		ID:              id,
-		SpecVersion:     CloudEventsSpecVersion,
-		DataContentType: "application/json",
-		Source:          source,
-		Type:            eventType,
-		Subject:         subject,
-		Topic:           topic,
-		PubsubName:      pubsubName,
-		Data:            j,
-		DaprTraceID:     traceID,
+	return map[string]interface{}{
+		"id":              id,
+		"specversion":     CloudEventsSpecVersion,
+		"datacontenttype": dataContentType,
+		"source":          source,
+		"type":            eventType,
+		"subject":         subject,
+		"topic":           topic,
+		"pubsubname":      pubsubName,
+		"data":            string(data),
+		"traceid":         traceID,
 	}
 }
 
@@ -102,7 +74,7 @@ func SetTraceID(data []byte, traceID string) ([]byte, error) {
 		return data, err
 	}
 
-	m[DaprTraceIDField] = traceID
+	m[TraceIDField] = traceID
 	b, err := jsoniter.Marshal(m)
 	if err != nil {
 		return data, err
@@ -112,9 +84,10 @@ func SetTraceID(data []byte, traceID string) ([]byte, error) {
 }
 
 // HasExpired determines if the current cloud event has expired.
-func (cloudEvent *CloudEventsEnvelope) HasExpired() bool {
-	if cloudEvent.Expiration != "" {
-		expiration, err := time.Parse(time.RFC3339, cloudEvent.Expiration)
+func HasExpired(cloudEvent map[string]interface{}) bool {
+	e, ok := cloudEvent[expirationField]
+	if ok && e != "" {
+		expiration, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", e))
 		if err != nil {
 			return false
 		}
@@ -126,7 +99,7 @@ func (cloudEvent *CloudEventsEnvelope) HasExpired() bool {
 }
 
 // ApplyMetadata will process metadata to modify the cloud event based on the component's feature set.
-func (cloudEvent *CloudEventsEnvelope) ApplyMetadata(componentFeatures []Feature, metadata map[string]string) {
+func ApplyMetadata(cloudEvent map[string]interface{}, componentFeatures []Feature, metadata map[string]string) {
 	ttl, hasTTL, _ := contrib_metadata.TryGetTTL(metadata)
 	if hasTTL && !FeatureMessageTTL.IsPresent(componentFeatures) {
 		// Dapr only handles Message TTL if component does not.
@@ -137,6 +110,6 @@ func (cloudEvent *CloudEventsEnvelope) ApplyMetadata(componentFeatures []Feature
 		// Max time in golang is currently 292277024627-12-06T15:30:07.999999999Z.
 		// So, we have some time before the overflow below happens :)
 		expiration := now.Add(ttl)
-		cloudEvent.Expiration = expiration.Format(time.RFC3339)
+		cloudEvent[expirationField] = expiration.Format(time.RFC3339)
 	}
 }

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -65,22 +65,9 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 	}
 }
 
-// SetTraceID adds the daprtraceid field to an existing cloudevents JSON
-func SetTraceID(data []byte, traceID string) ([]byte, error) {
-	var m map[string]interface{}
-
-	err := jsoniter.Unmarshal(data, &m)
-	if err != nil {
-		return data, err
-	}
-
-	m[TraceIDField] = traceID
-	b, err := jsoniter.Marshal(m)
-	if err != nil {
-		return data, err
-	}
-
-	return b, nil
+// SetTraceContext adds required trace fields to the cloudevents JSON
+func SetTraceContext(cloudEvent map[string]interface{}, traceID string) {
+	cloudEvent[TraceIDField] = traceID
 }
 
 // HasExpired determines if the current cloud event has expired.

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -16,6 +16,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	dataContentTypeField = "datacontenttype"
+	dataField            = "data"
+	specVersionField     = "specversion"
+	topicField           = "topic"
+	pubsubNameField      = "pubsubname"
+	typeField            = "type"
+)
+
 func TestCreateCloudEventsEnvelope(t *testing.T) {
 	envelope := NewCloudEventsEnvelope("a", "source", "eventType", "", "", "", "", nil, "")
 	assert.NotNil(t, envelope)
@@ -25,21 +34,21 @@ func TestEnvelopeXML(t *testing.T) {
 	t.Run("xml content", func(t *testing.T) {
 		str := `<root/>`
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "application/xml", []byte(str), "")
-		assert.Equal(t, "application/xml", envelope.DataContentType)
-		assert.Equal(t, str, envelope.Data)
-		assert.Equal(t, "1.0", envelope.SpecVersion)
-		assert.Equal(t, "routed.topic", envelope.Topic)
-		assert.Equal(t, "mypubsub", envelope.PubsubName)
+		assert.Equal(t, "application/xml", envelope[dataContentTypeField])
+		assert.Equal(t, str, envelope[dataField])
+		assert.Equal(t, "1.0", envelope[specVersionField])
+		assert.Equal(t, "routed.topic", envelope[topicField])
+		assert.Equal(t, "mypubsub", envelope[pubsubNameField])
 	})
 
 	t.Run("xml without content-type", func(t *testing.T) {
 		str := `<root/>`
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		assert.Equal(t, "text/plain", envelope.DataContentType)
-		assert.Equal(t, str, envelope.Data)
-		assert.Equal(t, "1.0", envelope.SpecVersion)
-		assert.Equal(t, "routed.topic", envelope.Topic)
-		assert.Equal(t, "mypubsub", envelope.PubsubName)
+		assert.Equal(t, "text/plain", envelope[dataContentTypeField])
+		assert.Equal(t, str, envelope[dataField])
+		assert.Equal(t, "1.0", envelope[specVersionField])
+		assert.Equal(t, "routed.topic", envelope[topicField])
+		assert.Equal(t, "mypubsub", envelope[pubsubNameField])
 	})
 }
 
@@ -54,8 +63,8 @@ func TestCreateFromJSON(t *testing.T) {
 		}
 		data, _ := json.Marshal(obj1)
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", data, "1")
-		t.Logf("data: %v", envelope.Data)
-		assert.Equal(t, "application/json", envelope.DataContentType)
+		t.Logf("data: %v", envelope[dataField])
+		assert.Equal(t, "application/json", envelope[dataContentTypeField])
 
 		obj2 := struct {
 			Val1 string
@@ -71,36 +80,36 @@ func TestCreateFromJSON(t *testing.T) {
 func TestCreateCloudEventsEnvelopeDefaults(t *testing.T) {
 	t.Run("default event type", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", nil, "")
-		assert.Equal(t, DefaultCloudEventType, envelope.Type)
+		assert.Equal(t, DefaultCloudEventType, envelope[typeField])
 	})
 
 	t.Run("non-default event type", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "source", "e1", "", "", "mypubsub", "", nil, "")
-		assert.Equal(t, "e1", envelope.Type)
+		assert.Equal(t, "e1", envelope[typeField])
 	})
 
 	t.Run("spec version", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", nil, "")
-		assert.Equal(t, CloudEventsSpecVersion, envelope.SpecVersion)
+		assert.Equal(t, CloudEventsSpecVersion, envelope[specVersionField])
 	})
 
 	t.Run("quoted data", func(t *testing.T) {
 		list := []string{"v1", "v2", "v3"}
 		data := strings.Join(list, ",")
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte(data), "")
-		t.Logf("data: %v", envelope.Data)
-		assert.Equal(t, "text/plain", envelope.DataContentType)
-		assert.Equal(t, data, envelope.Data.(string))
+		t.Logf("data: %v", envelope[dataField])
+		assert.Equal(t, "text/plain", envelope[dataContentTypeField])
+		assert.Equal(t, data, envelope[dataField].(string))
 	})
 
 	t.Run("string data content type", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte("data"), "")
-		assert.Equal(t, "text/plain", envelope.DataContentType)
+		assert.Equal(t, "text/plain", envelope[dataContentTypeField])
 	})
 
 	t.Run("trace id", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte("data"), "1")
-		assert.Equal(t, "1", envelope.DaprTraceID)
+		assert.Equal(t, "1", envelope[TraceIDField])
 	})
 }
 
@@ -119,59 +128,59 @@ func TestCreateCloudEventsEnvelopeExpiration(t *testing.T) {
 
 	t.Run("cloud event not expired", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.Expiration = time.Now().UTC().Add(time.Hour * 24).Format(time.RFC3339)
-		assert.False(t, envelope.HasExpired())
+		envelope[expirationField] = time.Now().UTC().Add(time.Hour * 24).Format(time.RFC3339)
+		assert.False(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event expired", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.Expiration = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC3339)
-		assert.True(t, envelope.HasExpired())
+		envelope[expirationField] = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC3339)
+		assert.True(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event expired but applied new TTL from metadata", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.Expiration = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC3339)
-		envelope.ApplyMetadata(nil, map[string]string{
+		envelope[expirationField] = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC3339)
+		ApplyMetadata(envelope, nil, map[string]string{
 			"ttlInSeconds": "10000",
 		})
-		assert.NotEqual(t, "", envelope.Expiration)
-		assert.False(t, envelope.HasExpired())
+		assert.NotEqual(t, "", envelope[expirationField])
+		assert.False(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event TTL from metadata does not apply due to component feature", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.ApplyMetadata([]Feature{FeatureMessageTTL}, map[string]string{
+		ApplyMetadata(envelope, []Feature{FeatureMessageTTL}, map[string]string{
 			"ttlInSeconds": "10000",
 		})
-		assert.Equal(t, "", envelope.Expiration)
-		assert.False(t, envelope.HasExpired())
+		assert.Equal(t, nil, envelope[expirationField])
+		assert.False(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event with max TTL metadata", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.ApplyMetadata(nil, map[string]string{
+		ApplyMetadata(envelope, nil, map[string]string{
 			"ttlInSeconds": fmt.Sprintf("%v", math.MaxInt64),
 		})
-		assert.NotEqual(t, "", envelope.Expiration)
-		assert.False(t, envelope.HasExpired())
+		assert.NotEqual(t, "", envelope[expirationField])
+		assert.False(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event with invalid expiration format", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.Expiration = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC1123)
-		assert.False(t, envelope.HasExpired())
+		envelope[expirationField] = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC1123)
+		assert.False(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event without expiration", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		assert.False(t, envelope.HasExpired())
+		assert.False(t, HasExpired(envelope))
 	})
 
 	t.Run("cloud event without expiration, without metadata", func(t *testing.T) {
 		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
-		envelope.ApplyMetadata(nil, map[string]string{})
-		assert.False(t, envelope.HasExpired())
+		ApplyMetadata(envelope, nil, map[string]string{})
+		assert.False(t, HasExpired(envelope))
 	})
 }
 
@@ -194,6 +203,6 @@ func TestSetTraceID(t *testing.T) {
 
 		json.Unmarshal(ce, &m)
 		assert.Equal(t, "1.0", m["specversion"])
-		assert.Equal(t, "1", m[DaprTraceIDField])
+		assert.Equal(t, "1", m[TraceIDField])
 	})
 }

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -17,14 +17,14 @@ import (
 )
 
 func TestCreateCloudEventsEnvelope(t *testing.T) {
-	envelope := NewCloudEventsEnvelope("a", "source", "eventType", "", "", "", "", nil)
+	envelope := NewCloudEventsEnvelope("a", "source", "eventType", "", "", "", "", nil, "")
 	assert.NotNil(t, envelope)
 }
 
 func TestEnvelopeXML(t *testing.T) {
 	t.Run("xml content", func(t *testing.T) {
 		str := `<root/>`
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "application/xml", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "application/xml", []byte(str), "")
 		assert.Equal(t, "application/xml", envelope.DataContentType)
 		assert.Equal(t, str, envelope.Data)
 		assert.Equal(t, "1.0", envelope.SpecVersion)
@@ -34,7 +34,7 @@ func TestEnvelopeXML(t *testing.T) {
 
 	t.Run("xml without content-type", func(t *testing.T) {
 		str := `<root/>`
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		assert.Equal(t, "text/plain", envelope.DataContentType)
 		assert.Equal(t, str, envelope.Data)
 		assert.Equal(t, "1.0", envelope.SpecVersion)
@@ -53,7 +53,7 @@ func TestCreateFromJSON(t *testing.T) {
 			1,
 		}
 		data, _ := json.Marshal(obj1)
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", data)
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", data, "1")
 		t.Logf("data: %v", envelope.Data)
 		assert.Equal(t, "application/json", envelope.DataContentType)
 
@@ -70,32 +70,37 @@ func TestCreateFromJSON(t *testing.T) {
 
 func TestCreateCloudEventsEnvelopeDefaults(t *testing.T) {
 	t.Run("default event type", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", nil)
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", nil, "")
 		assert.Equal(t, DefaultCloudEventType, envelope.Type)
 	})
 
 	t.Run("non-default event type", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "e1", "", "", "mypubsub", "", nil)
+		envelope := NewCloudEventsEnvelope("a", "source", "e1", "", "", "mypubsub", "", nil, "")
 		assert.Equal(t, "e1", envelope.Type)
 	})
 
 	t.Run("spec version", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", nil)
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", nil, "")
 		assert.Equal(t, CloudEventsSpecVersion, envelope.SpecVersion)
 	})
 
 	t.Run("quoted data", func(t *testing.T) {
 		list := []string{"v1", "v2", "v3"}
 		data := strings.Join(list, ",")
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte(data))
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte(data), "")
 		t.Logf("data: %v", envelope.Data)
 		assert.Equal(t, "text/plain", envelope.DataContentType)
 		assert.Equal(t, data, envelope.Data.(string))
 	})
 
 	t.Run("string data content type", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte("data"))
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte("data"), "")
 		assert.Equal(t, "text/plain", envelope.DataContentType)
+	})
+
+	t.Run("trace id", func(t *testing.T) {
+		envelope := NewCloudEventsEnvelope("a", "source", "", "", "", "mypubsub", "", []byte("data"), "1")
+		assert.Equal(t, "1", envelope.DaprTraceID)
 	})
 }
 
@@ -113,19 +118,19 @@ func TestCreateCloudEventsEnvelopeExpiration(t *testing.T) {
 	}`
 
 	t.Run("cloud event not expired", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.Expiration = time.Now().UTC().Add(time.Hour * 24).Format(time.RFC3339)
 		assert.False(t, envelope.HasExpired())
 	})
 
 	t.Run("cloud event expired", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.Expiration = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC3339)
 		assert.True(t, envelope.HasExpired())
 	})
 
 	t.Run("cloud event expired but applied new TTL from metadata", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.Expiration = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC3339)
 		envelope.ApplyMetadata(nil, map[string]string{
 			"ttlInSeconds": "10000",
@@ -135,7 +140,7 @@ func TestCreateCloudEventsEnvelopeExpiration(t *testing.T) {
 	})
 
 	t.Run("cloud event TTL from metadata does not apply due to component feature", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.ApplyMetadata([]Feature{FeatureMessageTTL}, map[string]string{
 			"ttlInSeconds": "10000",
 		})
@@ -144,7 +149,7 @@ func TestCreateCloudEventsEnvelopeExpiration(t *testing.T) {
 	})
 
 	t.Run("cloud event with max TTL metadata", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.ApplyMetadata(nil, map[string]string{
 			"ttlInSeconds": fmt.Sprintf("%v", math.MaxInt64),
 		})
@@ -153,64 +158,42 @@ func TestCreateCloudEventsEnvelopeExpiration(t *testing.T) {
 	})
 
 	t.Run("cloud event with invalid expiration format", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.Expiration = time.Now().UTC().Add(time.Hour * -24).Format(time.RFC1123)
 		assert.False(t, envelope.HasExpired())
 	})
 
 	t.Run("cloud event without expiration", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		assert.False(t, envelope.HasExpired())
 	})
 
 	t.Run("cloud event without expiration, without metadata", func(t *testing.T) {
-		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str))
+		envelope := NewCloudEventsEnvelope("a", "", "", "", "routed.topic", "mypubsub", "", []byte(str), "")
 		envelope.ApplyMetadata(nil, map[string]string{})
 		assert.False(t, envelope.HasExpired())
 	})
 }
 
-func TestIsCloudEvent(t *testing.T) {
-	t.Run("not cloud event: string", func(t *testing.T) {
-		r := IsCloudEvent([]byte("a"))
-		assert.False(t, r)
+func TestSetTraceID(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := SetTraceID([]byte("a"), "1")
+		assert.Error(t, err)
 	})
 
-	t.Run("not cloud event: non compliant json", func(t *testing.T) {
+	t.Run("valid json", func(t *testing.T) {
 		m := map[string]interface{}{
-			"a": "b",
+			"specversion": "1.0",
+			"customfield": "a",
 		}
+
 		b, err := json.Marshal(m)
 		assert.NoError(t, err)
-
-		r := IsCloudEvent(b)
-		assert.False(t, r)
-	})
-
-	t.Run("not cloud event: non compliant cloudevent", func(t *testing.T) {
-		m := map[string]interface{}{
-			"specversion": "b",
-			"type":        "b",
-			"id":          "b",
-		}
-		b, err := json.Marshal(m)
+		ce, err := SetTraceID(b, "1")
 		assert.NoError(t, err)
 
-		r := IsCloudEvent(b)
-		assert.False(t, r)
-	})
-
-	t.Run("is cloud event", func(t *testing.T) {
-		m := map[string]interface{}{
-			"specversion": "b",
-			"type":        "b",
-			"id":          "b",
-			"source":      "b",
-		}
-		b, err := json.Marshal(m)
-		assert.NoError(t, err)
-
-		r := IsCloudEvent(b)
-		assert.True(t, r)
+		json.Unmarshal(ce, &m)
+		assert.Equal(t, "1.0", m["specversion"])
+		assert.Equal(t, "1", m[DaprTraceIDField])
 	})
 }

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -185,24 +185,13 @@ func TestCreateCloudEventsEnvelopeExpiration(t *testing.T) {
 }
 
 func TestSetTraceID(t *testing.T) {
-	t.Run("invalid json", func(t *testing.T) {
-		_, err := SetTraceID([]byte("a"), "1")
-		assert.Error(t, err)
-	})
-
-	t.Run("valid json", func(t *testing.T) {
+	t.Run("trace id is present", func(t *testing.T) {
 		m := map[string]interface{}{
 			"specversion": "1.0",
 			"customfield": "a",
 		}
 
-		b, err := json.Marshal(m)
-		assert.NoError(t, err)
-		ce, err := SetTraceID(b, "1")
-		assert.NoError(t, err)
-
-		json.Unmarshal(ce, &m)
-		assert.Equal(t, "1.0", m["specversion"])
+		SetTraceContext(m, "1")
 		assert.Equal(t, "1", m[TraceIDField])
 	})
 }


### PR DESCRIPTION
This PR replaces the body check to determine if a payload is a CloudEvent or not by relying on `daprd` to make the decision based on a user supplied information, either via a header on HTTP or a special field in proto.

Determining a cloud event by inspecting the body has the following drawbacks:

1. Performance hit in terms of CPU
2. The method to determine if a Cloud Event is compliant to the spec will need to be maintained long term to keep up with any changes to the spec

In addition, the PR corrects a long time error in treating the `subject` field as a way to store the trace ID.
Based on this change, trace IDs will be saved in a `daprtraceid` extension field.
A method has been added to add the trace field to existing CE json based payloads.