### PR TITLE
Add new cloudevents creation method

### DIFF
--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -74,6 +74,7 @@ func FromCloudEvent(cloudEvent []byte, traceID string) (map[string]interface{}, 
 	}
 
 	setTraceContext(m, traceID)
+
 	return m, nil
 }
 

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -65,8 +65,19 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 	}
 }
 
-// SetTraceContext adds required trace fields to the cloudevents JSON
-func SetTraceContext(cloudEvent map[string]interface{}, traceID string) {
+// FromCloudEvent returns a map representation of an existing cloudevents JSON
+func FromCloudEvent(cloudEvent []byte, traceID string) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	err := jsoniter.Unmarshal(cloudEvent, &m)
+	if err != nil {
+		return m, err
+	}
+
+	setTraceContext(m, traceID)
+	return m, nil
+}
+
+func setTraceContext(cloudEvent map[string]interface{}, traceID string) {
 	cloudEvent[TraceIDField] = traceID
 }
 

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -191,7 +191,28 @@ func TestSetTraceID(t *testing.T) {
 			"customfield": "a",
 		}
 
-		SetTraceContext(m, "1")
+		setTraceContext(m, "1")
 		assert.Equal(t, "1", m[TraceIDField])
+	})
+}
+
+func TestNewFromExisting(t *testing.T) {
+	t.Run("valid cloudevent", func(t *testing.T) {
+		m := map[string]interface{}{
+			"specversion": "1.0",
+			"customfield": "a",
+		}
+		b, _ := json.Marshal(&m)
+
+		n, err := FromCloudEvent(b, "1")
+		assert.NoError(t, err)
+		assert.Equal(t, "1.0", n["specversion"])
+		assert.Equal(t, "a", n["customfield"])
+		assert.Equal(t, "1", n["traceid"])
+	})
+
+	t.Run("invalid cloudevent", func(t *testing.T) {
+		_, err := FromCloudEvent([]byte("a"), "1")
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
This PR does a small refactor that introduces a new method that returns a Cloud Event map based on an existing Cloud Event.