### PR TITLE
Fix RabbitMQ concurrency

### DIFF
--- a/pubsub/concurrency.go
+++ b/pubsub/concurrency.go
@@ -5,6 +5,8 @@
 
 package pubsub
 
+import "fmt"
+
 // ConcurrencyMode is a pub/sub metadata setting that allows to specify whether messages are delivered in a serial or parallel execution
 type ConcurrencyMode string
 
@@ -16,10 +18,17 @@ const (
 )
 
 // Concurrency takes a metadata object and returns the ConcurrencyMode configured. Default is Parallel
-func Concurrency(metadata map[string]string) ConcurrencyMode {
+func Concurrency(metadata map[string]string) (ConcurrencyMode, error) {
 	if val, ok := metadata[ConcurrencyKey]; ok && val != "" {
-		return ConcurrencyMode(val)
+		switch val {
+		case string(Single):
+			return Single, nil
+		case string(Parallel):
+			return Parallel, nil
+		default:
+			return "", fmt.Errorf("invalid %s %s", ConcurrencyKey, val)
+		}
 	}
 
-	return Parallel
+	return Parallel, nil
 }

--- a/pubsub/concurrency_test.go
+++ b/pubsub/concurrency_test.go
@@ -14,22 +14,30 @@ import (
 func TestConcurrency(t *testing.T) {
 	t.Run("default parallel", func(t *testing.T) {
 		m := map[string]string{}
-		c := Concurrency(m)
+		c, _ := Concurrency(m)
 
 		assert.Equal(t, Parallel, c)
 	})
 
 	t.Run("parallel", func(t *testing.T) {
 		m := map[string]string{ConcurrencyKey: string(Parallel)}
-		c := Concurrency(m)
+		c, _ := Concurrency(m)
 
 		assert.Equal(t, Parallel, c)
 	})
 
 	t.Run("single", func(t *testing.T) {
 		m := map[string]string{ConcurrencyKey: string(Single)}
-		c := Concurrency(m)
+		c, _ := Concurrency(m)
 
 		assert.Equal(t, Single, c)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		m := map[string]string{ConcurrencyKey: "a"}
+		c, err := Concurrency(m)
+
+		assert.Empty(t, c)
+		assert.Error(t, err)
 	})
 }

--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -79,9 +79,9 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 		}
 	}
 
-	c := pubsub.Concurrency(pubSubMetadata.Properties)
-	if string(c) == "" {
-		return nil, fmt.Errorf("invalid concurrencyMode %s", pubSubMetadata.Properties[pubsub.ConcurrencyKey])
+	c, err := pubsub.Concurrency(pubSubMetadata.Properties)
+	if err != nil {
+		return &result, err
 	}
 	result.concurrency = c
 

--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -79,7 +79,11 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 		}
 	}
 
-	result.concurrency = pubsub.Concurrency(pubSubMetadata.Properties)
+	c := pubsub.Concurrency(pubSubMetadata.Properties)
+	if string(c) == "" {
+		return nil, fmt.Errorf("invalid concurrencyMode %s", pubSubMetadata.Properties[pubsub.ConcurrencyKey])
+	}
+	result.concurrency = c
 
 	return &result, nil
 }

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -123,6 +123,21 @@ func TestCreateMetadata(t *testing.T) {
 		assert.Equal(t, uint8(2), m.deliveryMode)
 	})
 
+	t.Run("invalid concurrency", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[pubsub.ConcurrencyKey] = "a"
+
+		// act
+		_, err := createMetadata(fakeMetaData)
+
+		// assert
+		assert.Error(t, err)
+	})
+
 	t.Run("prefetchCount is set", func(t *testing.T) {
 		fakeProperties := getFakeProperties()
 

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -285,8 +285,19 @@ func (r *rabbitMQ) subscribeForever(
 }
 
 func (r *rabbitMQ) listenMessages(channel rabbitMQChannelBroker, msgs <-chan amqp.Delivery, topic string, handler func(msg *pubsub.NewMessage) error) error {
+	var err error
+	f := func(channel rabbitMQChannelBroker, d amqp.Delivery, topic string, handler func(msg *pubsub.NewMessage) error) error {
+		return r.handleMessage(channel, d, topic, handler)
+	}
 	for d := range msgs {
-		err := r.handleMessage(channel, d, topic, handler)
+		switch r.metadata.concurrency {
+		case pubsub.Single:
+			err = f(channel, d, topic, handler)
+		case pubsub.Parallel:
+			go func(channel rabbitMQChannelBroker, d amqp.Delivery, topic string, handler func(msg *pubsub.NewMessage) error) {
+				err = f(channel, d, topic, handler)
+			}(channel, d, topic, handler)
+		}
 		if (err != nil) && mustReconnect(channel, err) {
 			return err
 		}
@@ -301,23 +312,9 @@ func (r *rabbitMQ) handleMessage(channel rabbitMQChannelBroker, d amqp.Delivery,
 		Topic: topic,
 	}
 
-	var err error
-	f := func(msg *pubsub.NewMessage) {
-		err = handler(pubsubMsg)
-		if err != nil {
-			r.logger.Errorf("%s error handling message from topic '%s', %s", logMessagePrefix, topic, err)
-		}
-	}
-	switch r.metadata.concurrency {
-	case pubsub.Single:
-		f(pubsubMsg)
-	case pubsub.Parallel:
-		done := make(chan bool, 1)
-		go func(msg *pubsub.NewMessage, done chan bool) {
-			f(pubsubMsg)
-			done <- true
-		}(pubsubMsg, done)
-		<-done
+	err := handler(pubsubMsg)
+	if err != nil {
+		r.logger.Errorf("%s error handling message from topic '%s', %s", logMessagePrefix, topic, err)
 	}
 
 	//nolint:nestif


### PR DESCRIPTION
This PR moves the concurrency logic to the correct place due to how the RabbitMQ Golang driver operates over channels.
Fixes PR #575 