### PR TITLE
Added Exclusive Flag to RabbitMQ queues

### DIFF
--- a/bindings/rabbitmq/rabbitmq_integration_test.go
+++ b/bindings/rabbitmq/rabbitmq_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"strings"
 	"time"
 
 	"github.com/dapr/components-contrib/bindings"
@@ -177,4 +178,57 @@ func TestPublishingWithTTL(t *testing.T) {
 	assert.True(t, ok)
 	msgBody := string(msg.Body)
 	assert.Equal(t, testMsgContent, msgBody)
+}
+
+func TestExclusiveQueue(t *testing.T) {
+	rabbitmqHost := getTestRabbitMQHost()
+	assert.NotEmpty(t, rabbitmqHost, fmt.Sprintf("RabbitMQ host configuration must be set in environment variable '%s' (example 'amqp://guest:guest@localhost:5672/')", testRabbitMQHostEnvKey))
+
+	queueName := uuid.New().String()
+	durable := true
+	exclusive := true
+	const ttlInSeconds = 1
+	const maxGetDuration = ttlInSeconds * time.Second
+
+	metadata := bindings.Metadata{
+		Name: "testQueue",
+		Properties: map[string]string{
+			"queueName":             queueName,
+			"host":                  rabbitmqHost,
+			"deleteWhenUnused":      strconv.FormatBool(exclusive),
+			"durable":               strconv.FormatBool(durable),
+			"exclusive":             strconv.FormatBool(exclusive),
+			bindings.TTLMetadataKey: strconv.FormatInt(ttlInSeconds, 10),
+		},
+	}
+
+	logger := logger.NewLogger("test")
+
+	r := NewRabbitMQ(logger)
+	err := r.Init(metadata)
+	assert.Nil(t, err)
+
+	// Assert that if waited too long, we won't see any message
+	conn, err := amqp.Dial(rabbitmqHost)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	assert.Nil(t, err)
+
+	if _, err = ch.QueueDeclarePassive(queueName, durable, false, false, false, amqp.Table{}); err != nil {
+		// Assert that queue actually exists if an error is thrown
+		assert.Equal(t, strings.Contains(err.Error(), "404"), false)
+	}
+
+	ch.Close()
+
+	ch, err = conn.Channel()
+	assert.Nil(t, err)
+	defer ch.Close()
+
+	if _, err = ch.QueueDeclarePassive(queueName, durable, false, false, false, amqp.Table{}); err != nil {
+		// Assert that queue actually no longer exists if an error is thrown
+		assert.Equal(t, strings.Contains(err.Error(), "404"), true)
+	}
 }

--- a/bindings/rabbitmq/rabbitmq_test.go
+++ b/bindings/rabbitmq/rabbitmq_test.go
@@ -25,9 +25,9 @@ func TestParseMetadata(t *testing.T) {
 		properties               map[string]string
 		expectedDeleteWhenUnused bool
 		expectedDurable          bool
+		expectedExclusive        bool
 		expectedTTL              *time.Duration
 		expectedPrefetchCount    int
-		expectedExclusive        bool
 	}{
 		{
 			name:                     "Delete / Durable",

--- a/bindings/rabbitmq/rabbitmq_test.go
+++ b/bindings/rabbitmq/rabbitmq_test.go
@@ -27,6 +27,7 @@ func TestParseMetadata(t *testing.T) {
 		expectedDurable          bool
 		expectedTTL              *time.Duration
 		expectedPrefetchCount    int
+		expectedExclusive        bool
 	}{
 		{
 			name:                     "Delete / Durable",
@@ -60,6 +61,13 @@ func TestParseMetadata(t *testing.T) {
 			expectedDurable:          false,
 			expectedPrefetchCount:    1,
 		},
+		{
+			name:                     "Exclusive Queue",
+			properties:               map[string]string{"queueName": queueName, "host": host, "deleteWhenUnused": "false", "durable": "false", "exclusive": "true"},
+			expectedDeleteWhenUnused: false,
+			expectedDurable:          false,
+			expectedExclusive:        true,
+		},
 	}
 
 	for _, tt := range testCases {
@@ -75,6 +83,7 @@ func TestParseMetadata(t *testing.T) {
 			assert.Equal(t, tt.expectedDurable, r.metadata.Durable)
 			assert.Equal(t, tt.expectedTTL, r.metadata.defaultQueueTTL)
 			assert.Equal(t, tt.expectedPrefetchCount, r.metadata.PrefetchCount)
+			assert.Equal(t, tt.expectedExclusive, r.metadata.Exclusive)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Adding the Exclusive flag to the RabbitMQ binding to allow creation of exclusive queues;

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_577_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X ] Code compiles correctly
* [X ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
