### PR TITLE
Add missing error checks for etag errors

### DIFF
--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -208,6 +208,10 @@ func (aspike *Aerospike) Delete(req *state.DeleteRequest) error {
 
 	_, err = aspike.client.Delete(writePolicy, asKey)
 	if err != nil {
+		if req.ETag != "" {
+			return state.NewETagError(state.ETagMismatch, err)
+		}
+
 		return fmt.Errorf("aerospike: failed to delete key %s - %v", req.Key, err)
 	}
 

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -274,8 +274,10 @@ func (c *StateStore) Delete(req *state.DeleteRequest) error {
 		c.logger.Debugf("Error from cosmos.DeleteDocument e=%e, e.Error=%s", err, err.Error())
 	}
 
-	if req.ETag != "" {
-		return state.NewETagError(state.ETagMismatch, err)
+	if err != nil {
+		if req.ETag != "" {
+			return state.NewETagError(state.ETagMismatch, err)
+		}
 	}
 
 	return err

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -96,8 +96,10 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 	r.logger.Debugf("delete %s", req.Key)
 
 	err := r.deleteRow(req)
-	if req.ETag != "" {
-		return state.NewETagError(state.ETagMismatch, err)
+	if err != nil {
+		if req.ETag != "" {
+			return state.NewETagError(state.ETagMismatch, err)
+		}
 	}
 
 	return err
@@ -128,8 +130,10 @@ func (r *StateStore) Set(req *state.SetRequest) error {
 	r.logger.Debugf("saving %s", req.Key)
 
 	err := r.writeRow(req)
-	if req.ETag != "" {
-		return state.NewETagError(state.ETagMismatch, err)
+	if err != nil {
+		if req.ETag != "" {
+			return state.NewETagError(state.ETagMismatch, err)
+		}
 	}
 
 	return err


### PR DESCRIPTION
This PR adds a few nil error checks for state stores. A follow up for https://github.com/dapr/components-contrib/pull/579