### PR TITLE
Update developing-component.md

### DIFF
--- a/docs/developing-component.md
+++ b/docs/developing-component.md
@@ -5,6 +5,7 @@ This document describes how to build and test new component.
 ## Prerequisites
 
 1. [Dapr development environment setup](https://github.com/dapr/dapr/blob/master/docs/development/setup-dapr-development-env.md)
+2. [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
 
 ## Clone dapr and component-contrib
 


### PR DESCRIPTION
Adding golangci-lint as a prerequisite otherwise the make lint command will not work.

# Description

One of the steps to confirm your machine is ready to contribute a component is to type

```
make lint
```

However, that will fail unless you install golangci-lint.

## Issue reference

Addresses part of #2529

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
