### PR TITLE
Add conformance tests for output bindings

### DIFF
--- a/tests/config/bindings/output_tests.yml
+++ b/tests/config/bindings/output_tests.yml
@@ -1,0 +1,4 @@
+componentType: output-binding
+components:
+  - component: redis
+    operations: ["init", "create", "operations"]

--- a/tests/config/bindings/redis/bindings.yml
+++ b/tests/config/bindings/redis/bindings.yml
@@ -1,0 +1,15 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: redis-binding
+  namespace: default
+spec:
+  type: bindings.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: 
+  - name: enableTLS
+    value: false

--- a/tests/conformance/bindings/output/output_bindings.go
+++ b/tests/conformance/bindings/output/output_bindings.go
@@ -1,0 +1,101 @@
+package bindings
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/tests/conformance/utils"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type TestConfig struct {
+	utils.CommonConfig
+}
+
+func NewTestConfig(name string, allOperations bool, operations []string) TestConfig {
+	return TestConfig{
+		CommonConfig: utils.CommonConfig{
+			ComponentType: "output-binding",
+			ComponentName: name,
+			AllOperations: allOperations,
+			Operations:    sets.NewString(operations...),
+		},
+	}
+}
+
+func ConformanceTests(t *testing.T, props map[string]string, binding bindings.OutputBinding, config TestConfig) {
+	if config.CommonConfig.HasOperation("init") {
+		t.Run(config.GetTestName("init"), func(t *testing.T) {
+			err := binding.Init(bindings.Metadata{
+				Properties: props,
+			})
+			assert.NoError(t, err, "expected no error setting up binding")
+		})
+	}
+
+	if config.CommonConfig.HasOperation("operations") {
+		t.Run(config.GetTestName("operations"), func(t *testing.T) {
+			ops := binding.Operations()
+			for _, op := range ops {
+				assert.True(t, config.HasOperation(string(op)), fmt.Sprintf("Operation missing from conformance test config: %v", op))
+			}
+		})
+	}
+
+	req := bindings.InvokeRequest{
+		Data: []byte("Test Data"),
+		Metadata: map[string]string{
+			"key": "test-key",
+		},
+	}
+
+	createPerformed := false
+	// Order matters here, we use the result of the create in other validations.
+	if config.HasOperation(string(bindings.CreateOperation)) {
+		t.Run(config.GetTestName("create"), func(t *testing.T) {
+			req.Operation = bindings.CreateOperation
+			_, err := binding.Invoke(&req)
+			assert.Nil(t, err, "expected no error invoking output binding")
+			createPerformed = true
+		})
+	}
+
+	if config.HasOperation(string(bindings.GetOperation)) {
+		t.Run(config.GetTestName("get"), func(t *testing.T) {
+			req.Operation = bindings.GetOperation
+			resp, err := binding.Invoke(&req)
+			assert.Nil(t, err, "expected no error invoking output binding")
+			assert.NotNil(t, resp)
+
+			if createPerformed {
+				assert.Equal(t, req.Data, resp.Data)
+			}
+		})
+	}
+
+	if config.HasOperation(string(bindings.ListOperation)) {
+		t.Run(config.GetTestName("list"), func(t *testing.T) {
+			req.Operation = bindings.GetOperation
+			_, err := binding.Invoke(&req)
+			assert.Nil(t, err, "expected no error invoking output binding")
+		})
+	}
+
+	if config.HasOperation(string(bindings.DeleteOperation)) {
+		t.Run(config.GetTestName("delete"), func(t *testing.T) {
+			req.Operation = bindings.DeleteOperation
+			_, err := binding.Invoke(&req)
+			assert.Nil(t, err, "expected no error invoking output binding")
+
+			if createPerformed && config.HasOperation(string(bindings.GetOperation)) {
+				req.Operation = bindings.GetOperation
+				resp, err := binding.Invoke(&req)
+				assert.Nil(t, err, "expected no error invoking output binding")
+				assert.NotNil(t, resp)
+				assert.Nil(t, resp.Data)
+			}
+		})
+	}
+}

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"fortio.org/fortio/log"
+	"github.com/dapr/components-contrib/bindings"
+	b_redis "github.com/dapr/components-contrib/bindings/redis"
 	"github.com/dapr/components-contrib/pubsub"
 	p_redis "github.com/dapr/components-contrib/pubsub/redis"
 	"github.com/dapr/components-contrib/secretstores"
@@ -18,6 +20,7 @@ import (
 	ss_local_file "github.com/dapr/components-contrib/secretstores/local/file"
 	"github.com/dapr/components-contrib/state"
 	s_redis "github.com/dapr/components-contrib/state/redis"
+	conf_output_bindings "github.com/dapr/components-contrib/tests/conformance/bindings/output"
 	conf_pubsub "github.com/dapr/components-contrib/tests/conformance/pubsub"
 	conf_secret "github.com/dapr/components-contrib/tests/conformance/secretstores"
 	conf_state "github.com/dapr/components-contrib/tests/conformance/state"
@@ -28,6 +31,10 @@ import (
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	redis = "redis"
 )
 
 // nolint:gochecknoglobals
@@ -161,6 +168,13 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 			assert.NotNil(t, pubsub)
 			pubsubConfig := conf_pubsub.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
 			conf_pubsub.ConformanceTests(t, props, pubsub, pubsubConfig)
+		case "output-binding":
+			filepath := fmt.Sprintf("../config/bindings/%s", comp.Component)
+			props := tc.loadComponentsAndProperties(t, filepath)
+			binding := loadOutputBindings(comp)
+			assert.NotNil(t, binding)
+			bindingsConfig := conf_output_bindings.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations)
+			conf_output_bindings.ConformanceTests(t, props, binding, bindingsConfig)
 		default:
 			assert.Failf(t, "unknown component type %s", tc.ComponentType)
 		}
@@ -170,7 +184,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 func loadPubSub(tc TestComponent) pubsub.PubSub {
 	var pubsub pubsub.PubSub
 	switch tc.Component {
-	case "redis":
+	case redis:
 		pubsub = p_redis.NewRedisStreams(testLogger)
 	default:
 		return nil
@@ -196,11 +210,24 @@ func loadSecretStore(tc TestComponent) secretstores.SecretStore {
 func loadStateStore(tc TestComponent) state.Store {
 	var store state.Store
 	switch tc.Component {
-	case "redis":
+	case redis:
 		store = s_redis.NewRedisStateStore(testLogger)
 	default:
 		return nil
 	}
 
 	return store
+}
+
+func loadOutputBindings(tc TestComponent) bindings.OutputBinding {
+	var binding bindings.OutputBinding
+
+	switch tc.Component {
+	case redis:
+		binding = b_redis.NewRedis(testLogger)
+	default:
+		return nil
+	}
+
+	return binding
 }

--- a/tests/conformance/output_bindings_test.go
+++ b/tests/conformance/output_bindings_test.go
@@ -1,0 +1,16 @@
+// +build conftests
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutputBindingConformance(t *testing.T) {
+	tc, err := NewTestConfiguration("../config/bindings/output_tests.yml")
+	assert.NoError(t, err)
+	assert.NotNil(t, tc)
+	tc.Run(t)
+}


### PR DESCRIPTION
# Description

This commit adds new conformance tests for output binding components.
Redis is being used as a the introductory binding example.

## Issue reference

Closes: #409 

## Note
This change is currently built atop @mukundansundar's PR for the template and is subject to change based off of the feedback received there. Once that is committed, this PR will represent a single commit and no longer be a draft.

https://github.com/dapr/components-contrib/pull/586

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
