### PR TITLE
Updated GCP SecretManager BulkGetSecret #590

### DIFF
--- a/secretstores/gcp/secretmanager/secretmanager_test.go
+++ b/secretstores/gcp/secretmanager/secretmanager_test.go
@@ -81,3 +81,35 @@ func TestGetSecret(t *testing.T) {
 		assert.Equal(t, secretstores.GetSecretResponse{Data: nil}, v)
 	})
 }
+
+func TestBulkGetSecret(t *testing.T) {
+	sm := NewSecreteManager(logger.NewLogger("test"))
+
+	t.Run("Bulk Get Secret - without Init", func(t *testing.T) {
+		v, err := sm.BulkGetSecret(secretstores.BulkGetSecretRequest{})
+		assert.NotNil(t, err)
+		assert.Equal(t, err, fmt.Errorf("client is not initialized"))
+		assert.Equal(t, secretstores.BulkGetSecretResponse{Data: nil}, v)
+	})
+
+	t.Run("Bulk Get Secret - with wrong Init", func(t *testing.T) {
+		m := secretstores.Metadata{
+			Properties: map[string]string{
+				"type":                        "service_account",
+				"project_id":                  "a",
+				"private_key_id":              "a",
+				"private_key":                 "a",
+				"client_email":                "a",
+				"client_id":                   "a",
+				"auth_uri":                    "a",
+				"token_uri":                   "a",
+				"auth_provider_x509_cert_url": "a",
+				"client_x509_cert_url":        "a",
+			},
+		}
+		sm.Init(m)
+		v, err := sm.BulkGetSecret(secretstores.BulkGetSecretRequest{})
+		assert.NotNil(t, err)
+		assert.Equal(t, secretstores.BulkGetSecretResponse{Data: nil}, v)
+	})
+}


### PR DESCRIPTION
# Description

BulkGetSecret method now returns a map[string]map[string]string

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #590

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
