### PR TITLE
Refactor conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -114,7 +114,7 @@ jobs:
         echo "Running tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
 
         go test -v -tags=conftests -count=1 ./tests/conformance/... \
-          --run="Test${KIND_UPPER}Conformance/${KIND}/${NAME}" 2>&1 | tee output.log
+          --run="Test${KIND_UPPER}Conformance/${NAME}" 2>&1 | tee output.log
 
         # Fail the step if we found no test to run
         if grep -q "warning: no tests to run" output.log ; then

--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,4 @@ check-diff:
 ################################################################################
 .PHONY: conf-tests
 conf-tests:
-	@go test -v -tags=conftests -count=1 ./tests/...
+	@go test -v -tags=conftests -count=1 ./tests/conformance

--- a/tests/config/bindings/output_tests.yml
+++ b/tests/config/bindings/output_tests.yml
@@ -1,8 +1,13 @@
+# the config map is passed in a metadata map to the Invoke request for output bindings
 componentType: output-binding
 components:
   - component: redis
-    operations: ["init", "create", "operations"]
+    operations: ["create", "operations"]
+    config:
+      key: $((uuid))
   - component: azure.blobstorage
-    operations: ["init", "create"]
+    operations: ["create", "operations", "get"]
+    config:
+      blobName: $((uuid))
   - component: azure.storagequeues
-    operations: ["init", "create", "operations"]
+    operations: ["create", "operations"]

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -21,7 +21,5 @@
 5. To run specific tests, run:
 ```bash
 # TEST_NAME can be TestPubsubConformance, TestStateConformance, TestSecretStoreConformance or TestOutputBindingConformance
-# COMPONENT_TYPE is the type of the component can be pubsub, state, output-binding, secretstores
 # COMPONENT_NAME is the component name from the tests.yml file eg: azure.servicebus, redis, mongodb etc.
-go test -v -tags=conftests -count=1 ./tests/conformance -run="${TEST_NAME}/${COMPONENT_TYPE}/${COMPONENT_NAME}"
-```
+go test -v -tags=conftests -count=1 ./tests/conformance -run="${TEST_NAME}/${COMPONENT_NAME}"

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -180,8 +180,7 @@ func convertComponentNameToPath(componentName string) string {
 	return componentName
 }
 
-func (tc *TestConfiguration) Run(t *testing.T) []error {
-	var errs []error
+func (tc *TestConfiguration) Run(t *testing.T) {
 	// For each component in the tests file run the conformance test
 	for _, comp := range tc.Components {
 		t.Run(comp.Component, func(t *testing.T) {
@@ -194,7 +193,7 @@ func (tc *TestConfiguration) Run(t *testing.T) []error {
 				filepath := fmt.Sprintf("../config/state/%s", componentConfigPath)
 				props, err := tc.loadComponentsAndProperties(t, filepath)
 				if err != nil {
-					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
+					t.Errorf("error running conformance test for %s: %s", comp.Component, err)
 
 					break
 				}
@@ -206,7 +205,7 @@ func (tc *TestConfiguration) Run(t *testing.T) []error {
 				filepath := fmt.Sprintf("../config/secretstores/%s", componentConfigPath)
 				props, err := tc.loadComponentsAndProperties(t, filepath)
 				if err != nil {
-					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
+					t.Errorf("error running conformance test for %s: %s", comp.Component, err)
 
 					break
 				}
@@ -218,7 +217,7 @@ func (tc *TestConfiguration) Run(t *testing.T) []error {
 				filepath := fmt.Sprintf("../config/pubsub/%s", componentConfigPath)
 				props, err := tc.loadComponentsAndProperties(t, filepath)
 				if err != nil {
-					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
+					t.Errorf("error running conformance test for %s: %s", comp.Component, err)
 
 					break
 				}
@@ -230,7 +229,7 @@ func (tc *TestConfiguration) Run(t *testing.T) []error {
 				filepath := fmt.Sprintf("../config/bindings/%s", componentConfigPath)
 				props, err := tc.loadComponentsAndProperties(t, filepath)
 				if err != nil {
-					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
+					t.Errorf("error running conformance test for %s: %s", comp.Component, err)
 
 					break
 				}
@@ -243,8 +242,6 @@ func (tc *TestConfiguration) Run(t *testing.T) []error {
 			}
 		})
 	}
-
-	return errs
 }
 
 func loadPubSub(tc TestComponent) pubsub.PubSub {

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -9,12 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"fortio.org/fortio/log"
 	"github.com/dapr/components-contrib/bindings"
@@ -38,6 +36,7 @@ import (
 	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/components"
 	config "github.com/dapr/dapr/pkg/config/modes"
+	"github.com/google/uuid"
 
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +44,8 @@ import (
 )
 
 const (
-	redis = "redis"
+	redis        = "redis"
+	generateUUID = "$((uuid))"
 )
 
 // nolint:gochecknoglobals
@@ -100,6 +100,18 @@ func LookUpEnv(key string) string {
 	return ""
 }
 
+func ParseConfigurationMap(t *testing.T, configMap map[string]string) {
+	for k, v := range configMap {
+		val := v
+		if strings.EqualFold(val, generateUUID) {
+			// check if generate uuid is specified
+			val = uuid.New().String()
+			t.Logf("Generated UUID %s", val)
+		}
+		configMap[k] = val
+	}
+}
+
 func ConvertMetadataToProperties(items []v1alpha1.MetadataItem) (map[string]string, error) {
 	properties := map[string]string{}
 	for _, c := range items {
@@ -117,18 +129,6 @@ func ConvertMetadataToProperties(items []v1alpha1.MetadataItem) (map[string]stri
 	}
 
 	return properties, nil
-}
-
-// nolint:gosec
-func NewRandString(length int) string {
-	rand.Seed(time.Now().Unix())
-	var letters = []rune("abcdefghijklmnopqrstuvwxyz")
-	b := make([]rune, length)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-
-	return string(b)
 }
 
 // isYaml checks whether the file is yaml or not
@@ -184,59 +184,64 @@ func (tc *TestConfiguration) Run(t *testing.T) []error {
 	var errs []error
 	// For each component in the tests file run the conformance test
 	for _, comp := range tc.Components {
-		componentConfigPath := convertComponentNameToPath(comp.Component)
-		switch tc.ComponentType {
-		case "state":
-			filepath := fmt.Sprintf("../config/state/%s", componentConfigPath)
-			props, err := tc.loadComponentsAndProperties(t, filepath)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error running conformance test for %s: %w", comp.Component, err))
+		t.Run(comp.Component, func(t *testing.T) {
+			// Parse and generate any keys
+			ParseConfigurationMap(t, comp.Config)
 
-				continue
-			}
-			store := loadStateStore(comp)
-			assert.NotNil(t, store)
-			storeConfig := conf_state.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
-			conf_state.ConformanceTests(t, props, store, storeConfig)
-		case "secretstores":
-			filepath := fmt.Sprintf("../config/secretstores/%s", componentConfigPath)
-			props, err := tc.loadComponentsAndProperties(t, filepath)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error running conformance test for %s: %w", comp.Component, err))
+			componentConfigPath := convertComponentNameToPath(comp.Component)
+			switch tc.ComponentType {
+			case "state":
+				filepath := fmt.Sprintf("../config/state/%s", componentConfigPath)
+				props, err := tc.loadComponentsAndProperties(t, filepath)
+				if err != nil {
+					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
 
-				continue
-			}
-			store := loadSecretStore(comp)
-			assert.NotNil(t, store)
-			storeConfig := conf_secret.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations)
-			conf_secret.ConformanceTests(t, props, store, storeConfig)
-		case "pubsub":
-			filepath := fmt.Sprintf("../config/pubsub/%s", componentConfigPath)
-			props, err := tc.loadComponentsAndProperties(t, filepath)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error running conformance test for %s: %w", comp.Component, err))
+					break
+				}
+				store := loadStateStore(comp)
+				assert.NotNil(t, store)
+				storeConfig := conf_state.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				conf_state.ConformanceTests(t, props, store, storeConfig)
+			case "secretstores":
+				filepath := fmt.Sprintf("../config/secretstores/%s", componentConfigPath)
+				props, err := tc.loadComponentsAndProperties(t, filepath)
+				if err != nil {
+					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
 
-				continue
-			}
-			pubsub := loadPubSub(comp)
-			assert.NotNil(t, pubsub)
-			pubsubConfig := conf_pubsub.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
-			conf_pubsub.ConformanceTests(t, props, pubsub, pubsubConfig)
-		case "output-binding":
-			filepath := fmt.Sprintf("../config/bindings/%s", componentConfigPath)
-			props, err := tc.loadComponentsAndProperties(t, filepath)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error running conformance test for %s: %w", comp.Component, err))
+					break
+				}
+				store := loadSecretStore(comp)
+				assert.NotNil(t, store)
+				storeConfig := conf_secret.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations)
+				conf_secret.ConformanceTests(t, props, store, storeConfig)
+			case "pubsub":
+				filepath := fmt.Sprintf("../config/pubsub/%s", componentConfigPath)
+				props, err := tc.loadComponentsAndProperties(t, filepath)
+				if err != nil {
+					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
 
-				continue
+					break
+				}
+				pubsub := loadPubSub(comp)
+				assert.NotNil(t, pubsub)
+				pubsubConfig := conf_pubsub.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				conf_pubsub.ConformanceTests(t, props, pubsub, pubsubConfig)
+			case "output-binding":
+				filepath := fmt.Sprintf("../config/bindings/%s", componentConfigPath)
+				props, err := tc.loadComponentsAndProperties(t, filepath)
+				if err != nil {
+					t.Errorf("error running conformance test for %s: %w", comp.Component, err)
+
+					break
+				}
+				binding := loadOutputBindings(comp)
+				assert.NotNil(t, binding)
+				bindingsConfig := conf_output_bindings.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				conf_output_bindings.ConformanceTests(t, props, binding, bindingsConfig)
+			default:
+				t.Errorf("unknown component type %s", tc.ComponentType)
 			}
-			binding := loadOutputBindings(comp)
-			assert.NotNil(t, binding)
-			bindingsConfig := conf_output_bindings.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations)
-			conf_output_bindings.ConformanceTests(t, props, binding, bindingsConfig)
-		default:
-			assert.Failf(t, "unknown component type %s", tc.ComponentType)
-		}
+		})
 	}
 
 	return errs

--- a/tests/conformance/common_test.go
+++ b/tests/conformance/common_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 
 	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestDecodeYaml(t *testing.T) {
-	var config TestConfiguration
-	yam := `
-componentType: state
+	t.Run("valid yaml", func(t *testing.T) {
+		var config TestConfiguration
+		yam := `componentType: state
 components:
   - component: redis
     allOperations: false
@@ -22,16 +23,26 @@ components:
       maxSetDurationInMs: 20
       maxDeleteDurationInMs: 10
       maxGetDurationInMs: 10
-      numBulkRequests: 10
-`
-	config, err := decodeYaml([]byte(yam))
-	assert.NoError(t, err)
-	assert.NotNil(t, config)
-	assert.Equal(t, 1, len(config.Components))
-	assert.False(t, config.Components[0].AllOperations)
-	assert.Equal(t, "state", config.ComponentType)
-	assert.Equal(t, 2, len(config.Components[0].Operations))
-	assert.Equal(t, 5, len(config.Components[0].Config))
+      numBulkRequests: 10`
+		config, err := decodeYaml([]byte(yam))
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, 1, len(config.Components))
+		assert.False(t, config.Components[0].AllOperations)
+		assert.Equal(t, "state", config.ComponentType)
+		assert.Equal(t, 2, len(config.Components[0].Operations))
+		assert.Equal(t, 5, len(config.Components[0].Config))
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		var config TestConfiguration
+		yam := `componentType: state
+components:
+- : redis`
+		config, err := decodeYaml([]byte(yam))
+		assert.Error(t, err)
+		assert.Equal(t, TestConfiguration{}, config)
+	})
 }
 
 func TestIsYaml(t *testing.T) {
@@ -85,6 +96,19 @@ func TestConvertMetadataToProperties(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.Equal(t, 0, len(resp))
 	})
+}
+
+func TestParseConfigurationMap(t *testing.T) {
+	testMap := map[string]string{
+		"key":  "$((uuid))",
+		"blob": "testblob",
+	}
+
+	ParseConfigurationMap(t, testMap)
+	assert.Equal(t, 2, len(testMap))
+	assert.Equal(t, "testblob", testMap["blob"])
+	_, err := uuid.ParseBytes([]byte(testMap["key"]))
+	assert.NoError(t, err)
 }
 
 func TestConvertComponentNameToPath(t *testing.T) {

--- a/tests/conformance/output_bindings_test.go
+++ b/tests/conformance/output_bindings_test.go
@@ -12,11 +12,5 @@ func TestOutputBindingConformance(t *testing.T) {
 	tc, err := NewTestConfiguration("../config/bindings/output_tests.yml")
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
-	errs := tc.Run(t)
-	if len(errs) != 0 {
-		for _, err = range errs {
-			t.Log(err)
-		}
-		assert.Fail(t, "some of tests failed")
-	}
+	tc.Run(t)
 }

--- a/tests/conformance/pubsub_test.go
+++ b/tests/conformance/pubsub_test.go
@@ -12,11 +12,5 @@ func TestPubsubConformance(t *testing.T) {
 	tc, err := NewTestConfiguration("../config/pubsub/tests.yml")
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
-	errs := tc.Run(t)
-	if len(errs) != 0 {
-		for _, err = range errs {
-			t.Log(err)
-		}
-		assert.Fail(t, "some of tests failed")
-	}
+	tc.Run(t)
 }

--- a/tests/conformance/secretstores/secretstores.go
+++ b/tests/conformance/secretstores/secretstores.go
@@ -33,14 +33,16 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 	// For local env var based component test
 	os.Setenv("conftestsecret", "abcd")
 	defer os.Unsetenv("conftestsecret")
-	if config.HasOperation("init") {
-		t.Run(config.GetTestName("init"), func(t *testing.T) {
-			err := store.Init(secretstores.Metadata{
-				Properties: props,
-			})
-			assert.NoError(t, err, "expected no error on initializing store")
+
+	// Init
+	t.Run("init", func(t *testing.T) {
+		err := store.Init(secretstores.Metadata{
+			Properties: props,
 		})
-	}
+		assert.NoError(t, err, "expected no error on initializing store")
+	})
+
+	// Get
 	if config.HasOperation("get") {
 		getSecretRequest := secretstores.GetSecretRequest{
 			Name: "conftestsecret",
@@ -51,7 +53,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 			},
 		}
 
-		t.Run("secretstores/"+config.ComponentName+"/get", func(t *testing.T) {
+		t.Run("get", func(t *testing.T) {
 			resp, err := store.GetSecret(getSecretRequest)
 			assert.NoError(t, err, "expected no error on getting secret %v", getSecretRequest)
 			assert.NotNil(t, resp, "expected value to be returned")
@@ -60,6 +62,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 		})
 	}
 
+	// Bulkget
 	if config.HasOperation("bulkget") {
 		bulkReq := secretstores.BulkGetSecretRequest{}
 		bulkResponse := secretstores.BulkGetSecretResponse{
@@ -73,7 +76,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 			},
 		}
 
-		t.Run(config.GetTestName("bulkget"), func(t *testing.T) {
+		t.Run("bulkget", func(t *testing.T) {
 			resp, err := store.BulkGetSecret(bulkReq)
 			assert.NoError(t, err, "expected no error on getting secret %v", bulkReq)
 			assert.NotNil(t, resp, "expected value to be returned")

--- a/tests/conformance/secretstores_test.go
+++ b/tests/conformance/secretstores_test.go
@@ -12,11 +12,5 @@ func TestSecretStoreConformance(t *testing.T) {
 	tc, err := NewTestConfiguration("../config/secretstores/tests.yml")
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
-	errs := tc.Run(t)
-	if len(errs) != 0 {
-		for _, err = range errs {
-			t.Log(err)
-		}
-		assert.Fail(t, "some of tests failed")
-	}
+	tc.Run(t)
 }

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -88,23 +88,21 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 	b, _ := json.Marshal(ValueType{Message: "test"})
 	value := b
 
-	if config.HasOperation("init") {
-		// Init
-		t.Run(config.GetTestName("init"), func(t *testing.T) {
-			start := time.Now()
-			err := statestore.Init(state.Metadata{
-				Properties: props,
-			})
-			elapsed := time.Since(start)
-			assert.Nil(t, err)
-			assert.Lessf(t, elapsed.Microseconds(), config.maxInitDuration.Microseconds(),
-				"test took %dμs but must complete in less than %dμs", elapsed.Microseconds(), config.maxDeleteDuration.Microseconds())
+	// Init
+	t.Run("init", func(t *testing.T) {
+		start := time.Now()
+		err := statestore.Init(state.Metadata{
+			Properties: props,
 		})
-	}
+		elapsed := time.Since(start)
+		assert.Nil(t, err)
+		assert.Lessf(t, elapsed.Microseconds(), config.maxInitDuration.Microseconds(),
+			"test took %dμs but must complete in less than %dμs", elapsed.Microseconds(), config.maxDeleteDuration.Microseconds())
+	})
 
 	if config.HasOperation("set") {
 		// Set
-		t.Run(config.GetTestName("set"), func(t *testing.T) {
+		t.Run("set", func(t *testing.T) {
 			setReq := &state.SetRequest{
 				Key:   key,
 				Value: value,
@@ -120,7 +118,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 	if config.HasOperation("get") {
 		// Get
-		t.Run(config.GetTestName("get"), func(t *testing.T) {
+		t.Run("get", func(t *testing.T) {
 			getReq := &state.GetRequest{
 				Key: key,
 			}
@@ -136,7 +134,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 	if config.HasOperation("delete") {
 		// Delete
-		t.Run(config.GetTestName("delete"), func(t *testing.T) {
+		t.Run("delete", func(t *testing.T) {
 			delReq := &state.DeleteRequest{
 				Key: key,
 			}
@@ -166,7 +164,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 		if config.HasOperation("bulkset") {
 			// BulkSet
-			t.Run(config.GetTestName("bulkset"), func(t *testing.T) {
+			t.Run("bulkset", func(t *testing.T) {
 				start := time.Now()
 				err := statestore.BulkSet(bulkSetReqs)
 				elapsed := time.Since(start)
@@ -189,7 +187,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 		if config.HasOperation("bulkdelete") {
 			// BulkDelete
-			t.Run(config.GetTestName("bulkdelete"), func(t *testing.T) {
+			t.Run("bulkdelete", func(t *testing.T) {
 				start := time.Now()
 				err := statestore.BulkDelete(bulkDeleteReqs)
 				elapsed := time.Since(start)

--- a/tests/conformance/state_test.go
+++ b/tests/conformance/state_test.go
@@ -12,11 +12,5 @@ func TestStateConformance(t *testing.T) {
 	tc, err := NewTestConfiguration("../config/state/tests.yml")
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
-	errs := tc.Run(t)
-	if len(errs) != 0 {
-		for _, err = range errs {
-			t.Log(err)
-		}
-		assert.Fail(t, "some of tests failed")
-	}
+	tc.Run(t)
 }

--- a/tests/conformance/utils/utils.go
+++ b/tests/conformance/utils/utils.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -17,6 +15,11 @@ func (cc CommonConfig) HasOperation(operation string) bool {
 	return cc.AllOperations || cc.Operations.Has(operation)
 }
 
-func (cc CommonConfig) GetTestName(operation string) string {
-	return fmt.Sprintf("%s/%s/%s", cc.ComponentType, cc.ComponentName, operation)
+func (cc CommonConfig) CopyMap(config map[string]string) map[string]string {
+	m := map[string]string{}
+	for k, v := range config {
+		m[k] = v
+	}
+
+	return m
 }

--- a/tests/conformance/utils/utils_test.go
+++ b/tests/conformance/utils/utils_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestHasOperation(t *testing.T) {
+	t.Run("all operations", func(t *testing.T) {
+		cc := CommonConfig{
+			ComponentType: "state",
+			ComponentName: "redis",
+			AllOperations: true,
+		}
+		assert.True(t, cc.HasOperation("op"))
+	})
+	t.Run("operations list", func(t *testing.T) {
+		cc := CommonConfig{
+			ComponentType: "state",
+			ComponentName: "redis",
+			Operations:    sets.NewString("op1", "op2"),
+		}
+		assert.True(t, cc.HasOperation("op1"))
+		assert.True(t, cc.HasOperation("op2"))
+		assert.False(t, cc.HasOperation("op3"))
+	})
+}
+
+func TestCopyMap(t *testing.T) {
+	cc := CommonConfig{
+		ComponentType: "state",
+		ComponentName: "redis",
+		AllOperations: true,
+	}
+	in := map[string]string{
+		"k": "v",
+		"v": "k",
+	}
+	out := cc.CopyMap(in)
+	assert.Equal(t, in, out)
+	assert.NotEqual(t, reflect.ValueOf(in).Pointer(), reflect.ValueOf(out).Pointer())
+}


### PR DESCRIPTION
# Description
Fix running output bindings with errors.
Refactor tests to make it simpler for go test filtering.
Generate UUID dynamically when configured to do so.
Add get operation for blobstorage binding.
Fail particular tests if correct environment variables are not set.


```
$ make conf-tests
=== RUN   TestDecodeYaml
=== RUN   TestDecodeYaml/valid_yaml
=== RUN   TestDecodeYaml/invalid_yaml
17:23:24 W common.go:157> error parsing string as yaml yaml: line 2: did not find expected key
--- PASS: TestDecodeYaml (0.00s)
    --- PASS: TestDecodeYaml/valid_yaml (0.00s)
    --- PASS: TestDecodeYaml/invalid_yaml (0.00s)
=== RUN   TestIsYaml
--- PASS: TestIsYaml (0.00s)
=== RUN   TestLookUpEnv
--- PASS: TestLookUpEnv (0.00s)
=== RUN   TestConvertMetadataToProperties
=== RUN   TestConvertMetadataToProperties/env_var_set
=== RUN   TestConvertMetadataToProperties/env_var_not_set
--- PASS: TestConvertMetadataToProperties (0.00s)
    --- PASS: TestConvertMetadataToProperties/env_var_set (0.00s)
    --- PASS: TestConvertMetadataToProperties/env_var_not_set (0.00s)
=== RUN   TestParseConfigurationMap
    common.go:109: Generated UUID 9e0bf172-e2a7-4d1f-960e-3c38f1d9a947
--- PASS: TestParseConfigurationMap (0.00s)
=== RUN   TestConvertComponentNameToPath
--- PASS: TestConvertComponentNameToPath (0.00s)
=== RUN   TestOutputBindingConformance
=== RUN   TestOutputBindingConformance/redis
    common.go:109: Generated UUID e9430a24-b678-4e98-8922-57a7a2bab808
=== RUN   TestOutputBindingConformance/redis/init
=== RUN   TestOutputBindingConformance/redis/operations
=== RUN   TestOutputBindingConformance/redis/create
=== RUN   TestOutputBindingConformance/azure.blobstorage
    common.go:109: Generated UUID e1942b06-0af1-4d2a-a8c9-24ecd0041c19
    common.go:232: error running conformance test for azure.blobstorage: required env var is not set AzureBlobStorageAccount
=== RUN   TestOutputBindingConformance/azure.storagequeues
    common.go:232: error running conformance test for azure.storagequeues: required env var is not set AzureBlobStorageAccount
--- FAIL: TestOutputBindingConformance (0.01s)
    --- PASS: TestOutputBindingConformance/redis (0.01s)
        --- PASS: TestOutputBindingConformance/redis/init (0.01s)
        --- PASS: TestOutputBindingConformance/redis/operations (0.00s)
        --- PASS: TestOutputBindingConformance/redis/create (0.00s)
    --- FAIL: TestOutputBindingConformance/azure.blobstorage (0.00s)
    --- FAIL: TestOutputBindingConformance/azure.storagequeues (0.00s)
=== RUN   TestPubsubConformance
=== RUN   TestPubsubConformance/azure.servicebus
    common.go:220: error running conformance test for azure.servicebus: required env var is not set AzureServiceBusConnectionString
=== RUN   TestPubsubConformance/redis
=== RUN   TestPubsubConformance/redis/init
=== RUN   TestPubsubConformance/redis/subscribe
time="2021-01-21T17:23:24.227828-08:00" level=warning msg="redis streams: BUSYGROUP Consumer Group name already exists" instance=instance scope=testLogger type=log ver=edge
=== RUN   TestPubsubConformance/redis/publish
=== RUN   TestPubsubConformance/redis/verify_read
    pubsub.go:124: waiting for 10ms to complete read
--- FAIL: TestPubsubConformance (0.03s)
    --- FAIL: TestPubsubConformance/azure.servicebus (0.00s)
    --- PASS: TestPubsubConformance/redis (0.03s)
        --- PASS: TestPubsubConformance/redis/init (0.00s)
        --- PASS: TestPubsubConformance/redis/subscribe (0.00s)
        --- PASS: TestPubsubConformance/redis/publish (0.01s)
        --- PASS: TestPubsubConformance/redis/verify_read (0.01s)
=== RUN   TestSecretStoreConformance
=== RUN   TestSecretStoreConformance/localenv
=== RUN   TestSecretStoreConformance/localenv/init
=== RUN   TestSecretStoreConformance/localenv/get
=== RUN   TestSecretStoreConformance/localfile
=== RUN   TestSecretStoreConformance/localfile/init
=== RUN   TestSecretStoreConformance/localfile/get
=== RUN   TestSecretStoreConformance/localfile/bulkget
--- PASS: TestSecretStoreConformance (0.01s)
    --- PASS: TestSecretStoreConformance/localenv (0.00s)
        --- PASS: TestSecretStoreConformance/localenv/init (0.00s)
        --- PASS: TestSecretStoreConformance/localenv/get (0.00s)
    --- PASS: TestSecretStoreConformance/localfile (0.00s)
        --- PASS: TestSecretStoreConformance/localfile/init (0.00s)
        --- PASS: TestSecretStoreConformance/localfile/get (0.00s)
        --- PASS: TestSecretStoreConformance/localfile/bulkget (0.00s)
=== RUN   TestStateConformance
=== RUN   TestStateConformance/redis
time="2021-01-21T17:23:24.265452-08:00" level=error msg="redis streams: error reading from stream testTopic: redis: client is closed" instance=instance scope=testLogger type=log ver=edge
=== RUN   TestStateConformance/redis/init
=== RUN   TestStateConformance/redis/set
=== RUN   TestStateConformance/redis/get
=== RUN   TestStateConformance/redis/delete
=== RUN   TestStateConformance/redis/bulkset
=== RUN   TestStateConformance/redis/bulkdelete
=== RUN   TestStateConformance/mongodb
=== RUN   TestStateConformance/mongodb/init
=== RUN   TestStateConformance/mongodb/set
=== RUN   TestStateConformance/mongodb/get
=== RUN   TestStateConformance/mongodb/delete
=== RUN   TestStateConformance/mongodb/bulkset
=== RUN   TestStateConformance/mongodb/bulkdelete
=== RUN   TestStateConformance/cosmosdb
    common.go:196: error running conformance test for cosmosdb: required env var is not set AzureCosmosDBUrl
--- FAIL: TestStateConformance (0.09s)
    --- PASS: TestStateConformance/redis (0.04s)
        --- PASS: TestStateConformance/redis/init (0.00s)
        --- PASS: TestStateConformance/redis/set (0.00s)
        --- PASS: TestStateConformance/redis/get (0.00s)
        --- PASS: TestStateConformance/redis/delete (0.00s)
        --- PASS: TestStateConformance/redis/bulkset (0.02s)
        --- PASS: TestStateConformance/redis/bulkdelete (0.01s)
    --- PASS: TestStateConformance/mongodb (0.05s)
        --- PASS: TestStateConformance/mongodb/init (0.01s)
        --- PASS: TestStateConformance/mongodb/set (0.00s)
        --- PASS: TestStateConformance/mongodb/get (0.00s)
        --- PASS: TestStateConformance/mongodb/delete (0.00s)
        --- PASS: TestStateConformance/mongodb/bulkset (0.03s)
        --- PASS: TestStateConformance/mongodb/bulkdelete (0.02s)
    --- FAIL: TestStateConformance/cosmosdb (0.00s)
FAIL
FAIL	github.com/dapr/components-contrib/tests/conformance	0.371s
FAIL
make: *** [conf-tests] Error 1


$ # Run individual test. azure service bus env var not set. 
$ export TEST_NAME=TestPubsubConformance
$ export COMPONENT_NAME=redis
$ go test -v -tags=conftests -count=1 ./tests/conformance -run="${TEST_NAME}/${COMPONENT_NAME}"
=== RUN   TestPubsubConformance
=== RUN   TestPubsubConformance/redis
=== RUN   TestPubsubConformance/redis/init
=== RUN   TestPubsubConformance/redis/subscribe
time="2021-01-21T17:24:56.797751-08:00" level=warning msg="redis streams: BUSYGROUP Consumer Group name already exists" instance=instance scope=testLogger type=log ver=edge
=== RUN   TestPubsubConformance/redis/publish
=== RUN   TestPubsubConformance/redis/verify_read
    pubsub.go:124: waiting for 10ms to complete read
--- PASS: TestPubsubConformance (0.04s)
    --- PASS: TestPubsubConformance/redis (0.04s)
        --- PASS: TestPubsubConformance/redis/init (0.01s)
        --- PASS: TestPubsubConformance/redis/subscribe (0.00s)
        --- PASS: TestPubsubConformance/redis/publish (0.02s)
        --- PASS: TestPubsubConformance/redis/verify_read (0.01s)
PASS
ok  	github.com/dapr/components-contrib/tests/conformance	0.370s


$ # Run specific test when env var is not set 
$ export COMPONENT_NAME=azure.servicebus
$ go test -v -tags=conftests -count=1 ./tests/conformance -run="${TEST_NAME}/${COMPONENT_NAME}"
=== RUN   TestPubsubConformance
=== RUN   TestPubsubConformance/azure.servicebus
    common.go:220: error running conformance test for azure.servicebus: required env var is not set AzureServiceBusConnectionString
--- FAIL: TestPubsubConformance (0.00s)
    --- FAIL: TestPubsubConformance/azure.servicebus (0.00s)
FAIL
FAIL	github.com/dapr/components-contrib/tests/conformance	0.297s
FAIL
```



## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #409 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
