### PR TITLE
Added binary data type detection

### DIFF
--- a/contenttype/utils.go
+++ b/contenttype/utils.go
@@ -26,7 +26,7 @@ func IsJSONContentType(contentType string) bool {
 
 // IsStringContentType determines if content type is string
 func IsStringContentType(contentType string) bool {
-	if strings.HasPrefix(contentType, "text/") {
+	if strings.HasPrefix(strings.ToLower(contentType), "text/") {
 		return true
 	}
 

--- a/contenttype/utils.go
+++ b/contenttype/utils.go
@@ -24,6 +24,15 @@ func IsJSONContentType(contentType string) bool {
 	return isContentType(contentType, JSONContentType)
 }
 
+// IsStringContentType determines if content type is string
+func IsStringContentType(contentType string) bool {
+	if strings.HasPrefix(contentType, "text/") {
+		return true
+	}
+
+	return isContentType(contentType, "application/xml")
+}
+
 func isContentType(contentType string, expected string) bool {
 	lowerContentType := strings.ToLower(contentType)
 	if lowerContentType == expected {

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -6,6 +6,7 @@
 package pubsub
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -57,8 +58,10 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 	var err error
 	if contrib_contenttype.IsJSONContentType(dataContentType) {
 		err = jsoniter.Unmarshal(data, &ceData)
-	} else {
+	} else if contrib_contenttype.IsStringContentType(dataContentType) {
 		ceData = string(data)
+	} else {
+		ceData = base64.StdEncoding.EncodeToString(data)
 	}
 
 	if err != nil {

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -6,6 +6,7 @@
 package pubsub
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -197,4 +198,10 @@ func TestNewFromExisting(t *testing.T) {
 		_, err := FromCloudEvent([]byte("a"), "1", "", "")
 		assert.Error(t, err)
 	})
+}
+
+func TestCreateFromBinaryPayload(t *testing.T) {
+	base64Encoding := base64.StdEncoding.EncodeToString([]byte{0x1})
+	envelope := NewCloudEventsEnvelope("", "", "", "", "", "", "application/octet-stream", []byte{0x1}, "trace")
+	assert.Equal(t, base64Encoding, envelope[DataField])
 }


### PR DESCRIPTION
Added base64 encoding for binary data types

# Description

Added binary data type detection based on mime type.
Base 64 encoded binary data.

## Issue reference
This will not fix any issue but help in https://github.com/dapr/dapr/issues/2612
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
