### PR TITLE
Fix service bus new topic creation

### DIFF
--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	azservicebus "github.com/Azure/azure-service-bus-go"
@@ -58,6 +59,8 @@ type azureServiceBus struct {
 	logger        logger.Logger
 	subscriptions []*subscription
 	features      []pubsub.Feature
+	topics        map[string]*azservicebus.Topic
+	topicsLock    *sync.RWMutex
 }
 
 // NewAzureServiceBus returns a new Azure ServiceBus pub-sub implementation
@@ -66,6 +69,8 @@ func NewAzureServiceBus(logger logger.Logger) pubsub.PubSub {
 		logger:        logger,
 		subscriptions: []*subscription{},
 		features:      []pubsub.Feature{pubsub.FeatureMessageTTL},
+		topics:        map[string]*azservicebus.Topic{},
+		topicsLock:    &sync.RWMutex{},
 	}
 }
 
@@ -219,11 +224,24 @@ func (a *azureServiceBus) Publish(req *pubsub.PublishRequest) error {
 		}
 	}
 
-	sender, err := a.namespace.NewTopic(req.Topic)
-	if err != nil {
-		return err
+	var sender *azservicebus.Topic
+	var err error
+
+	a.topicsLock.RLock()
+	if topic, ok := a.topics[req.Topic]; ok {
+		sender = topic
 	}
-	defer sender.Close(context.Background())
+	a.topicsLock.RUnlock()
+
+	if sender == nil {
+		a.topicsLock.Lock()
+		sender, err = a.namespace.NewTopic(req.Topic)
+		a.topicsLock.Unlock()
+
+		if err != nil {
+			return err
+		}
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(a.metadata.TimeoutInSec))
 	defer cancel()
@@ -456,6 +474,10 @@ func (a *azureServiceBus) createSubscriptionManagementOptions() ([]azservicebus.
 func (a *azureServiceBus) Close() error {
 	for _, s := range a.subscriptions {
 		s.close(context.TODO())
+	}
+
+	for _, t := range a.topics {
+		t.Close(context.TODO())
 	}
 
 	return nil

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -236,6 +236,7 @@ func (a *azureServiceBus) Publish(req *pubsub.PublishRequest) error {
 	if sender == nil {
 		a.topicsLock.Lock()
 		sender, err = a.namespace.NewTopic(req.Topic)
+		a.topics[req.Topic] = sender
 		a.topicsLock.Unlock()
 
 		if err != nil {


### PR DESCRIPTION
Reported performance benchmarks have shown that a new topic creation on every Publish event is costly.

This PR introduces on-demand creation of topics and removes a redundant Close function after every Publish operation.