### PR TITLE
Use a channel to block server start before tests

### DIFF
--- a/tests/conformance/utils/utils.go
+++ b/tests/conformance/utils/utils.go
@@ -44,23 +44,27 @@ func (cc CommonConfig) CopyMap(config map[string]string) map[string]string {
 	return m
 }
 
-func StartHTTPServer(port int) {
+func StartHTTPServer(port int, ready chan bool) {
 	s = server{}
 	srv := http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
 		Handler: appRouter(),
 	}
 
+	testLogger.Info(("Starting HTTP Server"))
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
 			testLogger.Errorf("Error with http server: %s", err.Error())
 		}
 	}()
 
+	testLogger.Info(("Registering Signal"))
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
-
+	ready <- true
+	testLogger.Info(("Waiting to stop Server"))
 	<-stop
+	testLogger.Info(("Stopping Server"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
# Description

The http server required for the http binding tests was not up
before the tests began to execute. This change adds a channel to
allow the server to block until it's ready.

## Issue reference

No issue, just a fix.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
