### PR TITLE
State:Dynamodb - Dont require access key/secret

### DIFF
--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -203,7 +203,6 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 	if err != nil {
 		return nil, err
 	}
-	fmt.Errorf("%s", meta)
 	if meta.Table == "" {
 		return nil, fmt.Errorf("missing dynamodb table name")
 	}

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -205,7 +205,7 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 	}
 
 	if meta.Table == "" {
-		return nil, fmt.Errorf("Missing DynamoDB Table name")
+		return nil, fmt.Errorf("missing dynamodb table name")
 	}
 
 	return &meta, nil

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -204,10 +204,6 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 		return nil, err
 	}
 
-	if meta.SecretKey == "" || meta.AccessKey == "" || meta.Region == "" || meta.SessionToken == "" {
-		return nil, fmt.Errorf("missing aws credentials in metadata")
-	}
-
 	return &meta, nil
 }
 

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -204,6 +204,10 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 		return nil, err
 	}
 
+	if meta.Table == "" {
+		return nil, fmt.Errorf("Missing DynamoDB Table name")
+	}
+
 	return &meta, nil
 }
 

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -203,7 +203,7 @@ func (d *StateStore) getDynamoDBMetadata(metadata state.Metadata) (*dynamoDBMeta
 	if err != nil {
 		return nil, err
 	}
-
+	fmt.Errorf("%s", meta)
 	if meta.Table == "" {
 		return nil, fmt.Errorf("missing dynamodb table name")
 	}

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -45,9 +45,10 @@ func TestInit(t *testing.T) {
 	t.Run("Init with valid metadata", func(t *testing.T) {
 		m.Properties = map[string]string{
 			"AccessKey":    "a",
-			"Region":       "a",
+			"Region":       "eu-west-1",
 			"SecretKey":    "a",
 			"SessionToken": "a",
+			"Table":        "a",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)
@@ -65,6 +66,7 @@ func TestInit(t *testing.T) {
 	t.Run("Init with valid table", func(t *testing.T) {
 		m.Properties = map[string]string{
 			"Table": "a",
+			"Region":       "eu-west-1",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -65,8 +65,8 @@ func TestInit(t *testing.T) {
 
 	t.Run("Init with valid table", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"Table": "a",
-			"Region":       "eu-west-1",
+			"Table":  "a",
+			"Region": "eu-west-1",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -53,13 +53,21 @@ func TestInit(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("Init with missing metadata", func(t *testing.T) {
+	t.Run("Init with missing table", func(t *testing.T) {
 		m.Properties = map[string]string{
 			"Dummy": "a",
 		}
 		err := s.Init(m)
 		assert.NotNil(t, err)
-		assert.Equal(t, err, fmt.Errorf("missing aws credentials in metadata"))
+		assert.Equal(t, err, fmt.Errorf("Missing DynamoDB Table name"))
+	})
+
+	t.Run("Init with valid table", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"Table": "a",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
 	})
 }
 

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -59,7 +59,7 @@ func TestInit(t *testing.T) {
 		}
 		err := s.Init(m)
 		assert.NotNil(t, err)
-		assert.Equal(t, err, fmt.Errorf("Missing DynamoDB Table name"))
+		assert.Equal(t, err, fmt.Errorf("missing dynamodb table name"))
 	})
 
 	t.Run("Init with valid table", func(t *testing.T) {


### PR DESCRIPTION
# Description
Dont fail if aws access key/secret vars are empty. This is part of the "implicit aws auth flow" which we changed a way back. Dynamodb had some hard-coded checks that this PR removes.

Looks like we simply don't have any documentation for the dymamodb state store yet (https://v1-rc2.docs.dapr.io/operations/components/setup-state-store/supported-state-stores/) so I can try and get that in after this is merged (marking docs as "done" in the list below, since there's no doc updates blocking this PR)

See also https://github.com/dapr/dapr/issues/2469

## Issue reference
Please reference the issue this PR will close: #647

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
