### PR TITLE
Fix Azure KeyVault secretstore BulkGet URI parsing of the GetSecretsComplete response

### DIFF
--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -102,9 +102,11 @@ func (k *keyvaultSecretStore) BulkGetSecret(req secretstores.BulkGetSecretReques
 		Data: map[string]map[string]string{},
 	}
 
+	secretIDPrefix := vaultURI + secretItemIDPrefix
+
 	for secretsResp.NotDone() {
 		secretItem := secretsResp.Value()
-		secretName := strings.TrimPrefix(strings.TrimPrefix(*secretItem.ID, vaultURI), secretItemIDPrefix)
+		secretName := strings.TrimPrefix(*secretItem.ID, secretIDPrefix)
 
 		secretResp, err := k.vaultClient.GetSecret(context.Background(), vaultURI, secretName, "")
 		if err != nil {

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -25,6 +25,7 @@ const (
 	componentSPNTenantID            = "spnTenantId"
 	componentVaultName              = "vaultName"
 	VersionID                       = "version_id"
+	secretItemIdPrefix              = "/secrets/"
 )
 
 type keyvaultSecretStore struct {
@@ -103,7 +104,7 @@ func (k *keyvaultSecretStore) BulkGetSecret(req secretstores.BulkGetSecretReques
 
 	for secretsResp.NotDone() {
 		secretItem := secretsResp.Value()
-		secretName := strings.TrimPrefix(*secretItem.ID, vaultURI)
+		secretName := strings.TrimPrefix(strings.TrimPrefix(*secretItem.ID, vaultURI), secretItemIdPrefix)
 
 		secretResp, err := k.vaultClient.GetSecret(context.Background(), vaultURI, secretName, "")
 		if err != nil {

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -25,7 +25,7 @@ const (
 	componentSPNTenantID            = "spnTenantId"
 	componentVaultName              = "vaultName"
 	VersionID                       = "version_id"
-	secretItemIdPrefix              = "/secrets/"
+	secretItemIDPrefix              = "/secrets/"
 )
 
 type keyvaultSecretStore struct {
@@ -104,7 +104,7 @@ func (k *keyvaultSecretStore) BulkGetSecret(req secretstores.BulkGetSecretReques
 
 	for secretsResp.NotDone() {
 		secretItem := secretsResp.Value()
-		secretName := strings.TrimPrefix(strings.TrimPrefix(*secretItem.ID, vaultURI), secretItemIdPrefix)
+		secretName := strings.TrimPrefix(strings.TrimPrefix(*secretItem.ID, vaultURI), secretItemIDPrefix)
 
 		secretResp, err := k.vaultClient.GetSecret(context.Background(), vaultURI, secretName, "")
 		if err != nil {


### PR DESCRIPTION
# Description
Fix Azure KeyVault secretstore BulkGet URI parsing of the GetSecretsComplete response to make it works with URI of form `{vaultURI}/secrets/{itemID}` in the GetSecretsComplete response.


## Issue reference


Please reference the issue this PR will close: #655 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
