### PR TITLE
Improving the versatility of the HTTP output binding

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -92,11 +92,12 @@ jobs:
       if: matrix.required-secrets != ''
 
     - name: Start ngrok
+      if: contains(matrix.component, 'azure.eventgrid')
       run: |
         wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
         unzip -qq ngrok-stable-linux-amd64.zip
         ./ngrok authtoken ${{ env.AzureEventGridNgrokToken }}
-        ngrok http -log=stdout -host-header=localhost 9000 > /tmp/ngrok.log &
+        ./ngrok http -log=stdout -host-header=localhost 9000 > /tmp/ngrok.log &
         sleep 10
         export NGROK_ENDPOINT=`cat /tmp/ngrok.log |  grep -Eo 'https://.*'`
         echo "Ngrok's endpoint: ${NGROK_ENDPOINT}"

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -87,6 +87,7 @@ func (h *HTTPSource) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespon
 		body = bytes.NewBuffer(req.Data)
 	}
 
+	// nolint: noctx
 	request, err := http.NewRequest(method, u, body)
 	if err != nil {
 		return nil, err
@@ -97,7 +98,6 @@ func (h *HTTPSource) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespon
 	}
 	request.Header.Set("Accept", "application/json; charset=utf-8")
 
-	// nolint: noctx
 	resp, err := h.client.Do(request)
 	if err != nil {
 		return nil, err

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -59,6 +59,7 @@ func (h *HTTPSource) Init(metadata bindings.Metadata) error {
 		Timeout:   time.Second * 10,
 		Transport: &netTransport,
 	}
+
 	return nil
 }
 

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -65,7 +65,7 @@ func (h *HTTPSource) Init(metadata bindings.Metadata) error {
 // Operations returns the supported operations for this binding.
 func (h *HTTPSource) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{
-		bindings.CreateOperation, // For backward compatability
+		bindings.CreateOperation, // For backward compatibility
 		"get",
 		"head",
 		"post",
@@ -92,7 +92,7 @@ func (h *HTTPSource) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeRespon
 
 	var body io.Reader
 	method := strings.ToUpper(string(req.Operation))
-	// For backward compatability
+	// For backward compatibility
 	if method == "CREATE" {
 		method = "POST"
 	}

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -47,6 +47,10 @@ func TestInit(t *testing.T) {
 					input = string(b)
 				}
 			}
+			inputFromHeader := req.Header.Get("X-Input")
+			if inputFromHeader != "" {
+				input = inputFromHeader
+			}
 			w.Header().Set("Content-Type", "text/plain")
 			w.Write([]byte(strings.ToUpper(input)))
 		}),
@@ -73,6 +77,13 @@ func TestInit(t *testing.T) {
 			input:     "GET",
 			operation: "get",
 			metadata:  nil,
+			path:      "/",
+			err:       "",
+		},
+		"request headers": {
+			input:     "OVERRIDE",
+			operation: "get",
+			metadata:  map[string]string{"X-Input": "override"},
 			path:      "/",
 			err:       "",
 		},

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -118,7 +118,7 @@ func TestInit(t *testing.T) {
 			path:      "/",
 			err:       "",
 		},
-		"backward compatability": {
+		"backward compatibility": {
 			input:     "expected",
 			operation: "create",
 			metadata:  map[string]string{"path": "/test"},

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -52,6 +52,9 @@ func TestInit(t *testing.T) {
 				input = inputFromHeader
 			}
 			w.Header().Set("Content-Type", "text/plain")
+			if input == "internal server error" {
+				w.WriteHeader(500)
+			}
 			w.Write([]byte(strings.ToUpper(input)))
 		}),
 	)
@@ -149,6 +152,13 @@ func TestInit(t *testing.T) {
 			metadata:  map[string]string{"path": "/test"},
 			path:      "/test",
 			err:       "invalid operation: notvalid",
+		},
+		"internal server error": {
+			input:     "internal server error",
+			operation: "post",
+			metadata:  map[string]string{"path": "/"},
+			path:      "/",
+			err:       "received status code 500",
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/jackc/pgx/v4 v4.6.0
 	github.com/json-iterator/go v1.1.10
 	github.com/keighl/postmark v0.0.0-20190821160221-28358b1a94e3
+	github.com/mitchellh/mapstructure v1.3.3
 	github.com/nats-io/go-nats v1.7.2
 	github.com/nats-io/nats.go v1.9.1
 	github.com/nats-io/stan.go v0.6.0

--- a/tests/config/bindings/http/bindings.yml
+++ b/tests/config/bindings/http/bindings.yml
@@ -8,6 +8,4 @@ spec:
   version: v1
   metadata:
   - name: url
-    value: http://localhost:22222
-  - name: method
-    value: POST
+    value: http://localhost:22222/call

--- a/tests/config/bindings/tests.yml
+++ b/tests/config/bindings/tests.yml
@@ -19,7 +19,7 @@ components:
   - component: kafka
     operations: ["create", "operations"]
   - component: http
-    operations: ["create", "operations", "read"]
+    operations: ["create", "operations"]
     config:
       url: "localhost:22222"
       method: "POST"

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -3,8 +3,8 @@ components:
   - component: redis
     allOperations: true
     config:
-      maxInitDuration: 30
-      maxSetDuration: 20
+      maxInitDuration: 5000
+      maxSetDuration: 300
   - component: mongodb
     allOperations: true
     config:

--- a/tests/conformance/bindings/bindings.go
+++ b/tests/conformance/bindings/bindings.go
@@ -6,7 +6,6 @@
 package bindings
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -136,8 +135,18 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 	if config.HasOperation("operations") {
 		t.Run("operations", func(t *testing.T) {
 			ops := outputBinding.Operations()
-			for _, op := range ops {
-				assert.True(t, config.HasOperation(string(op)), fmt.Sprintf("Operation missing from conformance test config: %v", op))
+			for op := range config.Operations {
+				match := false
+				// remove all test related operation names
+				if strings.EqualFold(op, "operations") || strings.EqualFold(op, "read") {
+					continue
+				}
+				for _, o := range ops {
+					if strings.EqualFold(string(o), op) {
+						match = true
+					}
+				}
+				assert.Truef(t, match, "expected operation %s to match list", op)
 			}
 		})
 	}

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -332,8 +332,6 @@ func loadInputBindings(tc TestComponent) bindings.InputBinding {
 		binding = b_azure_eventgrid.NewAzureEventGrid(testLogger)
 	case "kafka":
 		binding = b_kafka.NewKafka(testLogger)
-	case "http":
-		binding = b_http.NewHTTP(testLogger)
 	default:
 		return nil
 	}


### PR DESCRIPTION
# Description

Improving the versatility of the HTTP output binding. Removed the `Read` method since it is not an input binding.

## Issue reference

Related to dapr/docs#153. Will update the docs for this binding as a follow up.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#153
