### PR TITLE
Handle []byte in cosmosdb state txn

### DIFF
--- a/state/azure/cosmosdb/cosmosdb_test.go
+++ b/state/azure/cosmosdb/cosmosdb_test.go
@@ -1,0 +1,78 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cosmosdb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/stretchr/testify/assert"
+)
+
+type widget struct {
+	Color string `json:"color"`
+}
+
+func TestCreateCosmosItem(t *testing.T) {
+	value := widget{Color: "red"}
+	partitionKey := "/partitionKey"
+	t.Run("create item for golang struct", func(t *testing.T) {
+		req := state.SetRequest{
+			Key:   "testKey",
+			Value: value,
+		}
+
+		item := createUpsertItem(req, partitionKey)
+		assert.Equal(t, partitionKey, item.PartitionKey)
+		assert.Equal(t, "testKey", item.ID)
+		assert.Equal(t, value, item.Value)
+
+		// items need to be marshallable to JSON with encoding/json
+		b, err := json.Marshal(item)
+		assert.NoError(t, err)
+
+		j := map[string]interface{}{}
+		err = json.Unmarshal(b, &j)
+		assert.NoError(t, err)
+
+		value := j["value"]
+		m, ok := value.(map[string]interface{})
+		assert.Truef(t, ok, "value should be a map")
+
+		assert.Equal(t, "red", m["color"])
+	})
+
+	t.Run("create item for JSON bytes", func(t *testing.T) {
+		// We have special handling for bytes, we assume that it's UTF-8 text containing
+		// JSON and special case it to avoid the serializer turning it into a base64 encoded string
+		bytes, err := json.Marshal(value)
+		assert.NoError(t, err)
+
+		req := state.SetRequest{
+			Key:   "testKey",
+			Value: bytes,
+		}
+
+		item := createUpsertItem(req, partitionKey)
+		assert.Equal(t, partitionKey, item.PartitionKey)
+		assert.Equal(t, "testKey", item.ID)
+
+		// items need to be marshallable to JSON with encoding/json
+		b, err := json.Marshal(item)
+		assert.NoError(t, err)
+
+		j := map[string]interface{}{}
+		err = json.Unmarshal(b, &j)
+		assert.NoError(t, err)
+
+		value := j["value"]
+		m, ok := value.(map[string]interface{})
+		assert.Truef(t, ok, "value should be a map")
+
+		assert.Equal(t, "red", m["color"])
+	})
+}


### PR DESCRIPTION
# Description

The issue here is that we had missed the case of pre-marshaled bytes in
the state transaction code path, which would result in the encoding/json
package doing it's normal thing and base64 encoding the data as a JSON
string.

The fix is to use json.RawMessage to avoid that. Turns out this code can
be simplified a bit.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Fixes: dapr/dotnet-sdk#579

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
