### PR TITLE
Enforce no code coverage drop in PRs

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -6,10 +6,9 @@ coverage:
       default:
         informational: true
     patch:
-      # Disable the coverage threshold of the patch, so that PRs are
-      # only failing because of overall project coverage threshold.
-      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
-      default: false
+      default:
+        target: auto
+        threshold: 0%
 comment:
   # Delete old comment and post new one for new coverage information.
   behavior: new


### PR DESCRIPTION
## Descrption
Enforce code coverage doesn't drop in a PR. 

## Issue reference
Closes: #502

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
