### PR TITLE
Change conformance test job name to avoid having env var / secret names in the title

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -84,7 +84,7 @@ jobs:
       cron-components: ${{ steps.cron-components.outputs.cron-components }}
 
   conformance:
-    name: conformance
+    name: ${{ matrix.component }} conformance
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
# Description

Change conformance test job name to avoid having env var / secret names in the title. Even though these are visible in the workflow file already, it's nice not to have a super long job name with a long list of env vars.

## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
