### PR TITLE
Fix Azure Service Bus connection issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	fortio.org/fortio v1.11.5
 	github.com/Azure/azure-event-hubs-go v1.3.1
 	github.com/Azure/azure-sdk-for-go v48.2.0+incompatible
-	github.com/Azure/azure-service-bus-go v0.10.6
+	github.com/Azure/azure-service-bus-go v0.10.10
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/azure-storage-queue-go v0.0.0-20191125232315-636801874cdd
 	github.com/Azure/go-autorest/autorest v0.11.12


### PR DESCRIPTION
# Description
As discussed in #649, an issue in the azure-service-bus-go sdk meant that credentials would eventually expire for the lock renewal connection. This was original raised by @XavierGeerinck on discord. We've detected the issue in the sdk as discussed in [this thread](https://github.com/Azure/azure-service-bus-go/issues/155). This has been fixed in `v0.10.10` so this PR bumps the version of the sdk we use from `v0.10.6` to `v0.10.10`.

I'm currently running soak tests to validate the fix and will publish the PR once confirmed.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #649 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
