### PR TITLE
Make failing conformance tests also fail the build

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -195,6 +195,7 @@ jobs:
     - name: Run tests
       continue-on-error: true
       run: |
+        set -e 
         KIND=$(echo ${{ matrix.component }} | cut -d. -f1)
         NAME=$(echo ${{ matrix.component }} | cut -d. -f2-)
         KIND_UPPER="$(tr '[:lower:]' '[:upper:]' <<< ${KIND:0:1})${KIND:1}"
@@ -205,8 +206,16 @@ jobs:
 
         echo "Running tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
 
+        set +e
         go test -v -tags=conftests -count=1 ./tests/conformance \
           --run="Test${KIND_UPPER}Conformance/${NAME}" 2>&1 | tee output.log
+        status=$?
+        echo "Completed tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
+        if test $status -ne 0; then
+          echo "Setting CONFORMANCE_FAILURE"
+          echo "CONFORMANCE_FAILURE=true" >> $GITHUB_ENV
+        fi
+        set -e
 
         # Fail the step if we found no test to run
         if grep -q "warning: no tests to run" output.log ; then
@@ -229,3 +238,11 @@ jobs:
           echo "Cleaning up the certificate file $CERT_FILE..."
           rm $CERT_FILE
         done
+
+    - name: Check conformance test passed
+      continue-on-error: false
+      run: |
+        echo "CONFORMANCE_FAILURE=$CONFORMANCE_FAILURE"
+        if [[ -v CONFORMANCE_FAILURE ]]; then
+          exit 1
+        fi

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -14,10 +14,11 @@ components:
     config:
       pubsubName: azure-servicebus
       testTopicName: dapr-conf-test
+      checkInOrderProcessing: false
   - component: redis
     allOperations: true
     config:
-      #checkInOrderProcessing: false
+      checkInOrderProcessing: false
   - component: natsstreaming
     allOperations: true
   - component: kafka

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -17,7 +17,7 @@ components:
   - component: redis
     allOperations: true
     config:
-      checkInOrderProcessing: false
+      #checkInOrderProcessing: false
   - component: natsstreaming
     allOperations: true
   - component: kafka


### PR DESCRIPTION
Setting `pipefail` option in Github workflow and purposefully making the Redis test fail to verify that the build fails (as expected)

It is expected that this build will fail initially. ~~If it does not, **PLEASE DO NOT MERGE**~~. A comment will follow when the bug is fixed.

Closes #714 