### PR TITLE
Conformance Test: PubSub - Ignore already processed messages

### DIFF
--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -112,6 +113,8 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 	// from being considered as part of this test.
 	runID := uuid.Must(uuid.NewRandom()).String()
 	awaitingMessages := make(map[string]struct{}, 20)
+	var mu sync.Mutex
+	processedMessages := make(map[int]struct{}, 20)
 	processedC := make(chan string, config.messageCount*2)
 	errorCount := 0
 	dataPrefix := "message-" + runID + "-"
@@ -133,8 +136,6 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 					return nil
 				}
 
-				counter++
-
 				sequence, err := strconv.Atoi(dataString[len(dataPrefix):])
 				if err != nil {
 					t.Logf("Message did not contain a sequence number")
@@ -142,6 +143,20 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 
 					return err
 				}
+
+				// Ignore already processed messages
+				// in case we receive a redelivery from the broker
+				// during retries.
+				mu.Lock()
+				_, alreadyProcessed := processedMessages[sequence]
+				mu.Unlock()
+				if alreadyProcessed {
+					t.Logf("Message was already processed: %d", sequence)
+
+					return nil
+				}
+
+				counter++
 
 				if sequence < lastSequence {
 					outOfOrder = true
@@ -164,6 +179,10 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 
 				t.Logf("Simulating subscriber success")
 				actualReadCount++
+
+				mu.Lock()
+				processedMessages[sequence] = struct{}{}
+				mu.Unlock()
 
 				processedC <- dataString
 

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -121,7 +121,7 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 	var outOfOrder bool
 
 	// Subscribe
-	if config.HasOperation("subscribe") {
+	if config.HasOperation("subscribe") { // nolint: nestif
 		t.Run("subscribe", func(t *testing.T) {
 			var counter int
 			var lastSequence int

--- a/tests/conformance/utils/utils.go
+++ b/tests/conformance/utils/utils.go
@@ -6,13 +6,13 @@
 package utils
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/gorilla/mux"
@@ -50,32 +50,33 @@ func (cc CommonConfig) CopyMap(config map[string]string) map[string]string {
 }
 
 func StartHTTPServer(port int, ready chan bool) {
-	s = server{}
-	srv := http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: appRouter(),
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		testLogger.Errorf("Error starting test HTTP serer: %v", err)
+
+		return
 	}
 
 	testLogger.Info(("Starting HTTP Server"))
-	go func() {
-		if err := srv.ListenAndServe(); err != nil {
-			testLogger.Errorf("Error with http server: %s", err.Error())
-		}
-	}()
+	ts := httptest.NewUnstartedServer(appRouter())
+	// NewUnstartedServer creates a listener. Close that listener and replace
+	// with the one we created.
+	ts.Listener.Close()
+	ts.Listener = l
+
+	// Start the server.
+	ts.Start()
+	defer ts.Close()
+
+	ready <- true
 
 	testLogger.Info(("Registering Signal"))
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
-	ready <- true
+
 	testLogger.Info(("Waiting to stop Server"))
 	<-stop
 	testLogger.Info(("Stopping Server"))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
-		testLogger.Errorf("Error shutting down http server: %s", err.Error())
-	}
 }
 
 func appRouter() *mux.Router {


### PR DESCRIPTION
# Description

Added a simple check to ignore already processed messages in case the pubsub broker redelivers the messages while retries are taking place. Without this check, the test can fail the in-order processing check.

The following log shows the current issue:

```
time="2021-02-26T02:20:41.762829894Z" level=debug msg="Processing MQTT message testTopic/7" instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:42.763089578Z" level=error msg="Error processing MQTT message: testTopic/7. Retrying..." instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:47.763361684Z" level=debug msg="Processing MQTT message testTopic/7" instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:47.763461085Z" level=info msg="Successfully processed MQTT message after it previously failed: testTopic/7" instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:47.763484586Z" level=debug msg="Processing MQTT message testTopic/8" instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:47.763533486Z" level=debug msg="Processing MQTT message testTopic/9" instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:47.76386099Z" level=debug msg="Processing MQTT message testTopic/10" instance=fv-az177-944 scope=testLogger type=log ver=edge
time="2021-02-26T02:20:47.763977292Z" level=debug msg="Processing MQTT message testTopic/7" instance=fv-az177-944 scope=testLogger type=log ver=edge
    pubsub.go:213: 
        	Error Trace:	pubsub.go:213
        	Error:      	Should be false
        	Test:       	TestPubsubConformance/mqtt-vernemq/verify_read
        	Messages:   	received messages out of order
```

The broker redelivered `testTopic/7` and makes the test think it received messages out of order when in fact it didn't.

After this fix the logs look like this:

```
time="2021-02-26T03:50:14.228639-05:00" level=error msg="Error processing MQTT message: testTopic/47. Retrying..." instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.231696-05:00" level=debug msg="Processing MQTT message testTopic/47" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.231861-05:00" level=info msg="Successfully processed MQTT message after it previously failed: testTopic/47" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.2319-05:00" level=debug msg="Processing MQTT message testTopic/48" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.231953-05:00" level=debug msg="Processing MQTT message testTopic/49" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.232117-05:00" level=debug msg="Processing MQTT message testTopic/50" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.232227-05:00" level=debug msg="Processing MQTT message testTopic/47" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.232359-05:00" level=debug msg="Processing MQTT message testTopic/48" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.232485-05:00" level=debug msg="Processing MQTT message testTopic/49" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
time="2021-02-26T03:50:19.232557-05:00" level=debug msg="Processing MQTT message testTopic/50" instance=Phils-MacBook-Pro.local scope=testLogger type=log ver=edge
.
.
.
        pubsub.go:154: Message was already processed: 7
        --- PASS: TestPubsubConformance/mqtt-vernemq/verify_read (24.01s)
        pubsub.go:154: Message was already processed: 8
        pubsub.go:154: Message was already processed: 9
        pubsub.go:154: Message was already processed: 10
```

## Issue reference

Fixes a bug in #717 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

cc: @artursouza @mukundansundar