### PR TITLE
Added Hazelcast to conformance tests and retry to prevent message loss

### DIFF
--- a/.github/infrastructure/docker-compose-hazelcast.yml
+++ b/.github/infrastructure/docker-compose-hazelcast.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  hazelcast:
+    image: hazelcast/hazelcast:3.12.12-1
+    ports:
+      - 5701:5701

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -38,6 +38,7 @@ jobs:
         - pubsub.mqtt-mosquitto
         - pubsub.mqtt-emqx
         - pubsub.mqtt-vernemq
+        - pubsub.hazelcast
         - secretstores.kubernetes
         - secretstores.localenv
         - secretstores.localfile
@@ -193,6 +194,10 @@ jobs:
     - name: Start VerneMQ (MQTT)
       run: docker-compose -f ./.github/infrastructure/docker-compose-vernemq.yml -p vernemq up -d
       if: contains(matrix.component, 'mqtt-vernemq')
+
+    - name: Start hazelcast
+      run: docker-compose -f ./.github/infrastructure/docker-compose-hazelcast.yml -p hazelcast up -d
+      if: contains(matrix.component, 'hazelcast')
 
     - name: Start KinD
       uses: helm/kind-action@v1.0.0

--- a/pubsub/hazelcast/hazelcast.go
+++ b/pubsub/hazelcast/hazelcast.go
@@ -1,23 +1,34 @@
 package hazelcast
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hazelcast/hazelcast-go-client"
+	hazelcastCore "github.com/hazelcast/hazelcast-go-client/core"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/logger"
-	"github.com/hazelcast/hazelcast-go-client"
-	hazelcastCore "github.com/hazelcast/hazelcast-go-client/core"
 )
 
 const (
-	hazelcastServers = "hazelcastServers"
+	hazelcastServers           = "hazelcastServers"
+	hazelcastBackOffMaxRetries = "backOffMaxRetries"
 )
 
 type Hazelcast struct {
-	client hazelcast.Client
-	logger logger.Logger
+	client   hazelcast.Client
+	logger   logger.Logger
+	metadata metadata
+
+	ctx     context.Context
+	cancel  context.CancelFunc
+	backOff backoff.BackOff
 }
 
 // NewHazelcastPubSub returns a new hazelcast pub-sub implementation
@@ -33,6 +44,14 @@ func parseHazelcastMetadata(meta pubsub.Metadata) (metadata, error) {
 		return m, errors.New("hazelcast error: missing hazelcast servers")
 	}
 
+	if val, ok := meta.Properties[hazelcastBackOffMaxRetries]; ok && val != "" {
+		backOffMaxRetriesInt, err := strconv.Atoi(val)
+		if err != nil {
+			return m, fmt.Errorf("hazelcast error: invalid backOffMaxRetries %s, %v", val, err)
+		}
+		m.backOffMaxRetries = backOffMaxRetriesInt
+	}
+
 	return m, nil
 }
 
@@ -42,6 +61,7 @@ func (p *Hazelcast) Init(metadata pubsub.Metadata) error {
 		return err
 	}
 
+	p.metadata = m
 	hzConfig := hazelcast.NewConfig()
 
 	servers := m.hazelcastServers
@@ -51,6 +71,12 @@ func (p *Hazelcast) Init(metadata pubsub.Metadata) error {
 	if err != nil {
 		return fmt.Errorf("hazelcast error: failed to create new client, %v", err)
 	}
+
+	p.ctx, p.cancel = context.WithCancel(context.Background())
+
+	// TODO: Make the backoff configurable for constant or exponential
+	b := backoff.NewConstantBackOff(5 * time.Second)
+	p.backOff = backoff.WithContext(b, p.ctx)
 
 	return nil
 }
@@ -74,7 +100,7 @@ func (p *Hazelcast) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pub
 		return fmt.Errorf("hazelcast error: failed to get topic for %s", req.Topic)
 	}
 
-	_, err = topic.AddMessageListener(&hazelcastMessageListener{topic.Name(), handler})
+	_, err = topic.AddMessageListener(&hazelcastMessageListener{p, topic.Name(), handler})
 	if err != nil {
 		return fmt.Errorf("hazelcast error: failed to add new listener, %v", err)
 	}
@@ -83,6 +109,7 @@ func (p *Hazelcast) Subscribe(req pubsub.SubscribeRequest, handler func(msg *pub
 }
 
 func (p *Hazelcast) Close() error {
+	p.cancel()
 	p.client.Shutdown()
 
 	return nil
@@ -93,6 +120,7 @@ func (p *Hazelcast) Features() []pubsub.Feature {
 }
 
 type hazelcastMessageListener struct {
+	p             *Hazelcast
 	topicName     string
 	pubsubHandler func(msg *pubsub.NewMessage) error
 }
@@ -103,14 +131,33 @@ func (l *hazelcastMessageListener) OnMessage(message hazelcastCore.Message) erro
 		return errors.New("hazelcast error: cannot cast message to byte array")
 	}
 
-	return l.handleMessageObject(msg)
+	if err := l.handleMessageObject(msg); err != nil {
+		l.p.logger.Error("Failure processing Hazelcast message")
+
+		return err
+	}
+
+	return nil
 }
 
 func (l *hazelcastMessageListener) handleMessageObject(message []byte) error {
-	pubsubMsg := &pubsub.NewMessage{
+	pubsubMsg := pubsub.NewMessage{
 		Data:  message,
 		Topic: l.topicName,
 	}
 
-	return l.pubsubHandler(pubsubMsg)
+	b := l.p.backOff
+	if l.p.metadata.backOffMaxRetries >= 0 {
+		b = backoff.WithMaxRetries(b, uint64(l.p.metadata.backOffMaxRetries))
+	}
+
+	return pubsub.RetryNotifyRecover(func() error {
+		l.p.logger.Debug("Processing Hazelcast message")
+
+		return l.pubsubHandler(&pubsubMsg)
+	}, b, func(err error, d time.Duration) {
+		l.p.logger.Error("Error processing Hazelcast message. Retrying...")
+	}, func() {
+		l.p.logger.Info("Successfully processed Hazelcast message after it previously failed")
+	})
 }

--- a/pubsub/hazelcast/metadata.go
+++ b/pubsub/hazelcast/metadata.go
@@ -1,5 +1,6 @@
 package hazelcast
 
 type metadata struct {
-	hazelcastServers string
+	hazelcastServers  string
+	backOffMaxRetries int
 }

--- a/tests/config/pubsub/hazelcast/pubsub.yml
+++ b/tests/config/pubsub/hazelcast/pubsub.yml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.hazelcast
+  version: v1
+  metadata:
+  - name: hazelcastServers
+    value: "localhost:5701"
+  - name: backOffMaxRetries
+    value: 3

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -34,3 +34,5 @@ components:
   - component: mqtt
     profile: vernemq
     allOperations: true
+  - component: hazelcast
+    allOperations: true

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -26,6 +26,7 @@ import (
 	b_redis "github.com/dapr/components-contrib/bindings/redis"
 	"github.com/dapr/components-contrib/pubsub"
 	p_servicebus "github.com/dapr/components-contrib/pubsub/azure/servicebus"
+	p_hazelcast "github.com/dapr/components-contrib/pubsub/hazelcast"
 	p_kafka "github.com/dapr/components-contrib/pubsub/kafka"
 	p_mqtt "github.com/dapr/components-contrib/pubsub/mqtt"
 	p_natsstreaming "github.com/dapr/components-contrib/pubsub/natsstreaming"
@@ -320,6 +321,8 @@ func loadPubSub(tc TestComponent) pubsub.PubSub {
 		pubsub = p_pulsar.NewPulsar(testLogger)
 	case "mqtt":
 		pubsub = p_mqtt.NewMQTTPubSub(testLogger)
+	case "hazelcast":
+		pubsub = p_hazelcast.NewHazelcastPubSub(testLogger)
 	default:
 		return nil
 	}


### PR DESCRIPTION
# Description

This PR adds the Hazelcast pubsub component to the conformance tests and fixes some issues to make it pass the tests.

The setting `backOffMaxRetries` was added to allow for a fixed number of retries or setting it to `-1` for unlimited retries. The default value is `0` which disables retries. A Docker Compose for Hazelcast was created.

## Issue reference

Resolves #697 #723 

Docs issue: dapr/docs/issues/1270

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#1270
