### PR TITLE
Handles empty eTag in postgres.

### DIFF
--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -104,7 +104,7 @@ func (p *postgresDBAccess) setValue(req *state.SetRequest) error {
 
 	// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
 	// Other parameters use sql.DB parameter substitution.
-	if req.ETag == nil {
+	if req.ETag == nil || *req.ETag == "" {
 		result, err = p.db.Exec(fmt.Sprintf(
 			`INSERT INTO %s (key, value) VALUES ($1, $2)
 			ON CONFLICT (key) DO UPDATE SET value = $2, updatedate = NOW();`,


### PR DESCRIPTION
# Description

Handles empty eTag in postgres.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #727

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

```txt
$ DAPR_E2E_TEST=actor_reminder make test-e2e-all
# Note: we can set -p 2 to run two tests apps at a time, because today we do not share state between
# tests. In the future, if we add any tests that modify global state (such as dapr config), we'll 
# have to be sure and run them after the main test suite, so as not to alter the state of a running
# test
# Note2: use env variable DAPR_E2E_TEST to pick one e2e test to run.
DAPR_CONTAINER_LOG_PATH=./dist/container_logs GOOS=darwin DAPR_TEST_NAMESPACE=dapr-tests DAPR_TEST_TAG=dev-linux-amd64 DAPR_TEST_REGISTRY=docker.io/artursouza DAPR_TEST_MINIKUBE_IP=192.168.64.41 go test -p 2 -count=1 -v -tags=e2e ./tests/e2e/actor_reminder/...
2021/02/26 19:38:33 Running setup...
2021/02/26 19:38:33 Installing test apps...
2021/02/26 19:38:33 Adding app {actorreminder 0  map[TEST_APP_ACTOR_TYPE:testactorreminder] true e2e-actorfeatures:dev-linux-amd64 docker.io/artursouza 1 true   4.0 0.1 800Mi 250Mi 4.0 0.1 512Mi 250Mi <nil>}
2021/02/26 19:39:10 Running tests...
=== RUN   TestActorReminder
2021/02/26 19:39:10 Waiting until service ingress is ready for actorreminder...
2021/02/26 19:39:10 Service ingress for actorreminder is ready...
    actor_reminder_test.go:104: Checking if app is healthy ...
=== RUN   TestActorReminder/Actor_reminder_unregister_then_restart_should_not_trigger_anymore.
    actor_reminder_test.go:123: Running iteration 7 out of 7 ...
    actor_reminder_test.go:123: Running iteration 1 out of 7 ...
    actor_reminder_test.go:123: Running iteration 2 out of 7 ...
    actor_reminder_test.go:123: Running iteration 4 out of 7 ...
    actor_reminder_test.go:123: Running iteration 3 out of 7 ...
    actor_reminder_test.go:123: Running iteration 5 out of 7 ...
    actor_reminder_test.go:123: Running iteration 6 out of 7 ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:136: Sleeping for 20 seconds ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:146: Getting logs from 192.168.64.41:30714/test/logs to see if reminders did trigger ...
    actor_reminder_test.go:150: Checking if all reminders did trigger ...
    actor_reminder_test.go:164: Restarting actorreminder ...
    actor_reminder_test.go:169: Checking if app is healthy ...
    actor_reminder_test.go:173: Sleeping for 20 seconds to see if reminders will trigger ...
    actor_reminder_test.go:176: Getting logs from 192.168.64.41:30714/test/logs ...
    actor_reminder_test.go:180: Checking if NO reminder triggered ...
    actor_reminder_test.go:191: Done.
--- PASS: TestActorReminder (74.57s)
    --- PASS: TestActorReminder/Actor_reminder_unregister_then_restart_should_not_trigger_anymore. (74.45s)
PASS
2021/02/26 19:40:24 Running teardown...
2021/02/26 19:40:24 Saved container logs to ./dist/container_logs/actorreminder-787dd79b5b-lt7jj.actorreminder.log
2021/02/26 19:40:24 Saved container logs to ./dist/container_logs/actorreminder-787dd79b5b-lt7jj.daprd.log
ok  	github.com/dapr/dapr/tests/e2e/actor_reminder	112.276s
```