### PR TITLE
Make state.GetResponse ETag to a *string

### DIFF
--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -14,9 +14,11 @@ import (
 
 	as "github.com/aerospike/aerospike-client-go"
 	"github.com/aerospike/aerospike-client-go/types"
+	"github.com/agrea/ptr"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-	jsoniter "github.com/json-iterator/go"
 )
 
 // metadata values
@@ -171,7 +173,7 @@ func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) 
 
 	return &state.GetResponse{
 		Data: value,
-		ETag: fmt.Sprintf("%d", record.Generation),
+		ETag: ptr.String(strconv.FormatUint(uint64(record.Generation), 10)),
 	}, nil
 }
 

--- a/state/azure/blobstorage/blobstorage.go
+++ b/state/azure/blobstorage/blobstorage.go
@@ -35,9 +35,11 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/agrea/ptr"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-	jsoniter "github.com/json-iterator/go"
 )
 
 const (
@@ -112,7 +114,7 @@ func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: data,
-		ETag: etag,
+		ETag: ptr.String(etag),
 	}, err
 }
 

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -12,9 +12,11 @@ import (
 	"strings"
 
 	"github.com/a8m/documentdb"
+	"github.com/agrea/ptr"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-	jsoniter "github.com/json-iterator/go"
 )
 
 // StateStore is a CosmosDB state store
@@ -175,7 +177,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 		return &state.GetResponse{
 			Data: bytes,
-			ETag: items[0].Etag,
+			ETag: ptr.String(items[0].Etag),
 		}, nil
 	}
 
@@ -186,7 +188,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: b,
-		ETag: items[0].Etag,
+		ETag: ptr.String(items[0].Etag),
 	}, nil
 }
 

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -34,10 +34,12 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
+	"github.com/agrea/ptr"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -248,22 +250,22 @@ func (r *StateStore) marshal(req *state.SetRequest) string {
 	return v
 }
 
-func (r *StateStore) unmarshal(row *storage.Entity) ([]byte, string, error) {
+func (r *StateStore) unmarshal(row *storage.Entity) ([]byte, *string, error) {
 	raw := row.Properties[valueEntityProperty]
 
 	// value column not present
 	if raw == nil {
-		return nil, "", nil
+		return nil, nil, nil
 	}
 
 	// must be a string
 	sv, ok := raw.(string)
 	if !ok {
-		return nil, "", errors.New(fmt.Sprintf("expected string in column '%s'", valueEntityProperty))
+		return nil, nil, errors.New(fmt.Sprintf("expected string in column '%s'", valueEntityProperty))
 	}
 
 	// use native ETag
 	etag := row.OdataEtag
 
-	return []byte(sv), etag, nil
+	return []byte(sv), ptr.String(etag), nil
 }

--- a/state/couchbase/couchbase.go
+++ b/state/couchbase/couchbase.go
@@ -10,11 +10,13 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/agrea/ptr"
+	jsoniter "github.com/json-iterator/go"
+	"gopkg.in/couchbase/gocb.v1"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
-	jsoniter "github.com/json-iterator/go"
-	"gopkg.in/couchbase/gocb.v1"
 )
 
 const (
@@ -184,7 +186,7 @@ func (cbs *Couchbase) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: data.([]byte),
-		ETag: fmt.Sprintf("%d", cas),
+		ETag: ptr.String(strconv.FormatUint(uint64(cas), 10)),
 	}, nil
 }
 

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -9,10 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
+	"github.com/agrea/ptr"
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 // Consul is a state store implementation for HashiCorp Consul.
@@ -103,7 +105,7 @@ func (c *Consul) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: resp.Value,
-		ETag: queryMeta.LastContentHash,
+		ETag: ptr.String(queryMeta.LastContentHash),
 	}, nil
 }
 

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -14,8 +14,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
+	"github.com/agrea/ptr"
 	"github.com/google/uuid"
 	json "github.com/json-iterator/go"
 	"go.mongodb.org/mongo-driver/bson"
@@ -23,6 +22,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -187,7 +189,7 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: value,
-		ETag: result.Etag,
+		ETag: ptr.String(result.Etag),
 	}, nil
 }
 

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -12,10 +12,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/agrea/ptr"
+	"github.com/google/uuid"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
-	"github.com/google/uuid"
 )
 
 // Optimistic Concurrency is implemented using a string column that stores
@@ -331,7 +333,7 @@ func (m *MySQL) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	response := &state.GetResponse{
-		ETag:     eTag,
+		ETag:     ptr.String(eTag),
 		Metadata: req.Metadata,
 		Data:     []byte(value),
 	}

--- a/state/mysql/mysql_integration_test.go
+++ b/state/mysql/mysql_integration_test.go
@@ -15,11 +15,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -172,7 +173,7 @@ func multiWithSetOnly(t *testing.T, mys *MySQL) {
 
 	for _, set := range setRequests {
 		assert.True(t, storeItemExists(t, set.Key))
-		deleteItem(t, mys, set.Key, "")
+		deleteItem(t, mys, set.Key, nil)
 	}
 }
 
@@ -183,7 +184,7 @@ func multiWithDeleteOnly(t *testing.T, mys *MySQL) {
 		req := state.DeleteRequest{Key: randomKey()}
 
 		// Add the item to the database
-		setItem(t, mys, req.Key, randomJSON(), "")
+		setItem(t, mys, req.Key, randomJSON(), nil)
 
 		// Add the item to a slice of delete requests
 		deleteRequests = append(deleteRequests, req)
@@ -212,7 +213,7 @@ func multiWithDeleteAndSet(t *testing.T, mys *MySQL) {
 		req := state.DeleteRequest{Key: randomKey()}
 
 		// Add the item to the database
-		setItem(t, mys, req.Key, randomJSON(), "")
+		setItem(t, mys, req.Key, randomJSON(), nil)
 
 		// Add the item to a slice of delete requests
 		deleteRequests = append(deleteRequests, req)
@@ -249,7 +250,7 @@ func multiWithDeleteAndSet(t *testing.T, mys *MySQL) {
 
 	for _, set := range setRequests {
 		assert.True(t, storeItemExists(t, set.Key))
-		deleteItem(t, mys, set.Key, "")
+		deleteItem(t, mys, set.Key, nil)
 	}
 }
 
@@ -276,7 +277,7 @@ func deleteWithInvalidEtagFails(t *testing.T, mys *MySQL) {
 	// Create new item
 	key := randomKey()
 	value := &fakeItem{Color: "mauve"}
-	setItem(t, mys, key, value, "")
+	setItem(t, mys, key, value, nil)
 
 	eTag := "1234"
 
@@ -310,7 +311,7 @@ func updateWithOldETagFails(t *testing.T, mys *MySQL) {
 	// Create and retrieve new item
 	key := randomKey()
 	value := &fakeItem{Color: "gray"}
-	setItem(t, mys, key, value, "")
+	setItem(t, mys, key, value, nil)
 
 	getResponse, _ := getItem(t, mys, key)
 	assert.NotNil(t, getResponse.ETag)
@@ -327,7 +328,7 @@ func updateWithOldETagFails(t *testing.T, mys *MySQL) {
 	newValue = &fakeItem{Color: "maroon"}
 	setReq := &state.SetRequest{
 		Key:   key,
-		ETag:  &originalEtag,
+		ETag:  originalEtag,
 		Value: newValue,
 	}
 
@@ -339,7 +340,7 @@ func updateAndDeleteWithETagSucceeds(t *testing.T, mys *MySQL) {
 	// Create and retrieve new item
 	key := randomKey()
 	value := &fakeItem{Color: "hazel"}
-	setItem(t, mys, key, value, "")
+	setItem(t, mys, key, value, nil)
 	getResponse, _ := getItem(t, mys, key)
 	assert.NotNil(t, getResponse.ETag)
 
@@ -405,7 +406,7 @@ func setItemWithNoKey(t *testing.T, mys *MySQL) {
 func setUpdatesTheUpdatedateField(t *testing.T, mys *MySQL) {
 	key := randomKey()
 	value := &fakeItem{Color: "orange"}
-	setItem(t, mys, key, value, "")
+	setItem(t, mys, key, value, nil)
 
 	// insertdate and updatedate should have a value
 	_, insertdate, updatedate, eTag := getRowData(t, key)
@@ -414,12 +415,12 @@ func setUpdatesTheUpdatedateField(t *testing.T, mys *MySQL) {
 
 	// insertdate should not change, updatedate should have a value
 	value = &fakeItem{Color: "aqua"}
-	setItem(t, mys, key, value, "")
+	setItem(t, mys, key, value, nil)
 	_, newinsertdate, _, newETag := getRowData(t, key)
 	assert.Equal(t, insertdate, newinsertdate, "InsertDate was changed")
 	assert.NotEqual(t, eTag, newETag, "eTag was not updated")
 
-	deleteItem(t, mys, key, "")
+	deleteItem(t, mys, key, nil)
 }
 
 // getItemWithNoKey validates that attempting a Get operation without providing
@@ -449,7 +450,7 @@ func setGetUpdateDeleteOneItem(t *testing.T, mys *MySQL) {
 	key := randomKey()
 	value := &fakeItem{Color: "yellow"}
 
-	setItem(t, mys, key, value, "")
+	setItem(t, mys, key, value, nil)
 
 	getResponse, outputObject := getItem(t, mys, key)
 	assert.Equal(t, value, outputObject)
@@ -550,10 +551,10 @@ func dropTable(t *testing.T, db *sql.DB, tableName string) {
 	assert.Nil(t, err)
 }
 
-func setItem(t *testing.T, mys *MySQL, key string, value interface{}, eTag string) {
+func setItem(t *testing.T, mys *MySQL, key string, value interface{}, eTag *string) {
 	setReq := &state.SetRequest{
 		Key:   key,
-		ETag:  &eTag,
+		ETag:  eTag,
 		Value: value,
 	}
 
@@ -578,10 +579,10 @@ func getItem(t *testing.T, mys *MySQL, key string) (*state.GetResponse, *fakeIte
 	return response, outputObject
 }
 
-func deleteItem(t *testing.T, mys *MySQL, key string, eTag string) {
+func deleteItem(t *testing.T, mys *MySQL, key string, eTag *string) {
 	deleteReq := &state.DeleteRequest{
 		Key:     key,
-		ETag:    &eTag,
+		ETag:    eTag,
 		Options: state.DeleteStateOption{},
 	}
 

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/agrea/ptr"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
@@ -148,7 +149,7 @@ func (p *postgresDBAccess) Get(req *state.GetRequest) (*state.GetResponse, error
 
 	response := &state.GetResponse{
 		Data:     []byte(value),
-		ETag:     strconv.Itoa(etag),
+		ETag:     ptr.String(strconv.Itoa(etag)),
 		Metadata: req.Metadata,
 	}
 

--- a/state/postgresql/postgresql_integration_test.go
+++ b/state/postgresql/postgresql_integration_test.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -135,7 +136,7 @@ func setGetUpdateDeleteOneItem(t *testing.T, pgs *PostgreSQL) {
 	key := randomKey()
 	value := &fakeItem{Color: "yellow"}
 
-	setItem(t, pgs, key, value, "")
+	setItem(t, pgs, key, value, nil)
 
 	getResponse, outputObject := getItem(t, pgs, key)
 	assert.Equal(t, value, outputObject)
@@ -206,7 +207,7 @@ func multiWithSetOnly(t *testing.T, pgs *PostgreSQL) {
 
 	for _, set := range setRequests {
 		assert.True(t, storeItemExists(t, set.Key))
-		deleteItem(t, pgs, set.Key, "")
+		deleteItem(t, pgs, set.Key, nil)
 	}
 }
 
@@ -217,7 +218,7 @@ func multiWithDeleteOnly(t *testing.T, pgs *PostgreSQL) {
 		req := state.DeleteRequest{Key: randomKey()}
 
 		// Add the item to the database
-		setItem(t, pgs, req.Key, randomJSON(), "") // Add the item to the database
+		setItem(t, pgs, req.Key, randomJSON(), nil) // Add the item to the database
 
 		// Add the item to a slice of delete requests
 		deleteRequests = append(deleteRequests, req)
@@ -246,7 +247,7 @@ func multiWithDeleteAndSet(t *testing.T, pgs *PostgreSQL) {
 		req := state.DeleteRequest{Key: randomKey()}
 
 		// Add the item to the database
-		setItem(t, pgs, req.Key, randomJSON(), "") // Add the item to the database
+		setItem(t, pgs, req.Key, randomJSON(), nil) // Add the item to the database
 
 		// Add the item to a slice of delete requests
 		deleteRequests = append(deleteRequests, req)
@@ -283,7 +284,7 @@ func multiWithDeleteAndSet(t *testing.T, pgs *PostgreSQL) {
 
 	for _, set := range setRequests {
 		assert.True(t, storeItemExists(t, set.Key))
-		deleteItem(t, pgs, set.Key, "")
+		deleteItem(t, pgs, set.Key, nil)
 	}
 }
 
@@ -291,7 +292,7 @@ func deleteWithInvalidEtagFails(t *testing.T, pgs *PostgreSQL) {
 	// Create new item
 	key := randomKey()
 	value := &fakeItem{Color: "mauve"}
-	setItem(t, pgs, key, value, "")
+	setItem(t, pgs, key, value, nil)
 
 	etag := "1234"
 	// Delete the item with a fake etag
@@ -330,7 +331,7 @@ func updateWithOldEtagFails(t *testing.T, pgs *PostgreSQL) {
 	// Create and retrieve new item
 	key := randomKey()
 	value := &fakeItem{Color: "gray"}
-	setItem(t, pgs, key, value, "")
+	setItem(t, pgs, key, value, nil)
 	getResponse, _ := getItem(t, pgs, key)
 	assert.NotNil(t, getResponse.ETag)
 	originalEtag := getResponse.ETag
@@ -345,7 +346,7 @@ func updateWithOldEtagFails(t *testing.T, pgs *PostgreSQL) {
 	newValue = &fakeItem{Color: "maroon"}
 	setReq := &state.SetRequest{
 		Key:   key,
-		ETag:  &originalEtag,
+		ETag:  originalEtag,
 		Value: newValue,
 	}
 	err := pgs.Set(setReq)
@@ -356,7 +357,7 @@ func updateAndDeleteWithEtagSucceeds(t *testing.T, pgs *PostgreSQL) {
 	// Create and retrieve new item
 	key := randomKey()
 	value := &fakeItem{Color: "hazel"}
-	setItem(t, pgs, key, value, "")
+	setItem(t, pgs, key, value, nil)
 	getResponse, _ := getItem(t, pgs, key)
 	assert.NotNil(t, getResponse.ETag)
 
@@ -399,7 +400,7 @@ func getItemWithNoKey(t *testing.T, pgs *PostgreSQL) {
 func setUpdatesTheUpdatedateField(t *testing.T, pgs *PostgreSQL) {
 	key := randomKey()
 	value := &fakeItem{Color: "orange"}
-	setItem(t, pgs, key, value, "")
+	setItem(t, pgs, key, value, nil)
 
 	// insertdate should have a value and updatedate should be nil
 	_, insertdate, updatedate := getRowData(t, key)
@@ -408,12 +409,12 @@ func setUpdatesTheUpdatedateField(t *testing.T, pgs *PostgreSQL) {
 
 	// insertdate should not change, updatedate should have a value
 	value = &fakeItem{Color: "aqua"}
-	setItem(t, pgs, key, value, "")
+	setItem(t, pgs, key, value, nil)
 	_, newinsertdate, updatedate := getRowData(t, key)
 	assert.Equal(t, insertdate, newinsertdate) // The insertdate should not change.
 	assert.NotEqual(t, "", updatedate.String)
 
-	deleteItem(t, pgs, key, "")
+	deleteItem(t, pgs, key, nil)
 }
 
 func setItemWithNoKey(t *testing.T, pgs *PostgreSQL) {
@@ -502,10 +503,10 @@ func getConnectionString() string {
 	return os.Getenv(connectionStringEnvKey)
 }
 
-func setItem(t *testing.T, pgs *PostgreSQL, key string, value interface{}, etag string) {
+func setItem(t *testing.T, pgs *PostgreSQL, key string, value interface{}, etag *string) {
 	setReq := &state.SetRequest{
 		Key:   key,
-		ETag:  &etag,
+		ETag:  etag,
 		Value: value,
 	}
 
@@ -530,10 +531,10 @@ func getItem(t *testing.T, pgs *PostgreSQL, key string) (*state.GetResponse, *fa
 	return response, outputObject
 }
 
-func deleteItem(t *testing.T, pgs *PostgreSQL, key string, etag string) {
+func deleteItem(t *testing.T, pgs *PostgreSQL, key string, etag *string) {
 	deleteReq := &state.DeleteRequest{
 		Key:     key,
-		ETag:    &etag,
+		ETag:    etag,
 		Options: state.DeleteStateOption{},
 	}
 

--- a/state/redis/redis_test.go
+++ b/state/redis/redis_test.go
@@ -9,12 +9,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/agrea/ptr"
 	miniredis "github.com/alicebob/miniredis/v2"
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
 	redis "github.com/go-redis/redis/v7"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 func TestGetKeyVersion(t *testing.T) {
@@ -23,7 +25,7 @@ func TestGetKeyVersion(t *testing.T) {
 		key, ver, err := store.getKeyVersion([]interface{}{"data", "TEST_KEY", "version", "TEST_VER"})
 		assert.Equal(t, nil, err, "failed to read all fields")
 		assert.Equal(t, "TEST_KEY", key, "failed to read key")
-		assert.Equal(t, "TEST_VER", ver, "failed to read version")
+		assert.Equal(t, ptr.String("TEST_VER"), ver, "failed to read version")
 	})
 	t.Run("With missing data", func(t *testing.T) {
 		_, _, err := store.getKeyVersion([]interface{}{"version", "TEST_VER"})
@@ -37,7 +39,7 @@ func TestGetKeyVersion(t *testing.T) {
 		key, ver, err := store.getKeyVersion([]interface{}{"version", "TEST_VER", "dragon", "TEST_DRAGON", "data", "TEST_KEY"})
 		assert.Equal(t, nil, err, "failed to read all fields")
 		assert.Equal(t, "TEST_KEY", key, "failed to read key")
-		assert.Equal(t, "TEST_VER", ver, "failed to read version")
+		assert.Equal(t, ptr.String("TEST_VER"), ver, "failed to read version")
 	})
 	t.Run("With no fields", func(t *testing.T) {
 		_, _, err := store.getKeyVersion([]interface{}{})
@@ -138,7 +140,7 @@ func TestTransactionalUpsert(t *testing.T) {
 	vals := res.([]interface{})
 	data, version, err := ss.getKeyVersion(vals)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "1", version)
+	assert.Equal(t, ptr.String("1"), version)
 	assert.Equal(t, `"deathstar"`, data)
 }
 

--- a/state/responses.go
+++ b/state/responses.go
@@ -8,14 +8,14 @@ package state
 // GetResponse is the request object for getting state
 type GetResponse struct {
 	Data     []byte            `json:"data"`
-	ETag     string            `json:"etag,omitempty"`
+	ETag     *string           `json:"etag,omitempty"`
 	Metadata map[string]string `json:"metadata"`
 }
 
 type BulkGetResponse struct {
 	Key      string            `json:"key"`
 	Data     []byte            `json:"data"`
-	ETag     string            `json:"etag,omitempty"`
+	ETag     *string           `json:"etag,omitempty"`
 	Metadata map[string]string `json:"metadata"`
 	Error    string            `json:"error,omitempty"`
 }

--- a/state/rethinkdb/rethinkdb.go
+++ b/state/rethinkdb/rethinkdb.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agrea/ptr"
 	r "github.com/dancannon/gorethink"
+	"github.com/pkg/errors"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -154,7 +156,7 @@ func (s *RethinkDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		return nil, errors.Wrap(err, "error parsing database content")
 	}
 
-	resp := &state.GetResponse{ETag: doc.Hash}
+	resp := &state.GetResponse{ETag: ptr.String(doc.Hash)}
 	b, ok := doc.Data.([]byte)
 	if ok {
 		resp.Data = b

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -14,10 +14,12 @@ import (
 	"strconv"
 	"unicode"
 
+	"github.com/agrea/ptr"
+	mssql "github.com/denisenkom/go-mssqldb"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/components-contrib/state/utils"
 	"github.com/dapr/dapr/pkg/logger"
-	mssql "github.com/denisenkom/go-mssqldb"
 )
 
 // KeyType defines type of the table identifier
@@ -446,7 +448,7 @@ func (s *SQLServer) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: []byte(data),
-		ETag: etag,
+		ETag: ptr.String(etag),
 	}, nil
 }
 

--- a/state/sqlserver/sqlserver_integration_test.go
+++ b/state/sqlserver/sqlserver_integration_test.go
@@ -17,10 +17,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
 	uuid "github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -145,13 +147,13 @@ func assertUserExists(t *testing.T, store *SQLServer, key string) (user, string)
 	assert.Nil(t, err)
 	assert.NotNil(t, getRes)
 	assert.NotNil(t, getRes.Data, "No data was returned")
-	assert.NotEmpty(t, getRes.ETag)
+	require.NotNil(t, getRes.ETag)
 
 	var loaded user
 	err = json.Unmarshal(getRes.Data, &loaded)
 	assert.Nil(t, err)
 
-	return loaded, getRes.ETag
+	return loaded, *getRes.ETag
 }
 
 func assertLoadedUserIsEqual(t *testing.T, store *SQLServer, key string, expected user) (user, string) {

--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dapr/components-contrib/state"
-	"github.com/dapr/dapr/pkg/logger"
+	"github.com/agrea/ptr"
 	"github.com/hashicorp/go-multierror"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/samuel/go-zookeeper/zk"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/logger"
 )
 
 const (
@@ -154,7 +156,7 @@ func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 	return &state.GetResponse{
 		Data: value,
-		ETag: strconv.Itoa(int(stat.Version)),
+		ETag: ptr.String(strconv.Itoa(int(stat.Version))),
 	}, nil
 }
 

--- a/state/zookeeper/zk_test.go
+++ b/state/zookeeper/zk_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dapr/components-contrib/state"
+	"github.com/agrea/ptr"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
 )
 
 //go:generate mockgen -package zookeeper -source zk.go -destination zk_mock.go
@@ -73,7 +75,7 @@ func TestGet(t *testing.T) {
 		res, err := s.Get(&state.GetRequest{Key: "foo"})
 		assert.NotNil(t, res, "Key must be exists")
 		assert.Equal(t, "bar", string(res.Data), "Value must be equals")
-		assert.Equal(t, "123", res.ETag, "ETag must be equals")
+		assert.Equal(t, ptr.String("123"), res.ETag, "ETag must be equals")
 		assert.NoError(t, err, "Key must be exists")
 	})
 

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -425,7 +425,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			err = statestore.Set(&state.SetRequest{
 				Key:   testKey,
 				Value: secondValue,
-				ETag:  &etag,
+				ETag:  etag,
 			})
 			assert.Nil(t, err)
 
@@ -448,7 +448,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			// Try and delete with correct ETag, expect success.
 			err = statestore.Delete(&state.DeleteRequest{
 				Key:  testKey,
-				ETag: &etag,
+				ETag: etag,
 			})
 			assert.Nil(t, err)
 		})


### PR DESCRIPTION
# Description

Per #731, this PR allows the ETag in `state.GetResponse` and `state.BulkGetResponse` to be returned as a `nil`. This is to make these structs consistent with `state.SetRequest` and `state.DeleteRequest` and to be able to copy the `ETag` field as-is when going between read and write operations.

Since there are not e2e tests for each of the changed state components, there is no way to verify these changes without a significant time investment to test test manually. These changes are fairly simple so I did not go that route but wanted to mention the risk and recommend a high level of scrutiny when reviewing the code.

**If this PR is merged, an issue in `dapr/dapr` should be created to adjust to the `ETag` field being `*string` instead of `string`.**

## Issue reference

Resolves #731

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
