### PR TITLE
refactor GCP pubsub

### DIFF
--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -1,7 +1,5 @@
 package pubsub
 
-
-
 // GCPPubSubMetaData pubsub metadata
 type metadata struct {
 	consumerID              string
@@ -18,5 +16,3 @@ type metadata struct {
 	AuthProviderCertURL     string
 	ClientCertURL           string
 }
-
-

--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -1,12 +1,13 @@
 package pubsub
 
-import "github.com/dapr/components-contrib/pubsub"
+
 
 // GCPPubSubMetaData pubsub metadata
 type metadata struct {
 	consumerID              string
 	DisableEntityManagement bool
 	Type                    string
+	IdentityProjectID       string
 	ProjectID               string
 	PrivateKeyID            string
 	PrivateKey              string
@@ -19,20 +20,3 @@ type metadata struct {
 }
 
 
-func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
-	// TODO: Add the rest of the metadata here, add defaults where applicable
-	result := metadata{
-		DisableEntityManagement: true,
-		Type: "service_account",
-	}
-
-	if val, found := pubSubMetadata.Properties[metadataTypeKey]; found && val != "" {
-		result.Type = val
-	}
-
-	if val, found := pubSubMetadata.Properties[metadataConsumerIDKey]; found && val != "" {
-		result.consumerID = val
-	}
-
-	return &result, nil
-}

--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -1,17 +1,38 @@
 package pubsub
 
+import "github.com/dapr/components-contrib/pubsub"
+
 // GCPPubSubMetaData pubsub metadata
 type metadata struct {
-	ConsumerID              string `json:"consumerID"`
-	DisableEntityManagement bool   `json:"disableEntityManagement"`
-	Type                    string `json:"type"`
-	ProjectID               string `json:"project_id"`
-	PrivateKeyID            string `json:"private_key_id"`
-	PrivateKey              string `json:"private_key"`
-	ClientEmail             string `json:"client_email"`
-	ClientID                string `json:"client_id"`
-	AuthURI                 string `json:"auth_uri"`
-	TokenURI                string `json:"token_uri"`
-	AuthProviderCertURL     string `json:"auth_provider_x509_cert_url"`
-	ClientCertURL           string `json:"client_x509_cert_url"`
+	consumerID              string
+	DisableEntityManagement bool
+	Type                    string
+	ProjectID               string
+	PrivateKeyID            string
+	PrivateKey              string
+	ClientEmail             string
+	ClientID                string
+	AuthURI                 string
+	TokenURI                string
+	AuthProviderCertURL     string
+	ClientCertURL           string
+}
+
+
+func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
+	// TODO: Add the rest of the metadata here, add defaults where applicable
+	result := metadata{
+		DisableEntityManagement: true,
+		Type: "service_account",
+	}
+
+	if val, found := pubSubMetadata.Properties[metadataTypeKey]; found && val != "" {
+		result.Type = val
+	}
+
+	if val, found := pubSubMetadata.Properties[metadataConsumerIDKey]; found && val != "" {
+		result.consumerID = val
+	}
+
+	return &result, nil
 }

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -127,25 +127,13 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 
 // Init parses metadata and creates a new Pub Sub client
 func (g *GCPPubSub) Init(meta pubsub.Metadata) error {
-	//meta, err := createMetadata(meta)
-	myMeta, err := createMetadata(meta)
-	if err != nil {
-		return err
-	}
-	b, err := g.parseMetadata(myMeta)
-	//g.logger.Debugf(string(b))
-	if err != nil {
-		return err
-	}
-
-	var pubsubMeta metadata
-	err = json.Unmarshal(b, &pubsubMeta)
+	metadata, err := createMetadata(meta)
 	if err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	pubsubClient, err := g.getPubSubClient(myMeta, ctx)
+	pubsubClient, err := g.getPubSubClient(metadata, ctx)
 	if err != nil {
 		return err
 	}
@@ -154,15 +142,8 @@ func (g *GCPPubSub) Init(meta pubsub.Metadata) error {
 		return fmt.Errorf("%s error creating pubsub client: %s", errorMessagePrefix, err)
 	}
 
-	if val, ok := meta.Properties[metadataConsumerIDKey]; ok && val != "" {
-		pubsubMeta.consumerID = val
-	} else {
-		return fmt.Errorf("%s missing consumerID", errorMessagePrefix)
-	}
-
 	g.client = pubsubClient
-	g.metadata = &pubsubMeta
-
+	g.metadata = metadata
 	return nil
 }
 
@@ -199,12 +180,6 @@ func (g *GCPPubSub) getPubSubClient(metadata *metadata, ctx context.Context) (*g
 		}
 	}
 	return pubsubClient, nil
-}
-
-func (g *GCPPubSub) parseMetadata(metadata *metadata) ([]byte, error) {
-	b, err := json.Marshal(metadata)
-
-	return b, err
 }
 
 // Publish the topic to GCP Pubsub

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -93,7 +93,6 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 		result.ClientEmail = val
 	}
 
-
 	if val, found := pubSubMetadata.Properties[metadataClientIdKey]; found && val != "" {
 		result.ClientID = val
 	}
@@ -168,10 +167,8 @@ func (g *GCPPubSub) Init(meta pubsub.Metadata) error {
 }
 
 func (g *GCPPubSub) getPubSubClient(metadata *metadata, ctx context.Context) (*gcppubsub.Client, error) {
-	pubsubClient, err := gcppubsub.NewClient(ctx, metadata.ProjectID)
-	if err != nil {
-		return pubsubClient, err
-	}
+	var pubsubClient *gcppubsub.Client
+	var err error
 
 	if metadata.PrivateKeyID != "" {
 		//TODO: validate that all auth json fields are filled
@@ -196,6 +193,10 @@ func (g *GCPPubSub) getPubSubClient(metadata *metadata, ctx context.Context) (*g
 		}
 	} else {
 		g.logger.Debugf("Using implicit credentials for GCP")
+		pubsubClient, err = gcppubsub.NewClient(ctx, metadata.ProjectID)
+		if err != nil {
+			return pubsubClient, err
+		}
 	}
 	return pubsubClient, nil
 }

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -1,36 +1,70 @@
 package pubsub
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/dapr/components-contrib/pubsub"
-	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInit(t *testing.T) {
-	m := pubsub.Metadata{}
-	m.Properties = map[string]string{
-		"auth_provider_x509_cert_url": "https://auth", "auth_uri": "https://auth", "client_x509_cert_url": "https://cert", "client_email": "test@test.com", "client_id": "id", "private_key": "****",
-		"private_key_id": "key_id", "project_id": "project1", "token_uri": "https://token", "type": "serviceaccount",
-	}
-	ps := GCPPubSub{logger: logger.NewLogger("test")}
-	b, err := ps.parseMetadata(m)
-	assert.Nil(t, err)
 
-	var pubsubMeta metadata
-	err = json.Unmarshal(b, &pubsubMeta)
-	assert.Nil(t, err)
+	t.Run("metadata is correct with explicit creds", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":               "superproject",
+			"authProviderX509CertUrl": "https://authcerturl",
+			"authUri":                 "https://auth",
+			"clientX509CertUrl":       "https://cert",
+			"clientEmail":             "test@test.com",
+			"clientId":                "id",
+			"privateKey":              "****",
+			"privateKeyId":            "key_id",
+			"identityProjectId":       "project1",
+			"tokenUri":                "https://token",
+			"type":                    "serviceaccount",
+		}
+		//ps := GCPPubSub{logger: logger.NewLogger("test")}
+		b, err := createMetadata(m)
+		assert.Nil(t, err)
 
-	assert.Equal(t, "https://auth", pubsubMeta.AuthProviderCertURL)
-	assert.Equal(t, "https://auth", pubsubMeta.AuthURI)
-	assert.Equal(t, "https://cert", pubsubMeta.ClientCertURL)
-	assert.Equal(t, "test@test.com", pubsubMeta.ClientEmail)
-	assert.Equal(t, "id", pubsubMeta.ClientID)
-	assert.Equal(t, "****", pubsubMeta.PrivateKey)
-	assert.Equal(t, "key_id", pubsubMeta.PrivateKeyID)
-	assert.Equal(t, "project1", pubsubMeta.ProjectID)
-	assert.Equal(t, "https://token", pubsubMeta.TokenURI)
-	assert.Equal(t, "serviceaccount", pubsubMeta.Type)
+		//var pubsubMeta metadata
+		//err = json.Unmarshal(b, &pubsubMeta)
+		//assert.Nil(t, err)
+
+		assert.Equal(t, "https://authcerturl", b.AuthProviderCertURL)
+		assert.Equal(t, "https://auth", b.AuthURI)
+		assert.Equal(t, "https://cert", b.ClientCertURL)
+		assert.Equal(t, "test@test.com", b.ClientEmail)
+		assert.Equal(t, "id", b.ClientID)
+		assert.Equal(t, "****", b.PrivateKey)
+		assert.Equal(t, "key_id", b.PrivateKeyID)
+		assert.Equal(t, "project1", b.IdentityProjectID)
+		assert.Equal(t, "https://token", b.TokenURI)
+		assert.Equal(t, "serviceaccount", b.Type)
+	})
+
+	t.Run("metadata is correct with implicit creds", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId": "superproject",
+		}
+		//ps := GCPPubSub{logger: logger.NewLogger("test")}
+		b, err := createMetadata(m)
+		assert.Nil(t, err)
+
+		//var pubsubMeta metadata
+		//err = json.Unmarshal(b, &pubsubMeta)
+		//assert.Nil(t, err)
+
+		assert.Equal(t, "superproject", b.ProjectID)
+		assert.Equal(t, "service_account", b.Type)
+	})
+
+	t.Run("missing project id", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{}
+		_, err := createMetadata(m)
+		assert.Error(t, err)
+	})
 }

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestInit(t *testing.T) {
-
 	t.Run("metadata is correct with explicit creds", func(t *testing.T) {
 		m := pubsub.Metadata{}
 		m.Properties = map[string]string{
@@ -24,13 +23,8 @@ func TestInit(t *testing.T) {
 			"tokenUri":                "https://token",
 			"type":                    "serviceaccount",
 		}
-		//ps := GCPPubSub{logger: logger.NewLogger("test")}
 		b, err := createMetadata(m)
 		assert.Nil(t, err)
-
-		//var pubsubMeta metadata
-		//err = json.Unmarshal(b, &pubsubMeta)
-		//assert.Nil(t, err)
 
 		assert.Equal(t, "https://authcerturl", b.AuthProviderCertURL)
 		assert.Equal(t, "https://auth", b.AuthURI)
@@ -49,13 +43,9 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"projectId": "superproject",
 		}
-		//ps := GCPPubSub{logger: logger.NewLogger("test")}
+
 		b, err := createMetadata(m)
 		assert.Nil(t, err)
-
-		//var pubsubMeta metadata
-		//err = json.Unmarshal(b, &pubsubMeta)
-		//assert.Nil(t, err)
 
 		assert.Equal(t, "superproject", b.ProjectID)
 		assert.Equal(t, "service_account", b.Type)


### PR DESCRIPTION
# Description
- Make GCP pubsub support implicit credentials, in addition to explicit
- Clean up GCP pubsub metadata so that it lines up with other dapr pubsubs (separate struct for the gcp auth json stuff, it seemed a bit cleaner)
- make project id (project where subscription/topic should live) separate from "identity project id" (where the service account lives)

## Issue reference

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#1308
