### PR TITLE
Fix cosmosdb state store to handle content-type, with JSON as default.

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -92,6 +92,18 @@ func (c *StateStore) Init(meta state.Metadata) error {
 		return err
 	}
 
+	if m.URL == "" {
+		return errors.New("url is required")
+	}
+	if m.MasterKey == "" {
+		return errors.New("masterKey is required")
+	}
+	if m.Database == "" {
+		return errors.New("database is required")
+	}
+	if m.Collection == "" {
+		return errors.New("collection is required")
+	}
 	if m.ContentType == "" {
 		return errors.New("contentType is required")
 	}

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/agrea/ptr"
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/dapr/components-contrib/contenttype"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/logger"
 )
@@ -22,20 +23,22 @@ import (
 // StateStore is a CosmosDB state store
 type StateStore struct {
 	state.DefaultBulkStore
-	client     *documentdb.DocumentDB
-	collection *documentdb.Collection
-	db         *documentdb.Database
-	sp         *documentdb.Sproc
+	client      *documentdb.DocumentDB
+	collection  *documentdb.Collection
+	db          *documentdb.Database
+	sp          *documentdb.Sproc
+	contentType string
 
 	features []state.Feature
 	logger   logger.Logger
 }
 
-type credentials struct {
-	URL        string `json:"url"`
-	MasterKey  string `json:"masterKey"`
-	Database   string `json:"database"`
-	Collection string `json:"collection"`
+type metadata struct {
+	URL         string `json:"url"`
+	MasterKey   string `json:"masterKey"`
+	Database    string `json:"database"`
+	Collection  string `json:"collection"`
+	ContentType string `json:"contentType"`
 }
 
 // CosmosItem is a wrapper around a CosmosDB document
@@ -70,54 +73,55 @@ func NewCosmosDBStateStore(logger logger.Logger) *StateStore {
 }
 
 // Init does metadata and connection parsing
-func (c *StateStore) Init(metadata state.Metadata) error {
+func (c *StateStore) Init(meta state.Metadata) error {
 	c.logger.Debugf("CosmosDB init start")
 
-	connInfo := metadata.Properties
+	connInfo := meta.Properties
 	b, err := json.Marshal(connInfo)
 	if err != nil {
 		return err
 	}
 
-	var creds credentials
-	err = json.Unmarshal(b, &creds)
+	var m metadata
+	err = json.Unmarshal(b, &m)
 	if err != nil {
 		return err
 	}
 
-	client := documentdb.New(creds.URL, &documentdb.Config{
+	client := documentdb.New(m.URL, &documentdb.Config{
 		MasterKey: &documentdb.Key{
-			Key: creds.MasterKey,
+			Key: m.MasterKey,
 		},
 	})
 
 	dbs, err := client.QueryDatabases(&documentdb.Query{
 		Query: "SELECT * FROM ROOT r WHERE r.id=@id",
 		Parameters: []documentdb.Parameter{
-			{Name: "@id", Value: creds.Database},
+			{Name: "@id", Value: m.Database},
 		},
 	})
 	if err != nil {
 		return err
 	} else if len(dbs) == 0 {
-		return fmt.Errorf("database %s for CosmosDB state store not found", creds.Database)
+		return fmt.Errorf("database %s for CosmosDB state store not found", m.Database)
 	}
 
 	c.db = &dbs[0]
 	colls, err := client.QueryCollections(c.db.Self, &documentdb.Query{
 		Query: "SELECT * FROM ROOT r WHERE r.id=@id",
 		Parameters: []documentdb.Parameter{
-			{Name: "@id", Value: creds.Collection},
+			{Name: "@id", Value: m.Collection},
 		},
 	})
 	if err != nil {
 		return err
 	} else if len(colls) == 0 {
-		return fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", creds.Collection)
+		return fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", m.Collection)
 	}
 
 	c.collection = &colls[0]
 	c.client = client
+	c.contentType = m.ContentType
 
 	sps, err := c.client.ReadStoredProcedures(c.collection.Self)
 	if err != nil {
@@ -225,7 +229,7 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 		options = append(options, documentdb.ConsistencyLevel(documentdb.Eventual))
 	}
 
-	doc := createUpsertItem(*req, partitionKey)
+	doc := createUpsertItem(c.contentType, *req, partitionKey)
 	_, err = c.client.UpsertDocument(c.collection.Self, doc, options...)
 
 	if err != nil {
@@ -305,7 +309,7 @@ func (c *StateStore) Multi(request *state.TransactionalStateRequest) error {
 		if o.Operation == state.Upsert {
 			req := o.Request.(state.SetRequest)
 
-			upsertOperation := createUpsertItem(req, partitionKey)
+			upsertOperation := createUpsertItem(c.contentType, req, partitionKey)
 			upserts = append(upserts, upsertOperation)
 		} else if o.Operation == state.Delete {
 			req := o.Request.(state.DeleteRequest)
@@ -335,6 +339,40 @@ func (c *StateStore) Multi(request *state.TransactionalStateRequest) error {
 	return nil
 }
 
+func createUpsertItem(contentType string, req state.SetRequest, partitionKey string) CosmosItem {
+	byteArray, isBinary := req.Value.([]uint8)
+	if isBinary {
+		if contentType == "" || contenttype.IsJSONContentType(contentType) {
+			var value map[string]interface{}
+			err := json.Unmarshal(byteArray, &value)
+			// if byte array is not a valid JSON, so keep it as-is to be Base64 encoded in CosmosDB.
+			// otherwise, we save it as JSON
+			if err == nil {
+				return CosmosItem{
+					ID:           req.Key,
+					Value:        value,
+					PartitionKey: partitionKey,
+					IsBinary:     false,
+				}
+			}
+		} else if contenttype.IsStringContentType(contentType) {
+			return CosmosItem{
+				ID:           req.Key,
+				Value:        string(byteArray),
+				PartitionKey: partitionKey,
+				IsBinary:     false,
+			}
+		}
+	}
+
+	return CosmosItem{
+		ID:           req.Key,
+		Value:        req.Value,
+		PartitionKey: partitionKey,
+		IsBinary:     isBinary,
+	}
+}
+
 // This is a helper to return the partition key to use.  If if metadata["partitionkey"] is present,
 // use that, otherwise use what's in "key".
 func populatePartitionMetadata(key string, requestMetadata map[string]string) string {
@@ -343,15 +381,4 @@ func populatePartitionMetadata(key string, requestMetadata map[string]string) st
 	}
 
 	return key
-}
-
-func createUpsertItem(req state.SetRequest, partitionKey string) CosmosItem {
-	_, isBinary := req.Value.([]uint8)
-
-	return CosmosItem{
-		ID:           req.Key,
-		Value:        req.Value,
-		PartitionKey: partitionKey,
-		IsBinary:     isBinary,
-	}
 }

--- a/state/azure/cosmosdb/cosmosdb_test.go
+++ b/state/azure/cosmosdb/cosmosdb_test.go
@@ -26,7 +26,7 @@ func TestCreateCosmosItem(t *testing.T) {
 			Value: value,
 		}
 
-		item := createUpsertItem("", req, partitionKey)
+		item := createUpsertItem("application/json", req, partitionKey)
 		assert.Equal(t, partitionKey, item.PartitionKey)
 		assert.Equal(t, "testKey", item.ID)
 		assert.Equal(t, value, item.Value)
@@ -55,7 +55,7 @@ func TestCreateCosmosItem(t *testing.T) {
 			Value: bytes,
 		}
 
-		item := createUpsertItem("", req, partitionKey)
+		item := createUpsertItem("application/json", req, partitionKey)
 		assert.Equal(t, partitionKey, item.PartitionKey)
 		assert.Equal(t, "testKey", item.ID)
 
@@ -111,7 +111,7 @@ func TestCreateCosmosItem(t *testing.T) {
 			Value: bytes,
 		}
 
-		item := createUpsertItem("", req, partitionKey)
+		item := createUpsertItem("application/json", req, partitionKey)
 		assert.Equal(t, partitionKey, item.PartitionKey)
 		assert.Equal(t, "testKey", item.ID)
 


### PR DESCRIPTION
# Description

Fix cosmosdb state store to handle content-type, with JSON as default.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #745 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
