### PR TITLE
feat: change binding mqtt options to the same as pubsub

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,9 @@ jobs:
         - bindings.http
         - bindings.kafka
         - bindings.redis
+        - bindings.mqtt-mosquitto
+        - bindings.mqtt-emqx
+        - bindings.mqtt-vernemq
         - pubsub.redis
         - pubsub.natsstreaming
         - pubsub.kafka

--- a/bindings/mqtt/metadata.go
+++ b/bindings/mqtt/metadata.go
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package mqtt
+
+type metadata struct {
+	tlsCfg
+	url               string
+	clientID          string
+	qos               byte
+	retain            bool
+	cleanSession      bool
+	backOffMaxRetries int
+	topic             string
+}
+
+type tlsCfg struct {
+	caCert     string
+	clientCert string
+	clientKey  string
+}

--- a/bindings/mqtt/mqtt.go
+++ b/bindings/mqtt/mqtt.go
@@ -298,7 +298,7 @@ func (m *MQTT) createClientOptions(uri *url.URL, clientID string) *mqtt.ClientOp
 	switch scheme {
 	case "mqtt":
 		scheme = "tcp"
-	case "mqtts":
+	case "mqtts", "tcps":
 		scheme = "ssl"
 	}
 	opts.AddBroker(scheme + "://" + uri.Host)

--- a/bindings/mqtt/mqtt.go
+++ b/bindings/mqtt/mqtt.go
@@ -6,33 +6,58 @@
 package mqtt
 
 import (
-	"encoding/json"
-	"errors"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/logger"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"github.com/google/uuid"
+)
+
+const (
+	// Keys
+	mqttURL               = "url"
+	mqttTopic             = "topic"
+	mqttQOS               = "qos"
+	mqttRetain            = "retain"
+	mqttClientID          = "consumerID"
+	mqttCleanSession      = "cleanSession"
+	mqttCACert            = "caCert"
+	mqttClientCert        = "clientCert"
+	mqttClientKey         = "clientKey"
+	mqttBackOffMaxRetries = "backOffMaxRetries"
+
+	// errors
+	errorMsgPrefix = "mqtt binding error:"
+
+	// Defaults
+	defaultQOS          = 0
+	defaultRetain       = false
+	defaultWait         = 3 * time.Second
+	defaultCleanSession = true
 )
 
 // MQTT allows sending and receiving data to/from an MQTT broker
 type MQTT struct {
-	metadata *mqttMetadata
-	client   mqtt.Client
+	producer mqtt.Client
+	consumer mqtt.Client
+	metadata *metadata
+	logger   logger.Logger
 
-	logger logger.Logger
-}
-
-// Metadata is the MQTT config
-type mqttMetadata struct {
-	URL   string `json:"url"`
-	Topic string `json:"topic"`
+	ctx     context.Context
+	cancel  context.CancelFunc
+	backOff backoff.BackOff
 }
 
 // NewMQTT returns a new MQTT instance
@@ -40,48 +65,119 @@ func NewMQTT(logger logger.Logger) *MQTT {
 	return &MQTT{logger: logger}
 }
 
-// Init does MQTT connection parsing
-func (m *MQTT) Init(metadata bindings.Metadata) error {
-	mqttMeta, err := m.getMQTTMetadata(metadata)
-	if err != nil {
-		return err
-	}
+// isValidPEM validates the provided input has PEM formatted block.
+func isValidPEM(val string) bool {
+	block, _ := pem.Decode([]byte(val))
 
-	m.metadata = mqttMeta
-	if m.metadata.URL == "" {
-		return errors.New("MQTT Error: URL required")
-	}
-
-	if m.metadata.Topic == "" {
-		return errors.New("MQTT error: topic required")
-	}
-
-	uri, err := url.Parse(m.metadata.URL)
-	if err != nil {
-		return err
-	}
-	client, err := m.connect(uuid.New().String(), uri)
-	if err != nil {
-		return err
-	}
-	m.client = client
-
-	return nil
+	return block != nil
 }
 
-func (m *MQTT) getMQTTMetadata(metadata bindings.Metadata) (*mqttMetadata, error) {
-	b, err := json.Marshal(metadata.Properties)
-	if err != nil {
-		return nil, err
+func parseMQTTMetaData(md bindings.Metadata) (*metadata, error) {
+	m := metadata{}
+
+	// required configuration settings
+	if val, ok := md.Properties[mqttURL]; ok && val != "" {
+		m.url = val
+	} else {
+		return &m, fmt.Errorf("%s missing url", errorMsgPrefix)
 	}
 
-	var mMetadata mqttMetadata
-	err = json.Unmarshal(b, &mMetadata)
-	if err != nil {
-		return nil, err
+	if val, ok := md.Properties[mqttTopic]; ok && val != "" {
+		m.topic = val
+	} else {
+		return &m, fmt.Errorf("%s missing topic", errorMsgPrefix)
 	}
 
-	return &mMetadata, nil
+	// optional configuration settings
+	m.qos = defaultQOS
+	if val, ok := md.Properties[mqttQOS]; ok && val != "" {
+		qosInt, err := strconv.Atoi(val)
+		if err != nil {
+			return &m, fmt.Errorf("%s invalid qos %s, %s", errorMsgPrefix, val, err)
+		}
+		m.qos = byte(qosInt)
+	}
+
+	m.retain = defaultRetain
+	if val, ok := md.Properties[mqttRetain]; ok && val != "" {
+		var err error
+		m.retain, err = strconv.ParseBool(val)
+		if err != nil {
+			return &m, fmt.Errorf("%s invalid retain %s, %s", errorMsgPrefix, val, err)
+		}
+	}
+
+	if val, ok := md.Properties[mqttClientID]; ok && val != "" {
+		m.clientID = val
+	} else {
+		return &m, fmt.Errorf("%s missing consumerID", errorMsgPrefix)
+	}
+
+	m.cleanSession = defaultCleanSession
+	if val, ok := md.Properties[mqttCleanSession]; ok && val != "" {
+		var err error
+		m.cleanSession, err = strconv.ParseBool(val)
+		if err != nil {
+			return &m, fmt.Errorf("%s invalid clean session %s, %s", errorMsgPrefix, val, err)
+		}
+	}
+
+	if val, ok := md.Properties[mqttCACert]; ok && val != "" {
+		if !isValidPEM(val) {
+			return &m, fmt.Errorf("%s invalid ca certificate", errorMsgPrefix)
+		}
+		m.tlsCfg.caCert = val
+	}
+	if val, ok := md.Properties[mqttClientCert]; ok && val != "" {
+		if !isValidPEM(val) {
+			return &m, fmt.Errorf("%s invalid client certificate", errorMsgPrefix)
+		}
+		m.tlsCfg.clientCert = val
+	}
+	if val, ok := md.Properties[mqttClientKey]; ok && val != "" {
+		if !isValidPEM(val) {
+			return &m, fmt.Errorf("%s invalid client certificate key", errorMsgPrefix)
+		}
+		m.tlsCfg.clientKey = val
+	}
+
+	if val, ok := md.Properties[mqttBackOffMaxRetries]; ok && val != "" {
+		backOffMaxRetriesInt, err := strconv.Atoi(val)
+		if err != nil {
+			return &m, fmt.Errorf("%s invalid backOffMaxRetries %s, %s", errorMsgPrefix, val, err)
+		}
+		m.backOffMaxRetries = backOffMaxRetriesInt
+	}
+
+	return &m, nil
+}
+
+// Init does MQTT connection parsing
+func (m *MQTT) Init(metadata bindings.Metadata) error {
+	mqttMeta, err := parseMQTTMetaData(metadata)
+	if err != nil {
+		return err
+	}
+	m.metadata = mqttMeta
+
+	// mqtt broker allows only one connection at a given time from a clientID.
+	producerClientID := fmt.Sprintf("%s-producer", m.metadata.clientID)
+	p, err := m.connect(producerClientID)
+	if err != nil {
+		return err
+	}
+
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+
+	// TODO: Make the backoff configurable for constant or exponential
+	b := backoff.NewConstantBackOff(5 * time.Second)
+	m.backOff = backoff.WithContext(b, m.ctx)
+
+	m.producer = p
+
+	m.logger.Debug("mqtt message bus initialization complete")
+
+	return nil
 }
 
 func (m *MQTT) Operations() []bindings.OperationKind {
@@ -89,31 +185,78 @@ func (m *MQTT) Operations() []bindings.OperationKind {
 }
 
 func (m *MQTT) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
-	m.client.Publish(m.metadata.Topic, 0, false, string(req.Data))
-	m.client.Disconnect(0)
+	m.logger.Debugf("mqtt publishing topic %s with data: %v", m.metadata.topic, req.Data)
+
+	token := m.producer.Publish(m.metadata.topic, m.metadata.qos, m.metadata.retain, req.Data)
+	if !token.WaitTimeout(defaultWait) || token.Error() != nil {
+		return nil, fmt.Errorf("mqtt error from publish: %v", token.Error())
+	}
 
 	return nil, nil
 }
 
 func (m *MQTT) Read(handler func(*bindings.ReadResponse) ([]byte, error)) error {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	sigterm := make(chan os.Signal, 1)
+	signal.Notify(sigterm, os.Interrupt, syscall.SIGTERM)
 
-	m.client.Subscribe(m.metadata.Topic, 0, func(client mqtt.Client, msg mqtt.Message) {
-		handler(&bindings.ReadResponse{
-			Data: msg.Payload(),
-		})
+	// reset synchronization
+	if m.consumer != nil {
+		m.logger.Warnf("re-initializing the subscriber")
+		m.consumer.Disconnect(0)
+		m.consumer = nil
+	}
+
+	// mqtt broker allows only one connection at a given time from a clientID.
+	consumerClientID := fmt.Sprintf("%s-consumer", m.metadata.clientID)
+	c, err := m.connect(consumerClientID)
+	if err != nil {
+		return err
+	}
+	m.consumer = c
+
+	token := m.consumer.Subscribe(m.metadata.topic, m.metadata.qos, func(client mqtt.Client, mqttMsg mqtt.Message) {
+		msg := bindings.ReadResponse{Data: mqttMsg.Payload()}
+
+		b := m.backOff
+		if m.metadata.backOffMaxRetries >= 0 {
+			b = backoff.WithMaxRetries(m.backOff, uint64(m.metadata.backOffMaxRetries))
+		}
+		if err := pubsub.RetryNotifyRecover(func() error {
+			m.logger.Debugf("Processing MQTT message %s/%d", mqttMsg.Topic(), mqttMsg.MessageID())
+			if _, err := handler(&msg); err != nil {
+				return err
+			}
+
+			mqttMsg.Ack()
+
+			return nil
+		}, b, func(err error, d time.Duration) {
+			m.logger.Errorf("Error processing MQTT message: %s/%d. Retrying...", mqttMsg.Topic(), mqttMsg.MessageID())
+		}, func() {
+			m.logger.Infof("Successfully processed MQTT message after it previously failed: %s/%d", mqttMsg.Topic(), mqttMsg.MessageID())
+		}); err != nil {
+			m.logger.Errorf("Failed processing MQTT message: %s/%d: %v", mqttMsg.Topic(), mqttMsg.MessageID(), err)
+		}
 	})
-	<-c
+	if err := token.Error(); err != nil {
+		m.logger.Errorf("mqtt error from subscribe: %v", err)
+
+		return err
+	}
+	<-sigterm
 
 	return nil
 }
 
-func (m *MQTT) connect(clientID string, uri *url.URL) (mqtt.Client, error) {
-	opts := m.createClientOptions(clientID, uri)
+func (m *MQTT) connect(clientID string) (mqtt.Client, error) {
+	uri, err := url.Parse(m.metadata.url)
+	if err != nil {
+		return nil, err
+	}
+	opts := m.createClientOptions(uri, clientID)
 	client := mqtt.NewClient(opts)
 	token := client.Connect()
-	for !token.WaitTimeout(3 * time.Second) {
+	for !token.WaitTimeout(defaultWait) {
 	}
 	if err := token.Error(); err != nil {
 		return nil, err
@@ -122,13 +265,39 @@ func (m *MQTT) connect(clientID string, uri *url.URL) (mqtt.Client, error) {
 	return client, nil
 }
 
-func (m *MQTT) createClientOptions(clientID string, uri *url.URL) *mqtt.ClientOptions {
+func (m *MQTT) newTLSConfig() *tls.Config {
+	tlsConfig := new(tls.Config)
+
+	if m.metadata.clientCert != "" && m.metadata.clientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(m.metadata.clientCert), []byte(m.metadata.clientKey))
+		if err != nil {
+			m.logger.Warnf("unable to load client certificate and key pair. Err: %v", err)
+
+			return tlsConfig
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	if m.metadata.caCert != "" {
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if ok := tlsConfig.RootCAs.AppendCertsFromPEM([]byte(m.metadata.caCert)); !ok {
+			m.logger.Warnf("unable to load ca certificate.")
+		}
+	}
+
+	return tlsConfig
+}
+
+func (m *MQTT) createClientOptions(uri *url.URL, clientID string) *mqtt.ClientOptions {
 	opts := mqtt.NewClientOptions()
-	opts.AddBroker(fmt.Sprintf("tcp://%s", uri.Host))
+	opts.SetClientID(clientID)
+	opts.SetCleanSession(m.metadata.cleanSession)
+	opts.AddBroker(uri.Scheme + "://" + uri.Host)
 	opts.SetUsername(uri.User.Username())
 	password, _ := uri.User.Password()
 	opts.SetPassword(password)
-	opts.SetClientID(clientID)
+	// tls config
+	opts.SetTLSConfig(m.newTLSConfig())
 
 	return opts
 }

--- a/bindings/mqtt/mqtt.go
+++ b/bindings/mqtt/mqtt.go
@@ -293,7 +293,15 @@ func (m *MQTT) createClientOptions(uri *url.URL, clientID string) *mqtt.ClientOp
 	opts := mqtt.NewClientOptions()
 	opts.SetClientID(clientID)
 	opts.SetCleanSession(m.metadata.cleanSession)
-	opts.AddBroker(uri.Scheme + "://" + uri.Host)
+	// URL scheme backward compatibility
+	scheme := uri.Scheme
+	switch scheme {
+	case "mqtt":
+		scheme = "tcp"
+	case "mqtts":
+		scheme = "ssl"
+	}
+	opts.AddBroker(scheme + "://" + uri.Host)
 	opts.SetUsername(uri.User.Username())
 	password, _ := uri.User.Password()
 	opts.SetPassword(password)

--- a/bindings/mqtt/mqtt.go
+++ b/bindings/mqtt/mqtt.go
@@ -214,6 +214,7 @@ func (m *MQTT) Read(handler func(*bindings.ReadResponse) ([]byte, error)) error 
 	}
 	m.consumer = c
 
+	m.logger.Debugf("mqtt subscribing to topic %s", m.metadata.topic)
 	token := m.consumer.Subscribe(m.metadata.topic, m.metadata.qos, func(client mqtt.Client, mqttMsg mqtt.Message) {
 		msg := bindings.ReadResponse{Data: mqttMsg.Payload()}
 

--- a/bindings/mqtt/mqtt.go
+++ b/bindings/mqtt/mqtt.go
@@ -298,7 +298,7 @@ func (m *MQTT) createClientOptions(uri *url.URL, clientID string) *mqtt.ClientOp
 	switch scheme {
 	case "mqtt":
 		scheme = "tcp"
-	case "mqtts", "tcps":
+	case "mqtts", "tcps", "tls":
 		scheme = "ssl"
 	}
 	opts.AddBroker(scheme + "://" + uri.Host)

--- a/bindings/mqtt/mqtt_test.go
+++ b/bindings/mqtt/mqtt_test.go
@@ -6,19 +6,176 @@
 package mqtt
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"testing"
 
 	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/dapr/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
+func getFakeProperties() map[string]string {
+	return map[string]string{
+		"consumerID":     "client",
+		mqttURL:          "tcp://fakeUser:fakePassword@fake.mqtt.host:1883",
+		mqttTopic:        "fake/topic",
+		mqttQOS:          "1",
+		mqttRetain:       "true",
+		mqttCleanSession: "false",
+	}
+}
+
 func TestParseMetadata(t *testing.T) {
-	m := bindings.Metadata{}
-	m.Properties = map[string]string{"URL": "a", "Topic": "a"}
-	mq := MQTT{logger: logger.NewLogger("test")}
-	mm, err := mq.getMQTTMetadata(m)
-	assert.Nil(t, err)
-	assert.Equal(t, "a", mm.URL)
-	assert.Equal(t, "a", mm.Topic)
+	t.Run("metadata is correct", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := bindings.Metadata{
+			Properties: fakeProperties,
+		}
+
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, fakeProperties[mqttURL], m.url)
+		assert.Equal(t, byte(1), m.qos)
+		assert.Equal(t, true, m.retain)
+		assert.Equal(t, false, m.cleanSession)
+	})
+
+	t.Run("missing topic", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties["topic"] = ""
+		_, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.Contains(t, err.Error(), "missing topic")
+	})
+
+	t.Run("missing consumerID", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties["consumerID"] = ""
+		_, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.Contains(t, err.Error(), "missing consumerID")
+	})
+
+	t.Run("url is not given", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttURL] = ""
+
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.EqualError(t, err, errors.New("mqtt binding error: missing url").Error())
+		assert.Equal(t, fakeProperties[mqttURL], m.url)
+	})
+
+	t.Run("qos and retain is not given", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttQOS] = ""
+		fakeMetaData.Properties[mqttRetain] = ""
+
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, fakeProperties[mqttURL], m.url)
+		assert.Equal(t, byte(0), m.qos)
+		assert.Equal(t, false, m.retain)
+	})
+
+	t.Run("invalid clean session field", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttCleanSession] = "randomString"
+
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.Contains(t, err.Error(), "invalid clean session")
+		assert.Equal(t, fakeProperties[mqttURL], m.url)
+	})
+
+	t.Run("invalid ca certificate", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttCACert] = "randomNonPEMBlockCA"
+		_, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.Contains(t, err.Error(), "invalid ca certificate")
+	})
+
+	t.Run("valid ca certificate", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttCACert] = "-----BEGIN CERTIFICATE-----\nMIICyDCCAbACCQDb8BtgvbqW5jANBgkqhkiG9w0BAQsFADAmMQswCQYDVQQGEwJJ\nTjEXMBUGA1UEAwwOZGFwck1xdHRUZXN0Q0EwHhcNMjAwODEyMDY1MzU4WhcNMjUw\nODEyMDY1MzU4WjAmMQswCQYDVQQGEwJJTjEXMBUGA1UEAwwOZGFwck1xdHRUZXN0\nQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDEXte1GBxFJaygsEnK\nHV2AxazZW6Vppv+i50AuURHcaGo0i8G5CTfHzSKrYtTFfBskUspl+2N8GPV5c8Eb\ng+PP6YFn1wiHVz+wRSk3BD35DcGOT2o4XsJw5tiAzJkbpAOYCYl7KAM+BtOf41uC\nd6TdqmawhRGtv1ND2WtyJOT6A3KcUfjhL4TFEhWoljPJVay4TQoJcZMAImD/Xcxw\n6urv6wmUJby3/RJ3I46ZNH3zxEw5vSq1TuzuXxQmfPJG0ZPKJtQZ2nkZ3PNZe4bd\nNUa83YgQap7nBhYdYMMsQyLES2qy3mPcemBVoBWRGODel4PMEcsQiOhAyloAF2d3\nhd+LAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAK13X5JYBy78vHYoP0Oq9fe5XBbL\nuRM8YLnet9b/bXTGG4SnCCOGqWz99swYK7SVyR5l2h8SAoLzeNV61PtaZ6fHrbar\noxSL7BoRXOhMH6LQATadyvwlJ71uqlagqya7soaPK09TtfzeebLT0QkRCWT9b9lQ\nDBvBVCaFidynJL1ts21m5yUdIY4JSu4sGZGb4FRGFdBv/hD3wH8LAkOppsSv3C/Q\nkfkDDSQzYbdMoBuXmafvi3He7Rv+e6Tj9or1rrWdx0MIKlZPzz4DOe5Rh112uRB9\n7xPHJt16c+Ya3DKpchwwdNcki0vFchlpV96HK8sMCoY9kBzPhkEQLdiBGv4=\n-----END CERTIFICATE-----\n"
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.NoError(t, err)
+		block, _ := pem.Decode([]byte(m.tlsCfg.caCert))
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Errorf("failed to parse ca certificate from metadata. %v", err)
+		}
+		assert.Equal(t, "daprMqttTestCA", cert.Subject.CommonName)
+	})
+
+	t.Run("invalid client certificate", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttClientCert] = "randomNonPEMBlockClientCert"
+		_, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.Contains(t, err.Error(), "invalid client certificate")
+	})
+
+	t.Run("valid client certificate", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttClientCert] = "-----BEGIN CERTIFICATE-----\nMIICzDCCAbQCCQDBKDMS3SHsDzANBgkqhkiG9w0BAQUFADAmMQswCQYDVQQGEwJJ\nTjEXMBUGA1UEAwwOZGFwck1xdHRUZXN0Q0EwHhcNMjAwODEyMDY1NTE1WhcNMjEw\nODA3MDY1NTE1WjAqMQswCQYDVQQGEwJJTjEbMBkGA1UEAwwSZGFwck1xdHRUZXN0\nQ2xpZW50MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5IDfsGI2pb4W\nt3CjckrKuNeTrgmla3sXxSI5wfDgLGd/XkNu++M6yi9ABaBiYChpxbylqIeAn/HT\n3r/nhcb+bldMtEkU9tODHy/QDhvN2UGFjRsMfzO9p1oMpTnRdJCHYinE+oqVced5\nHI+UEofAU+1eiIXqJGKrdfn4gvaHst4QfVPvui8WzJq9TMkEhEME+5hs3VKyKZr2\nqjIxzr7nLVod3DBf482VjxRI06Ip3fPvNuMWwzj2G+Rj8PMcBjoKeCLQL9uQh7f1\nTWHuACqNIrmFEUQWdGETnRjHWIvw0NEL40+Ur2b5+7/hoqnTzReJ3XUe1jM3l44f\nl0rOf4hu2QIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQAT9yoIeX0LTsvx7/b+8V3a\nkP+j8u97QCc8n5xnMpivcMEk5cfqXX5Llv2EUJ9kBsynrJwT7ujhTJXSA/zb2UdC\nKH8PaSrgIlLwQNZMDofbz6+zPbjStkgne/ZQkTDIxY73sGpJL8LsQVO9p2KjOpdj\nSf9KuJhLzcHolh7ry3ZrkOg+QlMSvseeDRAxNhpkJrGQ6piXoUiEeKKNa0rWTMHx\nIP1Hqj+hh7jgqoQR48NL2jNng7I64HqTl6Mv2fiNfINiw+5xmXTB0QYkGU5NvPBO\naKcCRcGlU7ND89BogQPZsl/P04tAuQqpQWffzT4sEEOyWSVGda4N2Ys3GSQGBv8e\n-----END CERTIFICATE-----\n"
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.NoError(t, err)
+		block, _ := pem.Decode([]byte(m.tlsCfg.clientCert))
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Errorf("failed to parse client certificate from metadata. %v", err)
+		}
+		assert.Equal(t, "daprMqttTestClient", cert.Subject.CommonName)
+	})
+
+	t.Run("invalid client certificate key", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttClientKey] = "randomNonPEMBlockClientKey"
+		_, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.Contains(t, err.Error(), "invalid client certificate key")
+	})
+
+	t.Run("valid client certificate key", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeMetaData := bindings.Metadata{Name: "binging-test", Properties: fakeProperties}
+		fakeMetaData.Properties[mqttClientKey] = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA5IDfsGI2pb4Wt3CjckrKuNeTrgmla3sXxSI5wfDgLGd/XkNu\n++M6yi9ABaBiYChpxbylqIeAn/HT3r/nhcb+bldMtEkU9tODHy/QDhvN2UGFjRsM\nfzO9p1oMpTnRdJCHYinE+oqVced5HI+UEofAU+1eiIXqJGKrdfn4gvaHst4QfVPv\nui8WzJq9TMkEhEME+5hs3VKyKZr2qjIxzr7nLVod3DBf482VjxRI06Ip3fPvNuMW\nwzj2G+Rj8PMcBjoKeCLQL9uQh7f1TWHuACqNIrmFEUQWdGETnRjHWIvw0NEL40+U\nr2b5+7/hoqnTzReJ3XUe1jM3l44fl0rOf4hu2QIDAQABAoIBAQCVMINb4TP20P55\n9IPyqlxjhPT563hijXK+lhMJyiBDPavOOs7qjLikq2bshYPVbm1o2jt6pkXXqAeB\n5t/d20fheQQurYyPfxecNBZuL78duwbcUy28m2aXLlcVRYO4zGhoMgdW4UajoNLV\nT/UIiDONWGyhTHXMHdP+6h9UOmvs3o4b225AuLrw9n6QO5I1Se8lcfOTIqR1fy4O\nGsUWEQPdW0X3Dhgpx7kDIuBTAQzbjD31PCR1U8h2wsCeEe6hPCrsMbo/D019weol\ndi40tbWR1/oNz0+vro2d9YDPJkXN0gmpT51Z4YJoexZBdyzO5z4DMSdn5yczzt6p\nQq8LsXAFAoGBAPYXRbC4OxhtuC+xr8KRkaCCMjtjUWFbFWf6OFgUS9b5uPz9xvdY\nXo7wBP1zp2dS8yFsdIYH5Six4Z5iOuDR4sVixzjabhwedL6bmS1zV5qcCWeASKX1\nURgSkfMmC4Tg3LBgZ9YxySFcVRjikxljkS3eK7Mp7Xmj5afe7qV73TJfAoGBAO20\nTtw2RGe02xnydZmmwf+NpQHOA9S0JsehZA6NRbtPEN/C8bPJIq4VABC5zcH+tfYf\nzndbDlGhuk+qpPA590rG5RSOUjYnQFq7njdSfFyok9dXSZQTjJwFnG2oy0LmgjCe\nROYnbCzD+a+gBKV4xlo2M80OLakQ3zOwPT0xNRnHAoGATLEj/tbrU8mdxP9TDwfe\nom7wyKFDE1wXZ7gLJyfsGqrog69y+lKH5XPXmkUYvpKTQq9SARMkz3HgJkPmpXnD\nelA2Vfl8pza2m1BShF+VxZErPR41hcLV6vKemXAZ1udc33qr4YzSaZskygSSYy8s\nZ2b9p3BBmc8CGzbWmKvpW3ECgYEAn7sFLxdMWj/+5221Nr4HKPn+wrq0ek9gq884\n1Ep8bETSOvrdvolPQ5mbBKJGsLC/h5eR/0Rx18sMzpIF6eOZ2GbU8z474mX36cCf\nrd9A8Gbbid3+9IE6gHGIz2uYwujw3UjNVbdyCpbahvjJhoQlDePUZVu8tRpAUpSA\nYklZvGsCgYBuIlOFTNGMVUnwfzrcS9a/31LSvWTZa8w2QFjsRPMYFezo2l4yWs4D\nPEpeuoJm+Gp6F6ayjoeyOw9mvMBH5hAZr4WjbiU6UodzEHREAsLAzCzcRyIpnDE6\nPW1c3j60r8AHVufkWTA+8B9WoLC5MqcYTV3beMGnNGGqS2PeBom63Q==\n-----END RSA PRIVATE KEY-----\n"
+		m, err := parseMQTTMetaData(fakeMetaData)
+
+		// assert
+		assert.NoError(t, err)
+		assert.NotNil(t, m.tlsCfg.clientKey, "failed to parse valid client certificate key")
+	})
 }

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -291,7 +291,7 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 	switch scheme {
 	case "mqtt":
 		scheme = "tcp"
-	case "mqtts":
+	case "mqtts", "tcps":
 		scheme = "ssl"
 	}
 	opts.AddBroker(scheme + "://" + uri.Host)

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -291,7 +291,7 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 	switch scheme {
 	case "mqtt":
 		scheme = "tcp"
-	case "mqtts", "tcps":
+	case "mqtts", "tcps", "tls":
 		scheme = "ssl"
 	}
 	opts.AddBroker(scheme + "://" + uri.Host)

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -286,7 +286,15 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 	opts := mqtt.NewClientOptions()
 	opts.SetClientID(clientID)
 	opts.SetCleanSession(m.metadata.cleanSession)
-	opts.AddBroker(uri.Scheme + "://" + uri.Host)
+	// URL scheme backward compatibility
+	scheme := uri.Scheme
+	switch scheme {
+	case "mqtt":
+		scheme = "tcp"
+	case "mqtts":
+		scheme = "ssl"
+	}
+	opts.AddBroker(scheme + "://" + uri.Host)
 	opts.SetUsername(uri.User.Username())
 	password, _ := uri.User.Password()
 	opts.SetPassword(password)

--- a/tests/config/bindings/mqtt/emqx/bindings.yml
+++ b/tests/config/bindings/mqtt/emqx/bindings.yml
@@ -1,0 +1,22 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: binding-mqtt-emqx
+spec:
+  type: bindings.mqtt
+  version: v1
+  metadata:
+  - name: url
+    value: "tcp://localhost:1884"
+  - name: consumerID
+    value: "testBindingConsumer"
+  - name: topic
+    value: "testBindingTopic"
+  - name: retain
+    value: false
+  - name: qos
+    value: 1
+  - name: cleanSession
+    value: false
+  - name: backOffMaxRetries
+    value: 5

--- a/tests/config/bindings/mqtt/mosquitto/bindings.yml
+++ b/tests/config/bindings/mqtt/mosquitto/bindings.yml
@@ -1,0 +1,22 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: binding-mqtt-mosquitto
+spec:
+  type: bindings.mqtt
+  version: v1
+  metadata:
+  - name: url
+    value: "tcp://localhost:1883"
+  - name: consumerID
+    value: "testBindingConsumer"
+  - name: topic
+    value: "testBindingTopic"
+  - name: retain
+    value: false
+  - name: qos
+    value: 1
+  - name: cleanSession
+    value: false
+  - name: backOffMaxRetries
+    value: 5

--- a/tests/config/bindings/mqtt/vernemq/bindings.yml
+++ b/tests/config/bindings/mqtt/vernemq/bindings.yml
@@ -1,0 +1,22 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: binding-mqtt-vernemq
+spec:
+  type: bindings.mqtt
+  version: v1
+  metadata:
+  - name: url
+    value: "tcp://localhost:1885"
+  - name: consumerID
+    value: "testBindingConsumer"
+  - name: topic
+    value: "testBindingTopic"
+  - name: retain
+    value: false
+  - name: qos
+    value: 1
+  - name: cleanSession
+    value: false
+  - name: backOffMaxRetries
+    value: 5

--- a/tests/config/bindings/tests.yml
+++ b/tests/config/bindings/tests.yml
@@ -31,3 +31,12 @@ components:
     config:
       url: "localhost:22222"
       method: "POST"
+  - component: mqtt
+    profile: mosquitto
+    operations: ["create", "operations", "read"]
+  - component: mqtt
+    profile: emqx
+    operations: ["create", "operations", "read"]
+  - component: mqtt
+    profile: vernemq
+    operations: ["create", "operations", "read"]

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -23,6 +23,7 @@ import (
 	b_azure_storagequeues "github.com/dapr/components-contrib/bindings/azure/storagequeues"
 	b_http "github.com/dapr/components-contrib/bindings/http"
 	b_kafka "github.com/dapr/components-contrib/bindings/kafka"
+	b_mqtt "github.com/dapr/components-contrib/bindings/mqtt"
 	b_redis "github.com/dapr/components-contrib/bindings/redis"
 	"github.com/dapr/components-contrib/pubsub"
 	p_servicebus "github.com/dapr/components-contrib/pubsub/azure/servicebus"
@@ -385,6 +386,8 @@ func loadOutputBindings(tc TestComponent) bindings.OutputBinding {
 		binding = b_kafka.NewKafka(testLogger)
 	case "http":
 		binding = b_http.NewHTTP(testLogger)
+	case "mqtt":
+		binding = b_mqtt.NewMQTT(testLogger)
 	default:
 		return nil
 	}
@@ -404,6 +407,8 @@ func loadInputBindings(tc TestComponent) bindings.InputBinding {
 		binding = b_azure_eventgrid.NewAzureEventGrid(testLogger)
 	case kafka:
 		binding = b_kafka.NewKafka(testLogger)
+	case "mqtt":
+		binding = b_mqtt.NewMQTT(testLogger)
 	default:
 		return nil
 	}

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -60,6 +60,7 @@ import (
 const (
 	redis        = "redis"
 	kafka        = "kafka"
+	mqtt         = "mqtt"
 	generateUUID = "$((uuid))"
 )
 
@@ -321,7 +322,7 @@ func loadPubSub(tc TestComponent) pubsub.PubSub {
 		pubsub = p_kafka.NewKafka(testLogger)
 	case "pulsar":
 		pubsub = p_pulsar.NewPulsar(testLogger)
-	case "mqtt":
+	case mqtt:
 		pubsub = p_mqtt.NewMQTTPubSub(testLogger)
 	case "hazelcast":
 		pubsub = p_hazelcast.NewHazelcastPubSub(testLogger)
@@ -386,7 +387,7 @@ func loadOutputBindings(tc TestComponent) bindings.OutputBinding {
 		binding = b_kafka.NewKafka(testLogger)
 	case "http":
 		binding = b_http.NewHTTP(testLogger)
-	case "mqtt":
+	case mqtt:
 		binding = b_mqtt.NewMQTT(testLogger)
 	default:
 		return nil
@@ -407,7 +408,7 @@ func loadInputBindings(tc TestComponent) bindings.InputBinding {
 		binding = b_azure_eventgrid.NewAzureEventGrid(testLogger)
 	case kafka:
 		binding = b_kafka.NewKafka(testLogger)
-	case "mqtt":
+	case mqtt:
 		binding = b_mqtt.NewMQTT(testLogger)
 	default:
 		return nil


### PR DESCRIPTION
# Description

This PR improve the MQTT binding to use the same options/code as the MQTT pubsub (TLS, qos, ...)

## Checklist

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation / dapr/docs#1328
