### PR TITLE
fix password config for redis sentinel state

### DIFF
--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -178,6 +178,7 @@ func (r *StateStore) newClient(m metadata) *redis.Client {
 func (r *StateStore) newFailoverClient(m metadata) *redis.Client {
 	opts := &redis.FailoverOptions{
 		MasterName:      r.metadata.sentinelMasterName,
+		Password:        m.password,
 		SentinelAddrs:   []string{r.metadata.host},
 		DB:              defaultDB,
 		MaxRetries:      m.maxRetries,


### PR DESCRIPTION
# Description

This PR fixes password configuration of Redis sentinel state component.

As written in #756, `redisPassword` metadata field did not work on Redis sentinel state.

In this commit, `redisPassword` is passed to FailOverClient as Redis master's password.

## Issue reference

Please reference the issue this PR will close: #756

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_