### PR TITLE
add queueName PubSub with RabbitMQ

### DIFF
--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -9,6 +9,7 @@ import (
 )
 
 type metadata struct {
+	queueName        string
 	consumerID       string
 	host             string
 	deleteWhenUnused bool
@@ -36,6 +37,10 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 
 	if val, found := pubSubMetadata.Properties[metadataConsumerIDKey]; found && val != "" {
 		result.consumerID = val
+	}
+
+	if val, found := pubSubMetadata.Properties[metadataQueueNameKey]; found && val != "" {
+		result.queueName = val
 	}
 
 	if val, found := pubSubMetadata.Properties[metadataDeliveryModeKey]; found && val != "" {

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -21,6 +21,7 @@ const (
 	errorChannelConnection = "channel/connection is not open"
 
 	metadataHostKey              = "host"
+	metadataQueueNameKey         = "queueName"
 	metadataConsumerIDKey        = "consumerID"
 	metadataDeleteWhenUnusedKey  = "deletedWhenUnused"
 	metadataAutoAckKey           = "autoAck"
@@ -198,7 +199,11 @@ func (r *rabbitMQ) Subscribe(req pubsub.SubscribeRequest, handler pubsub.Handler
 		return errors.New("consumerID is required for subscriptions")
 	}
 
-	queueName := fmt.Sprintf("%s-%s", r.metadata.consumerID, req.Topic)
+	queueName := r.metadata.queueName
+
+	if queueName == "" {
+		queueName = fmt.Sprintf("%s-%s", r.metadata.consumerID, req.Topic)
+	}
 
 	go r.subscribeForever(req, queueName, handler)
 


### PR DESCRIPTION
# Description

The current queueName={consumerID}-{Topic} can custom queueName ?  
if can accept  please.
if can't  refuse please. 

## Issue reference

https://github.com/dapr/quickstarts/issues/408

Please reference the issue this PR will close: #_[https://github.com/dapr/quickstarts/issues/408]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [√ ] Code compiles correctly
* [X ] Created/updated tests
* [ X] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
