### PR TITLE
Increasing overall test timeout to allow for conformance tests to run

### DIFF
--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -49,6 +49,9 @@ jobs:
           go-version: ${{ env.GOVER }}
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+      - name: Download Go dependencies
+        run: |
+          go mod download
       - name: Run golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         uses: golangci/golangci-lint-action@v2.2.1

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Download Go dependencies
+        if: matrix.target_arch != 'arm'
         run: |
           go mod download
       - name: Run golangci-lint

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -222,7 +222,8 @@ jobs:
       uses: actions/setup-go@v2
     
     - name: Download Go dependencies
-      run: go mod download
+      run: |
+        go mod download
 
     - name: Run tests
       continue-on-error: true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -236,7 +236,7 @@ jobs:
         echo "Running tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
 
         set +e
-        go test -v -tags=conftests -count=1 ./tests/conformance \
+        go test -timeout=15m -v -tags=conftests -count=1 ./tests/conformance \
           --run="Test${KIND_UPPER}Conformance/${NAME}" 2>&1 | tee output.log
         status=$?
         echo "Completed tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -220,6 +220,9 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v2
+    
+    - name: Download Go dependencies
+      run: go mod download
 
     - name: Run tests
       continue-on-error: true


### PR DESCRIPTION
# Description

Increased the timeout for running conformance tests. This error is periodically causing the Github actions workflow to fail.

![image](https://user-images.githubusercontent.com/714039/115620308-0324d500-a2c3-11eb-8bd8-add70df8473b.png)

The default `go test` timeout is `10m`. This PR bumps that up to `15m`. Also added a `go mod download` as a step before the `go test` command so that downloading dependencies does not count against the testing timeout.

At some point we should look at where all the time is being spent.