### PR TITLE
Removing the Download Go Dependencies step from the build workflow

### DIFF
--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -49,10 +49,6 @@ jobs:
           go-version: ${{ env.GOVER }}
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: Download Go dependencies
-        if: matrix.target_arch != 'arm'
-        run: |
-          go mod download
       - name: Run golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         uses: golangci/golangci-lint-action@v2.2.1

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -191,13 +191,15 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 	if config.HasOperation("subscribe") {
 		t.Run("verify read", func(t *testing.T) {
 			t.Logf("waiting for %v to complete read", config.MaxReadDuration)
+			timer := time.NewTimer(config.MaxReadDuration)
+			defer timer.Stop()
 			waiting := true
 			for waiting {
 				select {
 				case processed := <-processedC:
 					delete(awaitingMessages, processed)
 					waiting = len(awaitingMessages) > 0
-				case <-time.After(config.MaxReadDuration):
+				case <-timer.C:
 					// Break out after the mamimum read duration has elapsed
 					waiting = false
 				}


### PR DESCRIPTION
# Description

Lots of go lint errors are showing up in job runs since the `Download Go dependencies` step was added to `.github/workflows/components-contrib.yml`. Hoping removing it resolves the errors.

Also moved the timer in the pubsub conformance tests to a single variable used over each message iteration. Not 100% confident it will resolve the periodic conformance test timeouts but it is probably how the timer should work anyway.