### PR TITLE
Fixing backup current daprd command

### DIFF
--- a/docs/developing-component.md
+++ b/docs/developing-component.md
@@ -67,7 +67,7 @@ make DEBUG=1 build
 6. Replace the installed daprd with the test binary (then dapr cli will use the test binary)
 ```bash
 # Back up the current daprd
-mv /usr/local/bin/daprd /usr/local/bin/daprd.bak
+cp ~/.dapr/bin/daprd ~/.dapr/bin/daprd.bak
 cp ./dist/darwin_amd64/debug/daprd ~/.dapr/bin
 ```
 > Linux Debuggable Binary: ./dist/linux_amd64/debug/daprd


### PR DESCRIPTION
# Description

Fixes the shell command in step 6 that backs up your current `daprd` binary under **Validating with Dapr core** in `docs/developing-component.md`