### PR TITLE
Do not block indefinitely on XGroupRead for redis subscriber

### DIFF
--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -502,10 +502,12 @@ func (r *redisStreams) pollNewMessagesLoop(stream string, handler pubsub.Handler
 			Consumer: r.metadata.consumerID,
 			Streams:  []string{stream, ">"},
 			Count:    int64(r.metadata.queueDepth),
-			Block:    0,
+			Block:    r.metadata.readTimeout,
 		}).Result()
 		if err != nil {
-			r.logger.Errorf("redis streams: error reading from stream %s: %s", stream, err)
+			if !errors.Is(err, redis.Nil) {
+				r.logger.Errorf("redis streams: error reading from stream %s: %s", stream, err)
+			}
 
 			continue
 		}


### PR DESCRIPTION
# Description

Allow XGroupRead operation to timeout periodically so we will know when a connection has disappeared. There is an existing redis parameter to read timeout, we can use it for our XGroupRead interval.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #852

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
