### PR TITLE
Update redis metadata comments to reflect the new maxRetry default from v8

### DIFF
--- a/pubsub/redis/metadata.go
+++ b/pubsub/redis/metadata.go
@@ -20,7 +20,8 @@ type metadata struct {
 	redisType string
 
 	// Maximum number of retries before giving up.
-	// Default is to not retry failed commands.
+	// A value of -1 (not 0) disables retries
+	// Default is 3 retries
 	redisMaxRetries int
 	// Minimum backoff between each retry.
 	// Default is 8 milliseconds; -1 disables backoff.


### PR DESCRIPTION


# Description

Just a comment change to reflect that the redis/v8 API defaults to 3 retries. This is the desired behavior, since prior to v1.1, we were just hardcoding a value of 3 for this parameter anyway.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
