### PR TITLE
Add function to generate CloudEvent for raw subscribed events.

### DIFF
--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -18,6 +18,9 @@ const (
 	// TTLMetadataKey defines the metadata key for setting a time to live (in seconds)
 	TTLMetadataKey = "ttlInSeconds"
 
+	// RawPayloadKey defines the metadata key for forcing raw payload in pubsub
+	RawPayloadKey = "rawPayload"
+
 	// PriorityMetadataKey defines the metadata key for setting a priority
 	PriorityMetadataKey = "priority"
 )
@@ -65,4 +68,18 @@ func TryGetPriority(props map[string]string) (uint8, bool, error) {
 	}
 
 	return 0, false, nil
+}
+
+// TryIsRawPayload determines if payload should be used as-is.
+func TryIsRawPayload(props map[string]string) (bool, error) {
+	if val, ok := props[RawPayloadKey]; ok && val != "" {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, errors.Wrapf(err, "%s value must be a valid boolean: actual is '%s'", RawPayloadKey, val)
+		}
+
+		return boolVal, nil
+	}
+
+	return false, nil
 }

--- a/metadata/utils_test.go
+++ b/metadata/utils_test.go
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRawPayload(t *testing.T) {
+	t.Run("Metadata not found", func(t *testing.T) {
+		val, err := TryIsRawPayload(map[string]string{
+			"notfound": "1",
+		})
+
+		assert.Equal(t, false, val)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Metadata map is nil", func(t *testing.T) {
+		val, err := TryIsRawPayload(nil)
+
+		assert.Equal(t, false, val)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Metadata with bad value", func(t *testing.T) {
+		val, err := TryIsRawPayload(map[string]string{
+			"rawPayload": "Not a boolean",
+		})
+
+		assert.Equal(t, false, val)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Metadata with correct value as false", func(t *testing.T) {
+		val, err := TryIsRawPayload(map[string]string{
+			"rawPayload": "false",
+		})
+
+		assert.Equal(t, false, val)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Metadata with correct value as true", func(t *testing.T) {
+		val, err := TryIsRawPayload(map[string]string{
+			"rawPayload": "true",
+		})
+
+		assert.Equal(t, true, val)
+		assert.Nil(t, err)
+	})
+}

--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -106,6 +106,25 @@ func FromCloudEvent(cloudEvent []byte, topic, pubsub, traceID string) (map[strin
 	return m, nil
 }
 
+// FromRawPayload returns a CloudEvent for a raw payload on subscriber's end.
+func FromRawPayload(data []byte, topic, pubsub string) map[string]interface{} {
+	// Limitations of generating the CloudEvent on the subscriber side based on raw payload:
+	// - ID is supposed to be the app ID of the publisher but we get the subscriber's ID only.
+	// - The CloudEvent ID will be random, so the same message can be redelivered as a different ID.
+	// - TraceID is not useful since it is random and not from publisher side.
+	// - Data is always returned as `data_base64` since we don't know the actual content type.
+	return map[string]interface{}{
+		IDField:              uuid.New().String(),
+		SpecVersionField:     CloudEventsSpecVersion,
+		DataContentTypeField: "application/octet-stream",
+		SourceField:          DefaultCloudEventSource,
+		TypeField:            DefaultCloudEventType,
+		TopicField:           topic,
+		PubsubField:          pubsub,
+		DataBase64Field:      base64.StdEncoding.EncodeToString(data),
+	}
+}
+
 // HasExpired determines if the current cloud event has expired.
 func HasExpired(cloudEvent map[string]interface{}) bool {
 	e, ok := cloudEvent[ExpirationField]

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -258,3 +258,16 @@ func TestCreateFromBinaryPayload(t *testing.T) {
 	assert.Equal(t, base64Encoding, envelope[DataBase64Field])
 	assert.Nil(t, envelope[DataField])
 }
+
+func TestNewFromRawPayload(t *testing.T) {
+	t.Run("string data", func(t *testing.T) {
+		n := FromRawPayload([]byte("hello world"), "mytopic", "mypubsub")
+		assert.NotNil(t, n["id"])
+		assert.Equal(t, "1.0", n["specversion"])
+		assert.Equal(t, "mytopic", n["topic"])
+		assert.Equal(t, "mypubsub", n["pubsubname"])
+		assert.Nil(t, n["traceid"])
+		assert.Nil(t, n["data"])
+		assert.Equal(t, "aGVsbG8gd29ybGQ=", n["data_base64"])
+	})
+}


### PR DESCRIPTION
# Description

Add function to generate CloudEvent for raw subscribed events.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will partially address: https://github.com/dapr/dapr/issues/2308

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
