### PR TITLE
Update Aerospike to v4.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Shopify/sarama v1.23.1
 	github.com/a8m/documentdb v1.2.1-0.20190920062420-efdd52fe0905
-	github.com/aerospike/aerospike-client-go v2.7.0+incompatible
+	github.com/aerospike/aerospike-client-go v4.5.0+incompatible
 	github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alicebob/miniredis/v2 v2.13.3

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/a8m/documentdb v1.2.1-0.20190920062420-efdd52fe0905 h1:lrOYmNobGcyWEjvMIMJERJx1Y4ttPFobY7RHAD+6e10=
 github.com/a8m/documentdb v1.2.1-0.20190920062420-efdd52fe0905/go.mod h1:4Z0mpi7fkyqjxUdGiNMO3vagyiUoiwLncaIX6AsW5z0=
-github.com/aerospike/aerospike-client-go v2.7.0+incompatible h1:NbjGs0ZMHKge1+0m+XLdhcDm/2gCfjnlasSTtKSr8j4=
-github.com/aerospike/aerospike-client-go v2.7.0+incompatible/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
+github.com/aerospike/aerospike-client-go v4.5.0+incompatible h1:6ALev/Ge4jW5avSLoqgvPYTh+FLeeDD9xDhzoMCNgOo=
+github.com/aerospike/aerospike-client-go v4.5.0+incompatible/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
 github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b h1:WMhlIaJkDgEQSVJQM06YV+cYUl1r5OY5//ijMXJNqtA=
 github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b/go.mod h1:Tie46d3UWzXpj+Fh9+DQTyaUxEpFBPOLXrnx7nxlKRo=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=

--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -162,9 +162,11 @@ func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) 
 
 	policy := &as.BasePolicy{}
 	if req.Options.Consistency == state.Strong {
-		policy.ConsistencyLevel = as.CONSISTENCY_ALL
+		policy.ReadModeAP = as.ReadModeAPAll
+		policy.ReadModeSC = as.ReadModeSCLinearize
 	} else {
-		policy.ConsistencyLevel = as.CONSISTENCY_ONE
+		policy.ReadModeAP = as.ReadModeAPOne
+		policy.ReadModeSC = as.ReadModeSCSession
 	}
 	record, err := aspike.client.Get(policy, asKey)
 	if err != nil {


### PR DESCRIPTION
# Description

The Aerospike library was using microsecond precision sleep in a loop in its module init() function for random number generation. Windows, as it turns out, doesn't have microsecond precision sleep, so it was sleeping for for a total of nearly 8s. This is happening any time the daprd binary is invoked on windows. This has been fixed upstream, so the solution is to migrate to a newer version of this library.

With aerospike v2.7.0:
```
$ time dapr --version
CLI version: edge
Runtime version: 1.1.2

real    0m8.827s
user    0m0.000s
sys     0m0.015s
```

With aerospike v4.5.0:
```
$ time dapr --version
CLI version: edge
Runtime version: edge

real    0m0.531s
user    0m0.000s
sys     0m0.046s

```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #865



## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
