### PR TITLE
fix typo in error message in case of missing property

### DIFF
--- a/bindings/smtp/smtp.go
+++ b/bindings/smtp/smtp.go
@@ -63,7 +63,7 @@ func (s *Mailer) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, 
 	// Merge config metadata with request metadata
 	metadata := s.metadata.mergeWithRequestMetadata(req)
 	if metadata.EmailFrom == "" {
-		return nil, fmt.Errorf("smtp binding error: fromEmail property not supplied in configuration- or request-metadata")
+		return nil, fmt.Errorf("smtp binding error: emailFrom property not supplied in configuration- or request-metadata")
 	}
 	if metadata.EmailTo == "" {
 		return nil, fmt.Errorf("smtp binding error: emailTo property not supplied in configuration- or request-metadata")


### PR DESCRIPTION
# Description

If a request to invoke the SMTP binding was missing the `emailFrom` property, it would throw an slightly misleading error saying the `fromEmail` was missing.  

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
