### PR TITLE
Azure Service Bus: Fixing the handling of forced detach errors

### DIFF
--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -413,7 +413,14 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, handler pubsub.
 				a.metadata.MaxActiveMessages,
 				a.metadata.MaxActiveMessagesRecoveryInSec)
 			if innerErr != nil {
-				a.logger.Error(innerErr)
+				var detachError *amqp.DetachError
+				var ampqError *amqp.Error
+				if errors.Is(innerErr, detachError) ||
+					(errors.As(innerErr, &ampqError) && ampqError.Condition == amqp.ErrorDetachForced) {
+					a.logger.Debug(innerErr)
+				} else {
+					a.logger.Error(innerErr)
+				}
 			}
 			cancel() // Cancel receive context
 

--- a/pubsub/azure/servicebus/subscription.go
+++ b/pubsub/azure/servicebus/subscription.go
@@ -3,7 +3,6 @@ package servicebus
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -203,11 +202,7 @@ func (s *subscription) tryRenewLocks() {
 func (s *subscription) receiveMessage(ctx context.Context, handler azservicebus.HandlerFunc) error {
 	s.logger.Debugf("Waiting to receive message on topic %s", s.topic)
 	if err := s.entity.ReceiveOne(ctx, handler); err != nil {
-		if strings.Contains(err.Error(), "force detached") {
-			return nil
-		}
-
-		return fmt.Errorf("%s error receiving message on topic %s, %s", errorMessagePrefix, s.topic, err)
+		return fmt.Errorf("%s error receiving message on topic %s, %w", errorMessagePrefix, s.topic, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

This fixes the handling of `amqp:link:detach-forced` errors from Azure Service Bus. While the log message can be suppressed, this type of error should not be ignored because it prevents the component from reconnecting. Reconnecting is the desired behavior when the link is force detached.

## Issue reference

Resolves dapr/dapr#3468

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
