### PR TITLE
Upload conformance test logs as GitHub workflow artifacts

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -129,6 +129,12 @@ jobs:
       with:
         path: ./src/github.com/dapr/components-contrib
 
+    - name: Setup test output
+      shell: bash
+      run: |
+        export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/test_report
+        echo "TEST_OUTPUT_FILE_PREFIX=$TEST_OUTPUT_FILE_PREFIX" >> $GITHUB_ENV
+
     - uses: Azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -229,10 +235,13 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v2
+      with:
+        go-version: '^1.16.6'
     
     - name: Download Go dependencies
       run: |
         go mod download
+        go install gotest.tools/gotestsum@latest
 
     - name: Run tests
       continue-on-error: true
@@ -249,8 +258,9 @@ jobs:
         echo "Running tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
 
         set +e
-        go test -timeout=15m -v -tags=conftests -count=1 ./tests/conformance \
-          --run="Test${KIND_UPPER}Conformance/${NAME}" 2>&1 | tee output.log
+        gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json --format standard-verbose -- \
+          -p 2 -count=1 -timeout=15m -tags=conftests ./tests/conformance --run="Test${KIND_UPPER}Conformance/${NAME}"
+
         status=$?
         echo "Completed tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
         if test $status -ne 0; then
@@ -260,7 +270,7 @@ jobs:
         set -e
 
         # Fail the step if we found no test to run
-        if grep -q "warning: no tests to run" output.log ; then
+        if grep -q "warning: no tests to run" ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json ; then
           echo "::error:: No test was found for component ${{ matrix.component }}"
           exit -1
         fi
@@ -288,3 +298,11 @@ jobs:
         if [[ -v CONFORMANCE_FAILURE ]]; then
           exit 1
         fi
+
+    # Upload logs for dashboard like dapr/dapr E2E tests
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@master
+      with:
+        name: ${{ matrix.component }}_conformance_test.json
+        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json


### PR DESCRIPTION
# Description

The conformance tests do not currently upload their test results as GitHub workflow artifacts that analytics can be run on. This PR aligns test log reporting with dapr/dapr E2E tests so that maintainers can start applying the same analytics tools to the conformance test results as well.

## Issue reference

N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
