### PR TITLE
Increase wait between Read and Publish for EventGrid bindings conformance test

### DIFF
--- a/tests/config/bindings/tests.yml
+++ b/tests/config/bindings/tests.yml
@@ -2,6 +2,7 @@
 # Config map:
 ## output: A map of strings that will be part of the request for the output binding
 ## readBindingTimeout : timeout to wait to receive test event
+## readBindingWait : duration to wait after successful Read before attempting to Publish
 ## url: specific to http component, url of the http server
 ## method: specific to http component, what method to use
 componentType: bindings
@@ -22,6 +23,7 @@ components:
     operations: ["create", "operations", "read"]
     config:
       readBindingTimeout: 240s
+      readBindingWait: 8s
   - component: azure.storagequeues
     operations: ["create", "operations", "read"]
   - component: azure.servicebusqueues

--- a/tests/conformance/bindings/bindings.go
+++ b/tests/conformance/bindings/bindings.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	defaultTimeoutDuration = 60 * time.Second
+	defaultWaitDuration    = time.Second
 )
 
 // nolint:gochecknoglobals
@@ -38,6 +39,7 @@ type TestConfig struct {
 	InputMetadata      map[string]string `mapstructure:"input"`
 	OutputMetadata     map[string]string `mapstructure:"output"`
 	ReadBindingTimeout time.Duration     `mapstructure:"readBindingTimeout"`
+	ReadBindingWait    time.Duration     `mapstructure:"readBindingWait"`
 }
 
 func NewTestConfig(name string, allOperations bool, operations []string, configMap map[string]interface{}) (TestConfig, error) {
@@ -52,6 +54,7 @@ func NewTestConfig(name string, allOperations bool, operations []string, configM
 		InputMetadata:      make(map[string]string),
 		OutputMetadata:     make(map[string]string),
 		ReadBindingTimeout: defaultTimeoutDuration,
+		ReadBindingWait:    defaultWaitDuration,
 	}
 
 	err := config.Decode(configMap, &testConfig)
@@ -82,7 +85,7 @@ func startHTTPServer(url string) {
 }
 
 func (tc *TestConfig) createInvokeRequest() bindings.InvokeRequest {
-	// There is a possiblity that the metadata map might be modified by the Invoke function(eg: azure blobstorage).
+	// There is a possibility that the metadata map might be modified by the Invoke function(eg: azure blobstorage).
 	// So we are making a copy of the config metadata map and setting the Metadata field before each request
 	// Use CloudEvent as data because it is required by Azure's EventGrid.
 	cloudEvent := "[{\"eventType\":\"test\",\"eventTime\": \"2018-01-25T22:12:19.4556811Z\",\"subject\":\"dapr-conf-tests\",\"id\":\"A234-1234-1234\",\"data\":\"root/>\"}]"
@@ -159,7 +162,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 		// Need a small wait here because with brokers like MQTT
 		// if you publish before there is a consumer, the message is thrown out
 		// Currently, there is no way to know when Read is successfully subscribed.
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(config.ReadBindingWait)
 	}
 
 	// CreateOperation


### PR DESCRIPTION
# Description

- Replace existing 1s sleep after Read with `ReadBindingWait` config property in bindings.go conformance test 
- Customize `ReadBindingWait` for EventGrid bindings test to 8s

## Issue reference

Resolves #1003 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
