### PR TITLE
Adds Default TTL Option for Redis State Store

### DIFF
--- a/state/redis/metadata.go
+++ b/state/redis/metadata.go
@@ -10,4 +10,5 @@ import "time"
 type metadata struct {
 	maxRetries      int
 	maxRetryBackoff time.Duration
+	ttlInSeconds    *int
 }

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -87,7 +87,7 @@ func parseRedisMetadata(meta state.Metadata) (metadata, error) {
 		m.maxRetryBackoff = time.Duration(parsedVal)
 	}
 
-	if val, ok := meta.Properties[maxRetryBackoff]; ok && val != "" {
+	if val, ok := meta.Properties[ttlInSeconds]; ok && val != "" {
 		parsedVal, err := strconv.ParseInt(val, defaultBase, defaultBitSize)
 		if err != nil {
 			return m, fmt.Errorf("redis store error: can't parse ttlInSeconds field: %s", err)

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -87,6 +87,17 @@ func parseRedisMetadata(meta state.Metadata) (metadata, error) {
 		m.maxRetryBackoff = time.Duration(parsedVal)
 	}
 
+	if val, ok := meta.Properties[maxRetryBackoff]; ok && val != "" {
+		parsedVal, err := strconv.ParseInt(val, defaultBase, defaultBitSize)
+		if err != nil {
+			return m, fmt.Errorf("redis store error: can't parse ttlInSeconds field: %s", err)
+		}
+		intVal := int(parsedVal)
+		m.ttlInSeconds = &intVal
+	} else {
+		m.ttlInSeconds = nil
+	}
+
 	return m, nil
 }
 
@@ -235,6 +246,10 @@ func (r *StateStore) setValue(req *state.SetRequest) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse ttl from metadata: %s", err)
 	}
+	// apply global TTL
+	if ttl == nil {
+		ttl = r.metadata.ttlInSeconds
+	}
 
 	bt, _ := utils.Marshal(req.Value, r.json.Marshal)
 
@@ -295,6 +310,11 @@ func (r *StateStore) Multi(request *state.TransactionalStateRequest) error {
 			if err != nil {
 				return fmt.Errorf("failed to parse ttl from metadata: %s", err)
 			}
+			// apply global TTL
+			if ttl == nil {
+				ttl = r.metadata.ttlInSeconds
+			}
+
 			bt, _ := utils.Marshal(req.Value, r.json.Marshal)
 			pipe.Do(r.ctx, "EVAL", setQuery, 1, req.Key, ver, bt)
 			if ttl != nil && *ttl > 0 {

--- a/state/redis/redis_test.go
+++ b/state/redis/redis_test.go
@@ -308,6 +308,45 @@ func TestPing(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestRequestsWithGlobalTTL(t *testing.T) {
+	s, c := setupMiniredis()
+	defer s.Close()
+
+	globalTTLInSeconds := 100
+
+	ss := &StateStore{
+		client:   c,
+		json:     jsoniter.ConfigFastest,
+		logger:   logger.NewLogger("test"),
+		metadata: metadata{ttlInSeconds: &globalTTLInSeconds},
+	}
+	ss.ctx, ss.cancel = context.WithCancel(context.Background())
+
+	t.Run("TTL: Only global specified", func(t *testing.T) {
+		ss.Set(&state.SetRequest{
+			Key:   "weapon100",
+			Value: "deathstar100",
+		})
+		ttl, _ := ss.client.TTL(ss.ctx, "weapon100").Result()
+
+		assert.Equal(t, time.Duration(globalTTLInSeconds)*time.Second, ttl)
+	})
+
+	t.Run("TTL: Global and Request specified", func(t *testing.T) {
+		requestTTL := 200
+		ss.Set(&state.SetRequest{
+			Key:   "weapon100",
+			Value: "deathstar100",
+			Metadata: map[string]string{
+				"ttlInSeconds": strconv.Itoa(requestTTL),
+			},
+		})
+		ttl, _ := ss.client.TTL(ss.ctx, "weapon100").Result()
+
+		assert.Equal(t, time.Duration(requestTTL)*time.Second, ttl)
+	})
+}
+
 func TestSetRequestWithTTL(t *testing.T) {
 	s, c := setupMiniredis()
 	defer s.Close()


### PR DESCRIPTION
# Description

Redis unlike other databases that support TTL does not have an option to set a default TTL at the database or table / collection level.

This addition to the Redis State Store component allows defining a default TTL to be used whenever an individual State Store request does not specify a TTL.

Fixes #1060 

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
