### PR TITLE
Support publishing conformance test results to Azure DevOps

### DIFF
--- a/.azuredevops/pipelines/publish-test-results.yml
+++ b/.azuredevops/pipelines/publish-test-results.yml
@@ -24,6 +24,8 @@ steps:
       import requests
       import sys
       from ghapi.all import GhApi, paged
+      from requests.adapters import HTTPAdapter
+      from requests.packages.urllib3.util.retry import Retry
 
       # Input parameters are expected to be defined as pipeline variables with empty values
       # If variables are not defined, pipeline engine treats `$(name)` as string literals.
@@ -38,6 +40,11 @@ steps:
 
       print('Downloading test artifacts for {} workflow run {}'.format(repo_name, run_id))
 
+      retries = Retry(connect=5, backoff_factor=1)
+      adapter = HTTPAdapter(max_retries=retries)
+      http = requests.Session()
+      http.mount("https://", adapter)
+
       repo_segments = repo_name.split('/')
       api = GhApi(owner=repo_segments[0], repo=repo_segments[1])
 
@@ -49,7 +56,7 @@ steps:
               print("Downloading artifact: {} from {}".format(artifact.name, artifact.archive_download_url))
               filename = f"$(System.DefaultWorkingDirectory)/{artifact.name}.zip"
               headers = {"Authorization": f"token {os.getenv('GITHUB_TOKEN')}"}
-              response = requests.get(artifact.archive_download_url, headers=headers)
+              response = http.get(artifact.archive_download_url, headers=headers)
               if response.status_code == 200:
                   with open(filename, "wb") as fh:
                       fh.write(response.content)

--- a/.azuredevops/pipelines/publish-test-results.yml
+++ b/.azuredevops/pipelines/publish-test-results.yml
@@ -1,0 +1,74 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation and Dapr Contributors.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+trigger:
+- master
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+- script: |
+    python -m pip install --upgrade pip setuptools wheel
+    pip install ghapi
+  displayName: 'Install Python tools'
+
+- task: PythonScript@0
+  displayName: 'Download test artifacts'
+  inputs:
+    scriptSource: 'inline'
+    script: |
+      import os
+      import requests
+      import sys
+      from ghapi.all import GhApi, paged
+
+      # Input parameters are expected to be defined as pipeline variables with empty values
+      # If variables are not defined, pipeline engine treats `$(name)` as string literals.
+
+      repo_name = "$(GitHubRepository)"   # GITHUB_REPOSITORY of the triggering GitHub workflow
+      run_id = "$(GitHubRunId)"           # GITHUB_RUN_ID of the triggering GitHub workflow
+
+      if not repo_name:
+          sys.exit('GitHubRepository was not provided to the pipeline')
+      if not run_id:
+          sys.exit('GitHubRunId was not provided to the pipeline')
+
+      print('Downloading test artifacts for {} workflow run {}'.format(repo_name, run_id))
+
+      repo_segments = repo_name.split('/')
+      api = GhApi(owner=repo_segments[0], repo=repo_segments[1])
+
+      artifact_pages = paged(api.actions.list_workflow_run_artifacts, run_id=run_id, per_page=100)
+      for page in artifact_pages:
+          if len(page.artifacts) == 0:
+              break
+          for artifact in page.artifacts:
+              print("Downloading artifact: {} from {}".format(artifact.name, artifact.archive_download_url))
+              filename = f"$(System.DefaultWorkingDirectory)/{artifact.name}.zip"
+              headers = {"Authorization": f"token {os.getenv('GITHUB_TOKEN')}"}
+              response = requests.get(artifact.archive_download_url, headers=headers)
+              if response.status_code == 200:
+                  with open(filename, "wb") as fh:
+                      fh.write(response.content)
+              else:
+                  print("Request error: ", response.status_code)
+  env:
+    # Secret variables must be mapped to environment to be used
+    GITHUB_TOKEN: $(GitHubToken)
+
+- task: ExtractFiles@1
+  displayName: 'Extract test results'
+  inputs:
+    archiveFilePatterns: '$(System.DefaultWorkingDirectory)/*.zip'
+    destinationFolder: '$(System.DefaultWorkingDirectory)/results'
+    cleanDestinationFolder: true
+    overwriteExistingFiles: false
+
+- task: PublishTestResults@2
+  displayName: 'Publish test results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '$(System.DefaultWorkingDirectory)/results/*.xml'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Setup test output
       shell: bash
       run: |
-        export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/test_report
+        export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/${{ matrix.component }}_test_report
         echo "TEST_OUTPUT_FILE_PREFIX=$TEST_OUTPUT_FILE_PREFIX" >> $GITHUB_ENV
 
     - uses: Azure/login@v1
@@ -246,7 +246,7 @@ jobs:
     - name: Run tests
       continue-on-error: true
       run: |
-        set -e 
+        set -e
         KIND=$(echo ${{ matrix.component }} | cut -d. -f1)
         NAME=$(echo ${{ matrix.component }} | cut -d. -f2-)
         KIND_UPPER="$(tr '[:lower:]' '[:upper:]' <<< ${KIND:0:1})${KIND:1}"
@@ -258,8 +258,10 @@ jobs:
         echo "Running tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
 
         set +e
-        gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json --format standard-verbose -- \
-          -p 2 -count=1 -timeout=15m -tags=conftests ./tests/conformance --run="Test${KIND_UPPER}Conformance/${NAME}"
+        gotestsum --format standard-verbose \
+          --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json \
+          --junitfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.xml \
+          -- -p 2 -count=1 -timeout=15m -tags=conftests ./tests/conformance --run="Test${KIND_UPPER}Conformance/${NAME}"
 
         status=$?
         echo "Completed tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
@@ -280,7 +282,7 @@ jobs:
       continue-on-error: true
       run: pkill ngrok; cat /tmp/ngrok.log
 
-    # Download the required certificates into files, and set env var pointing to their names
+    # Remove any downloaded certificates
     - name: Clean up certs
       if: matrix.required-certs != ''
       run: |
@@ -299,10 +301,39 @@ jobs:
           exit 1
         fi
 
-    # Upload logs for dashboard like dapr/dapr E2E tests
+    # Upload logs for test analytics to use
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@master
       with:
-        name: ${{ matrix.component }}_conformance_test.json
-        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json
+        name: ${{ matrix.component }}_conformance_test
+        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.*
+
+  publish-to-azure-devops:
+    runs-on: ubuntu-latest
+    needs: conformance
+    if: always()
+    steps:
+      - name: Check if Azure DevOps token is defined
+        run: |
+          token="${{ secrets.AZURE_DEVOPS_TOKEN }}"
+          if [ -z "$token" ] ; then
+            echo "AZURE_DEVOPS_TOKEN not set, test results are not published ..."
+            exit 1
+          elif [[ ${token,,} = skip ]] ; then
+            echo "AZURE_DEVOPS_TOKEN set to SKIP, skipping publish of test results..."
+          else
+            echo "AZURE_DEVOPS_TOKEN found ..."
+            echo "AZURE_DEVOPS_TOKEN_FOUND=true" >> $GITHUB_ENV
+          fi
+      # TODO: It would be preferable to use the Azure/pipelines action once the `azure-pipeline-variables`
+      # property is supported. The current v1 release does not support it, contrary to some docs.
+      - name: Publish test results to Azure DevOps
+        if: env.AZURE_DEVOPS_TOKEN_FOUND == 'true'
+        env:
+          TEST_RESULTS_PIPELINE: components-contrib.publish-conformance-results
+        run: |
+          echo ${{ secrets.AZURE_DEVOPS_TOKEN }} | az devops login --org https://dev.azure.com/azure-octo
+          az devops configure --defaults organization=https://dev.azure.com/azure-octo project=Dapr
+          az pipelines run --name ${{ env.TEST_RESULTS_PIPELINE }} --branch $GITHUB_REF --variables GitHubRunId=$GITHUB_RUN_ID GitHubRepository=$GITHUB_REPOSITORY
+          az devops logout --org https://dev.azure.com/azure-octo


### PR DESCRIPTION
# Description

- Update conformance test to output junit xml reports that can be consumed by Azure DevOps test analytics.
- Add conformance test workflow job to trigger pipeline in Azure DevOps that publishes the test results.
- Add Azure pipeline definition for publishing test results from a specified GitHub workflow run to Azure DevOps.

> ⚠ There are a number of maintainer actions necessary for this to be useful:
> - An ADO project to publish test results into.
>    - A new PAT from a Dapr service account in ADO (`AZURE_DEVOPS_TOKEN`) with _Read and Execute build_ permissions for GitHub to trigger the test result publishing workflow.
>    - A new build pipeline in the ADO project named `components-contrib.publish-conformance-results` based on the `.azuredevops/pipelines/publish-test-results.yml` definition from the dapr/components-contrib project after this change is merged.
> - A new PAT from a Dapr service account (`GITHUB_TOKEN`) with _public_repo_ permissions for ADO to access test logs

## Issue reference

POC using components-contrib conformance tests to address test dashboard requirement suggested in https://github.com/dapr/dapr/issues/3316

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
