### PR TITLE
Update state.cosmosdb component to support first-write without ETags

### DIFF
--- a/.github/infrastructure/conformance/azure/conf-test-azure-cosmosdb.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure-cosmosdb.bicep
@@ -16,7 +16,7 @@ resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2021-04-15' = {
   tags: confTestTags
   properties: {
     consistencyPolicy: {
-      defaultConsistencyLevel: 'Session'
+      defaultConsistencyLevel: 'Strong' // Needed by conformance test state.go
     }
     locations: [
       {


### PR DESCRIPTION
# Description

Update cosmosdb.go to produce semantics consistent with #995 and pass the new state conformance tests.
- When ETag is `nil` or empty string and Concurrency is `FirstWrite`, auto-generate an ETag so that it will block a second write to the same key (cosmosdb permits the first write with a non-matching ETag when no previous key exists).
- Clean up existing setting of ETag when it is non-nil.
- Update conf-test-azure-cosmosdb.bicep to deploy with Strong default consistency configuration.

> ✅  Dapr test Cosmosdb instance has been updated for strong consistency.
> Note: The added `first-write without etag` and `first-write with etag` conformance tests also revealed an existing configuration issue with the Dapr conformance test cosmosdb instance: it only supported default consistency of Session, and did not support Strong consistency as required by the new tests.

## Issue reference

Fixes #1057

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
