### PR TITLE
[WIP] Enable ASB Message Metadata

### DIFF
--- a/pubsub/azure/servicebus/message.go
+++ b/pubsub/azure/servicebus/message.go
@@ -1,0 +1,164 @@
+package servicebus
+
+import (
+	"fmt"
+
+	azservicebus "github.com/Azure/azure-service-bus-go"
+	contrib_metadata "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/components-contrib/pubsub"
+)
+
+const (
+	// MessageIdMetadataKey defines the metadata key for the message id.
+	MessageIdMetadataKey = "MessageId"
+
+	// CorrelationIdMetadataKey defines the metadata key for the correlation id.
+	CorrelationIdMetadataKey = "CorrelationId"
+
+	// SessionIdMetadataKey defines the metadata key for the session id.
+	SessionIdMetadataKey = "SessionId"
+
+	// LabelMetadataKey defines the metadata key for the label.
+	LabelMetadataKey = "Label"
+
+	// ReplyToMetadataKey defines the metadata key for the reply to value.
+	ReplyToMetadataKey = "ReplyTo"
+
+	// ToMetadataKey defines the metadata key for the to value.
+	ToMetadataKey = "To"
+
+	// PartitionKeyMetadataKey defines the metadata key for the partition key.
+	PartitionKeyMetadataKey = "PartitionKey"
+
+	// ContentTypeMetadataKey defines the metadata key for the content type.
+	ContentTypeMetadataKey = "Content-Type"
+)
+
+// NewMessageFromRequest builds a new Azure Service Bus message from a PublishRequest.
+func NewMessageFromRequest(req *pubsub.PublishRequest) (*azservicebus.Message, error) {
+	msg := azservicebus.NewMessage(req.Data)
+
+	// Common properties.
+	ttl, hasTTL, _ := contrib_metadata.TryGetTTL(req.Metadata)
+	if hasTTL {
+		msg.TTL = &ttl
+	}
+
+	// Azure Service Bus specific properties.
+	// reference: https://docs.microsoft.com/en-us/rest/api/servicebus/message-headers-and-properties#message-headers
+	msgId, hasMsgId, _ := tryGetMessageId(req.Metadata)
+	if hasMsgId {
+		msg.ID = msgId
+	}
+
+	correlationId, hasCorrelationId, _ := tryGetCorrelationId(req.Metadata)
+	if hasCorrelationId {
+		msg.CorrelationID = correlationId
+	}
+
+	sessionId, hasSessionId, _ := tryGetSessionId(req.Metadata)
+	if hasSessionId {
+		msg.SessionID = &sessionId
+	}
+
+	label, hasLabel, _ := tryGetLabel(req.Metadata)
+	if hasLabel {
+		msg.Label = label
+	}
+
+	replyTo, hasReplyTo, _ := tryGetReplyTo(req.Metadata)
+	if hasReplyTo {
+		msg.ReplyTo = replyTo
+	}
+
+	to, hasTo, _ := tryGetTo(req.Metadata)
+	if hasTo {
+		msg.To = to
+	}
+
+	partitionKey, hasPartitionKey, _ := tryGetPartitionKey(req.Metadata)
+	if hasPartitionKey {
+		if hasSessionId {
+			if partitionKey != sessionId {
+				return nil, fmt.Errorf("session id %s and partition key %s should be equal when both present", sessionId, partitionKey)
+			}
+		}
+
+		if msg.SystemProperties == nil {
+			msg.SystemProperties = &azservicebus.SystemProperties{}
+		}
+
+		msg.SystemProperties.PartitionKey = &partitionKey
+	}
+
+	contentType, hasContentType, _ := tryGetContentType(req.Metadata)
+	if hasContentType {
+		msg.ContentType = contentType
+	}
+
+	return msg, nil
+}
+
+func tryGetMessageId(props map[string]string) (string, bool, error) {
+	if val, ok := props[MessageIdMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetCorrelationId(props map[string]string) (string, bool, error) {
+	if val, ok := props[CorrelationIdMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetSessionId(props map[string]string) (string, bool, error) {
+	if val, ok := props[SessionIdMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetLabel(props map[string]string) (string, bool, error) {
+	if val, ok := props[LabelMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetReplyTo(props map[string]string) (string, bool, error) {
+	if val, ok := props[ReplyToMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetTo(props map[string]string) (string, bool, error) {
+	if val, ok := props[ToMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetPartitionKey(props map[string]string) (string, bool, error) {
+	if val, ok := props[PartitionKeyMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}
+
+func tryGetContentType(props map[string]string) (string, bool, error) {
+	if val, ok := props[ContentTypeMetadataKey]; ok && val != "" {
+		return val, true, nil
+	}
+
+	return "", false, nil
+}

--- a/pubsub/azure/servicebus/message_test.go
+++ b/pubsub/azure/servicebus/message_test.go
@@ -1,0 +1,119 @@
+package servicebus
+
+import (
+	"testing"
+
+	azservicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMessageFromRequest(t *testing.T) {
+	testMessageData := []byte("test message")
+	testMessageId := "testMessageId"
+	testCorrelationId := "testCorrelationId"
+	testSessionId := "testSessionId"
+	testLabel := "testLabel"
+	testReplyTo := "testReplyTo"
+	testTo := "testTo"
+	testPartitionKey := testSessionId
+	testPartitionKeyUnique := "testPartitionKey"
+	testContentType := "testContentType"
+
+	testCases := []struct {
+		name            string
+		request         pubsub.PublishRequest
+		expectedMessage azservicebus.Message
+		expectError     bool
+	}{
+		{
+			name: "Sets valid values",
+			request: pubsub.PublishRequest{
+				Data: testMessageData,
+				Metadata: map[string]string{
+					MessageIdMetadataKey:     testMessageId,
+					CorrelationIdMetadataKey: testCorrelationId,
+					SessionIdMetadataKey:     testSessionId,
+					LabelMetadataKey:         testLabel,
+					ReplyToMetadataKey:       testReplyTo,
+					ToMetadataKey:            testTo,
+					PartitionKeyMetadataKey:  testPartitionKey,
+					ContentTypeMetadataKey:   testContentType,
+				},
+			},
+			expectedMessage: azservicebus.Message{
+				Data:          testMessageData,
+				ID:            testMessageId,
+				CorrelationID: testCorrelationId,
+				SessionID:     &testSessionId,
+				Label:         testLabel,
+				ReplyTo:       testReplyTo,
+				To:            testTo,
+				SystemProperties: &azservicebus.SystemProperties{
+					PartitionKey: &testPartitionKey,
+				},
+				ContentType: testContentType,
+			},
+			expectError: false,
+		},
+		{
+			name: "Errors when partition key and session id set but not equal",
+			request: pubsub.PublishRequest{
+				Data: testMessageData,
+				Metadata: map[string]string{
+					MessageIdMetadataKey:     testMessageId,
+					CorrelationIdMetadataKey: testCorrelationId,
+					SessionIdMetadataKey:     testSessionId,
+					LabelMetadataKey:         testLabel,
+					ReplyToMetadataKey:       testReplyTo,
+					ToMetadataKey:            testTo,
+					PartitionKeyMetadataKey:  testPartitionKeyUnique,
+					ContentTypeMetadataKey:   testContentType,
+				},
+			},
+			expectedMessage: azservicebus.Message{
+				Data:          testMessageData,
+				ID:            testMessageId,
+				CorrelationID: testCorrelationId,
+				SessionID:     &testSessionId,
+				Label:         testLabel,
+				ReplyTo:       testReplyTo,
+				To:            testTo,
+				SystemProperties: &azservicebus.SystemProperties{
+					PartitionKey: &testPartitionKey,
+				},
+				ContentType: testContentType,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// arrange
+			req := tc.request
+
+			// act
+			msg, err := NewMessageFromRequest(&req)
+
+			// assert
+			if tc.expectError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+				assert.Equal(t, tc.expectedMessage.Data, msg.Data)
+				assert.Equal(t, tc.expectedMessage.ID, msg.ID)
+				assert.Equal(t, tc.expectedMessage.CorrelationID, msg.CorrelationID)
+				assert.Equal(t, tc.expectedMessage.SessionID, msg.SessionID)
+				assert.Equal(t, tc.expectedMessage.ContentType, msg.ContentType)
+				assert.Equal(t, tc.expectedMessage.ReplyTo, msg.ReplyTo)
+				assert.Equal(t, tc.expectedMessage.TTL, msg.TTL)
+				assert.Equal(t, tc.expectedMessage.To, msg.To)
+				assert.Equal(t, tc.expectedMessage.Label, msg.Label)
+				assert.NotNil(t, msg.SystemProperties)
+				assert.Equal(t, tc.expectedMessage.SystemProperties.PartitionKey, msg.SystemProperties.PartitionKey)
+			}
+		})
+	}
+}

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 
 	azservicebus "github.com/Azure/azure-service-bus-go"
-	contrib_metadata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/retry"
@@ -296,10 +295,9 @@ func (a *azureServiceBus) Publish(req *pubsub.PublishRequest) error {
 		}
 	}
 
-	msg := azservicebus.NewMessage(req.Data)
-	ttl, hasTTL, _ := contrib_metadata.TryGetTTL(req.Metadata)
-	if hasTTL {
-		msg.TTL = &ttl
+	msg, err := NewMessageFromRequest(req)
+	if err != nil {
+		return err
 	}
 
 	return a.doPublish(sender, msg)


### PR DESCRIPTION
# Description

Added ability to set Azure Service Bus headers when publishing via the Azure Service Bus pubsub component.
See https://docs.microsoft.com/en-us/rest/api/servicebus/message-headers-and-properties#message-headers for reference.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1063 , #668 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
