### PR TITLE
Disabled CGO in contrib test run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 ################################################################################
 .PHONY: test
 test:
-	go test ./... $(COVERAGE_OPTS) $(BUILDMODE)
+	CGO_ENABLED=$(CGO) go test ./... $(COVERAGE_OPTS) $(BUILDMODE)
 
 ################################################################################
 # Target: lint                                                                 #
@@ -83,11 +83,11 @@ check-diff:
 ################################################################################
 .PHONY: conf-tests
 conf-tests:
-	@go test -v -tags=conftests -count=1 ./tests/conformance
+	CGO_ENABLED=$(CGO) go test -v -tags=conftests -count=1 ./tests/conformance
 
 ################################################################################
 # Target: e2e-tests-zeebe                                                      #
 ################################################################################
 .PHONY: e2e-tests-zeebe
 e2e-tests-zeebe:
-	@go test -v -tags=e2etests -count=1 ./tests/e2e/bindings/zeebe/...
+	CGO_ENABLED=$(CGO) go test -v -tags=e2etests -count=1 ./tests/e2e/bindings/zeebe/...


### PR DESCRIPTION
# Description

Disabled CGO in contrib test run - this is helpful for devs on Windows machines.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

RELEASE NOTE: N/A