### PR TITLE
smtp allow use smtp server without auth

### DIFF
--- a/bindings/smtp/smtp.go
+++ b/bindings/smtp/smtp.go
@@ -124,10 +124,18 @@ func (s *Mailer) parseMetadata(meta bindings.Metadata) (Metadata, error) {
 	smtpMeta := Metadata{}
 
 	// required metadata properties
-	if meta.Properties["host"] == "" || meta.Properties["port"] == "" ||
-		meta.Properties["user"] == "" || meta.Properties["password"] == "" {
-		return smtpMeta, errors.New("smtp binding error: host, port, user and password fields are required in metadata")
+	if meta.Properties["host"] == "" || meta.Properties["port"] == "" {
+		return smtpMeta, errors.New("smtp binding error: host and port fields are required in metadata")
 	}
+
+	//nolint
+	if (meta.Properties["user"] != "" && meta.Properties["password"] == "") ||
+		(meta.Properties["user"] == "" && meta.Properties["password"] != "") {
+		return smtpMeta, errors.New("smtp binding error: user and password fields are required in metadata")
+	} else {
+		s.logger.Warn("smtp binding warn: User and password are empty")
+	}
+
 	smtpMeta.Host = meta.Properties["host"]
 	port, err := strconv.Atoi(meta.Properties["port"])
 	if err != nil {

--- a/bindings/smtp/smtp_test.go
+++ b/bindings/smtp/smtp_test.go
@@ -95,6 +95,44 @@ func TestParseMetadata(t *testing.T) {
 		assert.NotNil(t, smtpMeta)
 		assert.NotNil(t, err)
 	})
+	t.Run("Incorrrect  metadata (user, no password)", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{
+			"host":          "mailserver.dapr.io",
+			"port":          "25",
+			"user":          "user@dapr.io",
+			"skipTLSVerify": "true",
+			"emailFrom":     "from@dapr.io",
+			"emailTo":       "to@dapr.io",
+			"emailCC":       "cc@dapr.io",
+			"emailBCC":      "bcc@dapr.io",
+			"subject":       "Test email",
+			"priority":      "0",
+		}
+		r := Mailer{logger: logger}
+		smtpMeta, err := r.parseMetadata(m)
+		assert.NotNil(t, smtpMeta)
+		assert.NotNil(t, err)
+	})
+	t.Run("Incorrrect  metadata (no user, password)", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{
+			"host":          "mailserver.dapr.io",
+			"port":          "25",
+			"password":      "P@$$w0rd!",
+			"skipTLSVerify": "true",
+			"emailFrom":     "from@dapr.io",
+			"emailTo":       "to@dapr.io",
+			"emailCC":       "cc@dapr.io",
+			"emailBCC":      "bcc@dapr.io",
+			"subject":       "Test email",
+			"priority":      "0",
+		}
+		r := Mailer{logger: logger}
+		smtpMeta, err := r.parseMetadata(m)
+		assert.NotNil(t, smtpMeta)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestMergeWithRequestMetadata(t *testing.T) {


### PR DESCRIPTION
# Description

Update SMTP binding to allow use a SMTP server without authentication by user and password

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/components-contrib/issues/1082

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
