### PR TITLE
add Close() function to Postgres binding

### DIFF
--- a/bindings/postgres/postgres.go
+++ b/bindings/postgres/postgres.go
@@ -129,6 +129,16 @@ func (p *Postgres) Invoke(req *bindings.InvokeRequest) (resp *bindings.InvokeRes
 	return resp, nil
 }
 
+// Close close PostgreSql instance
+func (p *Postgres) Close() error {
+	if p.db == nil {
+		return nil
+	}
+	p.db.Close()
+
+	return nil
+}
+
 func (p *Postgres) query(sql string) (result []byte, err error) {
 	p.logger.Debugf("query: %s", sql)
 

--- a/bindings/postgres/postgres_test.go
+++ b/bindings/postgres/postgres_test.go
@@ -112,6 +112,11 @@ func TestPostgresIntegration(t *testing.T) {
 		_, err := b.Invoke(req)
 		assert.NoError(t, err)
 	})
+
+	t.Run("Close", func(t *testing.T) {
+		err := b.Close()
+		assert.NoError(t, err, "expected no error closing output binding")
+	})
 }
 
 func assertResponse(t *testing.T, res *bindings.InvokeResponse, err error) {


### PR DESCRIPTION
# Description

Add Close() function to Postgres binding to clean up client

## Issue reference

Resolves [#901](https://github.com/dapr/components-contrib/issues/901)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
