### PR TITLE
Adding multi-valued secret support to the local file store component

### DIFF
--- a/secretstores/local/file/filestore_test.go
+++ b/secretstores/local/file/filestore_test.go
@@ -163,6 +163,7 @@ func TestMultiValuedSecrets(t *testing.T) {
 	s := localSecretStore{
 		logger: logger.NewLogger("test"),
 		readLocalFileFn: func(secretsFile string) (map[string]interface{}, error) {
+			//nolint:gosec
 			secretsJSON := `
 			{
 				"parent": {

--- a/secretstores/local/file/filestore_test.go
+++ b/secretstores/local/file/filestore_test.go
@@ -5,12 +5,14 @@
 package file
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/kit/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const secretValue = "secret"
@@ -25,8 +27,8 @@ func TestInit(t *testing.T) {
 	}
 	t.Run("Init with valid metadata", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"SecretsFile":     "a",
-			"NestedSeparator": "a",
+			"secretsFile":     "a",
+			"nestedSeparator": "a",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)
@@ -34,7 +36,7 @@ func TestInit(t *testing.T) {
 
 	t.Run("Init with missing metadata", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"Dummy": "a",
+			"dummy": "a",
 		}
 		err := s.Init(m)
 		assert.NotNil(t, err)
@@ -57,8 +59,8 @@ func TestSeparator(t *testing.T) {
 	}
 	t.Run("Init with custom separator", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"SecretsFile":     "a",
-			"NestedSeparator": ".",
+			"secretsFile":     "a",
+			"nestedSeparator": ".",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)
@@ -74,7 +76,7 @@ func TestSeparator(t *testing.T) {
 
 	t.Run("Init with default separator", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"SecretsFile": "a",
+			"secretsFile": "a",
 		}
 		err := s.Init(m)
 		assert.Nil(t, err)
@@ -92,8 +94,8 @@ func TestSeparator(t *testing.T) {
 func TestGetSecret(t *testing.T) {
 	m := secretstores.Metadata{}
 	m.Properties = map[string]string{
-		"SecretsFile":     "a",
-		"NestedSeparator": "a",
+		"secretsFile":     "a",
+		"nestedSeparator": "a",
 	}
 	s := localSecretStore{
 		logger: logger.NewLogger("test"),
@@ -130,8 +132,8 @@ func TestGetSecret(t *testing.T) {
 func TestBulkGetSecret(t *testing.T) {
 	m := secretstores.Metadata{}
 	m.Properties = map[string]string{
-		"SecretsFile":     "a",
-		"NestedSeparator": "a",
+		"secretsFile":     "a",
+		"nestedSeparator": "a",
 	}
 	s := localSecretStore{
 		logger: logger.NewLogger("test"),
@@ -149,5 +151,61 @@ func TestBulkGetSecret(t *testing.T) {
 		output, e := s.BulkGetSecret(req)
 		assert.Nil(t, e)
 		assert.Equal(t, "secret", output.Data["secret"]["secret"])
+	})
+}
+
+func TestMultiValuedSecrets(t *testing.T) {
+	m := secretstores.Metadata{}
+	m.Properties = map[string]string{
+		"secretsFile": "a",
+		"multiValued": "true",
+	}
+	s := localSecretStore{
+		logger: logger.NewLogger("test"),
+		readLocalFileFn: func(secretsFile string) (map[string]interface{}, error) {
+			secretsJSON := `
+			{
+				"parent": {
+					"child1": "12345",
+					"child2": {
+						"child3": "67890",
+						"child4": "00000"
+					}
+				}
+			}
+			`
+			var secrets map[string]interface{}
+			err := json.Unmarshal([]byte(secretsJSON), &secrets)
+
+			return secrets, err
+		},
+	}
+	err := s.Init(m)
+	require.NoError(t, err)
+
+	t.Run("successfully retrieve a single multi-valued secret", func(t *testing.T) {
+		req := secretstores.GetSecretRequest{
+			Name: "parent",
+		}
+		resp, err := s.GetSecret(req)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"child1":        "12345",
+			"child2:child3": "67890",
+			"child2:child4": "00000",
+		}, resp.Data)
+	})
+
+	t.Run("successfully retrieve multi-valued secrets", func(t *testing.T) {
+		req := secretstores.BulkGetSecretRequest{}
+		resp, err := s.BulkGetSecret(req)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]map[string]string{
+			"parent": {
+				"child1":        "12345",
+				"child2:child3": "67890",
+				"child2:child4": "00000",
+			},
+		}, resp.Data)
 	})
 }


### PR DESCRIPTION
# Description

This PR adds multi-value secret support to the local file store component. This is attempting to fix issues @paulyuk and I ran into when running through some of the samples.

## Issue reference

Resolves #1090

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/issues/1733
