### PR TITLE
Add Close() method to EventHubs bindings

### DIFF
--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -238,7 +238,7 @@ func (a *AzureEventHubs) Read(handler func(*bindings.ReadResponse) ([]byte, erro
 	signal.Notify(exitChan, os.Interrupt, syscall.SIGTERM)
 	<-exitChan
 
-	a.hub.Close(context.Background())
+	a.Close()
 
 	return nil
 }
@@ -323,4 +323,8 @@ func (a *AzureEventHubs) RegisterEventProcessor(handler func(*bindings.ReadRespo
 	}
 
 	return nil
+}
+
+func (a *AzureEventHubs) Close() error {
+	return a.hub.Close(context.Background())
 }


### PR DESCRIPTION
# Description

Add the Close() method that can trigger the cleanup of the Hub object.

## Issue reference

Addresses part of #894

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* ~~[ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
