### PR TITLE
Add junit format .xml logs to conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -263,7 +263,8 @@ jobs:
         echo "Running tests for Test${KIND_UPPER}Conformance/${KIND}/${NAME} ... "
 
         set +e
-        gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json --format standard-verbose -- \
+        gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json \
+          --junitfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.xml --format standard-verbose -- \
           -p 2 -count=1 -timeout=15m -tags=conftests ./tests/conformance --run="Test${KIND_UPPER}Conformance/${NAME}"
 
         status=$?
@@ -304,10 +305,10 @@ jobs:
           exit 1
         fi
 
-    # Upload logs for dashboard like dapr/dapr E2E tests
+    # Upload logs for test analytics to consume
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@master
       with:
-        name: ${{ matrix.component }}_conformance_test.json
-        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.json
+        name: ${{ matrix.component }}_conformance_test
+        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_conformance.*


### PR DESCRIPTION
# Description

Update the conformance.yml to also publish junit format .xml results that can be consumed by various test analytics services.

## Issue reference

Part of addressing https://github.com/dapr/dapr/issues/3316

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
