### PR TITLE
feat(pubsub): add in-memory pub/sub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/apache/pulsar-client-go v0.1.0
 	github.com/apache/rocketmq-client-go/v2 v2.1.0
 	github.com/apache/thrift v0.14.0 // indirect
+	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/aws/aws-sdk-go v1.36.30
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 h1:EFSB7Zo9Eg91v7
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
+github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef h1:2JGTg6JapxP9/R33ZaagQtAM4EkkSYnIAlOG5EI8gkM=
+github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=

--- a/pubsub/in-memory/in-memory.go
+++ b/pubsub/in-memory/in-memory.go
@@ -1,0 +1,56 @@
+package inmemory
+
+import (
+	"context"
+
+	"github.com/asaskevich/EventBus"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+type bus struct {
+	bus EventBus.Bus
+	ctx context.Context
+	log logger.Logger
+}
+
+func New(logger logger.Logger) pubsub.PubSub {
+	return &bus{
+		log: logger,
+	}
+}
+
+func (a *bus) Close() error {
+	return nil
+}
+
+func (a *bus) Features() []pubsub.Feature {
+	return nil
+}
+
+func (a *bus) Init(metadata pubsub.Metadata) error {
+	a.bus = EventBus.New()
+	a.ctx = context.Background()
+
+	return nil
+}
+
+func (a *bus) Publish(req *pubsub.PublishRequest) error {
+	a.bus.Publish(req.Topic, a.ctx, req.Data)
+
+	return nil
+}
+
+func (a *bus) Subscribe(req pubsub.SubscribeRequest, handler pubsub.Handler) error {
+	return a.bus.Subscribe(req.Topic, func(ctx context.Context, data []byte) {
+		for i := 0; i < 10; i++ {
+			if err := handler(ctx, &pubsub.NewMessage{Data: data, Topic: req.Topic, Metadata: req.Metadata}); err != nil {
+				a.log.Error(err)
+
+				continue
+			}
+
+			return
+		}
+	})
+}

--- a/pubsub/in-memory/in-memory_test.go
+++ b/pubsub/in-memory/in-memory_test.go
@@ -1,0 +1,71 @@
+package inmemory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewInMemoryBus(t *testing.T) {
+	bus := New(logger.NewLogger("test"))
+	bus.Init(pubsub.Metadata{})
+
+	ch := make(chan []byte)
+	bus.Subscribe(pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
+		return publish(ch, msg)
+	})
+
+	bus.Publish(&pubsub.PublishRequest{Data: []byte("ABCD"), Topic: "demo"})
+	assert.Equal(t, "ABCD", string(<-ch))
+}
+
+func TestMultipleSubscribers(t *testing.T) {
+	bus := New(logger.NewLogger("test"))
+	bus.Init(pubsub.Metadata{})
+
+	ch1 := make(chan []byte)
+	ch2 := make(chan []byte)
+	bus.Subscribe(pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
+		return publish(ch1, msg)
+	})
+
+	bus.Subscribe(pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
+		return publish(ch2, msg)
+	})
+
+	bus.Publish(&pubsub.PublishRequest{Data: []byte("ABCD"), Topic: "demo"})
+
+	assert.Equal(t, "ABCD", string(<-ch1))
+	assert.Equal(t, "ABCD", string(<-ch2))
+}
+
+func TestRetry(t *testing.T) {
+	bus := New(logger.NewLogger("test"))
+	bus.Init(pubsub.Metadata{})
+
+	ch := make(chan []byte)
+	i := -1
+
+	bus.Subscribe(pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
+		i++
+		if i < 5 {
+			return errors.New("if at first you don't succeed")
+		}
+
+		return publish(ch, msg)
+	})
+
+	bus.Publish(&pubsub.PublishRequest{Data: []byte("ABCD"), Topic: "demo"})
+	assert.Equal(t, "ABCD", string(<-ch))
+	assert.Equal(t, 5, i)
+}
+
+func publish(ch chan []byte, msg *pubsub.NewMessage) error {
+	go func() { ch <- msg.Data }()
+
+	return nil
+}

--- a/tests/config/pubsub/in-memory/pubsub.yml
+++ b/tests/config/pubsub/in-memory/pubsub.yml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+  namespace: default
+spec:
+  type: pubsub.in-memory
+  version: v1

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -46,3 +46,5 @@ components:
     allOperations: true
     config:
       checkInOrderProcessing: false
+  - component: in-memory
+    allOperations: true

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -39,6 +39,7 @@ import (
 	p_eventhubs "github.com/dapr/components-contrib/pubsub/azure/eventhubs"
 	p_servicebus "github.com/dapr/components-contrib/pubsub/azure/servicebus"
 	p_hazelcast "github.com/dapr/components-contrib/pubsub/hazelcast"
+	p_inmemory "github.com/dapr/components-contrib/pubsub/in-memory"
 	p_jetstream "github.com/dapr/components-contrib/pubsub/jetstream"
 	p_kafka "github.com/dapr/components-contrib/pubsub/kafka"
 	p_mqtt "github.com/dapr/components-contrib/pubsub/mqtt"
@@ -334,6 +335,9 @@ func loadPubSub(tc TestComponent) pubsub.PubSub {
 		pubsub = p_hazelcast.NewHazelcastPubSub(testLogger)
 	case "rabbitmq":
 		pubsub = p_rabbitmq.NewRabbitMQ(testLogger)
+	case "in-memory":
+		pubsub = p_inmemory.New(testLogger)
+
 	default:
 		return nil
 	}


### PR DESCRIPTION
# Description

Added an adapter for a hand-picked in-memory service bus implementation to support integration testing. In [this example](https://github.com/riezebosch/dapr-tdd/blob/main/DaprDemo.Api.IntegrationTests/DemoControllerTests.cs#L48), I use RabbitMQ as the underlying message broker but that makes it hard(er) to run integration tests in CI since you need to first spin it up from the pipeline.

Next thing I'll probably create is a C# wrapper to start and stop the self hosted sidecar from the integration test (and call it Dapr.Wrapr 🤟🏻 ).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/issues/1761
