### PR TITLE
Add Close() method to influx bindings

### DIFF
--- a/bindings/influx/influx.go
+++ b/bindings/influx/influx.go
@@ -104,7 +104,13 @@ func (i *Influx) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, 
 	if err != nil {
 		return nil, errors.New("Influx Error: Cannot write point")
 	}
-	i.client.Close()
 
 	return nil, nil
+}
+
+func (i *Influx) Close() error {
+	i.client.Close()
+	i.writeAPI = nil
+
+	return nil
 }


### PR DESCRIPTION
# Description

- Remove incorrect `client.Close()` call on every call to `Invoke()`.
- Add `Close()` method to `bindings.influx` to invoke `client.Close()` on teardown instead.

## Issue reference

Fixes #898

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (see separate PR #1115 for adding Influx bindings conformance test)
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
