### PR TITLE
Add conformance test for influx bindings

### DIFF
--- a/.github/infrastructure/docker-compose-influxdb.yml
+++ b/.github/infrastructure/docker-compose-influxdb.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  standalone:
+    image: influxdb:latest
+    container_name: influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=conf-test-user
+      - DOCKER_INFLUXDB_INIT_PASSWORD=conf-test-password
+      - DOCKER_INFLUXDB_INIT_ORG=dapr-conf-test
+      - DOCKER_INFLUXDB_INIT_BUCKET=dapr-conf-test-bucket
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_TOKEN}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         PR_COMPONENTS=$(yq -I0 --tojson eval - << EOF
         - bindings.http
+        - bindings.influx
         - bindings.kafka
         - bindings.redis
         - bindings.mqtt-mosquitto
@@ -227,6 +228,13 @@ jobs:
     - name: Start rabbitmq
       run: docker-compose -f ./.github/infrastructure/docker-compose-rabbitmq.yml -p rabbitmq up -d
       if: contains(matrix.component, 'rabbitmq')
+
+    - name: Start influxdb
+      run: |
+        export INFLUX_TOKEN=$(openssl rand -base64 32)
+        echo "INFLUX_TOKEN=$INFLUX_TOKEN" >> $GITHUB_ENV
+        docker-compose -f ./.github/infrastructure/docker-compose-influxdb.yml -p influxdb up -d
+      if: contains(matrix.component, 'influx')
 
     - name: Start KinD
       uses: helm/kind-action@v1.0.0

--- a/tests/config/bindings/influx/bindings.yml
+++ b/tests/config/bindings/influx/bindings.yml
@@ -1,0 +1,17 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: influx
+  namespace: default
+spec:
+  type: bindings.influx
+  version: v1
+  metadata:
+  - name: url # Required
+    value: http://localhost:8086
+  - name: token # Required
+    value: ${{ INFLUX_TOKEN }}
+  - name: org # Required
+    value: dapr-conf-test
+  - name: bucket # Required
+    value: dapr-conf-test-bucket

--- a/tests/config/bindings/tests.yml
+++ b/tests/config/bindings/tests.yml
@@ -35,6 +35,10 @@ components:
     config:
       url: "localhost:22222"
       method: "POST"
+  - component: influx
+    operations: ["create", "operations"]
+    config:
+      outputData: '{ "measurement": "TestMeasurement", "tags": "unit=temperature", "values": "avg=23.5" }'
   - component: mqtt
     profile: mosquitto
     operations: ["create", "operations", "read"]

--- a/tests/conformance/bindings/bindings.go
+++ b/tests/conformance/bindings/bindings.go
@@ -25,6 +25,9 @@ import (
 const (
 	defaultTimeoutDuration = 60 * time.Second
 	defaultWaitDuration    = time.Second
+
+	// Use CloudEvent as default data because it is required by Azure's EventGrid.
+	defaultOutputData = "[{\"eventType\":\"test\",\"eventTime\": \"2018-01-25T22:12:19.4556811Z\",\"subject\":\"dapr-conf-tests\",\"id\":\"A234-1234-1234\",\"data\":\"root/>\"}]"
 )
 
 // nolint:gochecknoglobals
@@ -41,6 +44,7 @@ type TestConfig struct {
 	URL                string            `mapstructure:"url"`
 	InputMetadata      map[string]string `mapstructure:"input"`
 	OutputMetadata     map[string]string `mapstructure:"output"`
+	OutputData         string            `mapstructure:"outputData"`
 	ReadBindingTimeout time.Duration     `mapstructure:"readBindingTimeout"`
 	ReadBindingWait    time.Duration     `mapstructure:"readBindingWait"`
 }
@@ -56,6 +60,7 @@ func NewTestConfig(name string, allOperations bool, operations []string, configM
 		},
 		InputMetadata:      make(map[string]string),
 		OutputMetadata:     make(map[string]string),
+		OutputData:         defaultOutputData,
 		ReadBindingTimeout: defaultTimeoutDuration,
 		ReadBindingWait:    defaultWaitDuration,
 	}
@@ -90,11 +95,8 @@ func startHTTPServer(url string) {
 func (tc *TestConfig) createInvokeRequest() bindings.InvokeRequest {
 	// There is a possibility that the metadata map might be modified by the Invoke function(eg: azure blobstorage).
 	// So we are making a copy of the config metadata map and setting the Metadata field before each request
-	// Use CloudEvent as data because it is required by Azure's EventGrid.
-	cloudEvent := "[{\"eventType\":\"test\",\"eventTime\": \"2018-01-25T22:12:19.4556811Z\",\"subject\":\"dapr-conf-tests\",\"id\":\"A234-1234-1234\",\"data\":\"root/>\"}]"
-
 	return bindings.InvokeRequest{
-		Data:     []byte(cloudEvent),
+		Data:     []byte(tc.OutputData),
 		Metadata: tc.CopyMap(tc.OutputMetadata),
 	}
 }

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -32,6 +32,7 @@ import (
 	b_azure_servicebusqueues "github.com/dapr/components-contrib/bindings/azure/servicebusqueues"
 	b_azure_storagequeues "github.com/dapr/components-contrib/bindings/azure/storagequeues"
 	b_http "github.com/dapr/components-contrib/bindings/http"
+	b_influx "github.com/dapr/components-contrib/bindings/influx"
 	b_kafka "github.com/dapr/components-contrib/bindings/kafka"
 	b_mqtt "github.com/dapr/components-contrib/bindings/mqtt"
 	b_redis "github.com/dapr/components-contrib/bindings/redis"
@@ -396,6 +397,8 @@ func loadOutputBindings(tc TestComponent) bindings.OutputBinding {
 		binding = b_kafka.NewKafka(testLogger)
 	case "http":
 		binding = b_http.NewHTTP(testLogger)
+	case "influx":
+		binding = b_influx.NewInflux(testLogger)
 	case mqtt:
 		binding = b_mqtt.NewMQTT(testLogger)
 	default:


### PR DESCRIPTION
# Description

- Add `OutputData` property to bindings conformance test `TestConfig`.
  This is necessary to accommodate bindings like influx, cosmosdbgraph,
  alibaba.table and other bindings that require a specific data format.

- Add docker-compose definition and conformance test configuration for
  influx binding.

- Add influx bindings to conformance test workflow matrix.

## Issue reference

Additional testing for #1114 addressing #898

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* ~[ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~
