### PR TITLE
Patch regression in cosmosdb state component Init

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -114,9 +114,11 @@ func (c *StateStore) Init(meta state.Metadata) error {
 	// Create the client; first, try authenticating with a master key, if present
 	var config *documentdb.Config
 	if m.MasterKey != "" {
-		config = documentdb.NewConfig(&documentdb.Key{
-			Key: m.MasterKey,
-		})
+		config = &documentdb.Config{
+			MasterKey: &documentdb.Key{
+				Key: m.MasterKey,
+			},
+		}
 	} else {
 		// Fallback to using Azure AD
 		env, errB := azure.NewEnvironmentSettings("cosmosdb", meta.Properties)


### PR DESCRIPTION
# Description

PR #1104 introduced a regression in cosmosdb state component `Init()` by creating a `NewConfig()` which sets a new DefaultIdentificationHydrator, which causes a panic later when invoked.

Patch this by restoring the configuration setting to use a struct with `nil` `IdentificationHydrator`.

> ⚠ This also suggests that the use of `NewConfigWithServicePrincipal` in the untested AD auth codepath will also fail and so PR #1104 does not work as intended. Separate testing will need to be done to fix that, and also a deeper investigation into why the `DefaultIdentificationHydrator` is panicking.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
