### PR TITLE
Adding `initialOffset` option to Kafka binding and pubsub components

### DIFF
--- a/bindings/kafka/kafka.go
+++ b/bindings/kafka/kafka.go
@@ -295,16 +295,13 @@ func (k *Kafka) Close() error {
 }
 
 func parseInitialOffset(value string) (initialOffset int64, err error) {
-	initialOffset = sarama.OffsetNewest
+	initialOffset = sarama.OffsetNewest // Default
 	if strings.EqualFold(value, "oldest") {
 		initialOffset = sarama.OffsetOldest
 	} else if strings.EqualFold(value, "newest") {
 		initialOffset = sarama.OffsetNewest
 	} else if value != "" {
-		initialOffset, err = strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("kafka error: cannot parse initialOffset: %v", err)
-		}
+		return 0, fmt.Errorf("kafka error: invalid initialOffset: %s", value)
 	}
 
 	return initialOffset, err

--- a/bindings/kafka/kafka.go
+++ b/bindings/kafka/kafka.go
@@ -36,6 +36,7 @@ type Kafka struct {
 	authRequired  bool
 	saslUsername  string
 	saslPassword  string
+	initialOffset int64
 	logger        logger.Logger
 }
 
@@ -47,6 +48,7 @@ type kafkaMetadata struct {
 	AuthRequired    bool     `json:"authRequired"`
 	SaslUsername    string   `json:"saslUsername"`
 	SaslPassword    string   `json:"saslPassword"`
+	InitialOffset   int64    `json:"initialOffset"`
 	MaxMessageBytes int
 }
 
@@ -99,6 +101,7 @@ func (k *Kafka) Init(metadata bindings.Metadata) error {
 	k.publishTopic = meta.PublishTopic
 	k.consumerGroup = meta.ConsumerGroup
 	k.authRequired = meta.AuthRequired
+	k.initialOffset = meta.InitialOffset
 
 	// ignore SASL properties if authRequired is false
 	if meta.AuthRequired {
@@ -135,6 +138,12 @@ func (k *Kafka) getKafkaMetadata(metadata bindings.Metadata) (*kafkaMetadata, er
 	meta := kafkaMetadata{}
 	meta.ConsumerGroup = metadata.Properties["consumerGroup"]
 	meta.PublishTopic = metadata.Properties["publishTopic"]
+
+	initialOffset, err := parseInitialOffset(metadata.Properties["initialOffset"])
+	if err != nil {
+		return nil, err
+	}
+	meta.InitialOffset = initialOffset
 
 	if val, ok := metadata.Properties["brokers"]; ok && val != "" {
 		meta.Brokers = strings.Split(val, ",")
@@ -210,6 +219,7 @@ func (k *Kafka) getSyncProducer(meta *kafkaMetadata) (sarama.SyncProducer, error
 func (k *Kafka) Read(handler func(*bindings.ReadResponse) ([]byte, error)) error {
 	config := sarama.NewConfig()
 	config.Version = sarama.V1_0_0_0
+	config.Consumer.Offsets.Initial = k.initialOffset
 	// ignore SASL properties if authRequired is false
 	if k.authRequired {
 		updateAuthInfo(config, k.saslUsername, k.saslPassword)
@@ -282,4 +292,20 @@ func (k *Kafka) Close() error {
 	}
 
 	return nil
+}
+
+func parseInitialOffset(value string) (initialOffset int64, err error) {
+	initialOffset = sarama.OffsetNewest
+	if strings.EqualFold(value, "oldest") {
+		initialOffset = sarama.OffsetOldest
+	} else if strings.EqualFold(value, "newest") {
+		initialOffset = sarama.OffsetNewest
+	} else if value != "" {
+		initialOffset, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("kafka error: cannot parse initialOffset: %v", err)
+		}
+	}
+
+	return initialOffset, err
 }

--- a/bindings/kafka/kafka_test.go
+++ b/bindings/kafka/kafka_test.go
@@ -9,9 +9,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Shopify/sarama"
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseMetadata(t *testing.T) {
@@ -272,5 +274,22 @@ func TestParseMetadata(t *testing.T) {
 		meta, err := k.getKafkaMetadata(m)
 		assert.Error(t, errors.New("kafka error: missing SASL Password"), err)
 		assert.Nil(t, meta)
+	})
+
+	t.Run("correct metadata (initialOffset)", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{"consumerGroup": "a", "publishTopic": "a", "brokers": "a", "topics": "a", "authRequired": "false", "initialOffset": "oldest"}
+		k := Kafka{logger: logger}
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, sarama.OffsetOldest, meta.InitialOffset)
+		m.Properties["initialOffset"] = "newest"
+		meta, err = k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, sarama.OffsetNewest, meta.InitialOffset)
+		m.Properties["initialOffset"] = "12345"
+		meta, err = k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), meta.InitialOffset)
 	})
 }

--- a/bindings/kafka/kafka_test.go
+++ b/bindings/kafka/kafka_test.go
@@ -287,9 +287,5 @@ func TestParseMetadata(t *testing.T) {
 		meta, err = k.getKafkaMetadata(m)
 		require.NoError(t, err)
 		assert.Equal(t, sarama.OffsetNewest, meta.InitialOffset)
-		m.Properties["initialOffset"] = "12345"
-		meta, err = k.getKafkaMetadata(m)
-		require.NoError(t, err)
-		assert.Equal(t, int64(12345), meta.InitialOffset)
 	})
 }

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -36,6 +36,7 @@ type Kafka struct {
 	authRequired  bool
 	saslUsername  string
 	saslPassword  string
+	initialOffset int64
 	cg            sarama.ConsumerGroup
 	topics        map[string]bool
 	cancel        context.CancelFunc
@@ -52,6 +53,7 @@ type kafkaMetadata struct {
 	AuthRequired    bool     `json:"authRequired"`
 	SaslUsername    string   `json:"saslUsername"`
 	SaslPassword    string   `json:"saslPassword"`
+	InitialOffset   int64    `json:"initialOffset"`
 	MaxMessageBytes int      `json:"maxMessageBytes"`
 }
 
@@ -120,9 +122,11 @@ func (k *Kafka) Init(metadata pubsub.Metadata) error {
 	k.brokers = meta.Brokers
 	k.consumerGroup = meta.ConsumerGroup
 	k.authRequired = meta.AuthRequired
+	k.initialOffset = meta.InitialOffset
 
 	config := sarama.NewConfig()
 	config.Version = sarama.V2_0_0_0
+	config.Consumer.Offsets.Initial = k.initialOffset
 
 	if meta.ClientID != "" {
 		config.ClientID = meta.ClientID
@@ -295,6 +299,12 @@ func (k *Kafka) getKafkaMetadata(metadata pubsub.Metadata) (*kafkaMetadata, erro
 		k.logger.Debugf("Using %s as ClientID", meta.ClientID)
 	}
 
+	initialOffset, err := parseInitialOffset(metadata.Properties["initialOffset"])
+	if err != nil {
+		return nil, err
+	}
+	meta.InitialOffset = initialOffset
+
 	if val, ok := metadata.Properties["brokers"]; ok && val != "" {
 		meta.Brokers = strings.Split(val, ",")
 	} else {
@@ -393,4 +403,20 @@ type asBase64String []byte
 
 func (s asBase64String) String() string {
 	return base64.StdEncoding.EncodeToString(s)
+}
+
+func parseInitialOffset(value string) (initialOffset int64, err error) {
+	initialOffset = sarama.OffsetNewest
+	if strings.EqualFold(value, "oldest") {
+		initialOffset = sarama.OffsetOldest
+	} else if strings.EqualFold(value, "newest") {
+		initialOffset = sarama.OffsetNewest
+	} else if value != "" {
+		initialOffset, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("kafka error: cannot parse initialOffset: %v", err)
+		}
+	}
+
+	return initialOffset, err
 }

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -406,16 +406,13 @@ func (s asBase64String) String() string {
 }
 
 func parseInitialOffset(value string) (initialOffset int64, err error) {
-	initialOffset = sarama.OffsetNewest
+	initialOffset = sarama.OffsetNewest // Default
 	if strings.EqualFold(value, "oldest") {
 		initialOffset = sarama.OffsetOldest
 	} else if strings.EqualFold(value, "newest") {
 		initialOffset = sarama.OffsetNewest
 	} else if value != "" {
-		initialOffset, err = strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("kafka error: cannot parse initialOffset: %v", err)
-		}
+		return 0, fmt.Errorf("kafka error: invalid initialOffset: %s", value)
 	}
 
 	return initialOffset, err

--- a/pubsub/kafka/kafka_test.go
+++ b/pubsub/kafka/kafka_test.go
@@ -111,8 +111,4 @@ func TestInitialOffset(t *testing.T) {
 	meta, err = k.getKafkaMetadata(m)
 	require.NoError(t, err)
 	assert.Equal(t, sarama.OffsetNewest, meta.InitialOffset)
-	m.Properties["initialOffset"] = "12345"
-	meta, err = k.getKafkaMetadata(m)
-	require.NoError(t, err)
-	assert.Equal(t, int64(12345), meta.InitialOffset)
 }

--- a/pubsub/kafka/kafka_test.go
+++ b/pubsub/kafka/kafka_test.go
@@ -8,9 +8,11 @@ package kafka
 import (
 	"testing"
 
+	"github.com/Shopify/sarama"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func getKafkaPubsub() *Kafka {
@@ -96,4 +98,21 @@ func TestInvalidAuthRequiredFlag(t *testing.T) {
 	assert.Nil(t, meta)
 
 	assert.Equal(t, "kafka error: invalid value for 'authRequired' attribute", err.Error())
+}
+
+func TestInitialOffset(t *testing.T) {
+	m := pubsub.Metadata{}
+	m.Properties = map[string]string{"consumerGroup": "a", "brokers": "a", "authRequired": "false", "initialOffset": "oldest"}
+	k := getKafkaPubsub()
+	meta, err := k.getKafkaMetadata(m)
+	require.NoError(t, err)
+	assert.Equal(t, sarama.OffsetOldest, meta.InitialOffset)
+	m.Properties["initialOffset"] = "newest"
+	meta, err = k.getKafkaMetadata(m)
+	require.NoError(t, err)
+	assert.Equal(t, sarama.OffsetNewest, meta.InitialOffset)
+	m.Properties["initialOffset"] = "12345"
+	meta, err = k.getKafkaMetadata(m)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12345), meta.InitialOffset)
 }

--- a/tests/config/bindings/kafka/bindings.yml
+++ b/tests/config/bindings/kafka/bindings.yml
@@ -17,3 +17,5 @@ spec:
     value: binding-topic
   - name: authRequired
     value: "false"
+  - name: initialOffset
+    value: oldest

--- a/tests/config/pubsub/kafka/pubsub.yml
+++ b/tests/config/pubsub/kafka/pubsub.yml
@@ -12,3 +12,5 @@ spec:
     value: pubsubgroup1
   - name: authRequired
     value: "false"
+  - name: initialOffset
+    value: oldest


### PR DESCRIPTION
# Description

Adding `initialOffset` option to Kafka binding and pubsub components which should be useful in e2e tests because Kafka can take a while to start consuming. Because the default is "consume newest", it is unpredictable where the consumer will start. Using "oldest" for this setting will remove the need to sleep or make assumptions e2e tests when the consumers have begun streaming. 

## Issue reference

Related to dapr/dapr#3522

Docs PR dapr/docs#1765

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#1765
