### PR TITLE
Support DefaultIdentificationHydrator in cosmosdb state component

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -114,11 +114,9 @@ func (c *StateStore) Init(meta state.Metadata) error {
 	// Create the client; first, try authenticating with a master key, if present
 	var config *documentdb.Config
 	if m.MasterKey != "" {
-		config = &documentdb.Config{
-			MasterKey: &documentdb.Key{
-				Key: m.MasterKey,
-			},
-		}
+		config = documentdb.NewConfig(&documentdb.Key{
+			Key: m.MasterKey,
+		})
 	} else {
 		// Fallback to using Azure AD
 		env, errB := azure.NewEnvironmentSettings("cosmosdb", meta.Properties)
@@ -273,7 +271,7 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.client.UpsertDocument(c.collection.Self, doc, options...)
+	_, err = c.client.UpsertDocument(c.collection.Self, &doc, options...)
 
 	if err != nil {
 		if req.ETag != nil {


### PR DESCRIPTION
# Description

Follow-up to #1104 to support AD Auth codepath as well.

`NewConfig()` and `NewConfigWithServicePrincipal()` both set the `Config.IdentificationHydrator` to the `DefaultIdentificationHydrator` in the underlying a8m/documentdb library. That implementation ends up calling `reflect.Value.Elem.FieldByName()`, which requires that the value passed to it is an interface or pointer, otherwise the `Elem()` call fails to dereference which causes a panic.

cosmosdb.go passes the input to `UpsertDocument` by value today, which is eventually passed to the `DefaultIdentificationHydrator`, so changing the value passed to a pointer resolves the failure.

## Issue reference

Follow-up to #1119

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
