### PR TITLE
Restored backwards compatibility with 1.3

### DIFF
--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -62,6 +62,7 @@ func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
 					vaultName = strings.TrimPrefix(vaultName, "https://")
 				}
 				metadata.Properties[componentVaultName] = vaultName
+
 				break
 			}
 		}

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -45,6 +45,29 @@ func NewAzureKeyvaultSecretStore(logger logger.Logger) secretstores.SecretStore 
 
 // Init creates a Azure Key Vault client
 func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
+	// Fix for maintaining backwards compatibility with a change introduced in 1.3 that allowed specifying an Azure environment by setting a FQDN for vault name
+	// This should be considered deprecated and users should rely the "azureEnvironment" metadata instead, but it's maintained here for backwards-compatibility
+	if vaultName, ok := metadata.Properties[componentVaultName]; ok {
+		keyVaultSuffixToEnvironment := map[string]string{
+			".vault.azure.net":         "AZUREPUBLICCLOUD",
+			".vault.azure.cn":          "AZURECHINACLOUD",
+			".vault.usgovcloudapi.net": "AZUREUSGOVERNMENTCLOUD",
+			".vault.microsoftazure.de": "AZUREGERMANCLOUD",
+		}
+		for suffix, environment := range keyVaultSuffixToEnvironment {
+			if strings.HasSuffix(vaultName, suffix) {
+				metadata.Properties["azureEnvironment"] = environment
+				vaultName = strings.TrimSuffix(vaultName, suffix)
+				if strings.HasPrefix(vaultName, "https://") {
+					vaultName = strings.TrimPrefix(vaultName, "https://")
+				}
+				metadata.Properties[componentVaultName] = vaultName
+				break
+			}
+		}
+	}
+
+	// Initialization code
 	settings, err := azauth.NewEnvironmentSettings("keyvault", metadata.Properties)
 	if err != nil {
 		return err

--- a/secretstores/azure/keyvault/keyvault_test.go
+++ b/secretstores/azure/keyvault/keyvault_test.go
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package keyvault
+
+import (
+	"testing"
+
+	"github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/kit/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	m := secretstores.Metadata{}
+	s := NewAzureKeyvaultSecretStore(logger.NewLogger("test"))
+	t.Run("Init with valid metadata", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "foo",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.azure.net")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+	t.Run("Init with valid metadata and Azure environment", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "foo",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+			"azureEnvironment":  "AZURECHINACLOUD",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.azure.cn")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+	t.Run("Init with Azure environment as part of vaultName FQDN (1) - legacy", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "foo.vault.azure.cn",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.azure.cn")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+	t.Run("Init with Azure environment as part of vaultName FQDN (2) - legacy", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "https://foo.vault.usgovcloudapi.net",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.usgovcloudapi.net")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+}


### PR DESCRIPTION
#972 accidentally introduced a backwards-incompatible change with a feature added in 1.3. Before, it was possible to specify an Azure environment for the AKV secret store by passing a FQDN as "vaultName" property that included the suffix for the Azure environment.
#972 introduced a better way to handle this (using the "azureEnvironment" metadata property), but accidentally broke the behavior added in 1.3
This patch restores full compatibility with 1.3. Although that behavior should be considered deprecated and thus discouraged (and it will be removed from docs), it will still be supported.

This should be considered a hotfix for the upcoming 1.4

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] N/A Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
