### PR TITLE
Cherry-pick: Restored backwards compatibility with 1.3 (#1131)

### DIFF
--- a/secretstores/azure/keyvault/keyvault_test.go
+++ b/secretstores/azure/keyvault/keyvault_test.go
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package keyvault
+
+import (
+	"testing"
+
+	"github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/kit/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	m := secretstores.Metadata{}
+	s := NewAzureKeyvaultSecretStore(logger.NewLogger("test"))
+	t.Run("Init with valid metadata", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "foo",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.azure.net")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+	t.Run("Init with valid metadata and Azure environment", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "foo",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+			"azureEnvironment":  "AZURECHINACLOUD",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.azure.cn")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+	t.Run("Init with Azure environment as part of vaultName FQDN (1) - legacy", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "foo.vault.azure.cn",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.azure.cn")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+	t.Run("Init with Azure environment as part of vaultName FQDN (2) - legacy", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"vaultName":         "https://foo.vault.usgovcloudapi.net",
+			"azureTenantId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientId":     "00000000-0000-0000-0000-000000000000",
+			"azureClientSecret": "passw0rd",
+		}
+		err := s.Init(m)
+		assert.Nil(t, err)
+		kv, ok := s.(*keyvaultSecretStore)
+		assert.True(t, ok)
+		assert.Equal(t, kv.vaultName, "foo")
+		assert.Equal(t, kv.vaultDNSSuffix, "vault.usgovcloudapi.net")
+		assert.NotNil(t, kv.vaultClient)
+		assert.NotNil(t, kv.vaultClient.Authorizer)
+	})
+}


### PR DESCRIPTION
* Restored backwards compatibility with 1.3
#972 accidentally introduced a backwards-incompatible change with a feature added in 1.3. Before, it was possible to specify an Azure environment for the AKV secret store by passing a FQDN as "vaultName" property that included the suffix for the Azure environment.
#972 introduced a better way to handle this (using the "azureEnvironment" metadata property), but accidentally broke the behavior added in 1.3
This patch restores full compatibility with 1.3. Although that behavior should be considered deprecated and thus discouraged (and it will be removed from docs), it will still be supported.

* Lint

# Description

Cherry pick of #1131 into release

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #972 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
