### PR TITLE
Update devcontainer to use dapr-dev:0.1.4 base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,6 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM daprio/dapr-dev:0.1.3
+FROM daprio/dapr-dev:0.1.4
 
 VOLUME [ "/go/src/github.com/dapr/dapr" ]


### PR DESCRIPTION
# Description

Update devcontainer to use dapr-dev:0.1.4 base image

## Issue reference

Follow-up to release for Dapr v1.4

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
