### PR TITLE
Add dapr user agent for Azure Components

### DIFF
--- a/authentication/azure/auth.go
+++ b/authentication/azure/auth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/dapr/kit/logger"
 	"golang.org/x/crypto/pkcs12"
 )
 
@@ -74,6 +75,7 @@ func (s EnvironmentSettings) GetAzureEnvironment() (*azure.Environment, error) {
 // 2. Client certificate
 // 3. MSI.
 func (s EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error) {
+	adal.AddToUserAgent("dapr-" + logger.DaprVersion)
 	spt, err := s.GetServicePrincipalToken()
 	if err != nil {
 		return nil, err

--- a/authentication/azure/auth.go
+++ b/authentication/azure/auth.go
@@ -75,7 +75,6 @@ func (s EnvironmentSettings) GetAzureEnvironment() (*azure.Environment, error) {
 // 2. Client certificate
 // 3. MSI.
 func (s EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error) {
-	adal.AddToUserAgent("dapr-" + logger.DaprVersion)
 	spt, err := s.GetServicePrincipalToken()
 	if err != nil {
 		return nil, err
@@ -89,6 +88,7 @@ func (s EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error) {
 // 2. Client certificate
 // 3. MSI.
 func (s EnvironmentSettings) GetServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
+	adal.AddToUserAgent("dapr-" + logger.DaprVersion)
 	// 1. Client credentials
 	if c, e := s.GetClientCredentials(); e == nil {
 		return c.ServicePrincipalToken()

--- a/authentication/azure/auth.go
+++ b/authentication/azure/auth.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/dapr/kit/logger"
 	"golang.org/x/crypto/pkcs12"
 )
 
@@ -88,7 +87,6 @@ func (s EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error) {
 // 2. Client certificate
 // 3. MSI.
 func (s EnvironmentSettings) GetServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
-	adal.AddToUserAgent("dapr-" + logger.DaprVersion)
 	// 1. Client credentials
 	if c, e := s.GetClientCredentials(); e == nil {
 		return c.ServicePrincipalToken()

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -119,7 +119,12 @@ func (a *AzureBlobStorage) Init(metadata bindings.Metadata) error {
 	if err != nil {
 		return fmt.Errorf("invalid credentials with error: %w", err)
 	}
-	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+
+	userAgent := "dapr-" + logger.DaprVersion
+	options := azblob.PipelineOptions{
+		Telemetry: azblob.TelemetryOptions{Value: userAgent},
+	}
+	p := azblob.NewPipeline(credential, options)
 
 	containerName := a.metadata.Container
 	URL, _ := url.Parse(

--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -132,13 +132,18 @@ func (a *AzureEventHubs) Init(metadata bindings.Metadata) error {
 	if err != nil {
 		return err
 	}
+	userAgent := "dapr-" + logger.DaprVersion
 	a.metadata = m
-	hub, err := eventhub.NewHubFromConnectionString(a.metadata.connectionString)
+	hub, err := eventhub.NewHubFromConnectionString(a.metadata.connectionString,
+		eventhub.HubWithUserAgent(userAgent),
+	)
 
 	// Create partitioned sender if the partitionID is configured
 	if a.metadata.partitioned() {
 		hub, err = eventhub.NewHubFromConnectionString(a.metadata.connectionString,
-			eventhub.HubWithPartitionedSender(a.metadata.partitionID))
+			eventhub.HubWithPartitionedSender(a.metadata.partitionID),
+			eventhub.HubWithUserAgent(userAgent),
+		)
 	}
 
 	if err != nil {

--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -51,9 +51,11 @@ func (a *AzureServiceBusQueues) Init(metadata bindings.Metadata) error {
 	if err != nil {
 		return err
 	}
+	userAgent := "dapr-" + logger.DaprVersion
 	a.metadata = meta
 
-	ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(a.metadata.ConnectionString))
+	ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(a.metadata.ConnectionString),
+		servicebus.NamespaceWithUserAgent(userAgent))
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/signalr/signalr.go
+++ b/bindings/azure/signalr/signalr.go
@@ -50,6 +50,7 @@ type SignalR struct {
 	accessKey  string
 	version    string
 	hub        string
+	userAgent  string
 	tokens     map[string]signalrCachedToken
 	httpClient *http.Client
 
@@ -58,6 +59,8 @@ type SignalR struct {
 
 // Init is responsible for initializing the SignalR output based on the metadata.
 func (s *SignalR) Init(metadata bindings.Metadata) error {
+	s.userAgent = "dapr-" + logger.DaprVersion
+
 	connectionString, ok := metadata.Properties[connectionStringKey]
 	if !ok || connectionString == "" {
 		return fmt.Errorf("missing connection string")
@@ -128,6 +131,7 @@ func (s *SignalR) sendMessageToSignalR(url string, token string, data []byte) er
 
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", s.userAgent)
 
 	resp, err := s.httpClient.Do(httpReq)
 	if err != nil {

--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -58,7 +58,13 @@ func (d *AzureQueueHelper) Init(accountName string, accountKey string, queueName
 	d.credential = credential
 	d.decodeBase64 = decodeBase64
 	u, _ := url.Parse(fmt.Sprintf(d.reqURI, accountName, queueName))
-	d.queueURL = azqueue.NewQueueURL(*u, azqueue.NewPipeline(credential, azqueue.PipelineOptions{}))
+	userAgent := "dapr-" + logger.DaprVersion
+	pipelineOptions := azqueue.PipelineOptions{
+		Telemetry: azqueue.TelemetryOptions{
+			Value: userAgent,
+		},
+	}
+	d.queueURL = azqueue.NewQueueURL(*u, azqueue.NewPipeline(credential, pipelineOptions))
 	ctx := context.TODO()
 	_, err = d.queueURL.Create(ctx, azqueue.Metadata{})
 	if err != nil {

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -27,7 +27,6 @@ const (
 	// metadata.
 	connectionString = "connectionString"
 	consumerID       = "consumerID" // passed by dapr runtime
-	userAgent        = "dapr"
 
 	// required by subscriber.
 	storageAccountName   = "storageAccountName"
@@ -158,6 +157,7 @@ func (aeh *AzureEventHubs) Init(metadata pubsub.Metadata) error {
 	if err != nil {
 		return err
 	}
+	userAgent := "dapr-" + logger.DaprVersion
 	aeh.metadata = m
 	hub, err := eventhub.NewHubFromConnectionString(aeh.metadata.connectionString,
 		eventhub.HubWithUserAgent(userAgent))

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -27,6 +27,7 @@ const (
 	// metadata.
 	connectionString = "connectionString"
 	consumerID       = "consumerID" // passed by dapr runtime
+	userAgent        = "dapr"
 
 	// required by subscriber.
 	storageAccountName   = "storageAccountName"
@@ -158,7 +159,8 @@ func (aeh *AzureEventHubs) Init(metadata pubsub.Metadata) error {
 		return err
 	}
 	aeh.metadata = m
-	hub, err := eventhub.NewHubFromConnectionString(aeh.metadata.connectionString)
+	hub, err := eventhub.NewHubFromConnectionString(aeh.metadata.connectionString,
+		eventhub.HubWithUserAgent(userAgent))
 	if err != nil {
 		return fmt.Errorf("unable to connect to azure event hubs: %v", err)
 	}

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -45,6 +45,7 @@ const (
 	publishMaxRetries               = "publishMaxRetries"
 	publishInitialRetryInternalInMs = "publishInitialRetryInternalInMs"
 	errorMessagePrefix              = "azure service bus error:"
+	userAgent                       = "dapr"
 
 	// Defaults.
 	defaultTimeoutInSec        = 60
@@ -258,7 +259,10 @@ func (a *azureServiceBus) Init(metadata pubsub.Metadata) error {
 	}
 
 	a.metadata = m
-	a.namespace, err = azservicebus.NewNamespace(azservicebus.NamespaceWithConnectionString(a.metadata.ConnectionString))
+	a.namespace, err = azservicebus.NewNamespace(
+		azservicebus.NamespaceWithConnectionString(a.metadata.ConnectionString),
+		azservicebus.NamespaceWithUserAgent(userAgent))
+
 	if err != nil {
 		return err
 	}

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -45,7 +45,6 @@ const (
 	publishMaxRetries               = "publishMaxRetries"
 	publishInitialRetryInternalInMs = "publishInitialRetryInternalInMs"
 	errorMessagePrefix              = "azure service bus error:"
-	userAgent                       = "dapr"
 
 	// Defaults.
 	defaultTimeoutInSec        = 60
@@ -258,6 +257,7 @@ func (a *azureServiceBus) Init(metadata pubsub.Metadata) error {
 		return err
 	}
 
+	userAgent := "dapr-" + logger.DaprVersion
 	a.metadata = m
 	a.namespace, err = azservicebus.NewNamespace(
 		azservicebus.NamespaceWithConnectionString(a.metadata.ConnectionString),

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -77,6 +77,7 @@ func (k *keyvaultSecretStore) Init(metadata secretstores.Metadata) error {
 	authorizer, err := settings.GetAuthorizer()
 	if err == nil {
 		k.vaultClient.Authorizer = authorizer
+		k.vaultClient.UserAgent = "dapr-" + logger.DaprVersion
 	}
 
 	k.vaultName = settings.Values[componentVaultName]

--- a/state/azure/blobstorage/blobstorage.go
+++ b/state/azure/blobstorage/blobstorage.go
@@ -84,7 +84,11 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 		return fmt.Errorf("invalid credentials with error: %s", err.Error())
 	}
 
-	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+	userAgent := "dapr-" + logger.DaprVersion
+	options := azblob.PipelineOptions{
+		Telemetry: azblob.TelemetryOptions{Value: userAgent},
+	}
+	p := azblob.NewPipeline(credential, options)
 
 	var containerURL azblob.ContainerURL
 	customEndpoint, ok := metadata.Properties[endpointKey]

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -50,6 +50,7 @@ const (
 	accountNameKey = "accountName"
 	accountKeyKey  = "accountKey"
 	tableNameKey   = "tableName"
+	userAgent      = "dapr"
 )
 
 type StateStore struct {
@@ -76,6 +77,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 
 	client, _ := storage.NewBasicClient(meta.accountName, meta.accountKey)
 	tables := client.GetTableService()
+	client.AddToUserAgent(userAgent)
 	r.table = tables.GetTableReference(meta.tableName)
 
 	// check table exists

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -50,7 +50,6 @@ const (
 	accountNameKey = "accountName"
 	accountKeyKey  = "accountKey"
 	tableNameKey   = "tableName"
-	userAgent      = "dapr"
 )
 
 type StateStore struct {
@@ -77,6 +76,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 
 	client, _ := storage.NewBasicClient(meta.accountName, meta.accountKey)
 	tables := client.GetTableService()
+	userAgent := "dapr-" + logger.DaprVersion
 	client.AddToUserAgent(userAgent)
 	r.table = tables.GetTableReference(meta.tableName)
 

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -313,6 +313,13 @@ func getMongoDBClient(metadata *mongoDBMetadata) (*mongo.Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), metadata.operationTimeout)
 	defer cancel()
 
+	daprUserAgent := "dapr-" + logger.DaprVersion
+	if clientOptions.AppName != nil {
+		clientOptions.SetAppName(daprUserAgent + ":" + *clientOptions.AppName)
+	} else {
+		clientOptions.SetAppName(daprUserAgent)
+	}
+
 	client, err := mongo.Connect(ctx, clientOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Set custom user agent for `dapr` to be used with various Azure services.

This change prepends `dapr-$version` to the user Agent, or sets this as the user Agent where no other value exists.

## Issue reference

#1014 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly

The upstream components already have tests for setting custom user agents. No additional tests needed here.
