### PR TITLE
Support setting up Azure IoT Hub for integration testing with EventHubs components

### DIFF
--- a/.github/infrastructure/conformance/azure/conf-test-azure-iothub.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure-iothub.bicep
@@ -1,0 +1,40 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+param iotHubName string
+param rgLocation string = resourceGroup().location
+param confTestTags object = {}
+
+var iotHubBindingsConsumerGroupName = '${iotHubName}/events/bindings-cg'
+
+resource iotHub 'Microsoft.Devices/IotHubs@2021-03-31' = {
+  name: iotHubName
+  location: rgLocation
+  tags: confTestTags
+  sku: {
+      capacity: 1
+      name: 'F1'
+  }
+  properties: {
+    eventHubEndpoints: {
+      events: {
+        retentionTimeInDays: 1
+        partitionCount: 2
+      }
+    }
+  }
+}
+
+resource iotHubBindingsConsumerGroup 'Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups@2021-03-31' = {
+  name: iotHubBindingsConsumerGroupName
+  properties: {
+    name: 'bindings-cg'
+  }
+  dependsOn: [
+    iotHub
+  ]
+}
+
+output iotHubBindingsConsumerGroupName string = iotHubBindingsConsumerGroup.name

--- a/.github/infrastructure/conformance/azure/conf-test-azure-iothub.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure-iothub.bicep
@@ -8,6 +8,7 @@ param rgLocation string = resourceGroup().location
 param confTestTags object = {}
 
 var iotHubBindingsConsumerGroupName = '${iotHubName}/events/bindings-cg'
+var iotHubPubsubConsumerGroupName = '${iotHubName}/events/pubsub-cg'
 
 resource iotHub 'Microsoft.Devices/IotHubs@2021-03-31' = {
   name: iotHubName
@@ -37,4 +38,15 @@ resource iotHubBindingsConsumerGroup 'Microsoft.Devices/IotHubs/eventHubEndpoint
   ]
 }
 
+resource iotHubPubsubConsumerGroup 'Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups@2021-03-31' = {
+  name: iotHubPubsubConsumerGroupName
+  properties: {
+    name: 'pubsub-cg'
+  }
+  dependsOn: [
+    iotHub
+  ]
+}
+
 output iotHubBindingsConsumerGroupName string = iotHubBindingsConsumerGroup.name
+output iotHubPubsubConsumerGroupName string = iotHubPubsubConsumerGroup.name

--- a/.github/infrastructure/conformance/azure/conf-test-azure.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure.bicep
@@ -128,6 +128,7 @@ output eventHubPubsubPolicyName string = eventHubsNamespace.outputs.eventHubPubs
 output eventHubPubsubConsumerGroupName string = eventHubsNamespace.outputs.eventHubPubsubConsumerGroupName
 output iotHubName string = iotHub.name
 output iotHubBindingsConsumerGroupName string = iotHub.outputs.iotHubBindingsConsumerGroupName
+output iotHubPubsubConsumerGroupName string = iotHub.outputs.iotHubPubsubConsumerGroupName
 output keyVaultName string = keyVault.name
 output serviceBusName string = serviceBus.name
 output storageName string = storage.name

--- a/.github/infrastructure/conformance/azure/conf-test-azure.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure.bicep
@@ -37,6 +37,7 @@ var confTestRgName = '${toLower(namePrefix)}-conf-test-rg'
 var cosmosDbName = '${toLower(namePrefix)}-conf-test-db'
 var eventGridTopicName = '${toLower(namePrefix)}-conf-test-eventgrid-topic'
 var eventHubsNamespaceName = '${toLower(namePrefix)}-conf-test-eventhubs'
+var iotHubName = '${toLower(namePrefix)}-conf-test-iothub'
 var keyVaultName = '${toLower(namePrefix)}-conf-test-kv'
 var serviceBusName = '${toLower(namePrefix)}-conf-test-servicebus'
 var storageName = '${toLower(namePrefix)}ctstorage'
@@ -71,6 +72,15 @@ module eventHubsNamespace 'conf-test-azure-eventHubs.bicep' = {
   params: {
     confTestTags: confTestTags
     eventHubsNamespaceName: eventHubsNamespaceName
+  }
+}
+
+module iotHub 'conf-test-azure-iothub.bicep' = {
+  name: iotHubName
+  scope: resourceGroup(confTestRg.name)
+  params: {
+    confTestTags: confTestTags
+    iotHubName: iotHubName
   }
 }
 
@@ -116,6 +126,8 @@ output eventHubBindingsConsumerGroupName string = eventHubsNamespace.outputs.eve
 output eventHubPubsubName string = eventHubsNamespace.outputs.eventHubPubsubName
 output eventHubPubsubPolicyName string = eventHubsNamespace.outputs.eventHubPubsubPolicyName
 output eventHubPubsubConsumerGroupName string = eventHubsNamespace.outputs.eventHubPubsubConsumerGroupName
+output iotHubName string = iotHub.name
+output iotHubBindingsConsumerGroupName string = iotHub.outputs.iotHubBindingsConsumerGroupName
 output keyVaultName string = keyVault.name
 output serviceBusName string = serviceBus.name
 output storageName string = storage.name

--- a/.github/infrastructure/conformance/azure/setup-azure-conf-test.sh
+++ b/.github/infrastructure/conformance/azure/setup-azure-conf-test.sh
@@ -177,6 +177,7 @@ EVENT_HUBS_PUBSUB_CONTAINER_VAR_NAME="AzureEventHubsPubsubContainer"
 IOT_HUB_NAME_VAR_NAME="AzureIotHubName"
 IOT_HUB_EVENT_HUB_CONNECTION_STRING_VAR_NAME="AzureIotHubEventHubConnectionString"
 IOT_HUB_BINDINGS_CONSUMER_GROUP_VAR_NAME="AzureIotHubBindingsConsumerGroup"
+IOT_HUB_PUBSUB_CONSUMER_GROUP_VAR_NAME="AzureIotHubPubsubConsumerGroup"
 
 KEYVAULT_CERT_NAME="AzureKeyVaultSecretStoreCert"
 KEYVAULT_CLIENT_ID_VAR_NAME="AzureKeyVaultSecretStoreClientId"
@@ -278,6 +279,8 @@ IOT_HUB_NAME="$(az deployment sub show --name "${DEPLOY_NAME}" --query "properti
 echo "INFO: IOT_HUB_NAME=${IOT_HUB_NAME}"
 IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME="$(az deployment sub show --name "${DEPLOY_NAME}" --query "properties.outputs.iotHubBindingsConsumerGroupName.value" | sed -E 's/[[:space:]]|\"//g')"
 echo "INFO: IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME=${IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME}"
+IOT_HUB_PUBSUB_CONSUMER_GROUP_FULLNAME="$(az deployment sub show --name "${DEPLOY_NAME}" --query "properties.outputs.iotHubPubsubConsumerGroupName.value" | sed -E 's/[[:space:]]|\"//g')"
+echo "INFO: IOT_HUB_PUBSUB_CONSUMER_GROUP_FULLNAME=${IOT_HUB_PUBSUB_CONSUMER_GROUP_FULLNAME}"
 
 # Update service principal credentials and roles for created resources
 echo "Creating ${CERT_AUTH_SP_NAME} certificate ..."
@@ -505,6 +508,10 @@ az keyvault secret set --name "${IOT_HUB_EVENT_HUB_CONNECTION_STRING_VAR_NAME}" 
 IOT_HUB_BINDINGS_CONSUMER_GROUP_NAME="$(basename ${IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME})"
 echo export ${IOT_HUB_BINDINGS_CONSUMER_GROUP_VAR_NAME}=\"${IOT_HUB_BINDINGS_CONSUMER_GROUP_NAME}\" >> "${ENV_CONFIG_FILENAME}"
 az keyvault secret set --name "${IOT_HUB_BINDINGS_CONSUMER_GROUP_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${IOT_HUB_BINDINGS_CONSUMER_GROUP_NAME}"
+
+IOT_HUB_PUBSUB_CONSUMER_GROUP_NAME="$(basename ${IOT_HUB_PUBSUB_CONSUMER_GROUP_FULLNAME})"
+echo export ${IOT_HUB_PUBSUB_CONSUMER_GROUP_VAR_NAME}=\"${IOT_HUB_PUBSUB_CONSUMER_GROUP_NAME}\" >> "${ENV_CONFIG_FILENAME}"
+az keyvault secret set --name "${IOT_HUB_PUBSUB_CONSUMER_GROUP_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${IOT_HUB_PUBSUB_CONSUMER_GROUP_NAME}"
 
 # ---------------------------
 # Display completion message

--- a/.github/infrastructure/conformance/azure/setup-azure-conf-test.sh
+++ b/.github/infrastructure/conformance/azure/setup-azure-conf-test.sh
@@ -174,6 +174,10 @@ EVENT_HUBS_PUBSUB_CONNECTION_STRING_VAR_NAME="AzureEventHubsPubsubConnectionStri
 EVENT_HUBS_PUBSUB_CONSUMER_GROUP_VAR_NAME="AzureEventHubsPubsubConsumerGroup"
 EVENT_HUBS_PUBSUB_CONTAINER_VAR_NAME="AzureEventHubsPubsubContainer"
 
+IOT_HUB_NAME_VAR_NAME="AzureIotHubName"
+IOT_HUB_EVENT_HUB_CONNECTION_STRING_VAR_NAME="AzureIotHubEventHubConnectionString"
+IOT_HUB_BINDINGS_CONSUMER_GROUP_VAR_NAME="AzureIotHubBindingsConsumerGroup"
+
 KEYVAULT_CERT_NAME="AzureKeyVaultSecretStoreCert"
 KEYVAULT_CLIENT_ID_VAR_NAME="AzureKeyVaultSecretStoreClientId"
 KEYVAULT_TENANT_ID_VAR_NAME="AzureKeyVaultSecretStoreTenantId"
@@ -194,6 +198,9 @@ DEPLOY_NAME="${PREFIX}-azure-conf-test"
 
 # Setup output path
 mkdir -p "${OUTPUT_PATH}"
+
+# Configure Azure CLI to install azure-iot and other extensions without prompts
+az config set extension.use_dynamic_install=yes_without_prompt
 
 # Create Service Principals for use with the conformance tests
 CERT_AUTH_SP_NAME="${PREFIX}-akv-conf-test-sp"
@@ -267,6 +274,10 @@ EVENT_HUB_PUBSUB_POLICY_NAME="$(az deployment sub show --name "${DEPLOY_NAME}" -
 echo "INFO: EVENT_HUB_PUBSUB_POLICY_NAME=${EVENT_HUB_PUBSUB_POLICY_NAME}"
 EVENT_HUBS_PUBSUB_CONSUMER_GROUP_NAME="$(az deployment sub show --name "${DEPLOY_NAME}" --query "properties.outputs.eventHubPubsubConsumerGroupName.value" | sed -E 's/[[:space:]]|\"//g')"
 echo "INFO: EVENT_HUBS_PUBSUB_CONSUMER_GROUP_NAME=${EVENT_HUBS_PUBSUB_CONSUMER_GROUP_NAME}"
+IOT_HUB_NAME="$(az deployment sub show --name "${DEPLOY_NAME}" --query "properties.outputs.iotHubName.value" | sed -E 's/[[:space:]]|\"//g')"
+echo "INFO: IOT_HUB_NAME=${IOT_HUB_NAME}"
+IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME="$(az deployment sub show --name "${DEPLOY_NAME}" --query "properties.outputs.iotHubBindingsConsumerGroupName.value" | sed -E 's/[[:space:]]|\"//g')"
+echo "INFO: IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME=${IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME}"
 
 # Update service principal credentials and roles for created resources
 echo "Creating ${CERT_AUTH_SP_NAME} certificate ..."
@@ -277,6 +288,11 @@ EVENT_GRID_SCOPE="/subscriptions/${SUB_ID}/resourceGroups/${RESOURCE_GROUP_NAME}
 # MSYS_NO_PATHCONV is needed to prevent MSYS in Git Bash from converting the scope string to a local filesystem path and is benign on Linux
 echo "Assigning \"EventGrid EventSubscription Contributor\" role to ${SDK_AUTH_SP_NAME} in scope \"${EVENT_GRID_SCOPE}\"..."
 MSYS_NO_PATHCONV=1 az role assignment create --assignee "${SDK_AUTH_SP_ID}" --role "EventGrid EventSubscription Contributor" --scope "${EVENT_GRID_SCOPE}"
+
+# Add Contributor role to the SDK auth Service Principal so it can add devices to the Azure IoT Hub for tests.
+IOT_HUB_SCOPE="/subscriptions/${SUB_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Devices/IotHubs/${IOT_HUB_NAME}"
+echo "Assigning \"Contributor\" role to ${SDK_AUTH_SP_NAME} in scope \"${IOT_HUB_SCOPE}\"..."
+MSYS_NO_PATHCONV=1 az role assignment create --assignee "${SDK_AUTH_SP_ID}" --role "Contributor" --scope "${IOT_HUB_SCOPE}"
 
 ##==============================================================================
 ##
@@ -474,6 +490,25 @@ EVENT_HUBS_PUBSUB_CONTAINER_NAME="${PREFIX}-eventhubs-pubsub-container"
 echo export ${EVENT_HUBS_PUBSUB_CONTAINER_VAR_NAME}=\"${EVENT_HUBS_PUBSUB_CONTAINER_NAME}\" >> "${ENV_CONFIG_FILENAME}"
 az keyvault secret set --name "${EVENT_HUBS_PUBSUB_CONTAINER_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${EVENT_HUBS_PUBSUB_CONTAINER_NAME}"
 
+# ----------------------------------
+# Populate IoT Hub test settings
+# ----------------------------------
+echo "Configuring IoT Hub test settings ..."
+
+echo export ${IOT_HUB_NAME_VAR_NAME}=\"${IOT_HUB_NAME}\" >> "${ENV_CONFIG_FILENAME}"
+az keyvault secret set --name "${IOT_HUB_NAME_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${IOT_HUB_NAME}"
+
+IOT_HUB_EVENT_HUB_CONNECTION_STRING="$(az iot hub connection-string show -n ${IOT_HUB_NAME} --default-eventhub --policy-name service --query connectionString | sed -E 's/[[:space:]]|\"//g')"
+echo export ${IOT_HUB_EVENT_HUB_CONNECTION_STRING_VAR_NAME}=\"${IOT_HUB_EVENT_HUB_CONNECTION_STRING}\" >> "${ENV_CONFIG_FILENAME}"
+az keyvault secret set --name "${IOT_HUB_EVENT_HUB_CONNECTION_STRING_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${IOT_HUB_EVENT_HUB_CONNECTION_STRING}"
+
+IOT_HUB_BINDINGS_CONSUMER_GROUP_NAME="$(basename ${IOT_HUB_BINDINGS_CONSUMER_GROUP_FULLNAME})"
+echo export ${IOT_HUB_BINDINGS_CONSUMER_GROUP_VAR_NAME}=\"${IOT_HUB_BINDINGS_CONSUMER_GROUP_NAME}\" >> "${ENV_CONFIG_FILENAME}"
+az keyvault secret set --name "${IOT_HUB_BINDINGS_CONSUMER_GROUP_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${IOT_HUB_BINDINGS_CONSUMER_GROUP_NAME}"
+
+# ---------------------------
+# Display completion message
+# ---------------------------
 echo "INFO: setup-azure-conf-test completed."
 echo "INFO: Remember to \`source ${ENV_CONFIG_FILENAME}\` before running local conformance tests."
 if [[ -z ${CREDENTIALS_PATH} ]]; then

--- a/bindings/azure/eventhubs/eventhubs_integration_test.go
+++ b/bindings/azure/eventhubs/eventhubs_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration_test
+// +build integration_test
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package eventhubs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	// Note: Reuse the environment variables names from the conformance tests where possible to support reuse of setup workflows
+
+	// iotHubConnectionStringEnvKey defines the key containing the integration test connection string
+	// For the default EventHub endpoint for an Azure IoT Hub, it will resemble:
+	// Endpoint=sb://<iotHubGeneratedNamespace>.servicebus.windows.net/;SharedAccessKeyName=service;SharedAccessKey=<key>;EntityPath=<iotHubGeneratedPath>
+	iotHubConnectionStringEnvKey = "AzureIotHubEventHubConnectionString"
+	iotHubConsumerGroupEnvKey    = "AzureIotHubBindingsConsumerGroup"
+	iotHubNameEnvKey             = "AzureIotHubName"
+	storageAccountNameEnvKey     = "AzureBlobStorageAccount"
+	storageAccountKeyEnvKey      = "AzureBlobStorageAccessKey"
+	azureCredentialsEnvKey       = "AZURE_CREDENTIALS"
+
+	testStorageContainerName = "iothub-bindings-integration-test"
+)
+
+func createIotHubBindingsMetadata() bindings.Metadata {
+	metadata := bindings.Metadata{
+		Properties: map[string]string{
+			connectionString:     os.Getenv(iotHubConnectionStringEnvKey),
+			consumerGroup:        os.Getenv(iotHubConsumerGroupEnvKey),
+			storageAccountName:   os.Getenv(storageAccountNameEnvKey),
+			storageAccountKey:    os.Getenv(storageAccountKeyEnvKey),
+			storageContainerName: testStorageContainerName,
+		},
+	}
+
+	return metadata
+}
+
+func testReadIotHubEvents(t *testing.T) {
+	logger := logger.NewLogger("bindings.azure.eventhubs.integration.test")
+	eh := NewAzureEventHubs(logger)
+	err := eh.Init(createIotHubBindingsMetadata())
+	assert.Nil(t, err)
+
+	// Invoke az CLI via bash script to send test IoT device events
+	// Requires the AZURE_CREDENTIALS environment variable to be already set (output of `az ad sp create-for-rbac`)
+	cmd := exec.Command("/bin/bash", "../../../tests/scripts/send-iot-device-events.sh")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("IOT_HUB_NAME=%s", os.Getenv(iotHubNameEnvKey)))
+	out, err := cmd.CombinedOutput()
+	assert.Nil(t, err, "Error in send-iot-device-events.sh:\n%s", out)
+
+	// Setup Read binding to capture readResponses in a closure so that test asserts can be
+	// performed on the main thread, including the case where the handler is never invoked.
+	var readResponses []bindings.ReadResponse
+	handler := func(data *bindings.ReadResponse) ([]byte, error) {
+		readResponses = append(readResponses, *data)
+		return nil, nil
+	}
+
+	go eh.Read(handler)
+
+	// Note: azure-event-hubs-go SDK defaultLeasePersistenceInterval is 5s
+	// Sleep long enough so that the azure event hubs SDK has time to persist updated checkpoints
+	// before the test process exits.
+	time.Sleep(10 * time.Second)
+
+	assert.Greater(t, len(readResponses), 0, "Failed to receive any IotHub events")
+	logger.Infof("Received %d messages", len(readResponses))
+	for _, r := range readResponses {
+		assert.Contains(t, string(r.Data), "Integration test message")
+
+		// Verify expected IoT Hub device event metadata exists
+		// TODO: add device messages than can populate the sysPropPartitionKey and sysPropIotHubConnectionModuleID metadata
+		assert.Contains(t, r.Metadata, sysPropSequenceNumber, "IoT device event missing: %s", sysPropSequenceNumber)
+		assert.Contains(t, r.Metadata, sysPropEnqueuedTime, "IoT device event missing: %s", sysPropEnqueuedTime)
+		assert.Contains(t, r.Metadata, sysPropOffset, "IoT device event missing: %s", sysPropOffset)
+		assert.Contains(t, r.Metadata, sysPropIotHubDeviceConnectionID, "IoT device event missing: %s", sysPropIotHubDeviceConnectionID)
+		assert.Contains(t, r.Metadata, sysPropIotHubAuthGenerationID, "IoT device event missing: %s", sysPropIotHubAuthGenerationID)
+		assert.Contains(t, r.Metadata, sysPropIotHubConnectionAuthMethod, "IoT device event missing: %s", sysPropIotHubConnectionAuthMethod)
+		assert.Contains(t, r.Metadata, sysPropIotHubEnqueuedTime, "IoT device event missing: %s", sysPropIotHubEnqueuedTime)
+	}
+
+	eh.Close()
+}
+
+func TestIntegrationCases(t *testing.T) {
+	connectionString := os.Getenv(iotHubConnectionStringEnvKey)
+	if connectionString == "" {
+		t.Skipf("EventHubs bindings integration to IoT Hub tests skipped. To enable them, define the endpoint connection string using environment variable '%s')", iotHubConnectionStringEnvKey)
+	}
+
+	t.Run("Read IoT Hub events", testReadIotHubEvents)
+}

--- a/pubsub/azure/eventhubs/eventhubs_integration_test.go
+++ b/pubsub/azure/eventhubs/eventhubs_integration_test.go
@@ -1,0 +1,115 @@
+//go:build integration_test
+// +build integration_test
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package eventhubs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	// Note: Reuse the environment variables names from the conformance tests where possible to support reuse of setup workflows
+
+	// iotHubConnectionStringEnvKey defines the key containing the integration test connection string
+	// For the default EventHub endpoint for an Azure IoT Hub, it will resemble:
+	// Endpoint=sb://<iotHubGeneratedNamespace>.servicebus.windows.net/;SharedAccessKeyName=service;SharedAccessKey=<key>;EntityPath=<iotHubGeneratedPath>
+	iotHubConnectionStringEnvKey = "AzureIotHubEventHubConnectionString"
+	iotHubConsumerGroupEnvKey    = "AzureIotHubPubsubConsumerGroup"
+	iotHubNameEnvKey             = "AzureIotHubName"
+	storageAccountNameEnvKey     = "AzureBlobStorageAccount"
+	storageAccountKeyEnvKey      = "AzureBlobStorageAccessKey"
+	azureCredentialsEnvKey       = "AZURE_CREDENTIALS"
+
+	testStorageContainerName = "iothub-pubsub-integration-test"
+	testTopic                = "integration-test-topic"
+)
+
+func createIotHubPubsubMetadata() pubsub.Metadata {
+	metadata := pubsub.Metadata{
+		Properties: map[string]string{
+			connectionString:     os.Getenv(iotHubConnectionStringEnvKey),
+			consumerID:           os.Getenv(iotHubConsumerGroupEnvKey),
+			storageAccountName:   os.Getenv(storageAccountNameEnvKey),
+			storageAccountKey:    os.Getenv(storageAccountKeyEnvKey),
+			storageContainerName: testStorageContainerName,
+		},
+	}
+
+	return metadata
+}
+
+func testReadIotHubEvents(t *testing.T) {
+	logger := logger.NewLogger("pubsub.azure.eventhubs.integration.test")
+	eh := NewAzureEventHubs(logger)
+	err := eh.Init(createIotHubPubsubMetadata())
+	assert.Nil(t, err)
+
+	// Invoke az CLI via bash script to send test IoT device events
+	// Requires the AZURE_CREDENTIALS environment variable to be already set (output of `az ad sp create-for-rbac`)
+	cmd := exec.Command("/bin/bash", "../../../tests/scripts/send-iot-device-events.sh")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("IOT_HUB_NAME=%s", os.Getenv(iotHubNameEnvKey)))
+	out, err := cmd.CombinedOutput()
+	assert.Nil(t, err, "Error in send-iot-device-events.sh:\n%s", out)
+
+	// Setup subscription to capture messages in a closure so that test asserts can be
+	// performed on the main thread, including the case where the handler is never invoked.
+	var messages []pubsub.NewMessage
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		messages = append(messages, *msg)
+		return nil
+	}
+
+	req := pubsub.SubscribeRequest{
+		Topic:    testTopic, // TODO: Handle Topic configuration after EventHubs pubsub rewrite #951
+		Metadata: map[string]string{},
+	}
+	err = eh.Subscribe(req, handler)
+	assert.Nil(t, err)
+
+	// Note: azure-event-hubs-go SDK defaultLeasePersistenceInterval is 5s
+	// Sleep long enough so that the azure event hubs SDK has time to persist updated checkpoints
+	// before the test process exits.
+	time.Sleep(10 * time.Second)
+
+	assert.Greater(t, len(messages), 0, "Failed to receive any IotHub events")
+	logger.Infof("Received %d messages", len(messages))
+	for _, r := range messages {
+		assert.Equal(t, r.Topic, testTopic, "Message topic doesn't match subscription")
+		assert.Contains(t, string(r.Data), "Integration test message")
+
+		// Verify expected IoT Hub device event metadata exists
+		// TODO: add device messages than can populate the sysPropPartitionKey and sysPropIotHubConnectionModuleID metadata
+		assert.Contains(t, r.Metadata, sysPropSequenceNumber, "IoT device event missing: %s", sysPropSequenceNumber)
+		assert.Contains(t, r.Metadata, sysPropEnqueuedTime, "IoT device event missing: %s", sysPropEnqueuedTime)
+		assert.Contains(t, r.Metadata, sysPropOffset, "IoT device event missing: %s", sysPropOffset)
+		assert.Contains(t, r.Metadata, sysPropIotHubDeviceConnectionID, "IoT device event missing: %s", sysPropIotHubDeviceConnectionID)
+		assert.Contains(t, r.Metadata, sysPropIotHubAuthGenerationID, "IoT device event missing: %s", sysPropIotHubAuthGenerationID)
+		assert.Contains(t, r.Metadata, sysPropIotHubConnectionAuthMethod, "IoT device event missing: %s", sysPropIotHubConnectionAuthMethod)
+		assert.Contains(t, r.Metadata, sysPropIotHubEnqueuedTime, "IoT device event missing: %s", sysPropIotHubEnqueuedTime)
+	}
+
+	eh.Close()
+}
+
+func TestIntegrationCases(t *testing.T) {
+	connectionString := os.Getenv(iotHubConnectionStringEnvKey)
+	if connectionString == "" {
+		t.Skipf("EventHubs pubsub integration to IoT Hub tests skipped. To enable them, define the endpoint connection string using environment variable '%s')", iotHubConnectionStringEnvKey)
+	}
+
+	t.Run("Read IoT Hub events", testReadIotHubEvents)
+}

--- a/tests/scripts/send-iot-device-events.sh
+++ b/tests/scripts/send-iot-device-events.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation and Dapr Contributors.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+set -e
+
+if [[ -z "${IOT_HUB_NAME}" ]]; then
+    echo "ERROR: IOT_HUB_NAME environment variable not defined."
+    exit 1
+fi
+if [[ -z "${AZURE_CREDENTIALS}" ]]; then
+    echo "ERROR: AZURE_CREDENTIALS environment variable not defined."
+    exit 1
+fi
+
+# Log in to Azure using provided Service Principal (SP) credentials
+# The provided SP must have Contributor role access to the IoT Hub specified by IOT_HUB_NAME
+SDK_AUTH_SP_APPID="$(echo "${AZURE_CREDENTIALS}" | grep 'clientId' | sed -E 's/(.*clientId\"\: \")|\",//g')"
+SDK_AUTH_SP_CLIENT_SECRET="$(echo "${AZURE_CREDENTIALS}" | grep 'clientSecret' | sed -E 's/(.*clientSecret\"\: \")|\",//g')"
+SDK_AUTH_SP_TENANT="$(echo "${AZURE_CREDENTIALS}" | grep 'tenantId' | sed -E 's/(.*tenantId\"\: \")|\",//g')"
+az login --service-principal -u ${SDK_AUTH_SP_APPID} -p ${SDK_AUTH_SP_CLIENT_SECRET} --tenant ${SDK_AUTH_SP_TENANT}
+
+# Create test device ID if not already present
+IOT_HUB_TEST_DEVICE_NAME="test-device"
+if [[ -z "$(az iot hub device-identity show -n ${IOT_HUB_NAME} -d ${IOT_HUB_TEST_DEVICE_NAME})" ]]; then
+    az iot hub device-identity create -n ${IOT_HUB_NAME} -d ${IOT_HUB_TEST_DEVICE_NAME}
+    sleep 5
+fi
+
+# Send the test IoT device messages to the IoT Hub
+az iot device send-d2c-message -n ${IOT_HUB_NAME} -d ${IOT_HUB_TEST_DEVICE_NAME} --data '{ "data": "Integration test message" }' --msg-count 2


### PR DESCRIPTION
# Description

- Add setup of Azure IoT Hub to setup-azure-conf-tests.sh for integration testing with EventHubs bindings/pubsub.
- Backfill functional tests for #1009

## Issue reference

Test follow-up to #227 
Test infrastructure to support #951 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
