### PR TITLE
Version SQLServer stored procedure due to previous changes made

### DIFF
--- a/state/sqlserver/migration.go
+++ b/state/sqlserver/migration.go
@@ -41,7 +41,7 @@ func (m *migration) newMigrationResult() migrationResult {
 	r := migrationResult{
 		bulkDeleteProcName:       fmt.Sprintf("sp_BulkDelete_%s", m.store.tableName),
 		itemRefTableTypeName:     fmt.Sprintf("[%s].%s_Table", m.store.schema, m.store.tableName),
-		upsertProcName:           fmt.Sprintf("sp_Upsert_%s", m.store.tableName),
+		upsertProcName:           fmt.Sprintf("sp_Upsert_v2_%s", m.store.tableName),
 		getCommand:               fmt.Sprintf("SELECT [Data], [RowVersion] FROM [%s].[%s] WHERE [Key] = @Key", m.store.schema, m.store.tableName),
 		deleteWithETagCommand:    fmt.Sprintf(`DELETE [%s].[%s] WHERE [Key]=@Key AND [RowVersion]=@RowVersion`, m.store.schema, m.store.tableName),
 		deleteWithoutETagCommand: fmt.Sprintf(`DELETE [%s].[%s] WHERE [Key]=@Key`, m.store.schema, m.store.tableName),


### PR DESCRIPTION
# Description

SQLServer upsert procedure is now versioned (new name) to ensure everyone uses the latest correct version of the stored procedure when updating Dapr.

## Issue reference
As per #1175 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

Manually ran conformance tests and integration tests against Azure SQL Server.