### PR TITLE
Improve mDNS nameresolver code quality

### DIFF
--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -482,7 +482,7 @@ func (m *resolver) getAppIDsIPv4() []string {
 	m.ipv4Mu.RLock()
 	defer m.ipv4Mu.RUnlock()
 
-	appIDs := make([]string, len(m.appAddressesIPv4))
+	appIDs := make([]string, 0, len(m.appAddressesIPv4))
 	for appID, addr := range m.appAddressesIPv4 {
 		old := len(addr.addresses)
 		addr.expire()
@@ -499,7 +499,7 @@ func (m *resolver) getAppIDsIPv6() []string {
 	m.ipv6Mu.RLock()
 	defer m.ipv6Mu.RUnlock()
 
-	appIDs := make([]string, len(m.appAddressesIPv6))
+	appIDs := make([]string, 0, len(m.appAddressesIPv6))
 	for appID, addr := range m.appAddressesIPv6 {
 		old := len(addr.addresses)
 		addr.expire()

--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -49,7 +49,7 @@ type address struct {
 // addressList represents a set of addresses along with
 // data used to control and access said addresses.
 type addressList struct {
-	addresses []*address
+	addresses []address
 	counter   uint32
 	mu        sync.RWMutex
 }
@@ -67,9 +67,6 @@ func (a *addressList) expire() {
 			i++
 		}
 	}
-	for j := i; j < len(a.addresses); j++ {
-		a.addresses[j] = nil // clear truncated pointers
-	}
 	a.addresses = a.addresses[:i] // resize slice
 }
 
@@ -81,14 +78,14 @@ func (a *addressList) add(ip string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for _, addr := range a.addresses {
-		if addr.ip == ip {
-			addr.expiresAt = time.Now().Add(addressTTL)
+	for i := range a.addresses {
+		if a.addresses[i].ip == ip {
+			a.addresses[i].expiresAt = time.Now().Add(addressTTL)
 
 			return
 		}
 	}
-	a.addresses = append(a.addresses, &address{
+	a.addresses = append(a.addresses, address{
 		ip:        ip,
 		expiresAt: time.Now().Add(addressTTL),
 	})

--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -35,7 +35,7 @@ const (
 	refreshInterval = time.Second * 30
 	// addressTTL is the duration an address has before
 	// becoming stale and being evicted.
-	addressTTL = time.Second * 45
+	addressTTL = time.Second * 60
 )
 
 // address is used to store an ip address along with
@@ -359,14 +359,13 @@ func (m *resolver) refreshAllApps(ctx context.Context) error {
 
 	// expired addresses will be evicted by getAppIDs()
 	for _, appID := range m.getAppIDs() {
-		_appID := appID
 		wg.Add(1)
 
-		go func() {
+		go func(a string) {
 			defer wg.Done()
 
-			m.refreshApp(ctx, _appID)
-		}()
+			m.refreshApp(ctx, a)
+		}(appID)
 	}
 
 	// wait for all the app refreshes to complete.

--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"strconv"
@@ -36,6 +35,8 @@ const (
 	// addressTTL is the duration an address has before
 	// becoming stale and being evicted.
 	addressTTL = time.Second * 60
+	// max integer value supported on this architecture.
+	maxInt = int(^uint(0) >> 1)
 )
 
 // address is used to store an ip address along with
@@ -50,7 +51,7 @@ type address struct {
 // data used to control and access said addresses.
 type addressList struct {
 	addresses []address
-	counter   uint32
+	counter   int
 	mu        sync.RWMutex
 }
 
@@ -103,10 +104,10 @@ func (a *addressList) next() *string {
 		return nil
 	}
 
-	if a.counter == math.MaxUint32 {
+	if a.counter == maxInt {
 		a.counter = 0
 	}
-	index := a.counter % uint32(len(a.addresses))
+	index := a.counter % len(a.addresses)
 	addr := a.addresses[index]
 	a.counter++
 

--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -67,7 +67,7 @@ func (a *addressList) expire() {
 			i++
 		}
 	}
-	a.addresses = a.addresses[:i] // resize slice
+	a.addresses = a.addresses[:i]
 }
 
 // add adds a new address to the address list with a
@@ -456,7 +456,8 @@ func (m *resolver) addAppAddressIPv4(appID string, addr string) {
 
 	m.logger.Debugf("Adding IPv4 address %s for app id %s cache entry.", addr, appID)
 	if _, ok := m.appAddressesIPv4[appID]; !ok {
-		m.appAddressesIPv4[appID] = &addressList{}
+		var addrList addressList
+		m.appAddressesIPv4[appID] = &addrList
 	}
 	m.appAddressesIPv4[appID].add(addr)
 }
@@ -469,7 +470,8 @@ func (m *resolver) addAppAddressIPv6(appID string, addr string) {
 
 	m.logger.Debugf("Adding IPv6 address %s for app id %s cache entry.", addr, appID)
 	if _, ok := m.appAddressesIPv6[appID]; !ok {
-		m.appAddressesIPv6[appID] = &addressList{}
+		var addrList addressList
+		m.appAddressesIPv6[appID] = &addrList
 	}
 	m.appAddressesIPv6[appID].add(addr)
 }

--- a/nameresolution/mdns/mdns_test.go
+++ b/nameresolution/mdns/mdns_test.go
@@ -7,7 +7,6 @@ package mdns
 
 import (
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -313,7 +312,7 @@ func TestAddressListNextMaxCounter(t *testing.T) {
 	require.Equal(t, "addr1", *addressList.next())
 	require.Equal(t, "addr2", *addressList.next())
 	require.Equal(t, "addr3", *addressList.next())
-	addressList.counter = math.MaxUint32
+	addressList.counter = maxInt
 	require.Equal(t, "addr0", *addressList.next())
 	require.Equal(t, "addr1", *addressList.next())
 	require.Equal(t, "addr2", *addressList.next())

--- a/nameresolution/mdns/mdns_test.go
+++ b/nameresolution/mdns/mdns_test.go
@@ -161,7 +161,7 @@ func TestAddressListExpire(t *testing.T) {
 	expired := base.Add(-60 * time.Second)
 	notExpired := base.Add(60 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "expired0",
 				expiresAt: expired,
@@ -188,7 +188,7 @@ func TestAddressListAddNewAddress(t *testing.T) {
 	// arrange
 	expiry := time.Now().Add(60 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "addr0",
 				expiresAt: expiry,
@@ -212,7 +212,7 @@ func TestAddressListAddExisitingAddress(t *testing.T) {
 	// arrange
 	expiry := time.Now().Add(10 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "addr0",
 				expiresAt: expiry,
@@ -226,18 +226,18 @@ func TestAddressListAddExisitingAddress(t *testing.T) {
 
 	// act
 	addressList.add("addr1")
-	deltaSec := int(addressList.addresses[1].expiresAt.Sub(expiry).Seconds())
+	expiryDeltaInSec := int(addressList.addresses[1].expiresAt.Sub(expiry).Seconds())
 
 	// assert
 	require.Len(t, addressList.addresses, 2)
-	require.Greater(t, deltaSec, 0)
+	require.Greater(t, expiryDeltaInSec, 0) // Ensures expiry has been extended for existing address.
 }
 
 func TestAddressListNext(t *testing.T) {
 	// arrange
 	expiry := time.Now().Add(10 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "addr0",
 				expiresAt: expiry,
@@ -280,7 +280,7 @@ func TestAddressListNextMaxCounter(t *testing.T) {
 	// arrange
 	expiry := time.Now().Add(10 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "addr0",
 				expiresAt: expiry,
@@ -322,7 +322,7 @@ func TestAddressListNextMaxCounter(t *testing.T) {
 func TestAddressListNextNoAddress(t *testing.T) {
 	// arrange
 	addressList := &addressList{
-		addresses: []*address{},
+		addresses: []address{},
 	}
 
 	// act & assert
@@ -333,7 +333,7 @@ func TestAddressListNextWithAdd(t *testing.T) {
 	// arrange
 	expiry := time.Now().Add(10 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "addr0",
 				expiresAt: expiry,
@@ -379,7 +379,7 @@ func TestAddressListNextWithExpiration(t *testing.T) {
 	expiry := time.Now().Add(10 * time.Second)
 	expired := time.Now().Add(-60 * time.Second)
 	addressList := &addressList{
-		addresses: []*address{
+		addresses: []address{
 			{
 				ip:        "addr0",
 				expiresAt: expired,

--- a/nameresolution/mdns/mdns_test.go
+++ b/nameresolution/mdns/mdns_test.go
@@ -225,11 +225,11 @@ func TestAddressListAddExisitingAddress(t *testing.T) {
 
 	// act
 	addressList.add("addr1")
-	expiryDeltaInSec := int(addressList.addresses[1].expiresAt.Sub(expiry).Seconds())
+	deltaSec := int(addressList.addresses[1].expiresAt.Sub(expiry).Seconds())
 
 	// assert
 	require.Len(t, addressList.addresses, 2)
-	require.Greater(t, expiryDeltaInSec, 0) // Ensures expiry has been extended for existing address.
+	require.Greater(t, deltaSec, 0) // Ensures expiry has been extended for existing address.
 }
 
 func TestAddressListNext(t *testing.T) {


### PR DESCRIPTION
# Description
I was just reading the mDNS nameresolver and noticed a few code smells I had left in there during the implementation, namely:
- loop closure variables
- slices of pointers
- over specialized types
- appending to none zero length initialized slices
- using explicit zero value initialization over empty literal initialization

So I've just cleaned these up in the PR.

I have also extended the mDNS address timeout from 45 secs to 60 secs. The addresses are refreshed every 30 secs so this shouldn't actually change any behavior and is just there increase the potential cache lifetime slightly.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
