### PR TITLE
Add state.sqlserver conformance test against Azure SQL

### DIFF
--- a/.github/infrastructure/conformance/azure/conf-test-azure-sqlserver.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure-sqlserver.bicep
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+param sqlServerName string
+param rgLocation string = resourceGroup().location
+param confTestTags object = {}
+param sqlServerAdminPassword string
+
+var sqlServerAdminName = '${sqlServerName}-admin'
+
+resource sqlServer 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: sqlServerName
+  location: rgLocation
+  tags: confTestTags
+  properties: {
+    administratorLogin: sqlServerAdminName
+    administratorLoginPassword: sqlServerAdminPassword
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+output sqlServerAdminName string = sqlServer.properties.administratorLogin

--- a/.github/infrastructure/conformance/azure/conf-test-azure.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure.bicep
@@ -33,6 +33,10 @@ param sdkAuthSpId string
 @description('Provide the objectId of the Service Principal using cert auth with get and list access to all assets in Azure Key Vault.')
 param certAuthSpId string
 
+@minLength(16)
+@description('Provide the SQL server admin password of at least 16 characters.')
+param sqlServerAdminPassword string
+
 var confTestRgName = '${toLower(namePrefix)}-conf-test-rg'
 var cosmosDbName = '${toLower(namePrefix)}-conf-test-db'
 var eventGridTopicName = '${toLower(namePrefix)}-conf-test-eventgrid-topic'
@@ -40,6 +44,7 @@ var eventHubsNamespaceName = '${toLower(namePrefix)}-conf-test-eventhubs'
 var iotHubName = '${toLower(namePrefix)}-conf-test-iothub'
 var keyVaultName = '${toLower(namePrefix)}-conf-test-kv'
 var serviceBusName = '${toLower(namePrefix)}-conf-test-servicebus'
+var sqlServerName = '${toLower(namePrefix)}-conf-test-sql'
 var storageName = '${toLower(namePrefix)}ctstorage'
 
 resource confTestRg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -105,6 +110,16 @@ module serviceBus 'conf-test-azure-servicebus.bicep' = {
   }
 }
 
+module sqlServer 'conf-test-azure-sqlserver.bicep' = {
+  name: sqlServerName
+  scope: resourceGroup(confTestRg.name)
+  params: {
+    confTestTags: confTestTags
+    sqlServerName: sqlServerName
+    sqlServerAdminPassword: sqlServerAdminPassword
+  }
+}
+
 module storage 'conf-test-azure-storage.bicep' = {
   name: storageName
   scope: resourceGroup(confTestRg.name)
@@ -131,4 +146,6 @@ output iotHubBindingsConsumerGroupName string = iotHub.outputs.iotHubBindingsCon
 output iotHubPubsubConsumerGroupName string = iotHub.outputs.iotHubPubsubConsumerGroupName
 output keyVaultName string = keyVault.name
 output serviceBusName string = serviceBus.name
+output sqlServerName string = sqlServer.name
+output sqlServerAdminName string = sqlServer.outputs.sqlServerAdminName
 output storageName string = storage.name

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -93,6 +93,8 @@ jobs:
         CRON_COMPONENTS=$(yq -I0 --tojson eval - << EOF
         - component: state.azure.cosmosdb
           required-secrets: AzureCosmosDBMasterKey,AzureCosmosDBUrl,AzureCosmosDB,AzureCosmosDBCollection
+        - component: state.azure.sql
+          required-secrets: AzureResourceGroupName, AzureSqlServerName, AzureSqlServerConnectionString
         - component: state.azure.tablestorage
           required-secrets: AzureBlobStorageAccessKey,AzureBlobStorageAccount
         - component: pubsub.azure.eventhubs
@@ -269,6 +271,18 @@ jobs:
         go mod download
         go install gotest.tools/gotestsum@latest
 
+    - name: Configure Azure SQL Firewall
+      run: |
+        set +e
+        TEST_OUTPUT="$(go test -v -tags=conftests -count=1 -timeout=1m ./tests/conformance -run=TestStateConformance/azure.sql)"
+        echo "Trial run result:\n\"$TEST_OUTPUT\""
+        PUBLIC_IP=$(echo "$TEST_OUTPUT" | grep -Po "Client with IP address '\K[^']*")
+        if [[ -n ${PUBLIC_IP} ]]; then
+          echo "Setting Azure SQL firewall-rule AllowTestRunnerIP to allow $PUBLIC_IP..."
+          az sql server firewall-rule create --resource-group ${{ env.AzureResourceGroupName }} --server ${{ env.AzureSqlServerName }} -n "AllowTestRunnerIP" --start-ip-address "$PUBLIC_IP" --end-ip-address "$PUBLIC_IP"
+        fi
+      if: contains(matrix.component, 'azure.sql')
+
     - name: Run tests
       continue-on-error: true
       run: |
@@ -306,6 +320,13 @@ jobs:
       if: contains(matrix.component, 'azure.eventgrid')
       continue-on-error: true
       run: pkill ngrok; cat /tmp/ngrok.log
+
+    - name: Cleanup Azure SQL Firewall and test DB instance
+      if: contains(matrix.component, 'azure.sql')
+      continue-on-error: true
+      run: |
+        az sql server firewall-rule delete --resource-group ${{ env.AzureResourceGroupName }} --server ${{ env.AzureSqlServerName }} -n "AllowTestRunnerIP"
+        az sql db delete --resource-group ${{ env.AzureResourceGroupName }} --server ${{ env.AzureSqlServerName }} -n dapr --yes
 
     # Download the required certificates into files, and set env var pointing to their names
     - name: Clean up certs

--- a/tests/config/state/azure/sql/statestore.yaml
+++ b/tests/config/state/azure/sql/statestore.yaml
@@ -1,0 +1,17 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.sqlserver
+  metadata:
+  - name: connectionString
+    value: ${{AzureSqlServerConnectionString}}
+  - name: tableName
+    value: dapr_conf_test
+  - name: keyType
+    value: string
+  - name: keyLength
+    value: 120
+  - name: schema
+    value: proto

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -7,6 +7,8 @@ components:
     allOperations: true
   - component: azure.cosmosdb
     allOperations: true
+  - component: azure.sql
+    allOperations: true
   - component: sqlserver
     allOperations: true
   - component: mysql

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -374,6 +374,8 @@ func loadStateStore(tc TestComponent) state.Store {
 		store = s_cosmosdb.NewCosmosDBStateStore(testLogger)
 	case "mongodb":
 		store = s_mongodb.NewMongoDB(testLogger)
+	case "azure.sql":
+		fallthrough
 	case "sqlserver":
 		store = s_sqlserver.NewSQLServerStateStore(testLogger)
 	case "mysql":


### PR DESCRIPTION
# Description

- Add support in setup-azure-conf-test.sh for deploying Azure SQL server the state.sqlserver conformance/integration testing.
   - Avoid pre-creating the database as Azure SQL DBs charge for hosting that does not scale to zero.
   - Provision the test runner Service Principal as Contributor so it can configure the firewall and create DBs as needed during testing.
- Add conformance test state.azure.sql for exercising state.sqlserver component against Azure SQL instance.
   - Add special handling in conformance.yml to configure Azure SQL firewall rules to permit test running IP to connect, and to clean up firewall rule and test DB afterwards.
   - Existing sqlserver_integration_test.go can reuse the deployed Azure SQL instance by following similar steps to configure the SQL firewall, and mapping `export DAPR_TEST_SQL_CONNSTRING="$AzureSqlServerConnectionString"`, where `AzureSqlServerConnectionString` can be sourced from the setup-azure-conf-test.sh generated conf-test-config.rc file.

## Issue reference

Rounding out conformance testing specifically against Azure SQL for https://github.com/dapr/components-contrib/issues/949

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
