### PR TITLE
Force lowercase name for Azure Service Bus Queue

### DIFF
--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -8,6 +8,7 @@ package servicebusqueues
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
@@ -129,6 +130,9 @@ func (a *AzureServiceBusQueues) parseMetadata(metadata bindings.Metadata) (*serv
 	}
 
 	m.ttl = ttl
+
+	// Queue names are case-insensitive and are forced to lowercase. This mimics the Azure portal's behavior.
+	m.QueueName = strings.ToLower(m.QueueName)
 
 	return &m, nil
 }


### PR DESCRIPTION
# Description

Azure Service Bus Queue names are case-insensitive. When one is
created it will always be forced to lowercase. If a queue with a
non-lowercase is provided, it will be created but can never be
matched causing the next Init to fail.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1185 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
