### PR TITLE
Managed Identity Certification Test for Azure KeyVault Component

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -76,7 +76,7 @@ jobs:
         # Only list the secrets you need for the component.
         CRON_COMPONENTS=$(yq -I0 --tojson eval - << EOF
         - component: secretstores.azure.keyvault
-          required-secrets: AzureKeyVaultName,AzureKeyVaultSecretStoreTenantId,AzureKeyVaultSecretStoreClientId,AzureKeyVaultSecretStoreServicePrincipalClientId,AzureKeyVaultSecretStoreServicePrincipalClientSecret
+          required-secrets: AzureKeyVaultName,AzureKeyVaultSecretStoreTenantId,AzureKeyVaultSecretStoreClientId,AzureKeyVaultSecretStoreServicePrincipalClientId,AzureKeyVaultSecretStoreServicePrincipalClientSecret,AzureContainerRegistryName
           required-certs: AzureKeyVaultSecretStoreCert
         - component: state.sqlserver
           required-secrets: AzureSqlServerConnectionString

--- a/tests/certification/secretstores/azure/keyvault/keyvault_test.go
+++ b/tests/certification/secretstores/azure/keyvault/keyvault_test.go
@@ -104,6 +104,8 @@ func TestKeyVault(t *testing.T) {
 		Step("Getting known secret", testGetKnownSecret, sidecar.Stop(sidecarName)).
 		Run()
 
+	// This test reuses the Azure conformance test resources created using
+	// .github/infrastructure/conformance/azure/setup-azure-conf-test.sh
 	managedIdentityTest := func(ctx flow.Context) error {
 		_, err := exec.LookPath("az")
 		if err != nil {

--- a/tests/certification/secretstores/azure/keyvault/keyvault_test.go
+++ b/tests/certification/secretstores/azure/keyvault/keyvault_test.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,8 +78,8 @@ func TestKeyVault(t *testing.T) {
 					return akv.NewAzureKeyvaultSecretStore(log)
 				}),
 			))).
-		Step("Getting known secret", testGetKnownSecret)
-		// Run()
+		Step("Getting known secret", testGetKnownSecret).
+		Run()
 
 	// Currently port reuse is still not quite working in the Dapr runtime.
 	ports, err = dapr_testing.GetFreePorts(2)
@@ -100,12 +101,10 @@ func TestKeyVault(t *testing.T) {
 					return akv.NewAzureKeyvaultSecretStore(log)
 				}),
 			))).
-		Step("Getting known secret", testGetKnownSecret, sidecar.Stop(sidecarName))
-		// Run()
+		Step("Getting known secret", testGetKnownSecret, sidecar.Stop(sidecarName)).
+		Run()
 
-	// az acr create -g dapr2-conf-test-rg -n dapr2conftestacr --sku Standard
-
-	msiFunc := func(ctx flow.Context) error {
+	managedIdentityTest := func(ctx flow.Context) error {
 		_, err := exec.LookPath("az")
 		if err != nil {
 			t.Error("azure-cli not installed")
@@ -121,21 +120,73 @@ func TestKeyVault(t *testing.T) {
 			t.Error("azure-managed-identity not found")
 		}
 
+		registryName, envVarFound := os.LookupEnv("AzureContainerRegistryName")
+		if envVarFound == false {
+			t.Error("AzureContainerRegistryName environment variable not set")
+		}
+		keyvaultName, envVarFound := os.LookupEnv("AzureKeyVaultName")
+		if envVarFound == false {
+			t.Error("AzureKeyVaultName environment variable not set")
+		}
+
+		// build and publish the image
+		buildContainerCommand := fmt.Sprintf("az acr build --image certification/keyvault:latest --registry %s --file managed-identity-app/Dockerfile ./managed-identity-app", registryName)
+		fmt.Printf("Building Container ==== : %s\n", buildContainerCommand)
+		err = exec.Command("bash", "-c", buildContainerCommand).Run()
+		if err != nil {
+			t.Error("failed to build and publish container")
+		}
+
 		// generate random string
 		rand.Seed(time.Now().UnixNano())
 		containerName := fmt.Sprintf("managedidentitytest%d", rand.Intn(10000)+1)
 
-		containerCreateCommand := fmt.Sprintf("az container create -g %s -n %s --image ubuntu:latest --command-line 'tail -f /dev/null' --memory 4 --cpu 2 --assign-identity %s", groupName, containerName, managedIdentityID)
-		fmt.Printf("Running Command ==== : %s", containerCreateCommand)
-		// err = exec.Command("bash", "-c", containerCreateCommand).Run()
-		// if err != nil {
-		// 	t.Error(fmt.Sprintf("container %s not created: %s", containerName, err))
-		// }
+		// run the container using Azure Container Instances with injected managed identity
+		registryPasswordSubcommand := fmt.Sprintf("az acr credential show -n %s --query passwords[0].value -otsv", registryName)
+		registryUsernameSubcommand := fmt.Sprintf("az acr credential show -n %s --query username -otsv", registryName)
+		containerCreateCommand := fmt.Sprintf("az container create -g %s -n %s --image %s.azurecr.io/certification/keyvault:latest --restart-policy never --environment-variables AzureKeyVaultName=%s --registry-password $(%s) --registry-username $(%s) --assign-identity %s", groupName, containerName, registryName, keyvaultName, registryPasswordSubcommand, registryUsernameSubcommand, managedIdentityID)
+		fmt.Printf("Running Container in Azure Container Instances ==== : %s\n", containerCreateCommand)
+		err = exec.Command("bash", "-c", containerCreateCommand).Run()
+		if err != nil {
+			t.Error(fmt.Sprintf("container %s not created: %s", containerName, err))
+		}
 
+		// read the container logs
+		logsCommand := fmt.Sprintf("az container logs -g %s -n %s", groupName, containerName)
+		fmt.Printf("Reading Container Logs ==== : %s\n", logsCommand)
+		output, err := exec.Command("bash", "-c", logsCommand).Output()
+		if err != nil {
+			t.Error(fmt.Sprintf("failed to get logs for container %s: %s", containerName, err))
+		}
+		expectedOuput := `{"secondsecret":"efgh"}`
+		outputFound := true
+		// if string contains "efgh" then the secret was successfully read
+		if !strings.Contains(string(output), expectedOuput) {
+			// in the unlikely event the operation has not completed yet we will check the logs one more time in 60 seconds
+			time.Sleep(time.Second * 60)
+			output, err = exec.Command("bash", "-c", logsCommand).Output()
+			if err != nil {
+				t.Error(fmt.Sprintf("failed to get logs for container %s: %s", containerName, err))
+			}
+			if !strings.Contains(string(output), expectedOuput) {
+				outputFound = false
+			}
+		}
+		// shut down the container
+		shutdownCommand := fmt.Sprintf("az container delete -g %s -n %s --yes", groupName, containerName)
+		fmt.Printf("Shutting Down Container ==== : %s\n", shutdownCommand)
+		err = exec.Command("bash", "-c", shutdownCommand).Run()
+		if err != nil {
+			t.Error(fmt.Sprintf("failed to shutdown container %s: %s", containerName, err))
+		}
+
+		if outputFound == false {
+			assert.Fail(t, fmt.Sprintf("failed to read secret secondsecret from KeyVault %s using managed identity %s in container %s: %s", keyvaultName, managedIdentityID, containerName, err))
+		}
 		return nil
 	}
 
 	flow.New(t, "keyvault authentication using managed identity").
-		Step("Run the thing", msiFunc).
+		Step("Test secret access using managed identity authentication", managedIdentityTest).
 		Run()
 }

--- a/tests/certification/secretstores/azure/keyvault/managed-identity-app/Dockerfile
+++ b/tests/certification/secretstores/azure/keyvault/managed-identity-app/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+COPY . /app
+WORKDIR /app
+RUN apt-get update && apt-get install wget curl --yes
+RUN wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
+RUN dapr init --slim
+ENV AzureKeyVaultName=dapr2-conf-test-kv
+ENTRYPOINT [ "bash", "startup.sh" ]

--- a/tests/certification/secretstores/azure/keyvault/managed-identity-app/components/keyvault.yaml
+++ b/tests/certification/secretstores/azure/keyvault/managed-identity-app/components/keyvault.yaml
@@ -1,0 +1,16 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: azurekeyvault
+  namespace: default
+spec:
+  type: secretstores.azure.keyvault
+  version: v1
+  metadata:
+  - name: vaultName
+    secretKeyRef:
+        name: AzureKeyVaultName
+        key:  AzureKeyVaultName
+
+auth:
+  secretStore: envvar-secret-store

--- a/tests/certification/secretstores/azure/keyvault/managed-identity-app/components/localsecrets.yaml
+++ b/tests/certification/secretstores/azure/keyvault/managed-identity-app/components/localsecrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: envvar-secret-store
+  namespace: default
+spec:
+  type: secretstores.local.env
+  version: v1
+  metadata:

--- a/tests/certification/secretstores/azure/keyvault/managed-identity-app/startup.sh
+++ b/tests/certification/secretstores/azure/keyvault/managed-identity-app/startup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 $(dapr run --app-id=secretsapp --dapr-http-port 3500 --app-protocol grpc --components-path components/) &
+DAPRD_PID=$!
 sleep 5
-curl http://127.0.0.1:3500/v1.0/secrets/azurekeyvault/bulk
+curl --silent http://127.0.0.1:3500/v1.0/secrets/azurekeyvault/secondsecret
+kill $DAPRD_PID

--- a/tests/certification/secretstores/azure/keyvault/managed-identity-app/startup.sh
+++ b/tests/certification/secretstores/azure/keyvault/managed-identity-app/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+$(dapr run --app-id=secretsapp --dapr-http-port 3500 --app-protocol grpc --components-path components/) &
+sleep 5
+curl http://127.0.0.1:3500/v1.0/secrets/azurekeyvault/bulk


### PR DESCRIPTION
# Description

Adds certification for Managed Identity Authentication to the Azure Key Vault Component.

This builds a container image and stores it using Azure Container Registry, then runs the container image in Azure Container Instances with injected managed identity.

The requisite `dapr2conftestacr` container registry (with standard SKU) has already been created.

## Issue reference

closes #959 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
