### PR TITLE
Add missing env variable for KV certification test

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -76,7 +76,7 @@ jobs:
         # Only list the secrets you need for the component.
         CRON_COMPONENTS=$(yq -I0 --tojson eval - << EOF
         - component: secretstores.azure.keyvault
-          required-secrets: AzureKeyVaultName,AzureKeyVaultSecretStoreTenantId,AzureKeyVaultSecretStoreClientId,AzureKeyVaultSecretStoreServicePrincipalClientId,AzureKeyVaultSecretStoreServicePrincipalClientSecret,AzureContainerRegistryName
+          required-secrets: AzureKeyVaultName,AzureKeyVaultSecretStoreTenantId,AzureKeyVaultSecretStoreClientId,AzureKeyVaultSecretStoreServicePrincipalClientId,AzureKeyVaultSecretStoreServicePrincipalClientSecret,AzureContainerRegistryName,AzureResourceGroupName
           required-certs: AzureKeyVaultSecretStoreCert
         - component: state.sqlserver
           required-secrets: AzureSqlServerConnectionString


### PR DESCRIPTION
# Description

GitHub Workflow for KV Certification is failing at the moment due to a missing environment variable / secret.

This PR injects the missing environment variable.
