### PR TITLE
Adds retry on CosmosDB Init in case of TooManyRequests error

### DIFF
--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/a8m/documentdb"
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 
 	"github.com/dapr/components-contrib/authentication/azure"
 

--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -38,6 +38,8 @@ type cosmosDBCredentials struct {
 	PartitionKey string `json:"partitionKey"`
 }
 
+const statusTooManyRequests = "429" // RFC 6585, 4
+
 // NewCosmosDB returns a new CosmosDB instance.
 func NewCosmosDB(logger logger.Logger) *CosmosDB {
 	return &CosmosDB{logger: logger}
@@ -218,7 +220,7 @@ func isTooManyRequestsError(err error) bool {
 	}
 
 	if requestError, ok := err.(*documentdb.RequestError); ok {
-		if requestError.Code == "429" {
+		if requestError.Code == statusTooManyRequests {
 			return true
 		}
 	}

--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -96,7 +96,7 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 			}
 			return backoff.Permanent(err)
 		} else if len(dbs) == 0 {
-			return fmt.Errorf("database %s for CosmosDB binding not found", m.Database)
+			return backoff.Permanent(fmt.Errorf("database %s for CosmosDB binding not found", m.Database))
 		}
 
 		c.db = &dbs[0]
@@ -112,7 +112,7 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 			}
 			return backoff.Permanent(err)
 		} else if len(colls) == 0 {
-			return fmt.Errorf("collection %s for CosmosDB binding not found", m.Collection)
+			return backoff.Permanent(fmt.Errorf("collection %s for CosmosDB binding not found", m.Collection))
 		}
 
 		c.collection = &colls[0]

--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -7,7 +7,6 @@ package cosmosdb
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -218,8 +217,7 @@ func isTooManyRequestsError(err error) bool {
 		return false
 	}
 
-	var requestError *documentdb.RequestError
-	if errors.As(err, requestError) {
+	if requestError, ok := err.(*documentdb.RequestError); ok {
 		if requestError.Code == "429" {
 			return true
 		}

--- a/go.mod
+++ b/go.mod
@@ -153,6 +153,8 @@ require (
 	k8s.io/client-go v0.20.0
 )
 
+require github.com/cenkalti/backoff v2.2.1+incompatible
+
 require (
 	github.com/99designs/keyring v1.1.5 // indirect
 	github.com/AthenZ/athenz v1.10.15 // indirect
@@ -178,7 +180,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/danieljoos/wincred v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -153,8 +153,6 @@ require (
 	k8s.io/client-go v0.20.0
 )
 
-require github.com/cenkalti/backoff v2.2.1+incompatible // indirect
-
 require (
 	github.com/99designs/keyring v1.1.5 // indirect
 	github.com/AthenZ/athenz v1.10.15 // indirect
@@ -180,6 +178,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/danieljoos/wincred v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	k8s.io/client-go v0.20.0
 )
 
-require github.com/cenkalti/backoff v2.2.1+incompatible
+require github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 
 require (
 	github.com/99designs/keyring v1.1.5 // indirect

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -65,10 +65,11 @@ type storedProcedureDefinition struct {
 }
 
 const (
-	storedProcedureName  = "__dapr__"
-	metadataPartitionKey = "partitionKey"
-	unknownPartitionKey  = "__UNKNOWN__"
-	metadataTTLKey       = "ttlInSeconds"
+	storedProcedureName   = "__dapr__"
+	metadataPartitionKey  = "partitionKey"
+	unknownPartitionKey   = "__UNKNOWN__"
+	metadataTTLKey        = "ttlInSeconds"
+	statusTooManyRequests = "429" // RFC 6585, 4
 )
 
 // NewCosmosDBStateStore returns a new CosmosDB state store.
@@ -518,7 +519,7 @@ func isTooManyRequestsError(err error) bool {
 	}
 
 	if requestError, ok := err.(*documentdb.RequestError); ok {
-		if requestError.Code == "429" {
+		if requestError.Code == statusTooManyRequests {
 			return true
 		}
 	}

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/a8m/documentdb"
 	"github.com/agrea/ptr"
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -517,8 +517,7 @@ func isTooManyRequestsError(err error) bool {
 		return false
 	}
 
-	var requestError *documentdb.RequestError
-	if errors.As(err, requestError) {
+	if requestError, ok := err.(*documentdb.RequestError); ok {
 		if requestError.Code == "429" {
 			return true
 		}

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -154,7 +154,7 @@ func (c *StateStore) Init(meta state.Metadata) error {
 			}
 			return backoff.Permanent(err)
 		} else if len(dbs) == 0 {
-			return fmt.Errorf("database %s for CosmosDB state store not found", m.Database)
+			return backoff.Permanent(fmt.Errorf("database %s for CosmosDB state store not found", m.Database))
 		}
 
 		c.db = &dbs[0]
@@ -170,7 +170,7 @@ func (c *StateStore) Init(meta state.Metadata) error {
 			}
 			return backoff.Permanent(err)
 		} else if len(colls) == 0 {
-			return fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", m.Collection)
+			return backoff.Permanent(fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", m.Collection))
 		}
 
 		c.metadata = m
@@ -212,7 +212,7 @@ func (c *StateStore) Init(meta state.Metadata) error {
 
 		return nil
 	}, bo, func(err error, d time.Duration) {
-		c.logger.Warnf("CosmosDB State Store %s init retry: %v", err)
+		c.logger.Warnf("CosmosDB state store initialization failed: %v; retrying in %s", err, d)
 	})
 	if err != nil {
 		return err

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -12,9 +12,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/a8m/documentdb"
 	"github.com/agrea/ptr"
+	"github.com/cenkalti/backoff"
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 
@@ -131,62 +133,89 @@ func (c *StateStore) Init(meta state.Metadata) error {
 		config = documentdb.NewConfigWithServicePrincipal(spt)
 	}
 	config.WithAppIdentifier("dapr-" + logger.DaprVersion)
-	client := documentdb.New(m.URL, config)
 
-	dbs, err := client.QueryDatabases(&documentdb.Query{
-		Query: "SELECT * FROM ROOT r WHERE r.id=@id",
-		Parameters: []documentdb.Parameter{
-			{Name: "@id", Value: m.Database},
-		},
-	})
-	if err != nil {
-		return err
-	} else if len(dbs) == 0 {
-		return fmt.Errorf("database %s for CosmosDB state store not found", m.Database)
-	}
+	// Retries initializing the client if a TooManyRequests error is encountered
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 2 * time.Second
+	bo.MaxElapsedTime = 5 * time.Minute
+	err = backoff.RetryNotify(func() (err error) {
+		client := documentdb.New(m.URL, config)
 
-	c.db = &dbs[0]
-	colls, err := client.QueryCollections(c.db.Self, &documentdb.Query{
-		Query: "SELECT * FROM ROOT r WHERE r.id=@id",
-		Parameters: []documentdb.Parameter{
-			{Name: "@id", Value: m.Collection},
-		},
-	})
-	if err != nil {
-		return err
-	} else if len(colls) == 0 {
-		return fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", m.Collection)
-	}
+		dbs, err := client.QueryDatabases(&documentdb.Query{
+			Query: "SELECT * FROM ROOT r WHERE r.id=@id",
+			Parameters: []documentdb.Parameter{
+				{Name: "@id", Value: m.Database},
+			},
+		})
 
-	c.metadata = m
-	c.collection = &colls[0]
-	c.client = client
-	c.contentType = m.ContentType
-
-	sps, err := c.client.ReadStoredProcedures(c.collection.Self)
-	if err != nil {
-		return err
-	}
-
-	// get a link to the sp
-	for i := range sps {
-		if sps[i].Id == storedProcedureName {
-			c.sp = &sps[i]
-
-			break
-		}
-	}
-
-	if c.sp == nil {
-		// register the stored procedure
-		createspBody := storedProcedureDefinition{ID: storedProcedureName, Body: spDefinition}
-		c.sp, err = c.client.CreateStoredProcedure(c.collection.Self, createspBody)
 		if err != nil {
-			// if it already exists that is success
-			if !strings.HasPrefix(err.Error(), "Conflict") {
+			if isTooManyRequestsError(err) {
 				return err
 			}
+			return backoff.Permanent(err)
+		} else if len(dbs) == 0 {
+			return fmt.Errorf("database %s for CosmosDB state store not found", m.Database)
 		}
+
+		c.db = &dbs[0]
+		colls, err := client.QueryCollections(c.db.Self, &documentdb.Query{
+			Query: "SELECT * FROM ROOT r WHERE r.id=@id",
+			Parameters: []documentdb.Parameter{
+				{Name: "@id", Value: m.Collection},
+			},
+		})
+		if err != nil {
+			if isTooManyRequestsError(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		} else if len(colls) == 0 {
+			return fmt.Errorf("collection %s for CosmosDB state store not found.  This must be created before Dapr uses it", m.Collection)
+		}
+
+		c.metadata = m
+		c.collection = &colls[0]
+		c.client = client
+		c.contentType = m.ContentType
+
+		sps, err := c.client.ReadStoredProcedures(c.collection.Self)
+		if err != nil {
+			if isTooManyRequestsError(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		}
+
+		// get a link to the sp
+		for i := range sps {
+			if sps[i].Id == storedProcedureName {
+				c.sp = &sps[i]
+
+				break
+			}
+		}
+
+		if c.sp == nil {
+			// register the stored procedure
+			createspBody := storedProcedureDefinition{ID: storedProcedureName, Body: spDefinition}
+			c.sp, err = c.client.CreateStoredProcedure(c.collection.Self, createspBody)
+			if err != nil {
+				if isTooManyRequestsError(err) {
+					return err
+				}
+				// if it already exists that is success
+				if !strings.HasPrefix(err.Error(), "Conflict") {
+					return backoff.Permanent(err)
+				}
+			}
+		}
+
+		return nil
+	}, bo, func(err error, d time.Duration) {
+		c.logger.Warnf("CosmosDB State Store %s init retry: %v", err)
+	})
+	if err != nil {
+		return err
 	}
 
 	c.logger.Debug("cosmos Init done")
@@ -481,4 +510,19 @@ func parseTTL(requestMetadata map[string]string) (*int, error) {
 	}
 
 	return nil, nil
+}
+
+func isTooManyRequestsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var requestError *documentdb.RequestError
+	if errors.As(err, requestError) {
+		if requestError.Code == "429" {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
# Description

Adds exponential backoff retry on Cosmos DB component initialization for up to 5 minutes total time.

Background: Cosmos DB makes a lot of Metadata requests upon client initialization. This limit is shared by all databases in a single Cosmos DB Account. It is easy to exceed this limits if multiple connections (for example via multiple sidecars) are made to the same Cosmos DB database account. To alleviate this problem we are introducing exponential backoff on init here.

As outlined in https://docs.microsoft.com/azure/cosmos-db/sql/troubleshoot-request-rate-too-large#recommended-solution-3

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
