### PR TITLE
1385 disable policy creation

### DIFF
--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -765,7 +765,7 @@ func (s *snsSqs) createQueueAttributesWithDeadLetters(queueInfo, deadLettersQueu
 }
 
 func (s *snsSqs) restrictQueuePublishPolicyToOnlySNS(sqsQueueInfo *sqsQueueInfo, snsARN string) error {
-	// not creating any policies of disableEntityManagement is true
+	// not creating any policies of disableEntityManagement is true.
 	if s.metadata.disableEntityManagement {
 		return nil
 	}

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -765,6 +765,10 @@ func (s *snsSqs) createQueueAttributesWithDeadLetters(queueInfo, deadLettersQueu
 }
 
 func (s *snsSqs) restrictQueuePublishPolicyToOnlySNS(sqsQueueInfo *sqsQueueInfo, snsARN string) error {
+	// not creating any policies of disableEntityManagement is true
+	if s.metadata.disableEntityManagement {
+		return nil
+	}
 	// only permit SNS to send messages to SQS using the created subscription.
 	getQueueAttributesOutput, err := s.sqsClient.GetQueueAttributes(&sqs.GetQueueAttributesInput{QueueUrl: &sqsQueueInfo.url, AttributeNames: []*string{aws.String(sqs.QueueAttributeNamePolicy)}})
 	if err != nil {


### PR DESCRIPTION
# Description

bug fix - `disableEntityManagement` feature #1313 introduced the ability to disable the creation of SNS topics, SQS queues and the subscription of the first to the second. However, the implementation of that issue did not disable the creation of SQS policy statement.
This PR simply avoids the creation of the policy if the user specified in the metadata to `disableEntityManagement`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1385 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
