### PR TITLE
Implement State Store for OCI ObjectStorage service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -243,6 +243,7 @@ require (
 	github.com/nats-io/nkeys v0.3.0 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/oracle/oci-go-sdk/v54 v54.0.0
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -300,5 +301,7 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 	stathat.com/c/consistent v1.0.0 // indirect
 )
+
+require github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b // indirect
 
 replace k8s.io/client => github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36

--- a/go.sum
+++ b/go.sum
@@ -985,6 +985,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
+github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
@@ -1113,6 +1115,8 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b h1:br+bPNZsJWKicw/5rALEo67QHs5weyD5tf8WST+4sJ0=
+github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/state/oci/objectstorage/objectstorage.go
+++ b/state/oci/objectstorage/objectstorage.go
@@ -1,0 +1,394 @@
+/*
+OCI Object Storage state store.
+
+Sample configuration in yaml:
+
+	apiVersion: dapr.io/v1alpha1
+	kind: Component
+	metadata:
+	  name: statestore
+	spec:
+	  type: state.oci.objectstorage
+	  metadata:
+	  - name: tenancyOCID
+		value: <tenancyOCID>
+	  - name: userOCID
+		value: <userOCID>
+	  - name: fingerPrint
+		value: <fingerPrint>
+	  - name: region
+		value: <region>
+	  - name: bucketName
+		value: <bucket Name>
+      - name: compartmentOCID
+        value: ocid1.compartment.oc1..aaaaaaaacsssekayq4d34nl5h3eqs5e6ak3j5s4jhlws6oxf7rr5pxmt3zrq
+      - name: privateKey
+        value: |
+               -----BEGIN RSA PRIVATE KEY-----
+               XAS
+               -----END RSA PRIVATE KEY-----
+
+*/
+
+package objectstorage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/oracle/oci-go-sdk/v54/common"
+
+	"github.com/oracle/oci-go-sdk/v54/objectstorage"
+)
+
+const (
+	keyDelimiter   = "||"
+	tenancyKey     = "tenancyOCID"
+	compartmentKey = "compartmentOCID"
+	regionKey      = "region"
+	fingerPrintKey = "fingerPrint"
+	privateKeyKey  = "privateKey"
+	userKey        = "userOCID"
+	bucketNameKey  = "bucketName"
+)
+
+type StateStore struct {
+	state.DefaultBulkStore
+
+	json                  jsoniter.API
+	features              []state.Feature
+	logger                logger.Logger
+	objectStorageMetadata *Metadata
+}
+
+type Metadata struct {
+	userOCID            string
+	bucketName          string
+	region              string
+	tenancyOCID         string
+	fingerPrint         string
+	privateKey          string
+	compartmentOCID     string
+	namespace           string
+	objectStorageClient *objectstorage.ObjectStorageClient
+}
+
+/*********  Interface Implementations Init, Features, Get, Set, Delete and the instantiation function NewOCIObjectStorageStore. */
+
+func (r *StateStore) Init(metadata state.Metadata) error {
+	r.logger.Debugf("Init OCI Object Storage State Store")
+	meta, err := getObjectStorageMetadata(metadata.Properties)
+	if err != nil {
+		return err
+	}
+	err = initStorageClientAndBucket(meta, r.logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize client or create bucket : %w", err)
+	}
+	r.logger.Debugf("OCI Object Storage State Store initialized using bucket '%s'", meta.bucketName)
+	r.objectStorageMetadata = meta
+	return nil
+}
+
+func initStorageClientAndBucket(meta *Metadata, logger logger.Logger) error {
+	logger.Debugf("1")
+	configurationProvider := common.NewRawConfigurationProvider(meta.tenancyOCID, meta.userOCID, meta.region, meta.fingerPrint, meta.privateKey, nil)
+	logger.Debugf("2")
+	objectStorageClient, cerr := objectstorage.NewObjectStorageClientWithConfigurationProvider(configurationProvider)
+	logger.Debugf("3")
+	if cerr != nil {
+		return fmt.Errorf("failed to create ObjectStorageClient : %w", cerr)
+	}
+	meta.objectStorageClient = &objectStorageClient
+	ctx := context.Background()
+	meta.namespace, cerr = getNamespace(ctx, objectStorageClient)
+	logger.Debugf("4 %w", cerr)
+	if cerr != nil {
+		return fmt.Errorf("failed to get namespace : %w", cerr)
+	}
+	cerr = ensureBucketExists(ctx, objectStorageClient, meta.namespace, meta.bucketName, meta.compartmentOCID, logger)
+	if cerr != nil {
+		return fmt.Errorf("failed to read or create bucket : %w", cerr)
+	}
+	return nil
+}
+
+func (r *StateStore) Features() []state.Feature {
+	return r.features
+}
+
+func (r *StateStore) Delete(req *state.DeleteRequest) error {
+	r.logger.Debugf("Delete entry from OCI Object Storage State Store with key ", req.Key)
+	err := r.deleteDocument(req)
+	return err
+}
+
+func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	r.logger.Debugf("Get from OCI Object Storage State Store with key ", req.Key)
+	content, etag, err := r.readDocument((req))
+	if err != nil {
+		r.logger.Debugf("error %s", err)
+		if err.Error() == "ObjectNotFound" {
+			return &state.GetResponse{Data: nil, ETag: nil, Metadata: nil}, nil
+		}
+
+		return &state.GetResponse{Data: nil, ETag: nil, Metadata: nil}, err
+	}
+	return &state.GetResponse{
+		Data:     content,
+		ETag:     etag,
+		Metadata: nil,
+	}, err
+}
+
+func (r *StateStore) Set(req *state.SetRequest) error {
+	r.logger.Debugf("saving %s to OCI Object Storage State Store", req.Key)
+	return r.writeDocument(req)
+}
+
+func (r *StateStore) Ping() error {
+	return r.pingBucket()
+}
+
+func NewOCIObjectStorageStore(logger logger.Logger) *StateStore {
+	s := &StateStore{
+		json:                  jsoniter.ConfigFastest,
+		features:              []state.Feature{state.FeatureETag},
+		logger:                logger,
+		objectStorageMetadata: nil,
+	}
+	s.DefaultBulkStore = state.NewDefaultBulkStore(s)
+
+	return s
+}
+
+/************** private helper functions. */
+
+func getObjectStorageMetadata(metadata map[string]string) (*Metadata, error) {
+	meta := Metadata{}
+	var err error
+	if meta.bucketName, err = getValue(metadata, bucketNameKey); err != nil {
+		return nil, err
+	}
+	if meta.region, err = getValue(metadata, regionKey); err != nil {
+		return nil, err
+	}
+	if meta.compartmentOCID, err = getValue(metadata, compartmentKey); err != nil {
+		return nil, err
+	}
+	if meta.userOCID, err = getValue(metadata, userKey); err != nil {
+		return nil, err
+	}
+	if meta.fingerPrint, err = getValue(metadata, fingerPrintKey); err != nil {
+		return nil, err
+	}
+	if meta.privateKey, err = getValue(metadata, privateKeyKey); err != nil {
+		return nil, err
+	}
+	if meta.tenancyOCID, err = getValue(metadata, tenancyKey); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
+func getValue(metadata map[string]string, key string) (string, error) {
+	if val, ok := metadata[key]; ok && val != "" {
+		return val, nil
+	}
+	return "", fmt.Errorf("missing or empty %s field from metadata", key)
+}
+
+func (r *StateStore) writeDocument(req *state.SetRequest) error {
+	if len(req.Key) == 0 || req.Key == "" {
+		return fmt.Errorf("key for value to set was missing from request")
+	}
+	r.logger.Debugf("Save state in OCI Object Storage Bucket under key %s ", req.Key)
+	objectName := getFileName(req.Key)
+	content := r.marshal(req)
+	objectLength := int64(len(content))
+	ctx := context.Background()
+	etag := req.ETag
+	if req.Options.Concurrency != state.FirstWrite {
+		etag = nil
+	}
+
+	err := putObject(ctx, *r.objectStorageMetadata.objectStorageClient, r.objectStorageMetadata.namespace, r.objectStorageMetadata.bucketName, objectName, objectLength, ioutil.NopCloser(bytes.NewReader(content)), nil, etag, r.logger)
+	return err
+}
+
+func (r *StateStore) readDocument(req *state.GetRequest) ([]byte, *string, error) {
+	objectName := getFileName(req.Key)
+	ctx := context.Background()
+	content, etag, err := getObject(ctx, *r.objectStorageMetadata.objectStorageClient, r.objectStorageMetadata.namespace, r.objectStorageMetadata.bucketName, objectName, r.logger)
+	if err != nil {
+		r.logger.Debugf("download file %s, err %s", req.Key, err)
+		return nil, nil, err
+	}
+	return content, etag, err
+}
+
+func (r *StateStore) pingBucket() error {
+	req := objectstorage.GetBucketRequest{
+		NamespaceName: &r.objectStorageMetadata.namespace,
+		BucketName:    &r.objectStorageMetadata.bucketName,
+	}
+	// Send the request using the service client.
+	_, err := r.objectStorageMetadata.objectStorageClient.GetBucket(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve bucket details : %w", err)
+	}
+	return nil
+}
+
+func (r *StateStore) deleteDocument(req *state.DeleteRequest) error {
+	if len(req.Key) == 0 || req.Key == "" {
+		return fmt.Errorf("key for value to delete was missing from request")
+	}
+
+	objectName := getFileName(req.Key)
+	ctx := context.Background()
+	etag := req.ETag
+	if req.Options.Concurrency != state.FirstWrite {
+		etag = nil
+	}
+	err := deleteObject(ctx, *r.objectStorageMetadata.objectStorageClient, r.objectStorageMetadata.namespace, r.objectStorageMetadata.bucketName, objectName, etag)
+	if err != nil {
+		r.logger.Debugf("error in deleting object from OCI object storage  %s, err %s", req.Key, err)
+		return fmt.Errorf("failed to delete object from OCI Object storage : %w", err)
+	}
+	return nil
+}
+
+func (r *StateStore) marshal(req *state.SetRequest) []byte {
+	var v string
+	b, ok := req.Value.([]byte)
+	if ok {
+		v = string(b)
+	} else {
+		v, _ = jsoniter.MarshalToString(req.Value)
+	}
+
+	return []byte(v)
+}
+
+func getFileName(key string) string {
+	pr := strings.Split(key, keyDelimiter)
+	if len(pr) != 2 {
+		return pr[0]
+	}
+
+	return pr[1]
+}
+
+/**************** functions with OCI ObjectStorage Service interaction.   */
+
+func getNamespace(ctx context.Context, client objectstorage.ObjectStorageClient) (string, error) {
+	request := objectstorage.GetNamespaceRequest{}
+	response, err := client.GetNamespace(ctx, request)
+	if err != nil {
+		return *response.Value, fmt.Errorf("failed to retrieve tenancy namespace : %w", err)
+	}
+
+	return *response.Value, nil
+}
+
+func deleteObject(ctx context.Context, client objectstorage.ObjectStorageClient, namespace, bucketname, objectname string, etag *string) (err error) {
+	request := objectstorage.DeleteObjectRequest{
+		NamespaceName: &namespace,
+		BucketName:    &bucketname,
+		ObjectName:    &objectname,
+		IfMatch:       etag,
+	}
+	_, err = client.DeleteObject(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to delete object from OCI : %w", err)
+	}
+	return nil
+}
+
+func getObject(ctx context.Context, client objectstorage.ObjectStorageClient, namespace string, bucketname string, objectname string, logger logger.Logger) ([]byte, *string, error) {
+	logger.Debugf("read file %s from OCI ObjectStorage StateStore %s ", objectname, bucketname)
+	request := objectstorage.GetObjectRequest{
+		NamespaceName: &namespace,
+		BucketName:    &bucketname,
+		ObjectName:    &objectname,
+	}
+	response, err := client.GetObject(ctx, request)
+	if err != nil {
+		logger.Debugf("Issue in OCI ObjectStorage with retrieving object %s, error:  %s", objectname, err)
+		if response.RawResponse.StatusCode == 404 {
+			return nil, nil, errors.New("ObjectNotFound")
+		}
+		return nil, nil, fmt.Errorf("failed to retrieve object : %w", err)
+	}
+	if response.ETag != nil {
+		logger.Debugf("OCI ObjectStorage StateStore metadata:  ETag %s", *response.ETag)
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Content)
+	return buf.Bytes(), response.ETag, nil
+}
+
+func putObject(ctx context.Context, client objectstorage.ObjectStorageClient, namespace, bucketname, objectname string, contentLen int64, content io.ReadCloser, metadata map[string]string, etag *string, logger logger.Logger) error {
+	request := objectstorage.PutObjectRequest{
+		NamespaceName: &namespace,
+		BucketName:    &bucketname,
+		ObjectName:    &objectname,
+		ContentLength: &contentLen,
+		PutObjectBody: content,
+		OpcMeta:       metadata,
+		IfMatch:       etag,
+	}
+	_, err := client.PutObject(ctx, request)
+	logger.Debugf("Put object ", objectname, " in bucket ", bucketname)
+	if err != nil {
+		return fmt.Errorf("failed to put object on OCI : %w", err)
+	}
+	return nil
+}
+
+// bucketname needs to be unique within compartment. there is no concept of "child" buckets.
+// the value returned is the bucket's OCID.
+func ensureBucketExists(ctx context.Context, client objectstorage.ObjectStorageClient, namespace string, name string, compartmentOCID string, logger logger.Logger) error {
+	req := objectstorage.GetBucketRequest{
+		NamespaceName: &namespace,
+		BucketName:    &name,
+	}
+	// verify if bucket exists.
+	response, err := client.GetBucket(ctx, req)
+	if err != nil {
+		if response.RawResponse.StatusCode == 404 {
+			err = createBucket(ctx, client, namespace, name, compartmentOCID)
+			if err == nil {
+				logger.Debugf("Created OCI Object Storage Bucket %s as State Store", name)
+			}
+			return err
+		}
+		return err
+	}
+	return nil
+}
+
+// bucketname needs to be unique within compartment. there is no concept of "child" buckets.
+func createBucket(ctx context.Context, client objectstorage.ObjectStorageClient, namespace string, name string, compartmentOCID string) error {
+	request := objectstorage.CreateBucketRequest{
+		NamespaceName: &namespace,
+	}
+	request.CompartmentId = &compartmentOCID
+	request.Name = &name
+	request.Metadata = make(map[string]string)
+	request.PublicAccessType = objectstorage.CreateBucketDetailsPublicAccessTypeNopublicaccess
+	_, err := client.CreateBucket(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to create bucket on OCI : %w", err)
+	}
+	return nil
+}

--- a/state/oci/objectstorage/objectstorage_test.go
+++ b/state/oci/objectstorage/objectstorage_test.go
@@ -1,0 +1,203 @@
+package objectstorage
+
+/*
+for example in ~/dapr-dev/components-contrib
+go test -v github.com/dapr/components-contrib/state/oci/objectstorage
+
+*/
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	namespace = "idtwlqf2hanz"
+)
+
+var ociObjectStorageConfiguration = map[string]string{
+	"bucketName":      "myBuck",
+	"tenancyOCID":     "ocid1.tenancy.oc1..aaaaaaaag7c7sq",
+	"userOCID":        "ocid1.user.oc1..aaaaaaaaby4oyytselv5q",
+	"compartmentOCID": "ocid1.compartment.oc1..aaaaaaaq",
+	"fingerPrint":     "02:91:6c:49:d8:04:56",
+	"privateKey":      "-----BEGIN RSA PRIVATE KEY-----\nMIIEogI=\n-----END RSA PRIVATE KEY-----",
+	"region":          "us-ashburn-1",
+}
+
+func TestInit(t *testing.T) {
+	m := state.Metadata{}
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	//s.logger.SetOutputLevel(logger.DebugLevel)
+	t.Run("Init with valid metadata", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		assert.Equal(t, "myBuck", s.objectStorageMetadata.bucketName)
+		assert.Equal(t, namespace, s.objectStorageMetadata.namespace)
+	})
+
+	t.Run("Init with missing metadata", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"invalidValue": "a",
+		}
+		err := s.Init(m)
+		assert.NotNil(t, err)
+		assert.Equal(t, err, fmt.Errorf("missing or empty bucketName field from metadata"), "Lacking configuration property should be spotted")
+	})
+}
+
+func TestGet(t *testing.T) {
+	m := state.Metadata{}
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	t.Run("Get an non-existing key", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		getResponse, err := s.Get(&state.GetRequest{Key: "xyzq"})
+		assert.Equal(t, &state.GetResponse{}, getResponse, "Response must be empty")
+		assert.NoError(t, err, "Non-existing key must not be treated as error")
+	})
+	t.Run("Get an existing key", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		err = s.Set(&state.SetRequest{Key: "test-key", Value: []byte("test-value")})
+		getResponse, err := s.Get(&state.GetRequest{Key: "test-key"})
+		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
+		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
+	})
+}
+
+func TestSet(t *testing.T) {
+	m := state.Metadata{}
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	t.Run("Set without a key", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		err = s.Set(&state.SetRequest{Value: []byte("test-value")})
+		assert.Equal(t, err, fmt.Errorf("key for value to set was missing from request"), "Lacking Key results in error")
+
+		// getResponse, err := s.Get(&state.GetRequest{Key: "test-key"})
+		// assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
+		// assert.NotNil(t, *getResponse.ETag, "ETag should be set")
+	})
+	t.Run("Regular Set Operation", func(t *testing.T) {
+		testKey := "test-key"
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
+		getResponse, err := s.Get(&state.GetRequest{Key: testKey})
+		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
+		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
+
+	})
+	t.Run("Testing Set & Concurrency (ETags)", func(t *testing.T) {
+		testKey := "etag-test-key"
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
+		getResponse, err := s.Get(&state.GetRequest{Key: testKey})
+		etag := getResponse.ETag
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: etag, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.Nil(t, err, "Updating value with proper etag should go fine")
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Updating value with the old etag should be refused")
+
+		// retrieve the latest etag - assigned by the previous set operation
+		getResponse, err = s.Get(&state.GetRequest{Key: testKey})
+		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
+		etag = getResponse.ETag
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.Nil(t, err, "Updating value with the latest etag should be accepted")
+
+	})
+}
+
+func TestDelete(t *testing.T) {
+	m := state.Metadata{}
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	t.Run("Delete without a key", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		err = s.Delete(&state.DeleteRequest{})
+		assert.Equal(t, err, fmt.Errorf("key for value to delete was missing from request"), "Lacking Key results in error")
+
+	})
+	t.Run("Regular Delete Operation", func(t *testing.T) {
+		testKey := "test-key"
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
+		err = s.Delete(&state.DeleteRequest{Key: testKey})
+		assert.Nil(t, err, "Deleting an existing value with a proper key should be errorfree")
+	})
+	t.Run("Testing Delete & Concurrency (ETags)", func(t *testing.T) {
+		testKey := "etag-test-delete-key"
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		// create document
+		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
+		getResponse, err := s.Get(&state.GetRequest{Key: testKey})
+		etag := getResponse.ETag
+
+		incorrectETag := "notTheCorrectETag"
+		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: &incorrectETag, Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Deleting value with an incorrect etag should be prevented")
+
+		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: etag, Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.Nil(t, err, "Deleting value with proper etag should go fine")
+
+	})
+}
+
+func TestFeatures(t *testing.T) {
+	m := state.Metadata{}
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	t.Run("Test contents of Features", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		features := s.Features()
+		assert.Contains(t, features, state.FeatureETag)
+	})
+}
+
+func TestPing(t *testing.T) {
+	m := state.Metadata{}
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	t.Run("Ping", func(t *testing.T) {
+		m.Properties = ociObjectStorageConfiguration
+		err := s.Init(m)
+		assert.Nil(t, err)
+		err = s.Ping()
+		assert.Nil(t, err, "Ping should be successful")
+
+	})
+}

--- a/state/oci/objectstorage/objectstorage_test.go
+++ b/state/oci/objectstorage/objectstorage_test.go
@@ -1,10 +1,8 @@
 package objectstorage
 
-/*
-for example in ~/dapr-dev/components-contrib
-go test -v github.com/dapr/components-contrib/state/oci/objectstorage
-
-*/
+// for example in ~/dapr-dev/components-contrib
+// go test -v github.com/dapr/components-contrib/state/oci/objectstorage
+// to run the test set for OCI ObjectStorage service based StateStore.
 
 import (
 	"fmt"
@@ -16,188 +14,41 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-const (
-	namespace = "idtwlqf2hanz"
-)
-
 var ociObjectStorageConfiguration = map[string]string{
 	"bucketName":      "myBuck",
 	"tenancyOCID":     "ocid1.tenancy.oc1..aaaaaaaag7c7sq",
-	"userOCID":        "ocid1.user.oc1..aaaaaaaaby4oyytselv5q",
+	"userOCID":        "ocid1.user.oc1..aaaaaaaaby",
 	"compartmentOCID": "ocid1.compartment.oc1..aaaaaaaq",
-	"fingerPrint":     "02:91:6c:49:d8:04:56",
+	"fingerPrint":     "02:91:6c",
 	"privateKey":      "-----BEGIN RSA PRIVATE KEY-----\nMIIEogI=\n-----END RSA PRIVATE KEY-----",
 	"region":          "us-ashburn-1",
 }
 
 func TestInit(t *testing.T) {
-	m := state.Metadata{}
-	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
-	//s.logger.SetOutputLevel(logger.DebugLevel)
-	t.Run("Init with valid metadata", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		assert.Equal(t, "myBuck", s.objectStorageMetadata.bucketName)
-		assert.Equal(t, namespace, s.objectStorageMetadata.namespace)
-	})
-
+	meta := state.Metadata{}
+	statestore := NewOCIObjectStorageStore(logger.NewLogger("logger"))
 	t.Run("Init with missing metadata", func(t *testing.T) {
-		m.Properties = map[string]string{
+		meta.Properties = map[string]string{
 			"invalidValue": "a",
 		}
-		err := s.Init(m)
+		err := statestore.Init(meta)
 		assert.NotNil(t, err)
-		assert.Equal(t, err, fmt.Errorf("missing or empty bucketName field from metadata"), "Lacking configuration property should be spotted")
+		assert.Equal(t, fmt.Errorf("missing or empty bucketName field from metadata"), err, "Lacking configuration property should be spotted")
 	})
-}
 
-func TestGet(t *testing.T) {
-	m := state.Metadata{}
-	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
-	t.Run("Get an non-existing key", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		getResponse, err := s.Get(&state.GetRequest{Key: "xyzq"})
-		assert.Equal(t, &state.GetResponse{}, getResponse, "Response must be empty")
-		assert.NoError(t, err, "Non-existing key must not be treated as error")
-	})
-	t.Run("Get an existing key", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		err = s.Set(&state.SetRequest{Key: "test-key", Value: []byte("test-value")})
-		getResponse, err := s.Get(&state.GetRequest{Key: "test-key"})
-		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
-		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
-	})
-}
-
-func TestSet(t *testing.T) {
-	m := state.Metadata{}
-	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
-	t.Run("Set without a key", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		err = s.Set(&state.SetRequest{Value: []byte("test-value")})
-		assert.Equal(t, err, fmt.Errorf("key for value to set was missing from request"), "Lacking Key results in error")
-
-		// getResponse, err := s.Get(&state.GetRequest{Key: "test-key"})
-		// assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
-		// assert.NotNil(t, *getResponse.ETag, "ETag should be set")
-	})
-	t.Run("Regular Set Operation", func(t *testing.T) {
-		testKey := "test-key"
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
-		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		getResponse, err := s.Get(&state.GetRequest{Key: testKey})
-		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
-		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
-
-	})
-	t.Run("Testing Set & Concurrency (ETags)", func(t *testing.T) {
-		testKey := "etag-test-key"
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
-		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		getResponse, err := s.Get(&state.GetRequest{Key: testKey})
-		etag := getResponse.ETag
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: etag, Options: state.SetStateOption{
-			Concurrency: state.FirstWrite,
-		}})
-		assert.Nil(t, err, "Updating value with proper etag should go fine")
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
-			Concurrency: state.FirstWrite,
-		}})
-		assert.NotNil(t, err, "Updating value with the old etag should be refused")
-
-		// retrieve the latest etag - assigned by the previous set operation
-		getResponse, err = s.Get(&state.GetRequest{Key: testKey})
-		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
-		etag = getResponse.ETag
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
-			Concurrency: state.FirstWrite,
-		}})
-		assert.Nil(t, err, "Updating value with the latest etag should be accepted")
-
-	})
-}
-
-func TestDelete(t *testing.T) {
-	m := state.Metadata{}
-	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
-	t.Run("Delete without a key", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		err = s.Delete(&state.DeleteRequest{})
-		assert.Equal(t, err, fmt.Errorf("key for value to delete was missing from request"), "Lacking Key results in error")
-
-	})
-	t.Run("Regular Delete Operation", func(t *testing.T) {
-		testKey := "test-key"
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
-		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		err = s.Delete(&state.DeleteRequest{Key: testKey})
-		assert.Nil(t, err, "Deleting an existing value with a proper key should be errorfree")
-	})
-	t.Run("Testing Delete & Concurrency (ETags)", func(t *testing.T) {
-		testKey := "etag-test-delete-key"
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		// create document
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
-		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		getResponse, err := s.Get(&state.GetRequest{Key: testKey})
-		etag := getResponse.ETag
-
-		incorrectETag := "notTheCorrectETag"
-		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: &incorrectETag, Options: state.DeleteStateOption{
-			Concurrency: state.FirstWrite,
-		}})
-		assert.NotNil(t, err, "Deleting value with an incorrect etag should be prevented")
-
-		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: etag, Options: state.DeleteStateOption{
-			Concurrency: state.FirstWrite,
-		}})
-		assert.Nil(t, err, "Deleting value with proper etag should go fine")
-
+	t.Run("Init with incorrect metadata", func(t *testing.T) {
+		meta.Properties = ociObjectStorageConfiguration
+		err := statestore.Init(meta)
+		assert.NotNil(t, err)
+		assert.Error(t, err, "Incorrect configuration data should result in failure to create client")
+		assert.Contains(t, err.Error(), "failed to initialize client", "Incorrect configuration data should result in failure to create client")
 	})
 }
 
 func TestFeatures(t *testing.T) {
-	m := state.Metadata{}
 	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
 	t.Run("Test contents of Features", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
 		features := s.Features()
 		assert.Contains(t, features, state.FeatureETag)
-	})
-}
-
-func TestPing(t *testing.T) {
-	m := state.Metadata{}
-	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
-	t.Run("Ping", func(t *testing.T) {
-		m.Properties = ociObjectStorageConfiguration
-		err := s.Init(m)
-		assert.Nil(t, err)
-		err = s.Ping()
-		assert.Nil(t, err, "Ping should be successful")
-
 	})
 }

--- a/state/oci/objectstorage/objectstorage_test.go
+++ b/state/oci/objectstorage/objectstorage_test.go
@@ -5,7 +5,9 @@ package objectstorage
 // to run the test set for OCI ObjectStorage service based StateStore.
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +16,7 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var ociObjectStorageConfiguration = map[string]string{
+var dummyOCIObjectStorageConfiguration = map[string]string{
 	"bucketName":      "myBuck",
 	"tenancyOCID":     "ocid1.tenancy.oc1..aaaaaaaag7c7sq",
 	"userOCID":        "ocid1.user.oc1..aaaaaaaaby",
@@ -36,8 +38,8 @@ func TestInit(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("missing or empty bucketName field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 
-	t.Run("Init with incorrect metadata", func(t *testing.T) {
-		meta.Properties = ociObjectStorageConfiguration
+	t.Run("Init with complete yet incorrect metadata", func(t *testing.T) {
+		meta.Properties = dummyOCIObjectStorageConfiguration
 		err := statestore.Init(meta)
 		assert.NotNil(t, err)
 		assert.Error(t, err, "Incorrect configuration data should result in failure to create client")
@@ -50,5 +52,152 @@ func TestFeatures(t *testing.T) {
 	t.Run("Test contents of Features", func(t *testing.T) {
 		features := s.Features()
 		assert.Contains(t, features, state.FeatureETag)
+	})
+}
+
+type mockedObjectStoreClient struct {
+	objectStoreClient
+}
+
+func (c *mockedObjectStoreClient) getObject(ctx context.Context, objectname string, logger logger.Logger) ([]byte, *string, error) {
+	etag := "etag"
+	return []byte("Hello World"), &etag, nil
+}
+
+func (c *mockedObjectStoreClient) deleteObject(ctx context.Context, objectname string, etag *string) (err error) {
+	if objectname == "unknownKey" {
+		return fmt.Errorf("failed to delete object that does not exist - HTTP status code 404")
+	}
+	if etag != nil && *etag == "notTheCorrectETag" {
+		return fmt.Errorf("failed to delete object because of incorrect etag-value ")
+	}
+	return nil
+}
+
+func (c *mockedObjectStoreClient) putObject(ctx context.Context, objectname string, contentLen int64, content io.ReadCloser, metadata map[string]string, etag *string, logger logger.Logger) error {
+	if etag != nil && *etag == "notTheCorrectETag" {
+		return fmt.Errorf("failed to delete object because of incorrect etag-value ")
+	}
+	if etag != nil && *etag == "correctETag" {
+		return nil
+	}
+	return nil
+}
+
+func (c *mockedObjectStoreClient) initStorageBucket(logger logger.Logger) error {
+	return nil
+}
+
+func (c *mockedObjectStoreClient) pingBucket(logger logger.Logger) error {
+	return nil
+}
+
+func TestGetWithMockClient(t *testing.T) {
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	s.client = &mockedObjectStoreClient{}
+
+	t.Run("Test contents of Features", func(t *testing.T) {
+		getResponse, err := s.Get(&state.GetRequest{Key: "test-key"})
+		assert.Equal(t, "Hello World", string(getResponse.Data), "Value retrieved should be equal to value set")
+		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
+		assert.Nil(t, err)
+	})
+}
+
+func TestInitWithMockClient(t *testing.T) {
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	s.client = &mockedObjectStoreClient{}
+
+	t.Run("Test Init", func(t *testing.T) {
+		getResponse, err := s.Get(&state.GetRequest{Key: "test-key"})
+		assert.Equal(t, "Hello World", string(getResponse.Data), "Value retrieved should be equal to value set")
+		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
+		assert.Nil(t, err)
+	})
+}
+
+func TestPingWithMockClient(t *testing.T) {
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	s.client = &mockedObjectStoreClient{}
+
+	t.Run("Test Ping", func(t *testing.T) {
+		err := s.Ping()
+		assert.Nil(t, err)
+	})
+}
+func TestSetWithMockClient(t *testing.T) {
+	statestore := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	statestore.client = &mockedObjectStoreClient{}
+	t.Run("Set without a key", func(t *testing.T) {
+		err := statestore.Set(&state.SetRequest{Value: []byte("test-value")})
+		assert.Equal(t, err, fmt.Errorf("key for value to set was missing from request"), "Lacking Key results in error")
+	})
+	t.Run("Regular Set Operation", func(t *testing.T) {
+		testKey := "test-key"
+		err := statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
+	})
+	t.Run("Testing Set & Concurrency (ETags)", func(t *testing.T) {
+		testKey := "etag-test-key"
+		incorrectETag := "notTheCorrectETag"
+		etag := "correctETag"
+
+		err := statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: &incorrectETag, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Updating value with wrong etag should fail")
+
+		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: nil, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Asking for FirstWrite concurrency policy without ETag should fail")
+
+		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: &etag, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.Nil(t, err, "Updating value with proper etag should go fine")
+
+		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: nil, Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Updating value with concurrency policy at FirstWrite should fail when ETag is missing")
+	})
+}
+
+func TestDeleteWithMockClient(t *testing.T) {
+	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	s.client = &mockedObjectStoreClient{}
+	t.Run("Delete without a key", func(t *testing.T) {
+		err := s.Delete(&state.DeleteRequest{})
+		assert.Equal(t, err, fmt.Errorf("key for value to delete was missing from request"), "Lacking Key results in error")
+	})
+	t.Run("Delete with an unknown key", func(t *testing.T) {
+		err := s.Delete(&state.DeleteRequest{Key: "unknownKey"})
+		assert.Contains(t, err.Error(), "404", "Unknown Key results in error: http status code 404, object not found")
+	})
+	t.Run("Regular Delete Operation", func(t *testing.T) {
+		testKey := "test-key"
+		err := s.Delete(&state.DeleteRequest{Key: testKey})
+		assert.Nil(t, err, "Deleting an existing value with a proper key should be errorfree")
+	})
+	t.Run("Testing Delete & Concurrency (ETags)", func(t *testing.T) {
+		testKey := "etag-test-delete-key"
+		incorrectETag := "notTheCorrectETag"
+		err := s.Delete(&state.DeleteRequest{Key: testKey, ETag: &incorrectETag, Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Deleting value with an incorrect etag should be prevented")
+
+		etag := "correctETag"
+		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: &etag, Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.Nil(t, err, "Deleting value with proper etag should go fine")
+
+		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: nil, Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		}})
+		assert.NotNil(t, err, "Asking for FirstWrite concurrency policy without ETag should fail")
+
 	})
 }


### PR DESCRIPTION
# Description

The OCI Object Storage Service is a cloud service on Oracle Cloud Infrastructure, very similar in nature to AWS S3 and Azure BlobStorage. This services support creating, retrieving, deleting objects that represent state. It has concurrency control through ETags. I believe that especially for Daprized applications running on OCI – either on OKE, the OCI container engine for Kubernetes or on a compute instance – it can be of value to leverage ObjectStorage as the state store. It is cheap, easily accessible and can easily be integrated into many technologies from within the OCI cloud as well as from elsewhere.

The contribution allows Dapr application operators to configure state store components backed by OCI Object Storage.

The code I submit in this PR has been described in some detail in [an article on Medium](https://lucasjellema.medium.com/composing-dapr-custom-state-store-component-for-oracle-cloud-object-storage-a4c2feb15b3). 

I am not sure how to deal with the conformance tests. If these are required as this point, please provide some guidance as to how to create these.

I have resolved most Linting alerts. There are some left of type exhaustivestruct. I fear that resolving these makes the code less readable and certainly less elegant. If you insist, I can of course fix these too. 

Note: the Dapr API for Set does not include a SetResponse. That means in the case of OCI Object Storage (that assigns generated ETag values) that the ETag assigned after a Set has been performed cannot be returned. Only by doing a Get immediately after a Set will the application get the ETag value - and not even guaranteed the correct one as potentially another process can already have changed the state. It would be nice to have a way to return this ETag from the Set operation.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[1400]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[2070]_  [link](https://github.com/dapr/docs/issues/2070)

