### PR TITLE
fix eventhubs conformance tests

### DIFF
--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -12,6 +12,8 @@ components:
   - component: azure.eventhubs
     allOperations: true
     config:
+      pubsubName: azure-eventhubs
+      testTopicName: dapr2-conf-test-eventhubs-pubsub-topic
       ## with partition key set, inorder processing is guaranteed.
       ## https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-features#mapping-of-events-to-partitions
       checkInOrderProcessing: true


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <msundar.ms@outlook.com>

# Description

As part of #951 changes were made to validate incoming topic name with the eventhub name in the connection string. This caused the conf tests to fail since the default topic name is testTopic. Modified configuration to fix that issue.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
