### PR TITLE
Temporarily disables the AKV managed identity test

### DIFF
--- a/tests/certification/secretstores/azure/keyvault/keyvault_test.go
+++ b/tests/certification/secretstores/azure/keyvault/keyvault_test.go
@@ -197,6 +197,7 @@ func TestKeyVault(t *testing.T) {
 	}
 
 	flow.New(t, "keyvault authentication using managed identity").
-		Step("Test secret access using managed identity authentication", managedIdentityTest).
-		Run()
+		Step("Test secret access using managed identity authentication", managedIdentityTest)
+		// temporarily disable the managed identity test until we decide whether to remove this test or find a different way to spin up the required environment.
+                // Run().
 }


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

The Azure Key Vault Certification test for Key Vault performs a very fragile end to end test to evaluate managed identity behavior.

This test isn't strictly necessary as verifying service principal auth exercises the same underlying code path and underlying SDKs.

For now, this PR disables the failing managed identity test which fails in the infrastructure provisioning stages. We can either remove this test in the future or implement the provisioning of required test infrastructure differently.