### PR TITLE
Fixing Certification tests failure

### DIFF
--- a/tests/certification/flow/watcher/watcher.go
+++ b/tests/certification/flow/watcher/watcher.go
@@ -125,6 +125,20 @@ func (w *Watcher) Add(data ...interface{}) {
 	w.expected = append(w.expected, data...)
 }
 
+// Remove is called if the network operation fails
+// and removes `data` from the `remaining` map added
+// during `Prepare`. This is so that if the `Publish` '
+// operation fails, `data` added for tracking could be
+// removed afterwards.
+func (w *Watcher) Remove(data ...interface{}) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for _, item := range data {
+		delete(w.remaining, item)
+	}
+}
+
 // Expect adds data to both the `remaining` map
 // add the expected slice in a single call.
 // Use this only when a test scenario can prepare

--- a/tests/certification/pubsub/kafka/kafka_test.go
+++ b/tests/certification/pubsub/kafka/kafka_test.go
@@ -203,6 +203,10 @@ func TestKafka(t *testing.T) {
 							m.Add(msg) // Success
 						}
 						counter++
+					} else {
+						for _, m := range messages {
+							m.Remove(msg) // Remove from Tracking
+						}
 					}
 				}
 			}

--- a/tests/certification/pubsub/mqtt/docker-compose.yml
+++ b/tests/certification/pubsub/mqtt/docker-compose.yml
@@ -6,3 +6,6 @@ services:
     container_name: emqx
     ports:
       - "1884:1883"
+    environment:
+    -  "EMQX_ZONE__EXTERNAL__RETRY_INTERVAL=30s"
+    -  "EMQX_ZONE__EXTERNAL__MAX_INFLIGHT=128"

--- a/tests/certification/pubsub/mqtt/docker-compose.yml
+++ b/tests/certification/pubsub/mqtt/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     environment:
     -  "EMQX_ZONE__EXTERNAL__RETRY_INTERVAL=30s"
     -  "EMQX_ZONE__EXTERNAL__MAX_INFLIGHT=128"
+    -  "EMQX_ZONE__EXTERNAL__MAX_MQUEUE_LEN=0"

--- a/tests/certification/pubsub/mqtt/mqtt_test.go
+++ b/tests/certification/pubsub/mqtt/mqtt_test.go
@@ -238,6 +238,10 @@ func TestMQTT(t *testing.T) {
 							m.Add(msg) // Success
 						}
 						counter++
+					} else {
+						for _, m := range messages {
+							m.Remove(msg) // Remove from Tracking
+						}
 					}
 				}
 			}


### PR DESCRIPTION
# Description

This is to fix certification test failure in kafka and mqtt. The tests are failing due to a small concurrency issue in which a message added for tracking before Publish event isn't removed in case the Publish fails. 

It also updates certain environment variables for emqx broker(MQTT) in which the default values ain't enough.

## Issue reference

Please reference the issue this PR will close: 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
