### PR TITLE
bingding/mysql: add TEXT column type to special case

### DIFF
--- a/bindings/mysql/mysql.go
+++ b/bindings/mysql/mysql.go
@@ -339,7 +339,7 @@ func (m *Mysql) convert(columnTypes []*sql.ColumnType, values []interface{}) map
 		case *sql.RawBytes:
 			// special case for sql.RawBytes, see https://github.com/go-sql-driver/mysql/blob/master/fields.go#L178
 			switch ct.DatabaseTypeName() {
-			case "VARCHAR", "CHAR":
+			case "VARCHAR", "CHAR", "TEXT":
 				value = string(*v)
 			}
 		}

--- a/bindings/mysql/mysql_integration_test.go
+++ b/bindings/mysql/mysql_integration_test.go
@@ -34,9 +34,10 @@ const (
 		id bigint NOT NULL,
 		v1 character varying(50) NOT NULL,
 		b  BOOLEAN,
-		ts TIMESTAMP)`
+		ts TIMESTAMP,
+		data LONGTEXT)`
 	testDropTable = `DROP TABLE foo`
-	testInsert    = "INSERT INTO foo (id, v1, b, ts) VALUES (%d, 'test-%d', %t, '%v')"
+	testInsert    = "INSERT INTO foo (id, v1, b, ts, data) VALUES (%d, 'test-%d', %t, '%v', '%s')"
 	testDelete    = "DELETE FROM foo"
 	testUpdate    = "UPDATE foo SET ts = '%v' WHERE id = %d"
 	testSelect    = "SELECT * FROM foo WHERE id < 3"
@@ -96,7 +97,7 @@ func TestMysqlIntegration(t *testing.T) {
 	t.Run("Invoke insert", func(t *testing.T) {
 		req.Operation = execOperation
 		for i := 0; i < 10; i++ {
-			req.Metadata[commandSQLKey] = fmt.Sprintf(testInsert, i, i, true, time.Now().Format(mySQLDateTimeFormat))
+			req.Metadata[commandSQLKey] = fmt.Sprintf(testInsert, i, i, true, time.Now().Format(mySQLDateTimeFormat), "{\"key\":\"val\"}")
 			res, err := b.Invoke(req)
 			assertResponse(t, res, err)
 		}
@@ -122,6 +123,7 @@ func TestMysqlIntegration(t *testing.T) {
 		assert.Contains(t, string(res.Data), "\"id\":1")
 		assert.Contains(t, string(res.Data), "\"b\":1")
 		assert.Contains(t, string(res.Data), "\"v1\":\"test-1\"")
+		assert.Contains(t, string(res.Data), "\"data\":\"{\\\"key\\\":\\\"val\\\"}\"")
 
 		result := make([]interface{}, 0)
 		err = json.Unmarshal(res.Data, &result)


### PR DESCRIPTION
Signed-off-by: zdianjiang <zdianjiang@gmail.com>

# Description

bingding/mysql not special case type of TEXT column, add TEXT type to string it.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
