### PR TITLE
Fix rabbitmq pubsub reconnect

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -338,7 +338,7 @@ func (r *rabbitMQ) ensureSubscription(req pubsub.SubscribeRequest, queueName str
 	defer r.channelMutex.RUnlock()
 
 	if r.channel == nil {
-		return nil, 0, nil, errors.New(errorChannelNotInitialized)
+		return nil, r.connectionCount, nil, errors.New(errorChannelNotInitialized)
 	}
 
 	q, err := r.prepareSubscription(r.channel, req, queueName)


### PR DESCRIPTION
# Description
When rabbitmq server-side close connection or restart, rabbitmq pubsub can not reconnect the server.

The `reset` function will set r.channel to nil, which means https://github.com/dapr/components-contrib/blob/master/pubsub/rabbitmq/rabbitmq.go#L341 should return r. connectionCount.
This change will not break the concurrence reconnect limit.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: dapr/dapr#4143

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
