### PR TITLE
Update postmark dependency

### DIFF
--- a/bindings/postmark/postmark.go
+++ b/bindings/postmark/postmark.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/keighl/postmark"
+	"github.com/mrz1836/postmark"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
@@ -149,7 +149,7 @@ func (p *Postmark) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse
 
 	// Email body is held in req.Data, after we tidy it up a bit
 	emailBody, _ := strconv.Unquote(string(req.Data))
-	email.HtmlBody = emailBody
+	email.HTMLBody = emailBody
 
 	// Send the email
 	client := postmark.NewClient(p.metadata.ServerToken, p.metadata.AccountToken)

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,6 @@ require (
 	github.com/json-iterator/go v1.1.11
 	github.com/kataras/go-errors v0.0.3 // indirect
 	github.com/kataras/go-serializer v0.0.4 // indirect
-	github.com/keighl/postmark v0.0.0-20190821160221-28358b1a94e3
 	github.com/kr/text v0.2.0 // indirect
 	github.com/machinebox/graphql v0.2.2
 	github.com/matoous/go-nanoid/v2 v2.0.0
@@ -252,6 +251,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/mrz1836/postmark v1.2.9 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -932,6 +932,8 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/moul/http2curl v1.0.0 h1:dRMWoAtb+ePxMlLkrCbAqh4TlPHXvoGUSQ323/9Zahs=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
+github.com/mrz1836/postmark v1.2.9 h1:gAqtnsyB2WKy+F0Iy3ebrATvSN60qW2yXTnoCdNANdA=
+github.com/mrz1836/postmark v1.2.9/go.mod h1:xNRms8jgTfqBneqg0+PzvBrhuojefqXIWc6Np0nHiEM=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

This PR removes the dependency on https://github.com/keighl/postmark and instead uses its fork. The original dependency is not actively developed and has a non-standard license. The fork, on the other hand, has MIT license and is actively worked on.

## Issue reference

<!-- We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation. -->

Please reference the issue this PR will close: #1474

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests (NA)
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_ (NA)
