### PR TITLE
statestore query API: remove 'value' prefix from key names in query JSON

### DIFF
--- a/state/azure/cosmosdb/cosmosdb_query.go
+++ b/state/azure/cosmosdb/cosmosdb_query.go
@@ -40,7 +40,7 @@ func (q *Query) VisitEQ(f *query.EQ) (string, error) {
 	}
 	name := q.setNextParameter(val)
 
-	return fmt.Sprintf("%s = %s", replaceKeywords("c."+f.Key), name), nil
+	return fmt.Sprintf("%s = %s", replaceKeywords("c.value"+f.Key), name), nil
 }
 
 func (q *Query) VisitIN(f *query.IN) (string, error) {
@@ -57,7 +57,7 @@ func (q *Query) VisitIN(f *query.IN) (string, error) {
 		names[i] = q.setNextParameter(val)
 	}
 
-	return fmt.Sprintf("%s IN (%s)", replaceKeywords("c."+f.Key), strings.Join(names, ", ")), nil
+	return fmt.Sprintf("%s IN (%s)", replaceKeywords("c.value"+f.Key), strings.Join(names, ", ")), nil
 }
 
 func (q *Query) visitFilters(op string, filters []query.Filter) (string, error) {
@@ -115,9 +115,9 @@ func (q *Query) Finalize(filters string, qq *query.Query) error {
 		order := make([]string, sz)
 		for i, item := range qq.Sort {
 			if item.Order == query.DESC {
-				order[i] = fmt.Sprintf("%s DESC", replaceKeywords("c."+item.Key))
+				order[i] = fmt.Sprintf("%s DESC", replaceKeywords("c.value"+item.Key))
 			} else {
-				order[i] = fmt.Sprintf("%s ASC", replaceKeywords("c."+item.Key))
+				order[i] = fmt.Sprintf("%s ASC", replaceKeywords("c.value"+item.Key))
 			}
 		}
 		orderBy = fmt.Sprintf(" ORDER BY %s", strings.Join(order, ", "))

--- a/state/azure/cosmosdb/cosmosdb_query_test.go
+++ b/state/azure/cosmosdb/cosmosdb_query_test.go
@@ -72,7 +72,7 @@ func TestCosmosDbQuery(t *testing.T) {
 		{
 			input: "../../../tests/state/query/q2.json",
 			query: documentdb.Query{
-				Query: "SELECT * FROM c WHERE c.state = @__param__0__",
+				Query: "SELECT * FROM c WHERE c['value'].state = @__param__0__",
 				Parameters: []documentdb.Parameter{
 					{
 						Name:  "@__param__0__",
@@ -84,7 +84,7 @@ func TestCosmosDbQuery(t *testing.T) {
 		{
 			input: "../../../tests/state/query/q3.json",
 			query: documentdb.Query{
-				Query: "SELECT * FROM c WHERE c.person.org = @__param__0__ AND c.state IN (@__param__1__, @__param__2__) ORDER BY c.state DESC, c.person.name ASC",
+				Query: "SELECT * FROM c WHERE c['value'].person.org = @__param__0__ AND c['value'].state IN (@__param__1__, @__param__2__) ORDER BY c['value'].state DESC, c['value'].person.name ASC",
 				Parameters: []documentdb.Parameter{
 					{
 						Name:  "@__param__0__",
@@ -104,7 +104,7 @@ func TestCosmosDbQuery(t *testing.T) {
 		{
 			input: "../../../tests/state/query/q4.json",
 			query: documentdb.Query{
-				Query: "SELECT * FROM c WHERE c.person.org = @__param__0__ OR (c.person.org = @__param__1__ AND c.state IN (@__param__2__, @__param__3__)) ORDER BY c.state DESC, c.person.name ASC",
+				Query: "SELECT * FROM c WHERE c['value'].person.org = @__param__0__ OR (c['value'].person.org = @__param__1__ AND c['value'].state IN (@__param__2__, @__param__3__)) ORDER BY c['value'].state DESC, c['value'].person.name ASC",
 				Parameters: []documentdb.Parameter{
 					{
 						Name:  "@__param__0__",

--- a/state/mongodb/mongodb_query.go
+++ b/state/mongodb/mongodb_query.go
@@ -37,7 +37,7 @@ type Query struct {
 
 func (q *Query) VisitEQ(f *query.EQ) (string, error) {
 	// { <key>: <val> }
-	return fmt.Sprintf("{ %q: %q }", f.Key, f.Val), nil
+	return fmt.Sprintf(`{ "value%s": %q }`, f.Key, f.Val), nil
 }
 
 func (q *Query) VisitIN(f *query.IN) (string, error) {
@@ -45,7 +45,7 @@ func (q *Query) VisitIN(f *query.IN) (string, error) {
 	if len(f.Vals) == 0 {
 		return "", fmt.Errorf("empty IN operator for key %q", f.Key)
 	}
-	str := fmt.Sprintf(`{ %q: { "$in": [ %q`, f.Key, f.Vals[0])
+	str := fmt.Sprintf(`{ "value%s": { "$in": [ %q`, f.Key, f.Vals[0])
 	for _, v := range f.Vals[1:] {
 		str += fmt.Sprintf(", %q", v)
 	}
@@ -117,7 +117,7 @@ func (q *Query) Finalize(filters string, qq *query.Query) error {
 			if s.Order == query.DESC {
 				order = -1
 			}
-			sort = append(sort, bson.E{Key: s.Key, Value: order})
+			sort = append(sort, bson.E{Key: "value" + s.Key, Value: order})
 		}
 		q.opts.SetSort(sort)
 	}

--- a/state/mongodb/mongodb_query_test.go
+++ b/state/mongodb/mongodb_query_test.go
@@ -34,15 +34,15 @@ func TestMongoQuery(t *testing.T) {
 		},
 		{
 			input: "../../tests/state/query/q2.json",
-			query: `{ "state": "CA" }`,
+			query: `{ "value.state": "CA" }`,
 		},
 		{
 			input: "../../tests/state/query/q3.json",
-			query: `{ "$and": [ { "person.org": "A" }, { "state": { "$in": [ "CA", "WA" ] } } ] }`,
+			query: `{ "$and": [ { "value.person.org": "A" }, { "value.state": { "$in": [ "CA", "WA" ] } } ] }`,
 		},
 		{
 			input: "../../tests/state/query/q4.json",
-			query: `{ "$or": [ { "person.org": "A" }, { "$and": [ { "person.org": "B" }, { "state": { "$in": [ "CA", "WA" ] } } ] } ] }`,
+			query: `{ "$or": [ { "value.person.org": "A" }, { "$and": [ { "value.person.org": "B" }, { "value.state": { "$in": [ "CA", "WA" ] } } ] } ] }`,
 		},
 	}
 	for _, test := range tests {

--- a/state/postgresql/postgresql_query.go
+++ b/state/postgresql/postgresql_query.go
@@ -184,6 +184,9 @@ func (q *Query) addParamValueAndReturnPosition(value interface{}) int {
 }
 
 func translateFieldToFilter(key string) string {
+	// remove preceding dot
+	key = strings.TrimPrefix(key, ".")
+
 	fieldParts := strings.Split(key, ".")
 	filterField := fieldParts[0]
 	fieldParts = fieldParts[1:]

--- a/state/postgresql/postgresql_query_test.go
+++ b/state/postgresql/postgresql_query_test.go
@@ -37,6 +37,10 @@ func TestPostgresqlQueryBuildQuery(t *testing.T) {
 			query: "SELECT key, value, xmin as etag FROM state WHERE state=$1 LIMIT 2",
 		},
 		{
+			input: "../../tests/state/query/q2-token.json",
+			query: "SELECT key, value, xmin as etag FROM state WHERE state=$1 LIMIT 2 OFFSET 2",
+		},
+		{
 			input: "../../tests/state/query/q3.json",
 			query: "SELECT key, value, xmin as etag FROM state WHERE (person->>'org'=$1 AND (state=$2 OR state=$3)) ORDER BY state DESC, person->>'name'",
 		},
@@ -46,11 +50,7 @@ func TestPostgresqlQueryBuildQuery(t *testing.T) {
 		},
 		{
 			input: "../../tests/state/query/q5.json",
-			query: "SELECT key, value, xmin as etag FROM state WHERE (value->'person'->>'org'=$1 AND (value->'person'->>'name'=$2 OR (value->>'state'=$3 OR value->>'state'=$4))) ORDER BY value->>'state' DESC, value->'person'->>'name' LIMIT 2",
-		},
-		{
-			input: "../../tests/state/query/q6.json",
-			query: "SELECT key, value, xmin as etag FROM state WHERE value->>'state'=$1 LIMIT 2 OFFSET 2",
+			query: "SELECT key, value, xmin as etag FROM state WHERE (person->>'org'=$1 AND (person->>'name'=$2 OR (state=$3 OR state=$4))) ORDER BY state DESC, person->>'name' LIMIT 2",
 		},
 	}
 	for _, test := range tests {

--- a/state/query/query_test.go
+++ b/state/query/query_test.go
@@ -41,7 +41,7 @@ func TestQuery(t *testing.T) {
 				Filters: nil,
 				Sort:    nil,
 				Page:    Pagination{Limit: 2, Token: ""},
-				Filter:  &EQ{Key: "state", Val: "CA"},
+				Filter:  &EQ{Key: ".state", Val: "CA"},
 			},
 		},
 		{
@@ -49,14 +49,14 @@ func TestQuery(t *testing.T) {
 			query: Query{
 				Filters: nil,
 				Sort: []Sorting{
-					{Key: "state", Order: "DESC"},
-					{Key: "person.name", Order: ""},
+					{Key: ".state", Order: "DESC"},
+					{Key: ".person.name", Order: ""},
 				},
 				Page: Pagination{Limit: 0, Token: ""},
 				Filter: &AND{
 					Filters: []Filter{
-						&EQ{Key: "person.org", Val: "A"},
-						&IN{Key: "state", Vals: []interface{}{"CA", "WA"}},
+						&EQ{Key: ".person.org", Val: "A"},
+						&IN{Key: ".state", Vals: []interface{}{"CA", "WA"}},
 					},
 				},
 			},
@@ -66,17 +66,17 @@ func TestQuery(t *testing.T) {
 			query: Query{
 				Filters: nil,
 				Sort: []Sorting{
-					{Key: "state", Order: "DESC"},
-					{Key: "person.name", Order: ""},
+					{Key: ".state", Order: "DESC"},
+					{Key: ".person.name", Order: ""},
 				},
 				Page: Pagination{Limit: 2, Token: ""},
 				Filter: &OR{
 					Filters: []Filter{
-						&EQ{Key: "person.org", Val: "A"},
+						&EQ{Key: ".person.org", Val: "A"},
 						&AND{
 							Filters: []Filter{
-								&EQ{Key: "person.org", Val: "B"},
-								&IN{Key: "state", Vals: []interface{}{"CA", "WA"}},
+								&EQ{Key: ".person.org", Val: "B"},
+								&IN{Key: ".state", Vals: []interface{}{"CA", "WA"}},
 							},
 						},
 					},

--- a/tests/state/query/q2-token.json
+++ b/tests/state/query/q2-token.json
@@ -2,7 +2,7 @@
 {
     "filter": {
         "EQ": {
-            "value.state": "CA"
+            ".state": "CA"
         }
     },
     "page": {

--- a/tests/state/query/q2.json
+++ b/tests/state/query/q2.json
@@ -2,7 +2,7 @@
 {
     "filter": {
         "EQ": {
-            "state": "CA"
+            ".state": "CA"
         }
     },
     "page": {

--- a/tests/state/query/q3.json
+++ b/tests/state/query/q3.json
@@ -3,23 +3,23 @@
         "AND": [
             {
                 "EQ": {
-                    "person.org": "A"
+                    ".person.org": "A"
                 }
             },
             {
                 "IN": {
-                    "state":["CA", "WA"]
+                    ".state":["CA", "WA"]
                 }
             }
         ]
     },
     "sort": [
         {
-            "key": "state",
+            "key": ".state",
             "order": "DESC"
         },
         {
-            "key": "person.name"
+            "key": ".person.name"
         }
     ]
 }

--- a/tests/state/query/q4.json
+++ b/tests/state/query/q4.json
@@ -3,19 +3,19 @@
         "OR": [
             {
                 "EQ": {
-                    "person.org": "A"
+                    ".person.org": "A"
                 }
             },
             {
                 "AND": [
                     {
                         "EQ": {
-                            "person.org": "B"
+                            ".person.org": "B"
                         }
                     },
                     {
                         "IN": {
-                            "state": ["CA", "WA"]
+                            ".state": ["CA", "WA"]
                         }
                     }
                 ]
@@ -24,11 +24,11 @@
     },
     "sort": [
         {
-            "key": "state",
+            "key": ".state",
             "order": "DESC"
         },
         {
-            "key": "person.name"
+            "key": ".person.name"
         }
     ],
     "page": {

--- a/tests/state/query/q5.json
+++ b/tests/state/query/q5.json
@@ -3,19 +3,19 @@
         "AND": [
             {
                 "EQ": {
-                    "value.person.org": "A"
+                    ".person.org": "A"
                 }
             },
             {
                 "OR": [
                     {
                         "EQ": {
-                            "value.person.name": "B"
+                            ".person.name": "B"
                         }
                     },
                     {
                         "IN": {
-                            "value.state": ["CA", "WA"]
+                            ".state": ["CA", "WA"]
                         }
                     }
                 ]
@@ -24,11 +24,11 @@
     },
     "sort": [
         {
-            "key": "value.state",
+            "key": ".state",
             "order": "DESC"
         },
         {
-            "key": "value.person.name"
+            "key": ".person.name"
         }
     ],
     "page": {


### PR DESCRIPTION
# Description

statestore query API: remove 'value' prefix from key names in query JSON object

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1490

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
