### PR TITLE
[WIP] Transaction order conformance test for state stores

### DIFF
--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -459,35 +459,39 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			}
 
 			transactionStore := statestore.(state.TransactionalStore)
-			err := transactionStore.Multi(&state.TransactionalStateRequest{
-				Operations: operations,
-				// For CosmosDB
-				Metadata: map[string]string{
-					"partitionKey": "myPartition",
-				},
-			})
-			assert.Nil(t, err)
 
-			// validate values
-			res, err := statestore.Get(&state.GetRequest{
-				Key: "key1",
-				// For CosmosDB
-				Metadata: map[string]string{
-					"partitionKey": "myPartition",
-				},
-			})
-			assert.Nil(t, err)
-			assert.Empty(t, res)
+			numRuns := 2
+			for n := 0; n < numRuns; n++ {
+				err := transactionStore.Multi(&state.TransactionalStateRequest{
+					Operations: operations,
+					// For CosmosDB
+					Metadata: map[string]string{
+						"partitionKey": "myPartition",
+					},
+				})
+				assert.Nil(t, err)
 
-			res, err = statestore.Get(&state.GetRequest{
-				Key: "key2",
-				// For CosmosDB
-				Metadata: map[string]string{
-					"partitionKey": "myPartition",
-				},
-			})
-			assert.Nil(t, err)
-			assert.Equal(t, "\"value2\"", string(res.Data))
+				// validate values
+				res, err := statestore.Get(&state.GetRequest{
+					Key: "key1",
+					// For CosmosDB
+					Metadata: map[string]string{
+						"partitionKey": "myPartition",
+					},
+				})
+				assert.Nil(t, err)
+				assert.Empty(t, res)
+
+				res, err = statestore.Get(&state.GetRequest{
+					Key: "key2",
+					// For CosmosDB
+					Metadata: map[string]string{
+						"partitionKey": "myPartition",
+					},
+				})
+				assert.Nil(t, err)
+				assert.Equal(t, "\"value2\"", string(res.Data))
+			}
 		})
 	} else {
 		// Check if transactional feature is NOT listed


### PR DESCRIPTION
# Description

Introduces a new test that checks the order of transactions. Say a transaction that contains the following:
```bash
upsert k1 v1
delete k1
upsert k2 v2
```
The order of operations must be respected, and `k1` should be deleted, whilst `k2` should have a value of `v2`.

Note, an anomaly was found in Cosmos DB state store in #1209, and it was also found that the transaction run fails to maintain the order in alternate runs.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1210

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_ (NA)
