### PR TITLE
Fix transaction API for Azure SQL server

### DIFF
--- a/state/errors.go
+++ b/state/errors.go
@@ -62,3 +62,21 @@ func NewETagError(kind ETagErrorKind, err error) *ETagError {
 		kind: kind,
 	}
 }
+
+// BulkDeleteRowMismatchError represents mismatch in rowcount while deleting rows.
+type BulkDeleteRowMismatchError struct {
+	expected uint64
+	affected uint64
+}
+
+func (e *BulkDeleteRowMismatchError) Error() string {
+	return fmt.Sprintf("delete affected only %d rows, expected %d", e.affected, e.expected)
+}
+
+// BulkDeleteRowMismatchError returns a BulkDeleteRowMismatchError.
+func NewBulkDeleteRowMismatchError(expected, affected uint64) *BulkDeleteRowMismatchError {
+	return &BulkDeleteRowMismatchError{
+		expected: expected,
+		affected: affected,
+	}
+}

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -342,22 +342,14 @@ func (s *SQLServer) Features() []state.Feature {
 }
 
 // Multi performs multiple updates on a Sql server store.
-// From the transaction request, only the most recent operation per key is applied.
-// Other operations are redundant, and therefore safe to remove. For example,
-//
-// Input transaction:
-//	upsert k1 v1 // redundant
-//	delete k1
-//	delete k2 // redundant
-// 	upsert k2 v2
-// Output transaction:
-//	delete k1
-// 	upsert k2 v2
 func (s *SQLServer) Multi(request *state.TransactionalStateRequest) error {
 	keyMap := make(map[string]struct{})
 	var sets []state.SetRequest
 	var deletes []state.DeleteRequest
 
+	// The order of unique key requests does not matter in an atomic transaction.
+	// Only the latest operation for any unique key is selected for execution.
+	// The other operations are redundant, and hence ignored.
 	for i := len(request.Operations) - 1; i >= 0; i-- {
 		req := request.Operations[i]
 		switch req.Operation {

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -347,7 +347,7 @@ func (s *SQLServer) Multi(request *state.TransactionalStateRequest) error {
 	var sets []state.SetRequest
 	var deletes []state.DeleteRequest
 
-	// The order of unique key requests does not matter in an atomic transaction.
+	// The order of unique key operations does not matter in an atomic transaction.
 	// Only the latest operation for any unique key is selected for execution.
 	// The other operations are redundant, and hence ignored.
 	for i := len(request.Operations) - 1; i >= 0; i-- {


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

This PR introduces a logic for only keeping the latest operations per key in a transaction. This is similar to what was proposed in https://github.com/dapr/components-contrib/issues/1209#issuecomment-982731149. For example, say the original transaction is:
```bash
upsert k1 v1  # redundant, gets deleted later
delete k1
delete k2     # redundant, gets set to v2 later
upsert k2 v2
```

Since #1517 was a prerequisite, I have merged the changes with this one. It ignores row mismatch error while using bulk delete in transactions.

## Issue reference

Please reference the issue this PR will close: #1505, #1517

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* (NA) Created/updated tests - will be added as part of #1210
* (NA) Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
