### PR TITLE
Update Dev Container Base Image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,6 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-FROM daprio/dapr-dev:0.1.5
+FROM daprio/dapr-dev:0.1.6a
 
 VOLUME [ "/go/src/github.com/dapr/dapr" ]


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

For some reason the Dev Container wasn't even using Dapr 1.6. We had to make another change to the dev container, so pinning this to 0.1.6a now.

Do not merge this PR until https://github.com/dapr/dapr/pull/4316 is merged.