### PR TITLE
[WIP] marshal mongodb bson into relaxed json

### DIFF
--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -225,7 +225,14 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	case string:
 		data = []byte(obj)
 	case primitive.D:
-		if data, err = bson.MarshalExtJSON(obj, true, true); err != nil {
+		// Setting canonical to `false`.
+		// See https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations
+		// Having bson marshalled into Relaxed JSON instead of canonical JSON, this way type preservation is lost but
+		// interoperability is preserved
+		// See https://mongodb.github.io/swift-bson/docs/current/SwiftBSON/json-interop.html
+		// A decimal value stored as BSON will be returned as {"d": 5.5} if canonical is set to false instead of
+		// {"d": {"$numberDouble": 5.5}} when canonical JSON is returned.
+		if data, err = bson.MarshalExtJSON(obj, false, true); err != nil {
 			return &state.GetResponse{}, err
 		}
 	default:

--- a/state/mongodb/mongodb_query.go
+++ b/state/mongodb/mongodb_query.go
@@ -157,7 +157,14 @@ func (q *Query) execute(ctx context.Context, collection *mongo.Collection) ([]st
 		case string:
 			result.Data = []byte(obj)
 		case primitive.D:
-			if result.Data, err = bson.MarshalExtJSON(obj, true, true); err != nil {
+			// Setting canonical to `false`.
+			// See https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations
+			// Having bson marshalled into Relaxed JSON instead of canonical JSON, this way type preservation is lost but
+			// interoperability is preserved
+			// See https://mongodb.github.io/swift-bson/docs/current/SwiftBSON/json-interop.html
+			// A decimal value stored as BSON will be returned as {"d": 5.5} if canonical is set to false instead of
+			// {"d": {"$numberDouble": 5.5}} when canonical JSON is returned.
+			if result.Data, err = bson.MarshalExtJSON(obj, false, true); err != nil {
 				result.Error = err.Error()
 			}
 		default:

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -33,7 +33,7 @@ type ValueType struct {
 	Message string `json:"message"`
 }
 
-type IntValueType struct {
+type intValueType struct {
 	Message int32 `json:"message"`
 }
 
@@ -103,7 +103,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 		},
 		{
 			key:         fmt.Sprintf("%s-struct-with-int", key),
-			value:       IntValueType{Message: 42},
+			value:       intValueType{Message: 42},
 			contentType: contenttype.JSONContentType,
 		},
 		{
@@ -767,7 +767,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 func assertEquals(t *testing.T, value interface{}, res *state.GetResponse) {
 	switch v := value.(type) {
-	case IntValueType:
+	case intValueType:
 		// Custom type requires case mapping
 		if err := json.Unmarshal(res.Data, &v); err != nil {
 			assert.Failf(t, "unmarshal error", "error: %w, json: %s", err, string(res.Data))

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -33,6 +33,10 @@ type ValueType struct {
 	Message string `json:"message"`
 }
 
+type IntValueType struct {
+	Message int32 `json:"message"`
+}
+
 type scenario struct {
 	key              string
 	value            interface{}
@@ -95,6 +99,11 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 		{
 			key:         fmt.Sprintf("%s-struct", key),
 			value:       ValueType{Message: fmt.Sprintf("test%s", key)},
+			contentType: contenttype.JSONContentType,
+		},
+		{
+			key:         fmt.Sprintf("%s-struct-with-int", key),
+			value:       IntValueType{Message: 42},
 			contentType: contenttype.JSONContentType,
 		},
 		{
@@ -664,6 +673,12 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 func assertEquals(t *testing.T, value interface{}, res *state.GetResponse) {
 	switch v := value.(type) {
+	case IntValueType:
+		// Custom type requires case mapping
+		if err := json.Unmarshal(res.Data, &v); err != nil {
+			assert.Failf(t, "unmarshal error", "error: %w, json: %s", err, string(res.Data))
+		}
+		assert.Equal(t, value, v)
 	case ValueType:
 		// Custom type requires case mapping
 		if err := json.Unmarshal(res.Data, &v); err != nil {


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <msundar.ms@outlook.com>

# Description

Change to marshal to Ext JSON with Relaxed format instead of Canonical Format. 

Without the change to `canonical` representation as false, the added conformance test scenario fails 
```
state.go:257: Checking value presence for b92a399b3889432782b78babd1169ab8-struct-with-int
    state.go:675: 
        	Error Trace:	state.go:675
        	            				state.go:266
        	Error:      	unmarshal error
        	Test:       	TestStateConformance/mongodb/get
        	Messages:   	error: %!w(*json.UnmarshalTypeError=&{object 0x10721fe20 12 IntValueType message}), json: {"message":{"$numberInt":"42"}}
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1582 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
