### PR TITLE
mongodb: fix querying non-string values

### DIFF
--- a/state/mongodb/mongodb_query_test.go
+++ b/state/mongodb/mongodb_query_test.go
@@ -44,6 +44,10 @@ func TestMongoQuery(t *testing.T) {
 			input: "../../tests/state/query/q4.json",
 			query: `{ "$or": [ { "value.person.org": "A" }, { "$and": [ { "value.person.org": "B" }, { "value.state": { "$in": [ "CA", "WA" ] } } ] } ] }`,
 		},
+		{
+			input: "../../tests/state/query/q6.json",
+			query: `{ "$or": [ { "value.person.id": 123 }, { "$and": [ { "value.person.org": "B" }, { "value.person.id": { "$in": [ 567, 890 ] } } ] } ] }`,
+		},
 	}
 	for _, test := range tests {
 		data, err := ioutil.ReadFile(test.input)

--- a/tests/state/query/q6.json
+++ b/tests/state/query/q6.json
@@ -1,0 +1,37 @@
+{
+    "filter": {
+        "OR": [
+            {
+                "EQ": {
+                    "person.id": 123
+                }
+            },
+            {
+                "AND": [
+                    {
+                        "EQ": {
+                            "person.org": "B"
+                        }
+                    },
+                    {
+                        "IN": {
+                            "person.id": [567, 890]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "sort": [
+        {
+            "key": "state",
+            "order": "DESC"
+        },
+        {
+            "key": "person.name"
+        }
+    ],
+    "page": {
+        "limit": 2
+    }
+}


### PR DESCRIPTION
# Description

Fixed a bug in MongoDB state component: querying non-string values returns an error.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1583

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
