### PR TITLE
Allow accepting self-signed TLS certs for S3

### DIFF
--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -99,6 +99,7 @@ func (s *AWSS3) Init(metadata bindings.Metadata) error {
 	if m.InsecureSSL {
 		customTransport := http.DefaultTransport.(*http.Transport).Clone()
 		customTransport.TLSClientConfig = &tls.Config{
+			//nolint:gosec
 			InsecureSkipVerify: true,
 		}
 		client := &http.Client{

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -15,9 +15,11 @@ package s3
 
 import (
 	"bytes"
+	"crypto/tls"
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,6 +62,7 @@ type s3Metadata struct {
 	EncodeBase64   bool   `json:"encodeBase64,string"`
 	ForcePathStyle bool   `json:"forcePathStyle,string"`
 	DisableSSL     bool   `json:"disableSSL,string"`
+	InsecureSSL    bool   `json:"insecureSSL,string"`
 }
 
 type createResponse struct {
@@ -91,6 +94,18 @@ func (s *AWSS3) Init(metadata bindings.Metadata) error {
 	}
 
 	cfg := aws.NewConfig().WithS3ForcePathStyle(m.ForcePathStyle).WithDisableSSL(m.DisableSSL)
+
+	// Use a custom HTTP client to allow self-signed certs
+	if m.InsecureSSL {
+		customTransport := http.DefaultTransport.(*http.Transport).Clone()
+		customTransport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		client := &http.Client{
+			Transport: customTransport,
+		}
+		cfg = cfg.WithHTTPClient(client)
+	}
 
 	s.metadata = m
 	s.s3Client = s3.New(session, cfg)

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -26,7 +26,7 @@ func TestParseMetadata(t *testing.T) {
 	t.Run("Has correct metadata", func(t *testing.T) {
 		m := bindings.Metadata{}
 		m.Properties = map[string]string{
-			"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint", "SessionToken": "token", "ForcePathStyle": "true", "DisableSSL": "true", "InsecureSSL": "true"
+			"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint", "SessionToken": "token", "ForcePathStyle": "true", "DisableSSL": "true", "InsecureSSL": "true",
 		}
 		s3 := AWSS3{}
 		meta, err := s3.parseMetadata(m)

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -26,7 +26,7 @@ func TestParseMetadata(t *testing.T) {
 	t.Run("Has correct metadata", func(t *testing.T) {
 		m := bindings.Metadata{}
 		m.Properties = map[string]string{
-			"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint", "SessionToken": "token", "ForcePathStyle": "true", "DisableSSL": "true",
+			"AccessKey": "key", "Region": "region", "SecretKey": "secret", "Bucket": "test", "Endpoint": "endpoint", "SessionToken": "token", "ForcePathStyle": "true", "DisableSSL": "true", "InsecureSSL": "true"
 		}
 		s3 := AWSS3{}
 		meta, err := s3.parseMetadata(m)
@@ -39,6 +39,7 @@ func TestParseMetadata(t *testing.T) {
 		assert.Equal(t, "token", meta.SessionToken)
 		assert.Equal(t, true, meta.ForcePathStyle)
 		assert.Equal(t, true, meta.DisableSSL)
+		assert.Equal(t, true, meta.InsecureSSL)
 	})
 }
 


### PR DESCRIPTION
# Description

Adds a metadata option `insecureSSL` for the S3 binding which allows accepting self-signed TLS certificates. This is especially useful when using Minio (see #1592).

Note: I'm not really sure on the name of the metadata. `insecureSSL` seemed short enough and mirrors `disableSSL` (which switches to using HTTP), and it's aligned with the `--insecure` flag of curl. But open to suggestions.

## Issue reference

Closes #1592

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation / Created issue in the https://github.com/dapr/docs/issues/2268
