### PR TITLE
[WIP] Fix serialization issue with 64 bit data type

### DIFF
--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -14,12 +14,13 @@ limitations under the License.
 package pubsub
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
 
 	contrib_contenttype "github.com/dapr/components-contrib/contenttype"
 	contrib_metadata "github.com/dapr/components-contrib/metadata"
@@ -49,9 +50,22 @@ const (
 	SubjectField                     = "subject"
 )
 
+// unmarshalPrecise is a wrapper around encoding/json's Decoder
+// with UseNumber. It prevents data loss for big numbers
+// while unmarshalling.
+func unmarshalPrecise(data []byte, v interface{}) error {
+	decoder := json.NewDecoder(bytes.NewBuffer(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+	return nil
+}
+
 // NewCloudEventsEnvelope returns a map representation of a cloudevents JSON.
 func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string, pubsubName string,
 	dataContentType string, data []byte, traceID string, traceState string) map[string]interface{} {
+
 	// defaults
 	if id == "" {
 		id = uuid.New().String()
@@ -70,7 +84,7 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 	ceDataField := DataField
 	var err error
 	if contrib_contenttype.IsJSONContentType(dataContentType) {
-		err = jsoniter.Unmarshal(data, &ceData)
+		err = unmarshalPrecise(data, &ceData)
 	} else if contrib_contenttype.IsBinaryContentType(dataContentType) {
 		ceData = base64.StdEncoding.EncodeToString(data)
 		ceDataField = DataBase64Field
@@ -106,7 +120,7 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 // FromCloudEvent returns a map representation of an existing cloudevents JSON.
 func FromCloudEvent(cloudEvent []byte, topic, pubsub, traceID string, traceState string) (map[string]interface{}, error) {
 	var m map[string]interface{}
-	err := jsoniter.Unmarshal(cloudEvent, &m)
+	err := unmarshalPrecise(cloudEvent, &m)
 	if err != nil {
 		return m, err
 	}


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

This PR changes the serialization logic in pubsub's CloudEvent envelope to use `encoding/json` with `UseNumber` on its decoder, to prevent data loss with float64 conversion,

## Issue reference

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/3837

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
