### PR TITLE
use releaxedJson for get behind a flag

### DIFF
--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -47,7 +47,7 @@ const (
 	writeConcern     = "writeConcern"
 	readConcern      = "readConcern"
 	operationTimeout = "operationTimeout"
-	relaxedJsonKey   = "relaxedJson"
+	relaxedJSONKey   = "relaxedJson"
 	params           = "params"
 	id               = "_id"
 	value            = "value"
@@ -205,12 +205,12 @@ func (m *MongoDB) setInternal(ctx context.Context, req *state.SetRequest) error 
 // Get retrieves state from MongoDB with a key.
 func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	var result Item
-	var relaxedJson bool
+	var relaxedJSON bool
 
-	if val, ok := req.Metadata[relaxedJsonKey]; ok && val != "" {
+	if val, ok := req.Metadata[relaxedJSONKey]; ok && val != "" {
 		v, err := strconv.ParseBool(val)
 		if err == nil {
-			relaxedJson = v
+			relaxedJSON = v
 		}
 	}
 
@@ -241,13 +241,13 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 		// See https://mongodb.github.io/swift-bson/docs/current/SwiftBSON/json-interop.html
 		// A decimal value stored as BSON will be returned as {"d": 5.5} if canonical is set to false instead of
 		// {"d": {"$numberDouble": 5.5}} when canonical JSON is returned.
-		if relaxedJson {
+		if relaxedJSON {
 			if data, err = bson.MarshalExtJSON(obj, false, true); err != nil {
 				return &state.GetResponse{}, err
 			}
 		} else {
 			m.logger.Warnf("MongoDB canonical extended JSON representation is returned for %s."+
-				"Use %q metadata for GetRequest as canonical representation is deprecated since v1.7.0 of Dapr.", req.Key, relaxedJsonKey)
+				"Use %q metadata for GetRequest as canonical representation is deprecated since v1.7.0 of Dapr.", req.Key, relaxedJSONKey)
 			if data, err = bson.MarshalExtJSON(obj, true, true); err != nil {
 				return &state.GetResponse{}, err
 			}

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -47,6 +47,7 @@ const (
 	writeConcern     = "writeConcern"
 	readConcern      = "readConcern"
 	operationTimeout = "operationTimeout"
+	relaxedJsonKey   = "relaxedJson"
 	params           = "params"
 	id               = "_id"
 	value            = "value"
@@ -204,6 +205,14 @@ func (m *MongoDB) setInternal(ctx context.Context, req *state.SetRequest) error 
 // Get retrieves state from MongoDB with a key.
 func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	var result Item
+	var relaxedJson bool
+
+	if val, ok := req.Metadata[relaxedJsonKey]; ok && val != "" {
+		v, err := strconv.ParseBool(val)
+		if err == nil {
+			relaxedJson = v
+		}
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), m.operationTimeout)
 	defer cancel()
@@ -227,14 +236,23 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	case primitive.D:
 		// Setting canonical to `false`.
 		// See https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations
-		// Having bson marshalled into Relaxed JSON instead of canonical JSON, this way type preservation is lost but
+		// Having bson marshalled into relaxed JSON instead of canonical JSON, this way type preservation is lost but
 		// interoperability is preserved
 		// See https://mongodb.github.io/swift-bson/docs/current/SwiftBSON/json-interop.html
 		// A decimal value stored as BSON will be returned as {"d": 5.5} if canonical is set to false instead of
 		// {"d": {"$numberDouble": 5.5}} when canonical JSON is returned.
-		if data, err = bson.MarshalExtJSON(obj, false, true); err != nil {
-			return &state.GetResponse{}, err
+		if relaxedJson {
+			if data, err = bson.MarshalExtJSON(obj, false, true); err != nil {
+				return &state.GetResponse{}, err
+			}
+		} else {
+			m.logger.Warnf("MongoDB canonical extended JSON representation is returned for %s."+
+				"Use %q metadata for GetRequest as canonical representation is deprecated since v1.7.0 of Dapr.", req.Key, relaxedJsonKey)
+			if data, err = bson.MarshalExtJSON(obj, true, true); err != nil {
+				return &state.GetResponse{}, err
+			}
 		}
+
 	default:
 		if data, err = json.Marshal(result.Value); err != nil {
 			return &state.GetResponse{}, err

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -5,6 +5,9 @@ components:
     allOperations: true
   - component: mongodb
     allOperations: true
+    config:
+      getRequestMetadata:
+        relaxedJson: true
   - component: azure.cosmosdb
     allOperations: true
   - component: azure.sql

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -289,7 +289,12 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				}
 				store := loadStateStore(comp)
 				assert.NotNil(t, store)
-				storeConfig := conf_state.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				storeConfig, err := conf_state.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				if err != nil {
+					t.Errorf("error running conformance test for %s: %s", comp.Component, err)
+
+					break
+				}
 				conf_state.ConformanceTests(t, props, store, storeConfig)
 			case "secretstores":
 				filepath := fmt.Sprintf("../config/secretstores/%s", componentConfigPath)


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <msundar.ms@outlook.com>

# Description

Follow up to #1581 , have put the relaxedJson representation behind a flag in GetRequest alone. 

When this metadata is passed in GetRequest, then relaxedJson representation is used, else the v1.6.0 behavior of canonicalJson will be used. This will make the PR 1581 as not a breaking change immediately for a Stable component Get API. 

After 2 releases following normal Dapr deprecation policy, this flag can be removed. 

For now it will be deprecated and a Warning log will be printed for every Get Request which uses canonical json representation. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
