### PR TITLE
Use go:embed for Cosmos DB stored procedures

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cosmosdb
 
 import (
+	_ "embed"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -34,6 +35,15 @@ import (
 	"github.com/dapr/components-contrib/state/query"
 	"github.com/dapr/kit/logger"
 )
+
+// Version of the stored procedure to use.
+const spVersion = 2
+
+//go:embed storedprocedures/__dapr_v2__.js
+var spDefinition string
+
+//go:embed storedprocedures/__daprver__.js
+var spVersionDefinition string
 
 // StateStore is a CosmosDB state store.
 type StateStore struct {

--- a/state/azure/cosmosdb/storedprocedures/__dapr_v2__.js
+++ b/state/azure/cosmosdb/storedprocedures/__dapr_v2__.js
@@ -1,21 +1,4 @@
-/*
-Copyright 2021 The Dapr Authors
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package cosmosdb
-
-const spVersion = 2
-
-const spDefinition string = `// operations - an array of objects to upsert or delete
+// operations - an array of objects to upsert or delete
 function dapr_multi_v2(operations) {
     if (typeof operations === "string") {
         throw new Error("arg is a string, expected array of objects");
@@ -117,9 +100,4 @@ function dapr_multi_v2(operations) {
             tryExecute(operations[operationCount], callback);
         }
     }
-}`
-
-const spVersionDefinition = `function daprSpVersion(prefix) {
-    var response = getContext().getResponse();
-    response.setBody(2);
-}`
+}

--- a/state/azure/cosmosdb/storedprocedures/__daprver__.js
+++ b/state/azure/cosmosdb/storedprocedures/__daprver__.js
@@ -1,0 +1,4 @@
+function daprSpVersion(prefix) {
+    var response = getContext().getResponse();
+    response.setBody(2);
+}


### PR DESCRIPTION
Sorry is this is so last-minute.

While writing the docs for manually creating the stored procedures for Cosmos DB (see: https://github.com/dapr/docs/issues/2325 ), I realized that I was going to have to include source code (the JS of the stored procedures) inside the docs. That was not ideal.

A better solution would be to just tell users to `curl` the JS source code of the stored procedures from a tag in this repository. However, currently the source of the stored procedures was included in a variable in a Go file, so it was not possible to fetch that code only. Using Go embeds allows maintaining the stored procedures' source code in a separate file and have it embedded at build time.

TL;DR: After this PR is merged and we have the source code of the stored procedures in a tag, users will be able to just do something like `curl -LO "https://raw.githubusercontent.com/dapr/components-contrib/v1.7.0/state/azure/cosmosdb/storedprocedures/__dapr_v2__.js"` to get the source code of the stored procedure. This would significantly improve the quality of life of users following our docs.