### PR TITLE
Cosmos DB: Delete does not need to query for the doc first 

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -473,8 +473,8 @@ func (c *StateStore) getCollectionLink() string {
 }
 
 // getDocumentLink returns the link to a document in the collection.
-func (c *StateStore) getDocumentLink(docId string) string {
-	return fmt.Sprintf("dbs/%s/colls/%s/docs/%s", c.metadata.Database, c.metadata.Collection, docId)
+func (c *StateStore) getDocumentLink(docID string) string {
+	return fmt.Sprintf("dbs/%s/colls/%s/docs/%s", c.metadata.Database, c.metadata.Collection, docID)
 }
 
 // getSprocLink returns the link to a stored procedure in the collection.


### PR DESCRIPTION
This, which is possible now because of improvements in the upstream SDK, should speed up delete operations significantly (and reducing RU usage).

Also, this should fix potential concurrency issues.

(Note this is built on top of #1643)