### PR TITLE
WIP add sqlite state store (pending for gRPC component)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -171,6 +171,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-sqlite3 v1.14.12 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -942,6 +942,8 @@ github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1y
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.0-20181025052659-b20a3daf6a39/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
+github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=

--- a/state/sqlite/dbaccess.go
+++ b/state/sqlite/dbaccess.go
@@ -1,0 +1,16 @@
+package sqlite
+
+import (
+	"github.com/dapr/components-contrib/state"
+)
+
+// dbAccess is a private interface which enables unit testing of SQLite.
+type dbAccess interface {
+	Init(metadata state.Metadata) error
+	Ping() error
+	Set(req *state.SetRequest) error
+	Get(req *state.GetRequest) (*state.GetResponse, error)
+	Delete(req *state.DeleteRequest) error
+	ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error
+	Close() error
+}

--- a/state/sqlite/dbaccess.go
+++ b/state/sqlite/dbaccess.go
@@ -11,6 +11,6 @@ type dbAccess interface {
 	Set(req *state.SetRequest) error
 	Get(req *state.GetRequest) (*state.GetResponse, error)
 	Delete(req *state.DeleteRequest) error
-	ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error
+	ExecuteMulti(reqs []state.TransactionalStateOperation) error
 	Close() error
 }

--- a/state/sqlite/sqlite.go
+++ b/state/sqlite/sqlite.go
@@ -1,0 +1,118 @@
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+)
+
+// SQLite Database state store.
+type Sqlite struct {
+	features []state.Feature
+	logger   logger.Logger
+	dbaccess dbAccess
+}
+
+// NewSqliteStateStore creates a new instance of Sqlite state store.
+func NewSqliteStateStore(logger logger.Logger) *Sqlite {
+	dba := newSqliteDBAccess(logger)
+
+	return newSqliteStateStore(logger, dba)
+}
+
+// newSqliteStateStore creates a newSqliteStateStore instance of an Sqlite state store.
+// This unexported constructor allows injecting a dbAccess instance for unit testing.
+func newSqliteStateStore(logger logger.Logger, dba dbAccess) *Sqlite {
+	return &Sqlite{
+		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		logger:   logger,
+		dbaccess: dba,
+	}
+}
+
+// Init initializes the Sql server state store.
+func (s *Sqlite) Init(metadata state.Metadata) error {
+	return s.dbaccess.Init(metadata)
+}
+
+func (s *Sqlite) Ping() error {
+	return s.dbaccess.Ping()
+}
+
+// Features returns the features available in this state store.
+func (s *Sqlite) Features() []state.Feature {
+	return s.features
+}
+
+// Delete removes an entity from the store.
+func (s *Sqlite) Delete(req *state.DeleteRequest) error {
+	return s.dbaccess.Delete(req)
+}
+
+// BulkDelete removes multiple entries from the store.
+func (s *Sqlite) BulkDelete(req []state.DeleteRequest) error {
+	return s.dbaccess.ExecuteMulti(nil, req)
+}
+
+// Get returns an entity from store.
+func (s *Sqlite) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	return s.dbaccess.Get(req)
+}
+
+// BulkGet performs a bulks get operations.
+func (s *Sqlite) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+	// TODO: replace with ExecuteMulti for performance.
+	return false, nil, nil
+}
+
+// Set adds/updates an entity on store.
+func (s *Sqlite) Set(req *state.SetRequest) error {
+	return s.dbaccess.Set(req)
+}
+
+// BulkSet adds/updates multiple entities on store.
+func (s *Sqlite) BulkSet(req []state.SetRequest) error {
+	return s.dbaccess.ExecuteMulti(req, nil)
+}
+
+// Multi handles multiple transactions. Implements TransactionalStore.
+func (s *Sqlite) Multi(request *state.TransactionalStateRequest) error {
+	var deletes []state.DeleteRequest
+	var sets []state.SetRequest
+	for _, req := range request.Operations {
+		switch req.Operation {
+		case state.Upsert:
+			if setReq, ok := req.Request.(state.SetRequest); ok {
+				sets = append(sets, setReq)
+			} else {
+				return fmt.Errorf("expecting set request")
+			}
+
+		case state.Delete:
+			if delReq, ok := req.Request.(state.DeleteRequest); ok {
+				deletes = append(deletes, delReq)
+			} else {
+				return fmt.Errorf("expecting delete request")
+			}
+
+		default:
+			return fmt.Errorf("unsupported operation: %s", req.Operation)
+		}
+	}
+
+	if len(sets) > 0 || len(deletes) > 0 {
+		return s.dbaccess.ExecuteMulti(sets, deletes)
+	}
+
+	return nil
+}
+
+// Close implements io.Closer.
+func (s *Sqlite) Close() error {
+	if s.dbaccess != nil {
+		return s.dbaccess.Close()
+	}
+
+	return nil
+}

--- a/state/sqlite/sqlite_integration_test.go
+++ b/state/sqlite/sqlite_integration_test.go
@@ -1,0 +1,826 @@
+package sqlite
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	connectionStringEnvKey = "DAPR_TEST_SQLITE_DATABASE_CONNECTSTRING" // Environment variable containing the connection string.
+)
+
+func TestSqliteIntegration(t *testing.T) {
+	cgo := os.Getenv("CGO_ENABLED")
+	if cgo != "1" {
+		t.Skipf("SQLite Database state integration tests skipped. To enable define CGO_ENABLED=1")
+	}
+	connectionString := getConnectionString()
+
+	t.Run("Test init configurations", func(t *testing.T) {
+		testInitConfiguration(t)
+	})
+
+	metadata := state.Metadata{
+		Properties: map[string]string{
+			connectionStringKey: connectionString,
+			tableNameKey:        "test_state",
+		},
+	}
+
+	s := NewSqliteStateStore(logger.NewLogger("test"))
+	t.Cleanup(func() {
+		defer s.Close()
+	})
+
+	if initerror := s.Init(metadata); initerror != nil {
+		t.Fatal(initerror)
+	}
+
+	t.Run("Create table succeeds", func(t *testing.T) {
+		testCreateTable(t, s.dbaccess.(*sqliteDBAccess))
+	})
+
+	t.Run("Get Set Delete one item", func(t *testing.T) {
+		setGetUpdateDeleteOneItem(t, s)
+	})
+
+	t.Run("Get item that does not exist", func(t *testing.T) {
+		getItemThatDoesNotExist(t, s)
+	})
+
+	t.Run("Get item with no key fails", func(t *testing.T) {
+		getItemWithNoKey(t, s)
+	})
+
+	t.Run("Set item with invalid (non numeric) TTL", func(t *testing.T) {
+		testSetItemWithInvalidTTL(t, s)
+	})
+	t.Run("Set item with negative TTL", func(t *testing.T) {
+		testSetItemWithNegativeTTL(t, s)
+	})
+	t.Run("Set with TTL updates the expiration field", func(t *testing.T) {
+		setTTLUpdatesExpiry(t, s)
+	})
+	t.Run("Set with TTL followed by set without TTL resets the expiration field", func(t *testing.T) {
+		setNoTTLUpdatesExpiry(t, s)
+	})
+	t.Run("Expired item cannot be read", func(t *testing.T) {
+		expiredStateCannotBeRead(t, s)
+	})
+	t.Run("Unexpired item be read", func(t *testing.T) {
+		unexpiredStateCanBeRead(t, s)
+	})
+	t.Run("Set updates the updatedate field", func(t *testing.T) {
+		setUpdatesTheUpdatedateField(t, s)
+	})
+
+	t.Run("Set item with no key fails", func(t *testing.T) {
+		setItemWithNoKey(t, s)
+	})
+
+	t.Run("Bulk set and bulk delete", func(t *testing.T) {
+		testBulkSetAndBulkDelete(t, s)
+	})
+
+	t.Run("Update and delete with etag succeeds", func(t *testing.T) {
+		updateAndDeleteWithEtagSucceeds(t, s)
+	})
+
+	t.Run("Update with old etag fails", func(t *testing.T) {
+		updateWithOldEtagFails(t, s)
+	})
+
+	t.Run("Insert with etag fails", func(t *testing.T) {
+		newItemWithEtagFails(t, s)
+	})
+
+	t.Run("Delete with invalid etag fails when first write is enforced", func(t *testing.T) {
+		deleteWithInvalidEtagFails(t, s)
+	})
+	t.Run("Update and Delete with invalid etag and no first write policy enforced succeeds", func(t *testing.T) {
+		updateAndDeleteWithWrongEtagAndNoFirstWriteSucceeds(t, s)
+	})
+
+	t.Run("Delete item with no key fails", func(t *testing.T) {
+		deleteWithNoKeyFails(t, s)
+	})
+
+	t.Run("Delete an item that does not exist", func(t *testing.T) {
+		deleteItemThatDoesNotExist(t, s)
+	})
+	t.Run("Multi with delete and set", func(t *testing.T) {
+		multiWithDeleteAndSet(t, s)
+	})
+
+	t.Run("Multi with delete only", func(t *testing.T) {
+		multiWithDeleteOnly(t, s)
+	})
+
+	t.Run("Multi with set only", func(t *testing.T) {
+		multiWithSetOnly(t, s)
+	})
+}
+
+// setGetUpdateDeleteOneItem validates setting one item, getting it, and deleting it.
+func setGetUpdateDeleteOneItem(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	value := &fakeItem{Color: "yellow"}
+
+	setItem(t, s, key, value, nil)
+
+	getResponse, outputObject := getItem(t, s, key)
+	assert.Equal(t, value, outputObject)
+
+	newValue := &fakeItem{Color: "green"}
+	setItem(t, s, key, newValue, getResponse.ETag)
+	getResponse, outputObject = getItem(t, s, key)
+
+	assert.Equal(t, newValue, outputObject)
+
+	deleteItem(t, s, key, getResponse.ETag)
+}
+
+// testCreateTable tests the ability to create the state table.
+func testCreateTable(t *testing.T, dba *sqliteDBAccess) {
+	tableName := "test_state_creation"
+
+	// Drop the table if it already exists.
+	exists, err := tableExists(dba.db, tableName)
+	assert.Nil(t, err)
+	if exists {
+		dropTable(t, dba.db, tableName)
+	}
+
+	// Create the state table and test for its existence.
+	err = dba.ensureStateTable(tableName)
+	assert.Nil(t, err)
+	exists, err = tableExists(dba.db, tableName)
+	assert.Nil(t, err)
+	assert.True(t, exists)
+
+	// Drop the state table.
+	dropTable(t, dba.db, tableName)
+}
+
+func dropTable(t *testing.T, db *sql.DB, tableName string) {
+	_, err := db.Exec(fmt.Sprintf("DROP TABLE %s", tableName))
+	assert.Nil(t, err)
+}
+
+func deleteItemThatDoesNotExist(t *testing.T, s *Sqlite) {
+	// Delete the item with a key not in the store.
+	deleteReq := &state.DeleteRequest{
+		Key: randomKey(),
+	}
+	err := s.Delete(deleteReq)
+	assert.Nil(t, err)
+}
+
+func multiWithSetOnly(t *testing.T, s *Sqlite) {
+	var operations []state.TransactionalStateOperation
+	var setRequests []state.SetRequest
+	for i := 0; i < 3; i++ {
+		req := state.SetRequest{
+			Key:   randomKey(),
+			Value: randomJSON(),
+		}
+		setRequests = append(setRequests, req)
+		operations = append(operations, state.TransactionalStateOperation{
+			Operation: state.Upsert,
+			Request:   req,
+		})
+	}
+
+	err := s.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.Nil(t, err)
+
+	for _, set := range setRequests {
+		assert.True(t, storeItemExists(t, s, set.Key))
+		deleteItem(t, s, set.Key, nil)
+	}
+}
+
+func multiWithDeleteOnly(t *testing.T, s *Sqlite) {
+	var operations []state.TransactionalStateOperation
+	var deleteRequests []state.DeleteRequest
+	for i := 0; i < 3; i++ {
+		req := state.DeleteRequest{Key: randomKey()}
+
+		// Add the item to the database.
+		setItem(t, s, req.Key, randomJSON(), nil) // Add the item to the database.
+
+		// Add the item to a slice of delete requests.
+		deleteRequests = append(deleteRequests, req)
+
+		// Add the item to the multi transaction request.
+		operations = append(operations, state.TransactionalStateOperation{
+			Operation: state.Delete,
+			Request:   req,
+		})
+	}
+
+	err := s.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.Nil(t, err)
+
+	for _, delete := range deleteRequests {
+		assert.False(t, storeItemExists(t, s, delete.Key))
+	}
+}
+
+func multiWithDeleteAndSet(t *testing.T, s *Sqlite) {
+	var operations []state.TransactionalStateOperation
+	var deleteRequests []state.DeleteRequest
+	for i := 0; i < 3; i++ {
+		req := state.DeleteRequest{Key: randomKey()}
+
+		// Add the item to the database.
+		setItem(t, s, req.Key, randomJSON(), nil) // Add the item to the database.
+
+		// Add the item to a slice of delete requests.
+		deleteRequests = append(deleteRequests, req)
+
+		// Add the item to the multi transaction request.
+		operations = append(operations, state.TransactionalStateOperation{
+			Operation: state.Delete,
+			Request:   req,
+		})
+	}
+
+	// Create the set requests.
+	var setRequests []state.SetRequest
+	for i := 0; i < 3; i++ {
+		req := state.SetRequest{
+			Key:   randomKey(),
+			Value: randomJSON(),
+		}
+		setRequests = append(setRequests, req)
+		operations = append(operations, state.TransactionalStateOperation{
+			Operation: state.Upsert,
+			Request:   req,
+		})
+	}
+
+	err := s.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.Nil(t, err)
+
+	for _, delete := range deleteRequests {
+		assert.False(t, storeItemExists(t, s, delete.Key))
+	}
+
+	for _, set := range setRequests {
+		assert.True(t, storeItemExists(t, s, set.Key))
+		deleteItem(t, s, set.Key, nil)
+	}
+}
+
+func deleteWithInvalidEtagFails(t *testing.T, s *Sqlite) {
+	// Create new item.
+	key := randomKey()
+	value := &fakeItem{Color: "mauvebrown"}
+	setItem(t, s, key, value, nil)
+
+	etag := "1234"
+	// Delete the item with a fake etag.
+	deleteReq := &state.DeleteRequest{
+		Key:  key,
+		ETag: &etag,
+		Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		},
+	}
+	err := s.Delete(deleteReq)
+	assert.NotNil(t, err, "Deleting an item with the wrong etag while enforcing FirstWrite policy should fail")
+}
+
+func deleteWithNoKeyFails(t *testing.T, s *Sqlite) {
+	deleteReq := &state.DeleteRequest{
+		Key: "",
+	}
+	err := s.Delete(deleteReq)
+	assert.NotNil(t, err)
+}
+
+// newItemWithEtagFails creates a new item and also supplies a non existent ETag and requests FirstWrite, which is invalid - expect failure.
+func newItemWithEtagFails(t *testing.T, s *Sqlite) {
+	value := &fakeItem{Color: "teal"}
+	invalidEtag := "12345"
+
+	setReq := &state.SetRequest{
+		Key:   randomKey(),
+		ETag:  &invalidEtag,
+		Value: value,
+		Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		},
+	}
+
+	err := s.Set(setReq)
+	assert.NotNil(t, err)
+}
+
+func updateWithOldEtagFails(t *testing.T, s *Sqlite) {
+	// Create and retrieve new item.
+	key := randomKey()
+	value := &fakeItem{Color: "gray"}
+	setItem(t, s, key, value, nil)
+	getResponse, _ := getItem(t, s, key)
+	assert.NotNil(t, getResponse.ETag)
+	originalEtag := getResponse.ETag
+
+	// Change the value and get the updated etag.
+	newValue := &fakeItem{Color: "silver"}
+	setItem(t, s, key, newValue, originalEtag)
+	_, updatedItem := getItem(t, s, key)
+	assert.Equal(t, newValue, updatedItem)
+	getResponse, _ = getItem(t, s, key)
+	assert.NotNil(t, getResponse.ETag)
+	// Update again with the original etag - expect update failure.
+	newValue = &fakeItem{Color: "maroon"}
+	setReq := &state.SetRequest{
+		Key:   key,
+		ETag:  originalEtag,
+		Value: newValue,
+		Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		},
+	}
+	err := s.Set(setReq)
+	assert.NotNil(t, err)
+}
+
+func updateAndDeleteWithEtagSucceeds(t *testing.T, s *Sqlite) {
+	// Create and retrieve new item.
+	key := randomKey()
+	value := &fakeItem{Color: "hazel"}
+	setItem(t, s, key, value, nil)
+	getResponse, _ := getItem(t, s, key)
+	assert.NotNil(t, getResponse.ETag)
+
+	// Change the value and compare.
+	value.Color = "purple"
+	setReq := &state.SetRequest{
+		Key:   key,
+		ETag:  getResponse.ETag,
+		Value: value,
+		Options: state.SetStateOption{
+			Concurrency: state.FirstWrite,
+		},
+	}
+	err := s.Set(setReq)
+	assert.Nil(t, err, "Setting the item should be successful")
+	updateResponse, updatedItem := getItem(t, s, key)
+	assert.Equal(t, value, updatedItem)
+
+	// ETag should change when item is updated..
+	assert.NotEqual(t, getResponse.ETag, updateResponse.ETag)
+
+	// Delete.
+	deleteReq := &state.DeleteRequest{
+		Key:  key,
+		ETag: updateResponse.ETag,
+		Options: state.DeleteStateOption{
+			Concurrency: state.FirstWrite,
+		},
+	}
+	err = s.Delete(deleteReq)
+	assert.Nil(t, err, "Deleting an item with the right etag while enforcing FirstWrite policy should succeed")
+
+	// Item is not in the data store.
+	assert.False(t, storeItemExists(t, s, key))
+}
+
+func updateAndDeleteWithWrongEtagAndNoFirstWriteSucceeds(t *testing.T, s *Sqlite) {
+	// Create and retrieve new item.
+	key := randomKey()
+	value := &fakeItem{Color: "hazel"}
+	setItem(t, s, key, value, nil)
+	getResponse, _ := getItem(t, s, key)
+	assert.NotNil(t, getResponse.ETag)
+
+	// Change the value and compare.
+	value.Color = "purple"
+	someInvalidEtag := "1234581736145"
+	setReq := &state.SetRequest{
+		Key:   key,
+		ETag:  &someInvalidEtag,
+		Value: value,
+		Options: state.SetStateOption{
+			Concurrency: state.LastWrite,
+		},
+	}
+	err := s.Set(setReq)
+	assert.Nil(t, err, "Setting the item should be successful")
+	_, updatedItem := getItem(t, s, key)
+	assert.Equal(t, value, updatedItem)
+
+	// Delete.
+	deleteReq := &state.DeleteRequest{
+		Key:  key,
+		ETag: &someInvalidEtag,
+		Options: state.DeleteStateOption{
+			Concurrency: state.LastWrite,
+		},
+	}
+	err = s.Delete(deleteReq)
+	assert.Nil(t, err, "Deleting an item with the wrong etag but not enforcing FirstWrite policy should succeed")
+
+	// Item is not in the data store.
+	assert.False(t, storeItemExists(t, s, key))
+}
+
+// getItemThatDoesNotExist validates the behavior of retrieving an item that does not exist.
+func getItemThatDoesNotExist(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	response, outputObject := getItem(t, s, key)
+	assert.Nil(t, response.Data)
+
+	assert.Equal(t, "", outputObject.Color)
+}
+
+// getItemWithNoKey validates that attempting a Get operation without providing a key will return an error.
+func getItemWithNoKey(t *testing.T, s *Sqlite) {
+	getReq := &state.GetRequest{
+		Key: "",
+	}
+
+	response, getErr := s.Get(getReq)
+	assert.NotNil(t, getErr)
+	assert.Nil(t, response)
+}
+
+// setUpdatesTheUpdatedateField proves that the updateddate is set for an update.
+func setUpdatesTheUpdatedateField(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	value := &fakeItem{Color: "orange"}
+	setItem(t, s, key, value, nil)
+
+	// insertdate should have a value and updatedate should be nil.
+	_, insertdate, updatedate := getRowData(t, s, key)
+	assert.NotNil(t, insertdate)
+	assert.Equal(t, insertdate.String, updatedate.String)
+
+	// make sure update time changes from creation.
+	time.Sleep(1 * time.Second)
+
+	// insertdate should not change, updatedate should have a value.
+	value = &fakeItem{Color: "aqua"}
+	setItem(t, s, key, value, nil)
+	_, newinsertdate, updatedate := getRowData(t, s, key)
+	assert.Equal(t, insertdate, newinsertdate) // The insertdate should not change.
+	assert.NotEqual(t, insertdate.String, updatedate.String)
+
+	deleteItem(t, s, key, nil)
+}
+
+// setTTLUpdatesExpiry proves that the expirydate is set when a TTL is passed for a key.
+func setTTLUpdatesExpiry(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	value := &fakeItem{Color: "darkgray"}
+	setOptions := state.SetStateOption{}
+	setReq := &state.SetRequest{
+		Key:     key,
+		ETag:    nil,
+		Value:   value,
+		Options: setOptions,
+		Metadata: map[string]string{
+			"ttlInSeconds": "1000",
+		},
+	}
+
+	err := s.Set(setReq)
+	assert.Nil(t, err)
+
+	// expirationTime should be set (to a date in the future).
+	_, _, expirationTime := getTimesForRow(t, s, key)
+
+	assert.NotNil(t, expirationTime)
+	assert.True(t, expirationTime.Valid, "Expiration Time should have a value after set with TTL value")
+	deleteItem(t, s, key, nil)
+}
+
+// setNoTTLUpdatesExpiry proves that the expirydate is reset when a state element with expiration time (TTL) loses TTL upon second set without TTL.
+func setNoTTLUpdatesExpiry(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	value := &fakeItem{Color: "darkorange"}
+	setOptions := state.SetStateOption{}
+	setReq := &state.SetRequest{
+		Key:     key,
+		ETag:    nil,
+		Value:   value,
+		Options: setOptions,
+		Metadata: map[string]string{
+			"ttlInSeconds": "1000",
+		},
+	}
+	err := s.Set(setReq)
+	assert.Nil(t, err)
+	delete(setReq.Metadata, "ttlInSeconds")
+	err = s.Set(setReq)
+	assert.Nil(t, err)
+
+	// expirationTime should not be set.
+	_, _, expirationTime := getTimesForRow(t, s, key)
+
+	assert.True(t, !expirationTime.Valid, "Expiration Time should not have a value after first being set with TTL value and then being set without TTL value")
+	deleteItem(t, s, key, nil)
+}
+
+// expiredStateCannotBeRead proves that an expired state element can not be read.
+func expiredStateCannotBeRead(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	value := &fakeItem{Color: "darkgray"}
+	setOptions := state.SetStateOption{}
+	setReq := &state.SetRequest{
+		Key:     key,
+		ETag:    nil,
+		Value:   value,
+		Options: setOptions,
+		Metadata: map[string]string{
+			"ttlInSeconds": "1",
+		},
+	}
+	err := s.Set(setReq)
+	assert.Nil(t, err)
+
+	time.Sleep(time.Second * time.Duration(2))
+	getResponse, err := s.Get(&state.GetRequest{Key: key})
+	assert.Equal(t, &state.GetResponse{}, getResponse, "Response must be empty")
+	assert.NoError(t, err, "Expired element must not be treated as error")
+
+	deleteItem(t, s, key, nil)
+}
+
+// unexpiredStateCanBeRead proves that a state element with TTL - but no yet expired - can be read.
+func unexpiredStateCanBeRead(t *testing.T, s *Sqlite) {
+	key := randomKey()
+	value := &fakeItem{Color: "dark white"}
+	setOptions := state.SetStateOption{}
+	setReq := &state.SetRequest{
+		Key:     key,
+		ETag:    nil,
+		Value:   value,
+		Options: setOptions,
+		Metadata: map[string]string{
+			"ttlInSeconds": "10000",
+		},
+	}
+	err := s.Set(setReq)
+	assert.Nil(t, err)
+	_, getValue := getItem(t, s, key)
+	assert.Equal(t, value.Color, getValue.Color, "Response must be as set")
+	assert.NoError(t, err, "Unexpired element with future expiration time must not be treated as error")
+
+	deleteItem(t, s, key, nil)
+}
+
+func setItemWithNoKey(t *testing.T, s *Sqlite) {
+	setReq := &state.SetRequest{
+		Key: "",
+	}
+
+	err := s.Set(setReq)
+	assert.NotNil(t, err)
+}
+
+func TestParseTTL(t *testing.T) {
+	log := logger.NewLogger("parseTTL")
+	t.Parallel()
+	t.Run("TTL Not an integer", func(t *testing.T) {
+		t.Parallel()
+		ttlInSeconds := "not an integer"
+		ttl, err := parseTTL(map[string]string{
+			"ttlInSeconds": ttlInSeconds,
+		}, log)
+		assert.Error(t, err)
+		assert.Nil(t, ttl)
+	})
+	t.Run("TTL specified with wrong key", func(t *testing.T) {
+		t.Parallel()
+		ttlInSeconds := 12345
+		ttl, err := parseTTL(map[string]string{
+			"expirationTime": strconv.Itoa(ttlInSeconds),
+		}, log)
+		assert.NoError(t, err)
+		assert.Nil(t, ttl)
+	})
+	t.Run("TTL is a number", func(t *testing.T) {
+		t.Parallel()
+		ttlInSeconds := 12345
+		ttl, err := parseTTL(map[string]string{
+			"ttlInSeconds": strconv.Itoa(ttlInSeconds),
+		}, log)
+		assert.NoError(t, err)
+		assert.Equal(t, *ttl, ttlInSeconds)
+	})
+	t.Run("TTL not set", func(t *testing.T) {
+		t.Parallel()
+		ttl, err := parseTTL(map[string]string{}, log)
+		assert.NoError(t, err)
+		assert.Nil(t, ttl)
+	})
+}
+
+func testSetItemWithInvalidTTL(t *testing.T, s *Sqlite) {
+	setReq := &state.SetRequest{
+		Key:   randomKey(),
+		Value: &fakeItem{Color: "oceanblue"},
+		Metadata: (map[string]string{
+			"ttlInSeconds": "XX",
+		}),
+	}
+	err := s.Set(setReq)
+	assert.NotNil(t, err, "Setting a value with a proper key and a incorrect TTL value should be produce an error")
+}
+
+func testSetItemWithNegativeTTL(t *testing.T, s *Sqlite) {
+	setReq := &state.SetRequest{
+		Key:   randomKey(),
+		Value: &fakeItem{Color: "oceanblue"},
+		Metadata: (map[string]string{
+			"ttlInSeconds": "-10",
+		}),
+	}
+	err := s.Set(setReq)
+	assert.NotNil(t, err, "Setting a value with a proper key and a negative (other than -1) TTL value should be produce an error")
+}
+
+// Tests valid bulk sets and deletes.
+func testBulkSetAndBulkDelete(t *testing.T, s *Sqlite) {
+	setReq := []state.SetRequest{
+		{
+			Key:   randomKey(),
+			Value: &fakeItem{Color: "oceanblue"},
+		},
+		{
+			Key:   randomKey(),
+			Value: &fakeItem{Color: "livingwhite"},
+		},
+	}
+
+	err := s.BulkSet(setReq)
+	assert.Nil(t, err)
+	assert.True(t, storeItemExists(t, s, setReq[0].Key))
+	assert.True(t, storeItemExists(t, s, setReq[1].Key))
+
+	deleteReq := []state.DeleteRequest{
+		{
+			Key: setReq[0].Key,
+		},
+		{
+			Key: setReq[1].Key,
+		},
+	}
+
+	err = s.BulkDelete(deleteReq)
+	assert.Nil(t, err)
+	assert.False(t, storeItemExists(t, s, setReq[0].Key))
+	assert.False(t, storeItemExists(t, s, setReq[1].Key))
+}
+
+// testInitConfiguration tests valid and invalid config settings.
+func testInitConfiguration(t *testing.T) {
+	logger := logger.NewLogger("test")
+	tests := []struct {
+		name        string
+		props       map[string]string
+		expectedErr string
+	}{
+		{
+			name:        "Empty",
+			props:       map[string]string{},
+			expectedErr: errMissingConnectionString,
+		},
+		{
+			name: "Valid connection string",
+			props: map[string]string{
+				connectionStringKey: getConnectionString(),
+				tableNameKey:        "test_state",
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewSqliteStateStore(logger)
+			defer p.Close()
+
+			metadata := state.Metadata{
+				Properties: tt.props,
+			}
+
+			err := p.Init(metadata)
+			if tt.expectedErr == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+				assert.Equal(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func getConnectionString() string {
+	s := os.Getenv(connectionStringEnvKey)
+	if s == "" {
+		// default integration test with in-memory db.
+		s = ":memory:"
+	}
+	return s
+}
+
+func setItem(t *testing.T, s *Sqlite, key string, value interface{}, etag *string) {
+	setOptions := state.SetStateOption{}
+	if etag != nil {
+		setOptions.Concurrency = state.FirstWrite
+	}
+
+	setReq := &state.SetRequest{
+		Key:     key,
+		ETag:    etag,
+		Value:   value,
+		Options: setOptions,
+	}
+
+	err := s.Set(setReq)
+	assert.Nil(t, err)
+	itemExists := storeItemExists(t, s, key)
+	assert.True(t, itemExists, "Item should exist after set has been executed ")
+}
+
+func getItem(t *testing.T, s *Sqlite, key string) (*state.GetResponse, *fakeItem) {
+	getReq := &state.GetRequest{
+		Key:     key,
+		Options: state.GetStateOption{},
+	}
+
+	response, getErr := s.Get(getReq)
+	assert.Nil(t, getErr)
+	assert.NotNil(t, response)
+	outputObject := &fakeItem{}
+	_ = json.Unmarshal(response.Data, outputObject)
+
+	return response, outputObject
+}
+
+func deleteItem(t *testing.T, s *Sqlite, key string, etag *string) {
+	deleteReq := &state.DeleteRequest{
+		Key:     key,
+		ETag:    etag,
+		Options: state.DeleteStateOption{},
+	}
+
+	deleteErr := s.Delete(deleteReq)
+	assert.Nil(t, deleteErr)
+	assert.False(t, storeItemExists(t, s, key), "item should no longer exist after delete has been performed")
+}
+
+func storeItemExists(t *testing.T, s *Sqlite, key string) bool {
+	dba := s.dbaccess.(*sqliteDBAccess)
+	tableName := dba.tableName
+	db := dba.db
+	var rowCount int32
+	stmttpl := "SELECT count(key) FROM %s WHERE key = ?"
+	statement := fmt.Sprintf(stmttpl, tableName)
+	err := db.QueryRow(statement, key).Scan(&rowCount)
+	assert.Nil(t, err)
+	exists := rowCount > 0
+	return exists
+}
+
+func getRowData(t *testing.T, s *Sqlite, key string) (returnValue string, insertdate sql.NullString, updatedate sql.NullString) {
+	dba := s.dbaccess.(*sqliteDBAccess)
+	tableName := dba.tableName
+	db := dba.db
+	err := db.QueryRow(fmt.Sprintf("SELECT value, creation_time, update_time FROM %s WHERE key = ?", tableName), key).Scan(
+		&returnValue, &insertdate, &updatedate)
+	assert.Nil(t, err)
+
+	return returnValue, insertdate, updatedate
+}
+
+func getTimesForRow(t *testing.T, s *Sqlite, key string) (insertdate sql.NullString, updatedate sql.NullString, expirationtime sql.NullString) {
+	dba := s.dbaccess.(*sqliteDBAccess)
+	tableName := dba.tableName
+	db := dba.db
+	err := db.QueryRow(fmt.Sprintf("SELECT creation_time, update_time, expiration_time FROM %s WHERE key = ?", tableName), key).Scan(&insertdate, &updatedate, &expirationtime)
+	assert.Nil(t, err)
+
+	return insertdate, updatedate, expirationtime
+}

--- a/state/sqlite/sqlite_integration_test.go
+++ b/state/sqlite/sqlite_integration_test.go
@@ -621,12 +621,11 @@ func TestParseTTL(t *testing.T) {
 	})
 	t.Run("TTL is a number", func(t *testing.T) {
 		t.Parallel()
-		ttlInSeconds := 12345
 		ttl, err := parseTTL(map[string]string{
-			"ttlInSeconds": strconv.Itoa(ttlInSeconds),
+			"ttlInSeconds": "12345",
 		}, log)
 		assert.NoError(t, err)
-		assert.Equal(t, *ttl, ttlInSeconds)
+		assert.Equal(t, *ttl, int64(12345))
 	})
 	t.Run("TTL not set", func(t *testing.T) {
 		t.Parallel()

--- a/state/sqlite/sqlite_test.go
+++ b/state/sqlite/sqlite_test.go
@@ -1,0 +1,218 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	fakeConnectionString = "not a real connection"
+)
+
+// Fake implementation of interface oracledatabase.dbaccess.
+type fakeDBaccess struct {
+	logger       logger.Logger
+	pingExecuted bool
+	initExecuted bool
+	setExecuted  bool
+	getExecuted  bool
+}
+
+func (m *fakeDBaccess) Ping() error {
+	m.pingExecuted = true
+	return nil
+}
+
+func (m *fakeDBaccess) Init(metadata state.Metadata) error {
+	m.initExecuted = true
+
+	return nil
+}
+
+func (m *fakeDBaccess) Set(req *state.SetRequest) error {
+	m.setExecuted = true
+
+	return nil
+}
+
+func (m *fakeDBaccess) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	m.getExecuted = true
+
+	return nil, nil
+}
+
+func (m *fakeDBaccess) Delete(req *state.DeleteRequest) error {
+	return nil
+}
+
+func (m *fakeDBaccess) ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error {
+	return nil
+}
+
+func (m *fakeDBaccess) Close() error {
+	return nil
+}
+
+// Proves that the Init method runs the init method.
+func TestInitRunsDBAccessInit(t *testing.T) {
+	t.Parallel()
+	ods, fake := createSqliteWithFake(t)
+	ods.Ping()
+	assert.True(t, fake.initExecuted)
+}
+
+func TestMultiWithNoRequestsReturnsNil(t *testing.T) {
+	t.Parallel()
+	var operations []state.TransactionalStateOperation
+	ods := createSqlite(t)
+	err := ods.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.Nil(t, err)
+}
+
+func TestInvalidMultiAction(t *testing.T) {
+	t.Parallel()
+	var operations []state.TransactionalStateOperation
+
+	operations = append(operations, state.TransactionalStateOperation{
+		Operation: "Something invalid",
+		Request:   createSetRequest(),
+	})
+
+	ods := createSqlite(t)
+	err := ods.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestValidSetRequest(t *testing.T) {
+	t.Parallel()
+	var operations []state.TransactionalStateOperation
+
+	operations = append(operations, state.TransactionalStateOperation{
+		Operation: state.Upsert,
+		Request:   createSetRequest(),
+	})
+
+	ods := createSqlite(t)
+	err := ods.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.Nil(t, err)
+}
+
+func TestInvalidMultiSetRequest(t *testing.T) {
+	t.Parallel()
+	var operations []state.TransactionalStateOperation
+
+	operations = append(operations, state.TransactionalStateOperation{
+		Operation: state.Upsert,
+		Request:   createDeleteRequest(), // Delete request is not valid for Upsert operation.
+	})
+
+	ods := createSqlite(t)
+	err := ods.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestValidMultiDeleteRequest(t *testing.T) {
+	t.Parallel()
+	var operations []state.TransactionalStateOperation
+
+	operations = append(operations, state.TransactionalStateOperation{
+		Operation: state.Delete,
+		Request:   createDeleteRequest(),
+	})
+
+	ods := createSqlite(t)
+	err := ods.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.Nil(t, err)
+}
+
+func TestInvalidMultiDeleteRequest(t *testing.T) {
+	t.Parallel()
+	var operations []state.TransactionalStateOperation
+
+	operations = append(operations, state.TransactionalStateOperation{
+		Operation: state.Delete,
+		Request:   createSetRequest(), // Set request is not valid for Delete operation.
+	})
+
+	ods := createSqlite(t)
+	err := ods.Multi(&state.TransactionalStateRequest{
+		Operations: operations,
+	})
+	assert.NotNil(t, err)
+}
+
+func createSetRequest() state.SetRequest {
+	return state.SetRequest{
+		Key:   randomKey(),
+		Value: randomJSON(),
+	}
+}
+
+func createDeleteRequest() state.DeleteRequest {
+	return state.DeleteRequest{
+		Key: randomKey(),
+	}
+}
+
+func createSqliteWithFake(t *testing.T) (*Sqlite, *fakeDBaccess) {
+	ods := createSqlite(t)
+	fake := ods.dbaccess.(*fakeDBaccess)
+	return ods, fake
+}
+
+// Proves that the Ping method runs the ping method.
+func TestPingRunsDBAccessPing(t *testing.T) {
+	t.Parallel()
+	odb, fake := createSqliteWithFake(t)
+	odb.Ping()
+	assert.True(t, fake.pingExecuted)
+}
+
+func createSqlite(t *testing.T) *Sqlite {
+	logger := logger.NewLogger("test")
+
+	dba := &fakeDBaccess{
+		logger: logger,
+	}
+
+	odb := newSqliteStateStore(logger, dba)
+	assert.NotNil(t, odb)
+
+	metadata := &state.Metadata{
+		Properties: map[string]string{connectionStringKey: fakeConnectionString},
+	}
+
+	err := odb.Init(*metadata)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, odb.dbaccess)
+
+	return odb
+}
+
+func randomKey() string {
+	return uuid.New().String()
+}
+
+type fakeItem struct {
+	Color string
+}
+
+func randomJSON() *fakeItem {
+	return &fakeItem{Color: randomKey()}
+}

--- a/state/sqlite/sqlite_test.go
+++ b/state/sqlite/sqlite_test.go
@@ -50,7 +50,7 @@ func (m *fakeDBaccess) Delete(req *state.DeleteRequest) error {
 	return nil
 }
 
-func (m *fakeDBaccess) ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error {
+func (m *fakeDBaccess) ExecuteMulti(reqs []state.TransactionalStateOperation) error {
 	return nil
 }
 
@@ -76,22 +76,6 @@ func TestMultiWithNoRequestsReturnsNil(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestInvalidMultiAction(t *testing.T) {
-	t.Parallel()
-	var operations []state.TransactionalStateOperation
-
-	operations = append(operations, state.TransactionalStateOperation{
-		Operation: "Something invalid",
-		Request:   createSetRequest(),
-	})
-
-	ods := createSqlite(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
-		Operations: operations,
-	})
-	assert.NotNil(t, err)
-}
-
 func TestValidSetRequest(t *testing.T) {
 	t.Parallel()
 	var operations []state.TransactionalStateOperation
@@ -108,22 +92,6 @@ func TestValidSetRequest(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestInvalidMultiSetRequest(t *testing.T) {
-	t.Parallel()
-	var operations []state.TransactionalStateOperation
-
-	operations = append(operations, state.TransactionalStateOperation{
-		Operation: state.Upsert,
-		Request:   createDeleteRequest(), // Delete request is not valid for Upsert operation.
-	})
-
-	ods := createSqlite(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
-		Operations: operations,
-	})
-	assert.NotNil(t, err)
-}
-
 func TestValidMultiDeleteRequest(t *testing.T) {
 	t.Parallel()
 	var operations []state.TransactionalStateOperation
@@ -138,22 +106,6 @@ func TestValidMultiDeleteRequest(t *testing.T) {
 		Operations: operations,
 	})
 	assert.Nil(t, err)
-}
-
-func TestInvalidMultiDeleteRequest(t *testing.T) {
-	t.Parallel()
-	var operations []state.TransactionalStateOperation
-
-	operations = append(operations, state.TransactionalStateOperation{
-		Operation: state.Delete,
-		Request:   createSetRequest(), // Set request is not valid for Delete operation.
-	})
-
-	ods := createSqlite(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
-		Operations: operations,
-	})
-	assert.NotNil(t, err)
 }
 
 func createSetRequest() state.SetRequest {

--- a/state/sqlite/sqliteconstants.go
+++ b/state/sqlite/sqliteconstants.go
@@ -1,0 +1,52 @@
+package sqlite
+
+const (
+	connectionStringKey         = "connectionString"
+	metadataTTLKey              = "ttlInSeconds"
+	errMissingConnectionString  = "missing connection string"
+	tableNameKey                = "tableName"
+	cleanupIntervalKey          = "cleanupIntervalInSeconds"
+	defaultTableName            = "state"
+	defaultCleanupInternalInSec = 3600
+
+	createTableTpl = `
+      CREATE TABLE %s (
+				key TEXT NOT NULL PRIMARY KEY,
+				value TEXT NOT NULL,
+				is_binary BOOLEAN NOT NULL,
+				etag TEXT NOT NULL,
+				creation_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				expiration_time TIMESTAMP DEFAULT NULL,
+				update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);`
+
+	createTableExpirationTimeIdx = `
+			CREATE INDEX idx_%s_expiration_time ON %s(expiration_time)`
+
+	tableExistsStmt = `
+		SELECT EXISTS (
+			SELECT name FROM sqlite_master WHERE type='table' AND name = ?
+		) AS 'exists'`
+
+	cleanupTimeoutStmtTpl = `
+		DELETE FROM %s WHERE expiration_time IS NOT NULL AND expiration_time < CURRENT_TIMESTAMP`
+
+	getValueTpl = `
+		SELECT value, is_binary, etag FROM %s
+	  	WHERE key = ?
+	      AND (expiration_time IS NULL OR expiration_time > CURRENT_TIMESTAMP)`
+
+	delValueTpl         = "DELETE FROM %s WHERE key = ?"
+	delValueWithETagTpl = "DELETE FROM %s WHERE key = ? and etag = ?"
+
+	expirationTpl = "DATETIME(CURRENT_TIMESTAMP, '+%d seconds')"
+
+	setValueTpl = `
+		INSERT OR REPLACE INTO %s (
+			key, value, is_binary, etag, update_time, expiration_time, creation_time)
+		VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, %s,
+			(SELECT creation_time FROM %s WHERE key=?));`
+	setValueWithETagTpl = `
+		UPDATE %s SET value = ?, etag = ?, is_binary = ?, update_time = CURRENT_TIMESTAMP, expiration_time = %s
+		WHERE key = ? AND eTag = ?;`
+)

--- a/state/sqlite/sqlitedbaccess.go
+++ b/state/sqlite/sqlitedbaccess.go
@@ -1,0 +1,363 @@
+package sqlite
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+
+	// Blank import for the underlying SQLite Driver.
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// sqliteDBAccess implements dbaccess.
+type sqliteDBAccess struct {
+	logger           logger.Logger
+	metadata         state.Metadata
+	connectionString string
+	tableName        string
+	db               *sql.DB
+	cleanupInterval  *time.Duration
+
+	// Lock only on public write API. Any public API's implementation should not call other public write APIs.
+	writeMu *sync.Mutex
+}
+
+// newSqliteDBAccess creates a new instance of sqliteDbAccess.
+func newSqliteDBAccess(logger logger.Logger) *sqliteDBAccess {
+	logger.Debug("Instantiating new SQLite state store")
+
+	return &sqliteDBAccess{
+		logger:  logger,
+		writeMu: &sync.Mutex{},
+	}
+}
+
+// Init sets up SQLite Database connection and ensures that the state table
+// exists.
+func (a *sqliteDBAccess) Init(metadata state.Metadata) error {
+	a.logger.Debug("Initializing SQLite state store")
+	a.metadata = metadata
+
+	tableName, ok := metadata.Properties[tableNameKey]
+	if !ok || tableName == "" {
+		tableName = defaultTableName
+	}
+	a.tableName = tableName
+
+	cleanupInterval, err := a.parseCleanupInterval(metadata)
+	if err != nil {
+		return err
+	}
+	a.cleanupInterval = cleanupInterval
+
+	if val, ok := metadata.Properties[connectionStringKey]; ok && val != "" {
+		a.connectionString = val
+	} else {
+		a.logger.Error("Missing SQLite connection string")
+
+		return fmt.Errorf(errMissingConnectionString)
+	}
+
+	db, err := sql.Open("sqlite3", a.connectionString)
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	a.db = db
+
+	if pingErr := db.Ping(); pingErr != nil {
+		return pingErr
+	}
+
+	err = a.ensureStateTable(tableName)
+	if err != nil {
+		return err
+	}
+
+	a.scheduleCleanupExpiredData()
+
+	return nil
+}
+
+func (a *sqliteDBAccess) Ping() error {
+	return a.db.Ping()
+}
+
+func (a *sqliteDBAccess) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	a.logger.Debug("Get state value from SQLite")
+	if req.Key == "" {
+		return nil, fmt.Errorf("missing key in get operation")
+	}
+	var value string
+	var isBinary bool
+	var etag string
+
+	// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
+	stmt := fmt.Sprintf(getValueTpl, a.tableName)
+	err := a.db.QueryRow(stmt, req.Key).Scan(&value, &isBinary, &etag)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &state.GetResponse{
+				Metadata: req.Metadata,
+			}, nil
+		}
+		return nil, err
+	}
+	if isBinary {
+		var s string
+		var data []byte
+		if err = json.Unmarshal([]byte(value), &s); err != nil {
+			return nil, err
+		}
+		if data, err = base64.StdEncoding.DecodeString(s); err != nil {
+			return nil, err
+		}
+		return &state.GetResponse{
+			Data:     data,
+			ETag:     &etag,
+			Metadata: req.Metadata,
+		}, nil
+	}
+	return &state.GetResponse{
+		Data:     []byte(value),
+		ETag:     &etag,
+		Metadata: req.Metadata,
+	}, nil
+}
+
+func (a *sqliteDBAccess) Set(req *state.SetRequest) error {
+	a.logger.Debug("Set state value in SQLite")
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	tx, err := a.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	err = state.SetWithOptions(func(req *state.SetRequest) error { return a.setValue(tx, req) }, req)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (a *sqliteDBAccess) Delete(req *state.DeleteRequest) error {
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	tx, err := a.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	err = state.DeleteWithOptions(func(req *state.DeleteRequest) error { return a.deleteValue(tx, req) }, req)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (a *sqliteDBAccess) ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error {
+	a.logger.Debug("Executing multiple SQLite operations, within a single transaction")
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+
+	tx, err := a.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	if len(deletes) > 0 {
+		for _, d := range deletes {
+			da := d // Fix for gosec  G601: Implicit memory aliasing in for loop.
+			err = a.deleteValue(tx, &da)
+			if err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+	}
+	if len(sets) > 0 {
+		for _, s := range sets {
+			sa := s // Fix for gosec  G601: Implicit memory aliasing in for loop.
+			err = a.setValue(tx, &sa)
+			if err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+	}
+	return tx.Commit()
+}
+
+// Close implements io.Close.
+func (a *sqliteDBAccess) Close() error {
+	if a.db != nil {
+		return a.db.Close()
+	}
+	return nil
+}
+
+// Create table if not exists.
+func (a *sqliteDBAccess) ensureStateTable(stateTableName string) error {
+	exists, err := tableExists(a.db, stateTableName)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		a.logger.Infof("Creating SQLite state table '%s'", stateTableName)
+		tx, err := a.db.Begin()
+		if err != nil {
+			return err
+		}
+
+		stmt := fmt.Sprintf(createTableTpl, stateTableName)
+		_, err = tx.Exec(stmt)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		stmt = fmt.Sprintf(createTableExpirationTimeIdx, stateTableName, stateTableName)
+		_, err = tx.Exec(stmt)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+		return tx.Commit()
+	}
+
+	return nil
+}
+
+// Check if table exists.
+func tableExists(db *sql.DB, tableName string) (bool, error) {
+	exists := ""
+	// Returns 1 or 0 as a string if the table exists or not.
+	err := db.QueryRow(tableExistsStmt, tableName).Scan(&exists)
+	return exists == "1", err
+}
+
+func (a *sqliteDBAccess) setValue(tx *sql.Tx, req *state.SetRequest) error {
+	r, err := prepareSetRequest(a, tx, req)
+	if err != nil {
+		return err
+	}
+
+	hasUpdate, err := r.setValue()
+	if err != nil {
+		if req.ETag != nil && *req.ETag != "" {
+			return state.NewETagError(state.ETagMismatch, err)
+		}
+		return err
+	}
+
+	if !hasUpdate {
+		return fmt.Errorf("no item was updated")
+	}
+	return nil
+}
+
+func (a *sqliteDBAccess) deleteValue(tx *sql.Tx, req *state.DeleteRequest) error {
+	a.logger.Debug("Deleting state value from SQLite")
+	r, err := prepareDeleteRequest(a, tx, req)
+	if err != nil {
+		return err
+	}
+
+	hasUpdate, err := r.deleteValue()
+	if err != nil {
+		return err
+	}
+
+	if !hasUpdate && req.ETag != nil && *req.ETag != "" && req.Options.Concurrency == state.FirstWrite {
+		return state.NewETagError(state.ETagMismatch, nil)
+	}
+	return nil
+}
+
+func (a *sqliteDBAccess) scheduleCleanupExpiredData() {
+	if a.cleanupInterval == nil {
+		return
+	}
+
+	d := *a.cleanupInterval
+	a.logger.Infof("Schedule timeouted data clean up every %d seconds", d)
+	ticker := time.NewTicker(d)
+	go func() {
+		for range ticker.C {
+			a.cleanupTimeout()
+		}
+	}()
+}
+
+func (a *sqliteDBAccess) cleanupTimeout() {
+	if !a.writeMu.TryLock() {
+		return
+	}
+	defer a.writeMu.Unlock()
+	tx, err := a.db.Begin()
+	if err != nil {
+		a.logger.Errorf("Error cleanup SQLite state store timeout data", err)
+		return
+	}
+
+	stmt := fmt.Sprintf(cleanupTimeoutStmtTpl, a.tableName)
+	res, err := tx.Exec(stmt)
+	if err != nil {
+		a.logger.Errorf("Error cleanup SQLite state store timeout data", err)
+		return
+	}
+
+	cleaned, err := res.RowsAffected()
+	if err != nil {
+		tx.Rollback()
+		a.logger.Errorf("Error cleanup SQLite state store timeout data", err)
+		return
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		a.logger.Errorf("Error cleanup SQLite state store timeout data", err)
+		return
+	}
+
+	a.logger.Debugf("Cleaned %d timeout data from SQLite state store", cleaned)
+}
+
+// Returns nil duration means never cleanup timeouted data.
+func (a *sqliteDBAccess) parseCleanupInterval(metadata state.Metadata) (*time.Duration, error) {
+	s, ok := metadata.Properties[cleanupIntervalKey]
+	if ok && s != "" {
+		cleanupIntervalInSec, err := strconv.ParseInt(s, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("illegal cleanupIntervalInSec value: %s", s)
+		}
+
+		// Non-postitive value from meta means disable auto cleanup.
+		if cleanupIntervalInSec > 0 {
+			d := time.Duration(cleanupIntervalInSec) * time.Second
+			return &d, nil
+		}
+	} else {
+		d := defaultCleanupInternalInSec * time.Second
+		return &d, nil
+	}
+
+	return nil, nil
+}

--- a/state/sqlite/sqlitedbaccess.go
+++ b/state/sqlite/sqlitedbaccess.go
@@ -307,9 +307,7 @@ func (a *sqliteDBAccess) scheduleCleanupExpiredData() {
 }
 
 func (a *sqliteDBAccess) cleanupTimeout() {
-	if !a.writeMu.TryLock() {
-		return
-	}
+	a.writeMu.Lock()
 	defer a.writeMu.Unlock()
 	tx, err := a.db.Begin()
 	if err != nil {

--- a/state/sqlite/sqlitedeletevalue.go
+++ b/state/sqlite/sqlitedeletevalue.go
@@ -1,0 +1,70 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/dapr/components-contrib/state"
+)
+
+// Parsed DeleteRequest.
+type deleteRequest struct {
+	dbAccess *sqliteDBAccess
+
+	tx          *sql.Tx
+	key         string
+	concurrency *string
+	etag        *string
+}
+
+func prepareDeleteRequest(a *sqliteDBAccess, tx *sql.Tx, req *state.DeleteRequest) (*deleteRequest, error) {
+	err := state.CheckRequestOptions(req.Options)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Key == "" {
+		return nil, fmt.Errorf("missing key in delete operation")
+	}
+
+	if req.Options.Concurrency == state.FirstWrite && (req.ETag == nil || len(*req.ETag) == 0) {
+		a.logger.Debugf("when FirstWrite is to be enforced, a value must be provided for the ETag")
+		return nil, fmt.Errorf("when FirstWrite is to be enforced, a value must be provided for the ETag")
+	}
+	return &deleteRequest{
+		dbAccess: a,
+		tx:       tx,
+
+		key:         req.Key,
+		concurrency: &req.Options.Concurrency,
+		etag:        req.ETag,
+	}, nil
+}
+
+// Returns if any value deleted, or an execution error.
+func (req *deleteRequest) deleteValue() (bool, error) {
+	tableName := req.dbAccess.tableName
+	tx := req.tx
+
+	var result sql.Result
+	var err error
+	if *req.concurrency != state.FirstWrite {
+		// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
+		stmt := fmt.Sprintf(delValueTpl, tableName)
+		result, err = tx.Exec(stmt, req.key)
+	} else {
+		// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
+		stmt := fmt.Sprintf(delValueWithETagTpl, tableName)
+		result, err = tx.Exec(stmt, req.key, *req.etag)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}

--- a/state/sqlite/sqlitedeletevalue.go
+++ b/state/sqlite/sqlitedeletevalue.go
@@ -9,9 +9,9 @@ import (
 
 // Parsed DeleteRequest.
 type deleteRequest struct {
-	dbAccess *sqliteDBAccess
+	tx        *sql.Tx
+	tableName string
 
-	tx          *sql.Tx
 	key         string
 	concurrency *string
 	etag        *string
@@ -32,8 +32,8 @@ func prepareDeleteRequest(a *sqliteDBAccess, tx *sql.Tx, req *state.DeleteReques
 		return nil, fmt.Errorf("when FirstWrite is to be enforced, a value must be provided for the ETag")
 	}
 	return &deleteRequest{
-		dbAccess: a,
-		tx:       tx,
+		tx:        tx,
+		tableName: a.tableName,
 
 		key:         req.Key,
 		concurrency: &req.Options.Concurrency,
@@ -43,12 +43,12 @@ func prepareDeleteRequest(a *sqliteDBAccess, tx *sql.Tx, req *state.DeleteReques
 
 // Returns if any value deleted, or an execution error.
 func (req *deleteRequest) deleteValue() (bool, error) {
-	tableName := req.dbAccess.tableName
+	tableName := req.tableName
 	tx := req.tx
 
 	var result sql.Result
 	var err error
-	if *req.concurrency != state.FirstWrite {
+	if req.etag == nil || *req.etag == "" {
 		// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
 		stmt := fmt.Sprintf(delValueTpl, tableName)
 		result, err = tx.Exec(stmt, req.key)

--- a/state/sqlite/sqlitesetvalue.go
+++ b/state/sqlite/sqlitesetvalue.go
@@ -16,8 +16,8 @@ import (
 
 // Parsed Set Request.
 type setRequest struct {
-	dbAccess sqliteDBAccess
-	tx       *sql.Tx
+	tx        *sql.Tx
+	tableName string
 
 	key         string
 	value       string
@@ -60,8 +60,9 @@ func prepareSetRequest(a *sqliteDBAccess, tx *sql.Tx, req *state.SetRequest) (*s
 	value := string(bt)
 
 	return &setRequest{
-		dbAccess:    *a,
-		tx:          tx,
+		tx:        tx,
+		tableName: a.tableName,
+
 		key:         req.Key,
 		value:       value,
 		concurrency: &req.Options.Concurrency,
@@ -74,7 +75,7 @@ func prepareSetRequest(a *sqliteDBAccess, tx *sql.Tx, req *state.SetRequest) (*s
 func (req *setRequest) setValue() (bool, error) {
 	newEtag := uuid.New().String()
 	tx := req.tx
-	tableName := req.dbAccess.tableName
+	tableName := req.tableName
 
 	// Only check for etag if FirstWrite specified (ref oracledatabaseaccess)
 	var res sql.Result

--- a/state/sqlite/sqlitesetvalue.go
+++ b/state/sqlite/sqlitesetvalue.go
@@ -1,0 +1,157 @@
+package sqlite
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/components-contrib/state/utils"
+	"github.com/dapr/kit/logger"
+)
+
+// Parsed Set Request.
+type setRequest struct {
+	dbAccess sqliteDBAccess
+	tx       *sql.Tx
+
+	key         string
+	value       string
+	isBinary    bool
+	ttlSeconds  *int
+	concurrency *string
+	etag        *string
+}
+
+func prepareSetRequest(a *sqliteDBAccess, tx *sql.Tx, req *state.SetRequest) (*setRequest, error) {
+	err := checkRequestOptions(a, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Key == "" {
+		return nil, fmt.Errorf("missing key in set option")
+	}
+
+	if v, ok := req.Value.(string); ok && v == "" {
+		return nil, fmt.Errorf("empty string is not allowed in st operation")
+	}
+
+	ttlSeconds, err := parseTTL(req.Metadata, a.logger)
+	if err != nil {
+		return nil, fmt.Errorf("error in parsing TTL %w", err)
+	}
+
+	requestValue := req.Value
+	byteArray, isBinary := req.Value.([]uint8)
+	if isBinary {
+		requestValue = base64.StdEncoding.EncodeToString(byteArray)
+	}
+
+	// Convert to json string.
+	bt, _ := utils.Marshal(requestValue, json.Marshal)
+	value := string(bt)
+
+	return &setRequest{
+		dbAccess:    *a,
+		tx:          tx,
+		key:         req.Key,
+		value:       value,
+		concurrency: &req.Options.Concurrency,
+		ttlSeconds:  ttlSeconds,
+		isBinary:    isBinary,
+		etag:        req.ETag,
+	}, nil
+}
+
+func (req *setRequest) setValue() (bool, error) {
+	newEtag := uuid.New().String()
+	tx := req.tx
+	tableName := req.dbAccess.tableName
+
+	// Only check for etag if FirstWrite specified (ref oracledatabaseaccess)
+	var res sql.Result
+	var err error
+	if req.etag == nil || *req.etag == "" {
+		// Reset expiration time in case of an update
+		var expiration string
+		if req.ttlSeconds != nil {
+			expiration = fmt.Sprintf(expirationTpl, *req.ttlSeconds)
+		} else {
+			expiration = "NULL"
+		}
+		// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
+		// And the same is for DATETIME function's seconds parameter.
+		stmt := fmt.Sprintf(setValueTpl, tableName, expiration, tableName)
+		res, err = tx.Exec(stmt, req.key, req.value, req.isBinary, newEtag, req.key)
+	} else {
+		// First write, existing record has to be updated
+		var expiration string
+		if req.ttlSeconds != nil {
+			expiration = fmt.Sprintf(expirationTpl, *req.ttlSeconds)
+		} else {
+			expiration = "NULL"
+		}
+		// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
+		// And the same is for DATETIME function's seconds parameter.
+		stmt := fmt.Sprintf(setValueWithETagTpl, tableName, expiration)
+		res, err = tx.Exec(stmt, req.value, newEtag, req.isBinary, req.key, *req.etag)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
+func checkRequestOptions(a *sqliteDBAccess, req *state.SetRequest) error {
+	err := state.CheckRequestOptions(req.Options)
+	if err != nil {
+		return err
+	}
+
+	if req.Options.Concurrency == state.FirstWrite {
+		if req.ETag == nil || len(*req.ETag) == 0 {
+			a.logger.Debugf("when FirstWrite is to be enforced, a value must be provided for the ETag")
+			return fmt.Errorf("when FirstWrite is to be enforced, a value must be provided for the ETag")
+		}
+	} else if req.Options.Concurrency == state.LastWrite {
+		if req.ETag != nil {
+			a.logger.Warn("when LastWrite is set, ignore the etag")
+			req.ETag = nil
+		}
+	}
+
+	return nil
+}
+
+// Returns nil or non-negative value, nil means never expire.
+func parseTTL(requestMetadata map[string]string, logger logger.Logger) (*int, error) {
+	if val, found := requestMetadata[metadataTTLKey]; found && val != "" {
+		parsedVal, err := strconv.ParseInt(val, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("error in parsing ttl metadata : %w", err)
+		}
+		parsedInt := int(parsedVal)
+
+		if parsedInt < -1 {
+			return nil, fmt.Errorf("incorrect value for %s %d", metadataTTLKey, parsedInt)
+		} else if parsedInt == -1 {
+			logger.Debugf("TTL is set to -1; this means: never expire.")
+			return nil, nil
+		}
+
+		return &parsedInt, nil
+	}
+
+	return nil, nil
+}

--- a/tests/config/state/sqlite/statestore.yaml
+++ b/tests/config/state/sqlite/statestore.yaml
@@ -1,0 +1,13 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.sqlite
+  metadata:
+  - name: connectionString
+    value: ':memory:'
+  - name: tableName
+    value: dapr_state
+  - name: cleanupIntervalInSeconds
+    value: 10

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -28,3 +28,6 @@ components:
   - component: cockroachdb
     allOperations: false
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "query" ]
+  - component: sqlite
+    allOperations: false
+    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag" ]

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -70,6 +70,7 @@ import (
 	s_mysql "github.com/dapr/components-contrib/state/mysql"
 	s_postgresql "github.com/dapr/components-contrib/state/postgresql"
 	s_redis "github.com/dapr/components-contrib/state/redis"
+	s_sqlite "github.com/dapr/components-contrib/state/sqlite"
 	s_sqlserver "github.com/dapr/components-contrib/state/sqlserver"
 	conf_bindings "github.com/dapr/components-contrib/tests/conformance/bindings"
 	conf_pubsub "github.com/dapr/components-contrib/tests/conformance/pubsub"
@@ -425,6 +426,8 @@ func loadStateStore(tc TestComponent) state.Store {
 		store = s_cassandra.NewCassandraStateStore(testLogger)
 	case "cockroachdb":
 		store = s_cockroachdb.New(testLogger)
+	case "sqlite":
+		store = s_sqlite.NewSqliteStateStore(testLogger)
 	default:
 		return nil
 	}


### PR DESCRIPTION
# Description

Implemented a sqlite state store.

The implementation is largely a copy of the oracle state store. And since it uses [github.com/mattn/go-sqlite3](github.com/mattn/go-sqlite3) as sqlite driver, `CGO` needs to enabled.

## Issue reference


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
