### PR TITLE
eh-certification test : Install azure-iot-cli-extension if not found for IOT tests

### DIFF
--- a/tests/certification/pubsub/azure/eventhubs/README.md
+++ b/tests/certification/pubsub/azure/eventhubs/README.md
@@ -10,7 +10,7 @@ This project aims to test the Azure Event Hubs pubsub component under various co
     - Start an app with 1 publisher and 1 subscriber
     - The publisher publishes to 2 topics 
     - The subscriber is subscribed to 1 topic
-    - Test: Sends 100+ unique messages
+    - Test: Sends 10+ unique messages
     - App: Simulates periodic errors
     - Component: Retries on error
     - App: Observes successful messages
@@ -20,7 +20,7 @@ This project aims to test the Azure Event Hubs pubsub component under various co
     - Start an app with 1 publisher and 2 subscribers
     - The publisher publishes to 1 topic with 2 partitions (EventHub scalable consumer pattern)
     - The subscriber is subscribed to 1 topic
-    - Test: Sends 100+ unique messages
+    - Test: Sends 10+ unique messages
     - App: Simulates periodic errors
     - Component: Retries on error
     - App: Observes successful messages
@@ -30,7 +30,7 @@ This project aims to test the Azure Event Hubs pubsub component under various co
     - Start an app with 1 publisher and 2 subscribers
     - The publisher publishes to 1 topic with 2 partitions (EventHub scalable consumer pattern)
     - The subscriber is subscribed to 1 topic
-    - Test: Sends 100+ unique messages
+    - Test: Sends 10+ unique messages
     - App: Simulates periodic errors
     - Component: Retries on error
     - App: Observes successful messages
@@ -40,7 +40,7 @@ This project aims to test the Azure Event Hubs pubsub component under various co
     - Start an app with 2 publishers and 2 subscribers
     - The publisher publishes to 1 topic with 2 partitions (EventHub scalable consumer pattern)
     - The subscriber is subscribed to 1 topic
-    - Test: Sends 100+ unique messages from each publisher
+    - Test: Sends 10+ unique messages from each publisher
     - App: Simulates periodic errors
     - Component: Retries on error
     - App: Observes successful messages
@@ -49,14 +49,14 @@ This project aims to test the Azure Event Hubs pubsub component under various co
  - Test entity management
    - Start a publisher and subscriber with a topic that does not exist
    - Test: Confirm creation of topic/eventHub in given eventHub namespace
-   - Test: Send 100+ unique messasges to the newly created eventHub topic
+   - Test: Send 10+ unique messasges to the newly created eventHub topic
    - App: Observe successful messages
    - Test: Confirm that subscriber receives all messages
- - Test IOT Event Hub : [TODO]
+ - Test IOT Event Hub
    - Start an app with 1 publisher and 1 subscriber
    - The publisher publishes to 1 IOT EventHub with 1 partition 
    - The subscriber is subscribed to 1 topic
-   - Test: Sends 100+ unique messages
+   - Test: Sends 10+ unique messages
    - App: Simulates periodic errors
    - Component: Retries on error
    - App: Observes successful messages
@@ -66,9 +66,7 @@ This project aims to test the Azure Event Hubs pubsub component under various co
   - Test connection string based authentication mechanism
   - Test AAD Service Principal based authentication
     - Utilize a service principal with appropriate roles granted
-  - Test MSI based authentication : [TODO]
-    - Utilize Managed Identity
-### Network Tests?
+### Network Tests
   - Simulate network interruptions [TODO : network interruptions during publish]
     - Test: Simulate network interruptions 
     - Component: Begins to reconnect and resubscribe

--- a/tests/certification/pubsub/azure/eventhubs/eventhubs_test.go
+++ b/tests/certification/pubsub/azure/eventhubs/eventhubs_test.go
@@ -62,7 +62,7 @@ const (
 	appID4 = "app-4"
 	appID5 = "app-5"
 
-	numMessages      = 100
+	numMessages      = 10
 	appPort          = 8000
 	portOffset       = 2
 	messageKey       = "partitionKey"

--- a/tests/certification/pubsub/azure/eventhubs/send-iot-device-events.sh
+++ b/tests/certification/pubsub/azure/eventhubs/send-iot-device-events.sh
@@ -24,6 +24,11 @@ fi
 # `IoT Hub Data Contributor` scoped at this resource
 # `Owner` scoped at this resource
 
+# Install azure-iot extension without prompt 
+# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
+# https://github.com/Azure/azure-iot-cli-extension
+az config set extension.use_dynamic_install=yes_without_prompt
+
 # login to azure
 az login --service-principal -u $AzureCertificationServicePrincipalClientId -p $AzureCertificationServicePrincipalClientSecret --tenant $AzureCertificationTenantId
 


### PR DESCRIPTION
Signed-off-by: Surender Singh Malik <surenderssm@users.noreply.github.com>

# Description

azure-iot-cli-extension is required for the IOT devise test cases.
The installation of the same is enabled via azure-iot extension without prompt.
https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
https://github.com/Azure/azure-iot-cli-extension



## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
