### PR TITLE
Pin certification tests to latest daprd with binding context change

### DIFF
--- a/tests/certification/bindings/azure/blobstorage/go.mod
+++ b/tests/certification/bindings/azure/blobstorage/go.mod
@@ -4,9 +4,9 @@ go 1.17
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.2.0
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/stretchr/testify v1.7.0

--- a/tests/certification/bindings/azure/blobstorage/go.sum
+++ b/tests/certification/bindings/azure/blobstorage/go.sum
@@ -176,8 +176,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/bindings/azure/cosmosdb/go.mod
+++ b/tests/certification/bindings/azure/cosmosdb/go.mod
@@ -4,9 +4,9 @@ go 1.17
 
 require (
 	github.com/a8m/documentdb v1.3.1-0.20220405205223-5b41ba0aaeb1
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/google/uuid v1.3.0

--- a/tests/certification/bindings/azure/cosmosdb/go.sum
+++ b/tests/certification/bindings/azure/cosmosdb/go.sum
@@ -175,8 +175,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/bindings/azure/servicebusqueues/go.mod
+++ b/tests/certification/bindings/azure/servicebusqueues/go.mod
@@ -3,9 +3,9 @@ module servicebusqueue_test
 go 1.17
 
 require (
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/stretchr/testify v1.7.0

--- a/tests/certification/bindings/azure/servicebusqueues/go.sum
+++ b/tests/certification/bindings/azure/servicebusqueues/go.sum
@@ -179,8 +179,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/dapr/components-contrib v1.7.0-rc.4
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/google/go-cmp v0.5.6

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -129,8 +129,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/pubsub/azure/eventhubs/go.mod
+++ b/tests/certification/pubsub/azure/eventhubs/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/pubsub/azure/event
 go 1.17
 
 require (
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v1.4.0-rc2
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/azure/eventhubs/go.sum
+++ b/tests/certification/pubsub/azure/eventhubs/go.sum
@@ -195,8 +195,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/pubsub/kafka/go.mod
+++ b/tests/certification/pubsub/kafka/go.mod
@@ -5,9 +5,9 @@ go 1.17
 require (
 	github.com/Shopify/sarama v1.23.1
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/kafka/go.sum
+++ b/tests/certification/pubsub/kafka/go.sum
@@ -135,8 +135,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/pubsub/mqtt/go.mod
+++ b/tests/certification/pubsub/mqtt/go.mod
@@ -4,9 +4,9 @@ go 1.17
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v1.4.0-rc2
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/eclipse/paho.mqtt.golang v1.3.5

--- a/tests/certification/pubsub/mqtt/go.sum
+++ b/tests/certification/pubsub/mqtt/go.sum
@@ -129,8 +129,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/pubsub/rabbitmq/go.mod
+++ b/tests/certification/pubsub/rabbitmq/go.mod
@@ -4,9 +4,9 @@ go 1.17
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/streadway/amqp v1.0.0

--- a/tests/certification/pubsub/rabbitmq/go.sum
+++ b/tests/certification/pubsub/rabbitmq/go.sum
@@ -129,8 +129,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/secretstores/azure/keyvault/go.mod
+++ b/tests/certification/secretstores/azure/keyvault/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/secretstores/azure
 go 1.17
 
 require (
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/stretchr/testify v1.7.0

--- a/tests/certification/secretstores/azure/keyvault/go.sum
+++ b/tests/certification/secretstores/azure/keyvault/go.sum
@@ -177,8 +177,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/certification/state/sqlserver/go.mod
+++ b/tests/certification/state/sqlserver/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/secretstores/azure
 go 1.17
 
 require (
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1-0.20220426033643-068938c67654
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.7.0
+	github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb
 	github.com/dapr/go-sdk v1.4.0
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/stretchr/testify v1.7.0

--- a/tests/certification/state/sqlserver/go.sum
+++ b/tests/certification/state/sqlserver/go.sum
@@ -129,8 +129,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.7.0 h1:6D92cycMjrzxOSASfXDMfn1t3dGaDysA28ONogaOE4s=
-github.com/dapr/dapr v1.7.0/go.mod h1:MIXtm4c4Vv1Z7GScHOgctDcjZ28W2jGYxXvr28+LGpM=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb h1:RWHECgn8jl19roRMLis7Muuo8kYdld2dWMPWvBOlqfQ=
+github.com/dapr/dapr v1.7.1-0.20220426092903-063b1611d1cb/go.mod h1:EGgvmGvSTgIMRg9Qtd51uOEwunBb/aSmxlQScfkTyBQ=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Pin certification tests to latest daprd with binding context change

This should make the certification tests pass again.