### PR TITLE
Support custom queueEndpoint in Azure Storage Queues

### DIFF
--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -74,6 +74,7 @@ func getEndpoint(endpoint, reqURI, accountName, queueName string) (*url.URL, err
 
 	return url.Parse(fmt.Sprintf(reqURI, accountName, queueName))
 }
+
 // Init sets up this helper.
 func (d *AzureQueueHelper) Init(endpoint string, accountName string, accountKey string, queueName string, decodeBase64 bool) error {
 	credential, err := azqueue.NewSharedKeyCredential(accountName, accountKey)
@@ -179,12 +180,12 @@ type AzureStorageQueues struct {
 }
 
 type storageQueuesMetadata struct {
-	AccountKey   string `json:"storageAccessKey"`
-	QueueName    string `json:"queue"`
+	AccountKey    string `json:"storageAccessKey"`
+	QueueName     string `json:"queue"`
 	QueueEndpoint string `json:"queueEndpoint"`
-	AccountName  string `json:"storageAccount"`
-	DecodeBase64 string `json:"decodeBase64"`
-	ttl          *time.Duration
+	AccountName   string `json:"storageAccount"`
+	DecodeBase64  string `json:"decodeBase64"`
+	ttl           *time.Duration
 }
 
 // NewAzureStorageQueues returns a new AzureStorageQueues instance.

--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -182,7 +182,7 @@ type AzureStorageQueues struct {
 type storageQueuesMetadata struct {
 	AccountKey    string `json:"storageAccessKey"`
 	QueueName     string `json:"queue"`
-	QueueEndpoint string `json:"queueEndpoint"`
+	QueueEndpoint string `json:"queueEndpointUrl"`
 	AccountName   string `json:"storageAccount"`
 	DecodeBase64  string `json:"decodeBase64"`
 	ttl           *time.Duration

--- a/bindings/azure/storagequeues/storagequeues_test.go
+++ b/bindings/azure/storagequeues/storagequeues_test.go
@@ -266,40 +266,40 @@ func TestParseMetadata(t *testing.T) {
 	var oneSecondDuration time.Duration = time.Second
 
 	testCases := []struct {
-		name               string
-		properties         map[string]string
-		expectedAccountKey string
-		expectedQueueName  string
+		name                  string
+		properties            map[string]string
+		expectedAccountKey    string
+		expectedQueueName     string
 		expectedQueueEndpoint string
-		expectedTTL        *time.Duration
+		expectedTTL           *time.Duration
 	}{
 		{
-			name:               "Account and key",
-			properties:         map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1"},
-			expectedAccountKey: "myKey",
-			expectedQueueName:  "queue1",
+			name:                  "Account and key",
+			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1"},
+			expectedAccountKey:    "myKey",
+			expectedQueueName:     "queue1",
 			expectedQueueEndpoint: "",
 		},
 		{
-			name:               "Accout, key, and endpoint",
-			properties:         map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "someAccount", "queueEndpoint": "https://foo.example.com:10001"},
-			expectedAccountKey: "myKey",
-			expectedQueueName:  "queue1",
+			name:                  "Accout, key, and endpoint",
+			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "someAccount", "queueEndpoint": "https://foo.example.com:10001"},
+			expectedAccountKey:    "myKey",
+			expectedQueueName:     "queue1",
 			expectedQueueEndpoint: "https://foo.example.com:10001",
 		},
 		{
-			name:               "Empty TTL",
-			properties:         map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: ""},
-			expectedAccountKey: "myKey",
-			expectedQueueName:  "queue1",
+			name:                  "Empty TTL",
+			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: ""},
+			expectedAccountKey:    "myKey",
+			expectedQueueName:     "queue1",
 			expectedQueueEndpoint: "",
 		},
 		{
-			name:               "With TTL",
-			properties:         map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"},
-			expectedAccountKey: "myKey",
-			expectedQueueName:  "queue1",
-			expectedTTL:        &oneSecondDuration,
+			name:                  "With TTL",
+			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"},
+			expectedAccountKey:    "myKey",
+			expectedQueueName:     "queue1",
+			expectedTTL:           &oneSecondDuration,
 			expectedQueueEndpoint: "",
 		},
 	}

--- a/bindings/azure/storagequeues/storagequeues_test.go
+++ b/bindings/azure/storagequeues/storagequeues_test.go
@@ -266,41 +266,41 @@ func TestParseMetadata(t *testing.T) {
 	var oneSecondDuration time.Duration = time.Second
 
 	testCases := []struct {
-		name                  string
-		properties            map[string]string
-		expectedAccountKey    string
-		expectedQueueName     string
-		expectedQueueEndpoint string
-		expectedTTL           *time.Duration
+		name                     string
+		properties               map[string]string
+		expectedAccountKey       string
+		expectedQueueName        string
+		expectedQueueEndpointUrl string
+		expectedTTL              *time.Duration
 	}{
 		{
-			name:                  "Account and key",
-			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1"},
-			expectedAccountKey:    "myKey",
-			expectedQueueName:     "queue1",
-			expectedQueueEndpoint: "",
+			name:                     "Account and key",
+			properties:               map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1"},
+			expectedAccountKey:       "myKey",
+			expectedQueueName:        "queue1",
+			expectedQueueEndpointUrl: "",
 		},
 		{
-			name:                  "Accout, key, and endpoint",
-			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "someAccount", "queueEndpoint": "https://foo.example.com:10001"},
-			expectedAccountKey:    "myKey",
-			expectedQueueName:     "queue1",
-			expectedQueueEndpoint: "https://foo.example.com:10001",
+			name:                     "Accout, key, and endpoint",
+			properties:               map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "someAccount", "queueEndpointUrl": "https://foo.example.com:10001"},
+			expectedAccountKey:       "myKey",
+			expectedQueueName:        "queue1",
+			expectedQueueEndpointUrl: "https://foo.example.com:10001",
 		},
 		{
-			name:                  "Empty TTL",
-			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: ""},
-			expectedAccountKey:    "myKey",
-			expectedQueueName:     "queue1",
-			expectedQueueEndpoint: "",
+			name:                     "Empty TTL",
+			properties:               map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: ""},
+			expectedAccountKey:       "myKey",
+			expectedQueueName:        "queue1",
+			expectedQueueEndpointUrl: "",
 		},
 		{
-			name:                  "With TTL",
-			properties:            map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"},
-			expectedAccountKey:    "myKey",
-			expectedQueueName:     "queue1",
-			expectedTTL:           &oneSecondDuration,
-			expectedQueueEndpoint: "",
+			name:                     "With TTL",
+			properties:               map[string]string{"storageAccessKey": "myKey", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"},
+			expectedAccountKey:       "myKey",
+			expectedQueueName:        "queue1",
+			expectedTTL:              &oneSecondDuration,
+			expectedQueueEndpointUrl: "",
 		},
 	}
 
@@ -316,7 +316,7 @@ func TestParseMetadata(t *testing.T) {
 			assert.Equal(t, tt.expectedAccountKey, meta.AccountKey)
 			assert.Equal(t, tt.expectedQueueName, meta.QueueName)
 			assert.Equal(t, tt.expectedTTL, meta.ttl)
-			assert.Equal(t, tt.expectedQueueEndpoint, meta.QueueEndpoint)
+			assert.Equal(t, tt.expectedQueueEndpointUrl, meta.QueueEndpoint)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Adds support for a custom endpoint URL for Azure Storage Queues. This is useful for using [production-style URLs](https://github.com/Azure/Azurite#production-style-url) with [Azurite](https://github.com/Azure/Azurite) for local development.

## Issue reference

- #581 

Please reference the issue this PR will close: #_[issue number]_

- #581 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#2424