### PR TITLE
WIP - Azure and AWS Bindings with Azure Auth

### DIFF
--- a/authentication/azure/auth.go
+++ b/authentication/azure/auth.go
@@ -129,6 +129,23 @@ func (s EnvironmentSettings) GetTokenCredential() (azcore.TokenCredential, error
 		}
 	}
 
+	// 4. MSI using Default Credential
+	// DefaultAzureCredential is a default credential chain for applications that will be deployed to Azure.
+	// It combines credentials suitable for deployed applications with credentials suitable in local development.
+	// It attempts to authenticate with each of these credential types, in the following order:
+	//	- EnvironmentCredential
+	//	- ManagedIdentityCredential
+	//	- AzureCLICredential
+	// Consult the documentation for these credential types for more information on how they authenticate.
+	{
+		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		if err == nil {
+			creds = append(creds, cred)
+		} else {
+			errMsg += err.Error() + "\n"
+		}
+	}
+
 	if len(creds) == 0 {
 		return nil, fmt.Errorf("no suitable token provider for Azure AD; errors: %v", errMsg)
 	}

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -38,6 +38,7 @@ type sqsMetadata struct {
 	QueueName    string `json:"queueName"`
 	Region       string `json:"region"`
 	Endpoint     string `json:"endpoint"`
+	QueueURL     string `json:"queueURL"`
 	AccessKey    string `json:"accessKey"`
 	SecretKey    string `json:"secretKey"`
 	SessionToken string `json:"sessionToken"`
@@ -60,15 +61,19 @@ func (a *AWSSQS) Init(metadata bindings.Metadata) error {
 		return err
 	}
 
-	queueName := m.QueueName
-	resultURL, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
-		QueueName: aws.String(queueName),
-	})
-	if err != nil {
-		return err
-	}
+	if m.QueueURL != "" {
+		a.QueueURL = &m.QueueURL
+	} else {
+		queueName := m.QueueName
+		resultURL, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
+			QueueName: aws.String(queueName),
+		})
+		if err != nil {
+			return err
+		}
 
-	a.QueueURL = resultURL.QueueUrl
+		a.QueueURL = resultURL.QueueUrl
+	}
 	a.Client = client
 
 	return nil

--- a/bindings/aws/sqs/sqs_test.go
+++ b/bindings/aws/sqs/sqs_test.go
@@ -24,7 +24,7 @@ import (
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{
-		"QueueName": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a", "SessionToken": "t",
+		"QueueName": "a", "Region": "a", "AccessKey": "a", "SecretKey": "a", "Endpoint": "a", "SessionToken": "t", "QueueURL": "a",
 	}
 	s := AWSSQS{}
 	sqsM, err := s.parseSQSMetadata(m)
@@ -35,4 +35,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "a", sqsM.SecretKey)
 	assert.Equal(t, "a", sqsM.Endpoint)
 	assert.Equal(t, "t", sqsM.SessionToken)
+	assert.Equal(t, "a", sqsM.QueueURL)
 }


### PR DESCRIPTION
# Description

Testing the waters here to see how to get some changes in:
1.  The change to Azure Auth allows the Default Credential to move through the chain of potential creds including the Azure CLI that is useful from the developer desktop
2.  For AWS SQS queue it is possible to have a cred that allows reading of the queue but not use of the method GetQueueURL on the AWS Client.  The change enables the use of the full URL in the component spec of the binding.
3.  For Azure Service Bus binding the send and receive will look to see if the message has populated user properties in addition to the standard system properties.

## Issue reference

1.  Looks like this is in flux with the move to the new Azure SDK for GO
2.  Addresses an issue I have in a live scenario
3.  same as 2

I have (2) and (3) running in an AKS cluster with a custom build of Dapr and seems to be working well

## Checklist
Test changes are a bit limited and no document changes at this time.
Happy to discuss

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
