### PR TITLE
Add context in state component

### DIFF
--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -14,6 +14,7 @@ limitations under the License.
 package aerospike
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -110,7 +111,7 @@ func (aspike *Aerospike) Features() []state.Feature {
 }
 
 // Set stores value for a key to Aerospike. It honors ETag (for concurrency) and consistency settings.
-func (aspike *Aerospike) Set(req *state.SetRequest) error {
+func (aspike *Aerospike) Set(ctx context.Context, req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -162,7 +163,7 @@ func (aspike *Aerospike) Set(req *state.SetRequest) error {
 }
 
 // Get retrieves state from Aerospike with a key.
-func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (aspike *Aerospike) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	asKey, err := as.NewKey(aspike.namespace, aspike.set, req.Key)
 	if err != nil {
 		return nil, err
@@ -196,7 +197,7 @@ func (aspike *Aerospike) Get(req *state.GetRequest) (*state.GetResponse, error) 
 }
 
 // Delete performs a delete operation.
-func (aspike *Aerospike) Delete(req *state.DeleteRequest) error {
+func (aspike *Aerospike) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -238,7 +239,7 @@ func (aspike *Aerospike) Delete(req *state.DeleteRequest) error {
 	return nil
 }
 
-func (aspike *Aerospike) Ping() error {
+func (aspike *Aerospike) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/alicloud/tablestore/tablestore.go
+++ b/state/alicloud/tablestore/tablestore.go
@@ -14,6 +14,7 @@ limitations under the License.
 package tablestore
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/agrea/ptr"
@@ -68,7 +69,7 @@ func (s *AliCloudTableStore) Features() []state.Feature {
 	return s.features
 }
 
-func (s *AliCloudTableStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (s *AliCloudTableStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	criteria := &tablestore.SingleRowQueryCriteria{
 		PrimaryKey: s.primaryKey(req.Key),
 		TableName:  s.metadata.TableName,
@@ -103,7 +104,7 @@ func (s *AliCloudTableStore) getResp(columns []*tablestore.AttributeColumn) *sta
 	return getResp
 }
 
-func (s *AliCloudTableStore) BulkGet(reqs []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (s *AliCloudTableStore) BulkGet(ctx context.Context, reqs []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	// "len == 0": empty request, directly return empty response
 	if len(reqs) == 0 {
 		return true, []state.BulkGetResponse{}, nil
@@ -139,7 +140,7 @@ func (s *AliCloudTableStore) BulkGet(reqs []state.GetRequest) (bool, []state.Bul
 	return true, responseList, nil
 }
 
-func (s *AliCloudTableStore) Set(req *state.SetRequest) error {
+func (s *AliCloudTableStore) Set(ctx context.Context, req *state.SetRequest) error {
 	change := s.updateRowChange(req)
 
 	request := &tablestore.UpdateRowRequest{
@@ -183,7 +184,7 @@ func unmarshal(val interface{}) []byte {
 	return []byte(output)
 }
 
-func (s *AliCloudTableStore) Delete(req *state.DeleteRequest) error {
+func (s *AliCloudTableStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	change := s.deleteRowChange(req)
 
 	deleteRowReq := &tablestore.DeleteRowRequest{
@@ -205,11 +206,11 @@ func (s *AliCloudTableStore) deleteRowChange(req *state.DeleteRequest) *tablesto
 	return change
 }
 
-func (s *AliCloudTableStore) BulkSet(reqs []state.SetRequest) error {
+func (s *AliCloudTableStore) BulkSet(ctx context.Context, reqs []state.SetRequest) error {
 	return s.batchWrite(reqs, nil)
 }
 
-func (s *AliCloudTableStore) BulkDelete(reqs []state.DeleteRequest) error {
+func (s *AliCloudTableStore) BulkDelete(ctx context.Context, reqs []state.DeleteRequest) error {
 	return s.batchWrite(nil, reqs)
 }
 
@@ -234,7 +235,7 @@ func (s *AliCloudTableStore) batchWrite(setReqs []state.SetRequest, deleteReqs [
 	return nil
 }
 
-func (s *AliCloudTableStore) Ping() error {
+func (s *AliCloudTableStore) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/alicloud/tablestore/tablestore_test.go
+++ b/state/alicloud/tablestore/tablestore_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package tablestore
 
 import (
+	"context"
 	"testing"
 
 	"github.com/agrea/ptr"
@@ -63,7 +64,7 @@ func TestReadAndWrite(t *testing.T) {
 			Value: "value of key",
 			ETag:  ptr.String("the etag"),
 		}
-		err := store.Set(setReq)
+		err := store.Set(context.Background(), setReq)
 		assert.Nil(t, err)
 	})
 
@@ -71,7 +72,7 @@ func TestReadAndWrite(t *testing.T) {
 		getReq := &state.GetRequest{
 			Key: "theFirstKey",
 		}
-		resp, err := store.Get(getReq)
+		resp, err := store.Get(context.Background(), getReq)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, "value of key", string(resp.Data))
@@ -83,7 +84,7 @@ func TestReadAndWrite(t *testing.T) {
 			Value: "1234",
 			ETag:  ptr.String("the etag"),
 		}
-		err := store.Set(setReq)
+		err := store.Set(context.Background(), setReq)
 		assert.Nil(t, err)
 	})
 
@@ -91,14 +92,14 @@ func TestReadAndWrite(t *testing.T) {
 		getReq := &state.GetRequest{
 			Key: "theSecondKey",
 		}
-		resp, err := store.Get(getReq)
+		resp, err := store.Get(context.Background(), getReq)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, "1234", string(resp.Data))
 	})
 
 	t.Run("test BulkSet", func(t *testing.T) {
-		err := store.BulkSet([]state.SetRequest{{
+		err := store.BulkSet(context.Background(), []state.SetRequest{{
 			Key:   "theFirstKey",
 			Value: "666",
 		}, {
@@ -110,7 +111,7 @@ func TestReadAndWrite(t *testing.T) {
 	})
 
 	t.Run("test BulkGet", func(t *testing.T) {
-		_, resp, err := store.BulkGet([]state.GetRequest{{
+		_, resp, err := store.BulkGet(context.Background(), []state.GetRequest{{
 			Key: "theFirstKey",
 		}, {
 			Key: "theSecondKey",
@@ -126,12 +127,12 @@ func TestReadAndWrite(t *testing.T) {
 		req := &state.DeleteRequest{
 			Key: "theFirstKey",
 		}
-		err := store.Delete(req)
+		err := store.Delete(context.Background(), req)
 		assert.Nil(t, err)
 	})
 
 	t.Run("test BulkGet2", func(t *testing.T) {
-		_, resp, err := store.BulkGet([]state.GetRequest{{
+		_, resp, err := store.BulkGet(context.Background(), []state.GetRequest{{
 			Key: "theFirstKey",
 		}, {
 			Key: "theSecondKey",

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -14,6 +14,7 @@ limitations under the License.
 package dynamodb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -70,7 +71,7 @@ func (d *StateStore) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (d *StateStore) Ping() error {
+func (d *StateStore) Ping(ctx context.Context) error {
 	return nil
 }
 
@@ -80,7 +81,7 @@ func (d *StateStore) Features() []state.Feature {
 }
 
 // Get retrieves a dynamoDB item.
-func (d *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (d *StateStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	input := &dynamodb.GetItemInput{
 		ConsistentRead: aws.Bool(req.Options.Consistency == state.Strong),
 		TableName:      aws.String(d.table),
@@ -124,13 +125,13 @@ func (d *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // BulkGet performs a bulk get operations.
-func (d *StateStore) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (d *StateStore) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	// TODO: replace with dynamodb.BatchGetItem for performance
 	return false, nil, nil
 }
 
 // Set saves a dynamoDB item.
-func (d *StateStore) Set(req *state.SetRequest) error {
+func (d *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	value, err := d.marshalToString(req.Value)
 	if err != nil {
 		return fmt.Errorf("dynamodb error: failed to set key %s: %s", req.Key, err)
@@ -176,7 +177,7 @@ func (d *StateStore) Set(req *state.SetRequest) error {
 }
 
 // BulkSet performs a bulk set operation.
-func (d *StateStore) BulkSet(req []state.SetRequest) error {
+func (d *StateStore) BulkSet(ctx context.Context, req []state.SetRequest) error {
 	writeRequests := []*dynamodb.WriteRequest{}
 
 	for _, r := range req {
@@ -234,7 +235,7 @@ func (d *StateStore) BulkSet(req []state.SetRequest) error {
 }
 
 // Delete performs a delete operation.
-func (d *StateStore) Delete(req *state.DeleteRequest) error {
+func (d *StateStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	input := &dynamodb.DeleteItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
 			"key": {
@@ -249,7 +250,7 @@ func (d *StateStore) Delete(req *state.DeleteRequest) error {
 }
 
 // BulkDelete performs a bulk delete operation.
-func (d *StateStore) BulkDelete(req []state.DeleteRequest) error {
+func (d *StateStore) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
 	writeRequests := []*dynamodb.WriteRequest{}
 
 	for _, r := range req {

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package dynamodb
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -117,7 +118,7 @@ func TestGet(t *testing.T) {
 				Consistency: "strong",
 			},
 		}
-		out, err := ss.Get(req)
+		out, err := ss.Get(context.Background(), req)
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("some value"), out.Data)
 	})
@@ -149,7 +150,7 @@ func TestGet(t *testing.T) {
 				Consistency: "strong",
 			},
 		}
-		out, err := ss.Get(req)
+		out, err := ss.Get(context.Background(), req)
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("some value"), out.Data)
 	})
@@ -181,7 +182,7 @@ func TestGet(t *testing.T) {
 				Consistency: "strong",
 			},
 		}
-		out, err := ss.Get(req)
+		out, err := ss.Get(context.Background(), req)
 		assert.Nil(t, err)
 		assert.Nil(t, out.Data)
 	})
@@ -200,7 +201,7 @@ func TestGet(t *testing.T) {
 				Consistency: "strong",
 			},
 		}
-		out, err := ss.Get(req)
+		out, err := ss.Get(context.Background(), req)
 		assert.NotNil(t, err)
 		assert.Nil(t, out)
 	})
@@ -221,7 +222,7 @@ func TestGet(t *testing.T) {
 				Consistency: "strong",
 			},
 		}
-		out, err := ss.Get(req)
+		out, err := ss.Get(context.Background(), req)
 		assert.Nil(t, err)
 		assert.Nil(t, out.Data)
 	})
@@ -246,7 +247,7 @@ func TestGet(t *testing.T) {
 				Consistency: "strong",
 			},
 		}
-		out, err := ss.Get(req)
+		out, err := ss.Get(context.Background(), req)
 		assert.Nil(t, err)
 		assert.Empty(t, out.Data)
 	})
@@ -287,7 +288,7 @@ func TestSet(t *testing.T) {
 				Value: "value",
 			},
 		}
-		err := ss.Set(req)
+		err := ss.Set(context.Background(), req)
 		assert.Nil(t, err)
 	})
 
@@ -323,7 +324,7 @@ func TestSet(t *testing.T) {
 				"ttlInSeconds": "-1",
 			},
 		}
-		err := ss.Set(req)
+		err := ss.Set(context.Background(), req)
 		assert.Nil(t, err)
 	})
 	t.Run("Successfully set item with 'correct' ttl", func(t *testing.T) {
@@ -358,7 +359,7 @@ func TestSet(t *testing.T) {
 				"ttlInSeconds": "180",
 			},
 		}
-		err := ss.Set(req)
+		err := ss.Set(context.Background(), req)
 		assert.Nil(t, err)
 	})
 
@@ -376,7 +377,7 @@ func TestSet(t *testing.T) {
 				Value: "value",
 			},
 		}
-		err := ss.Set(req)
+		err := ss.Set(context.Background(), req)
 		assert.NotNil(t, err)
 	})
 	t.Run("Successfully set item with correct ttl but without component metadata", func(t *testing.T) {
@@ -412,7 +413,7 @@ func TestSet(t *testing.T) {
 				"ttlInSeconds": "180",
 			},
 		}
-		err := ss.Set(req)
+		err := ss.Set(context.Background(), req)
 		assert.Nil(t, err)
 	})
 	t.Run("Unsuccessfully set item with ttl (invalid value)", func(t *testing.T) {
@@ -451,7 +452,7 @@ func TestSet(t *testing.T) {
 				"ttlInSeconds": "invalidvalue",
 			},
 		}
-		err := ss.Set(req)
+		err := ss.Set(context.Background(), req)
 		assert.NotNil(t, err)
 		assert.Equal(t, "dynamodb error: failed to parse ttlInSeconds: strconv.ParseInt: parsing \"invalidvalue\": invalid syntax", err.Error())
 	})
@@ -517,7 +518,7 @@ func TestBulkSet(t *testing.T) {
 				},
 			},
 		}
-		err := ss.BulkSet(req)
+		err := ss.BulkSet(context.Background(), req)
 		assert.Nil(t, err)
 	})
 	t.Run("Successfully set items with ttl = -1", func(t *testing.T) {
@@ -582,7 +583,7 @@ func TestBulkSet(t *testing.T) {
 				},
 			},
 		}
-		err := ss.BulkSet(req)
+		err := ss.BulkSet(context.Background(), req)
 		assert.Nil(t, err)
 	})
 	t.Run("Successfully set items with ttl", func(t *testing.T) {
@@ -649,7 +650,7 @@ func TestBulkSet(t *testing.T) {
 				},
 			},
 		}
-		err := ss.BulkSet(req)
+		err := ss.BulkSet(context.Background(), req)
 		assert.Nil(t, err)
 	})
 	t.Run("Unsuccessfully set items", func(t *testing.T) {
@@ -668,7 +669,7 @@ func TestBulkSet(t *testing.T) {
 				},
 			},
 		}
-		err := ss.BulkSet(req)
+		err := ss.BulkSet(context.Background(), req)
 		assert.NotNil(t, err)
 	})
 }
@@ -692,7 +693,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 		}
-		err := ss.Delete(req)
+		err := ss.Delete(context.Background(), req)
 		assert.Nil(t, err)
 	})
 
@@ -707,7 +708,7 @@ func TestDelete(t *testing.T) {
 		req := &state.DeleteRequest{
 			Key: "key",
 		}
-		err := ss.Delete(req)
+		err := ss.Delete(context.Background(), req)
 		assert.NotNil(t, err)
 	})
 }
@@ -756,7 +757,7 @@ func TestBulkDelete(t *testing.T) {
 				Key: "key2",
 			},
 		}
-		err := ss.BulkDelete(req)
+		err := ss.BulkDelete(context.Background(), req)
 		assert.Nil(t, err)
 	})
 	t.Run("Unsuccessfully delete items", func(t *testing.T) {
@@ -772,7 +773,7 @@ func TestBulkDelete(t *testing.T) {
 				Key: "key",
 			},
 		}
-		err := ss.BulkDelete(req)
+		err := ss.BulkDelete(context.Background(), req)
 		assert.NotNil(t, err)
 	})
 }

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -15,6 +15,7 @@ package cosmosdb
 
 import (
 	// For go:embed.
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -212,7 +213,7 @@ func (c *StateStore) Features() []state.Feature {
 }
 
 // Get retrieves a CosmosDB item.
-func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (c *StateStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	key := req.Key
 
 	partitionKey := populatePartitionMetadata(req.Key, req.Metadata)
@@ -269,7 +270,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // Set saves a CosmosDB item.
-func (c *StateStore) Set(req *state.SetRequest) error {
+func (c *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -321,7 +322,7 @@ func (c *StateStore) Set(req *state.SetRequest) error {
 }
 
 // Delete performs a delete operation.
-func (c *StateStore) Delete(req *state.DeleteRequest) error {
+func (c *StateStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -463,7 +464,7 @@ func (c *StateStore) Query(req *state.QueryRequest) (*state.QueryResponse, error
 	}, nil
 }
 
-func (c *StateStore) Ping() error {
+func (c *StateStore) Ping(ctx context.Context) error {
 	return retryOperation(func() error {
 		_, innerErr := c.findCollection()
 		if innerErr != nil {

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -38,6 +38,7 @@ Concurrency is supported with ETags according to https://docs.microsoft.com/en-u
 package tablestorage
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -110,7 +111,7 @@ func (r *StateStore) Features() []state.Feature {
 	return r.features
 }
 
-func (r *StateStore) Delete(req *state.DeleteRequest) error {
+func (r *StateStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	r.logger.Debugf("delete %s", req.Key)
 
 	err := r.deleteRow(req)
@@ -126,7 +127,7 @@ func (r *StateStore) Delete(req *state.DeleteRequest) error {
 	return err
 }
 
-func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (r *StateStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	r.logger.Debugf("fetching %s", req.Key)
 	pk, rk := getPartitionAndRowKey(req.Key)
 	entity := r.table.GetEntityReference(pk, rk)
@@ -147,7 +148,7 @@ func (r *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}, err
 }
 
-func (r *StateStore) Set(req *state.SetRequest) error {
+func (r *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	r.logger.Debugf("saving %s", req.Key)
 
 	err := r.writeRow(req)
@@ -275,7 +276,7 @@ func (r *StateStore) deleteRow(req *state.DeleteRequest) error {
 	return entity.Delete(true, nil)
 }
 
-func (r *StateStore) Ping() error {
+func (r *StateStore) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/cassandra/cassandra.go
+++ b/state/cassandra/cassandra.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cassandra
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -230,12 +231,12 @@ func getCassandraMetadata(metadata state.Metadata) (*cassandraMetadata, error) {
 }
 
 // Delete performs a delete operation.
-func (c *Cassandra) Delete(req *state.DeleteRequest) error {
+func (c *Cassandra) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return c.session.Query(fmt.Sprintf("DELETE FROM %s WHERE key = ?", c.table), req.Key).Exec()
 }
 
 // Get retrieves state from cassandra with a key.
-func (c *Cassandra) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (c *Cassandra) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	session := c.session
 
 	if req.Options.Consistency == state.Strong {
@@ -269,7 +270,7 @@ func (c *Cassandra) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // Set saves state into cassandra.
-func (c *Cassandra) Set(req *state.SetRequest) error {
+func (c *Cassandra) Set(ctx context.Context, req *state.SetRequest) error {
 	var bt []byte
 	b, ok := req.Value.([]byte)
 	if ok {
@@ -308,7 +309,7 @@ func (c *Cassandra) Set(req *state.SetRequest) error {
 	return session.Query(fmt.Sprintf("INSERT INTO %s (key, value) VALUES (?, ?)", c.table), req.Key, bt).Exec()
 }
 
-func (c *Cassandra) Ping() error {
+func (c *Cassandra) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/cockroachdb/cockroachdb.go
+++ b/state/cockroachdb/cockroachdb.go
@@ -14,6 +14,8 @@ limitations under the License.
 package cockroachdb
 
 import (
+	"context"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
 )
@@ -53,39 +55,39 @@ func (c *CockroachDB) Features() []state.Feature {
 }
 
 // Delete removes an entity from the store.
-func (c *CockroachDB) Delete(req *state.DeleteRequest) error {
-	return c.dbaccess.Delete(req)
+func (c *CockroachDB) Delete(ctx context.Context, req *state.DeleteRequest) error {
+	return c.dbaccess.Delete(ctx, req)
 }
 
 // Get returns an entity from store.
-func (c *CockroachDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
-	return c.dbaccess.Get(req)
+func (c *CockroachDB) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
+	return c.dbaccess.Get(ctx, req)
 }
 
 // Set adds/updates an entity on store.
-func (c *CockroachDB) Set(req *state.SetRequest) error {
-	return c.dbaccess.Set(req)
+func (c *CockroachDB) Set(ctx context.Context, req *state.SetRequest) error {
+	return c.dbaccess.Set(ctx, req)
 }
 
 // Ping checks if database is available.
-func (c *CockroachDB) Ping() error {
-	return c.dbaccess.Ping()
+func (c *CockroachDB) Ping(ctx context.Context) error {
+	return c.dbaccess.Ping(ctx)
 }
 
 // BulkDelete removes multiple entries from the store.
-func (c *CockroachDB) BulkDelete(req []state.DeleteRequest) error {
-	return c.dbaccess.BulkDelete(req)
+func (c *CockroachDB) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
+	return c.dbaccess.BulkDelete(ctx, req)
 }
 
 // BulkGet performs a bulks get operations.
-func (c *CockroachDB) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (c *CockroachDB) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	// TODO: replace with ExecuteMulti for performance.
 	return false, nil, nil
 }
 
 // BulkSet adds/updates multiple entities on store.
-func (c *CockroachDB) BulkSet(req []state.SetRequest) error {
-	return c.dbaccess.BulkSet(req)
+func (c *CockroachDB) BulkSet(ctx context.Context, req []state.SetRequest) error {
+	return c.dbaccess.BulkSet(ctx, req)
 }
 
 // Multi handles multiple transactions. Implements TransactionalStore.

--- a/state/cockroachdb/cockroachdb_access_test.go
+++ b/state/cockroachdb/cockroachdb_access_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cockroachdb
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -334,7 +335,7 @@ func TestInvalidBulkSetNoKey(t *testing.T) {
 	})
 
 	// Act
-	err := m.roachDba.BulkSet(sets)
+	err := m.roachDba.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -356,7 +357,7 @@ func TestInvalidBulkSetEmptyValue(t *testing.T) {
 	})
 
 	// Act
-	err := m.roachDba.BulkSet(sets)
+	err := m.roachDba.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -379,7 +380,7 @@ func TestValidBulkSet(t *testing.T) {
 	})
 
 	// Act
-	err := m.roachDba.BulkSet(sets)
+	err := m.roachDba.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.Nil(t, err)
@@ -400,7 +401,7 @@ func TestInvalidBulkDeleteNoKey(t *testing.T) {
 	})
 
 	// Act
-	err := m.roachDba.BulkDelete(deletes)
+	err := m.roachDba.BulkDelete(context.Background(), deletes)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -422,7 +423,7 @@ func TestValidBulkDelete(t *testing.T) {
 	})
 
 	// Act
-	err := m.roachDba.BulkDelete(deletes)
+	err := m.roachDba.BulkDelete(context.Background(), deletes)
 
 	// Assert
 	assert.Nil(t, err)

--- a/state/cockroachdb/cockroachdb_integration_test.go
+++ b/state/cockroachdb/cockroachdb_integration_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cockroachdb
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -210,7 +211,7 @@ func deleteItemThatDoesNotExist(t *testing.T, pgs *CockroachDB) {
 			Consistency: "",
 		},
 	}
-	err := pgs.Delete(deleteReq)
+	err := pgs.Delete(context.TODO(), deleteReq)
 	assert.Nil(t, err)
 }
 
@@ -375,7 +376,7 @@ func deleteWithInvalidEtagFails(t *testing.T, pgs *CockroachDB) {
 			Consistency: "",
 		},
 	}
-	err := pgs.Delete(deleteReq)
+	err := pgs.Delete(context.TODO(), deleteReq)
 	assert.NotNil(t, err)
 }
 
@@ -391,7 +392,7 @@ func deleteWithNoKeyFails(t *testing.T, pgs *CockroachDB) {
 			Consistency: "",
 		},
 	}
-	err := pgs.Delete(deleteReq)
+	err := pgs.Delete(context.TODO(), deleteReq)
 	assert.NotNil(t, err)
 }
 
@@ -414,7 +415,7 @@ func newItemWithEtagFails(t *testing.T, pgs *CockroachDB) {
 		ContentType: nil,
 	}
 
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.TODO(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -448,7 +449,7 @@ func updateWithOldEtagFails(t *testing.T, pgs *CockroachDB) {
 		},
 		ContentType: nil,
 	}
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.TODO(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -500,7 +501,7 @@ func getItemWithNoKey(t *testing.T, pgs *CockroachDB) {
 		},
 	}
 
-	response, getErr := pgs.Get(getReq)
+	response, getErr := pgs.Get(context.TODO(), getReq)
 	assert.NotNil(t, getErr)
 	assert.Nil(t, response)
 }
@@ -543,7 +544,7 @@ func setItemWithNoKey(t *testing.T, pgs *CockroachDB) {
 		ContentType: nil,
 	}
 
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.TODO(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -562,7 +563,7 @@ func testBulkSetAndBulkDelete(t *testing.T, pgs *CockroachDB) {
 		},
 	}
 
-	err := pgs.BulkSet(setReq)
+	err := pgs.BulkSet(context.TODO(), setReq)
 	assert.Nil(t, err)
 	assert.True(t, storeItemExists(t, setReq[0].Key))
 	assert.True(t, storeItemExists(t, setReq[1].Key))
@@ -576,7 +577,7 @@ func testBulkSetAndBulkDelete(t *testing.T, pgs *CockroachDB) {
 		},
 	}
 
-	err = pgs.BulkDelete(deleteReq)
+	err = pgs.BulkDelete(context.TODO(), deleteReq)
 	assert.Nil(t, err)
 	assert.False(t, storeItemExists(t, setReq[0].Key))
 	assert.False(t, storeItemExists(t, setReq[1].Key))
@@ -643,7 +644,7 @@ func setItem(t *testing.T, pgs *CockroachDB, key string, value interface{}, etag
 		ContentType: nil,
 	}
 
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.TODO(), setReq)
 	assert.Nil(t, err)
 	itemExists := storeItemExists(t, key)
 	assert.True(t, itemExists)
@@ -660,7 +661,7 @@ func getItem(t *testing.T, pgs *CockroachDB, key string) (*state.GetResponse, *f
 		Metadata: map[string]string{},
 	}
 
-	response, getErr := pgs.Get(getReq)
+	response, getErr := pgs.Get(context.TODO(), getReq)
 	assert.Nil(t, getErr)
 	assert.NotNil(t, response)
 	outputObject := &fakeItem{
@@ -684,7 +685,7 @@ func deleteItem(t *testing.T, pgs *CockroachDB, key string, etag *string) {
 		Metadata: map[string]string{},
 	}
 
-	deleteErr := pgs.Delete(deleteReq)
+	deleteErr := pgs.Delete(context.TODO(), deleteReq)
 	assert.Nil(t, deleteErr)
 	assert.False(t, storeItemExists(t, key))
 }

--- a/state/cockroachdb/cockroachdb_test.go
+++ b/state/cockroachdb/cockroachdb_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cockroachdb
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,29 +42,29 @@ func (m *fakeDBaccess) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (m *fakeDBaccess) Set(req *state.SetRequest) error {
+func (m *fakeDBaccess) Set(ctx context.Context, req *state.SetRequest) error {
 	m.setExecuted = true
 
 	return nil
 }
 
-func (m *fakeDBaccess) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (m *fakeDBaccess) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	m.getExecuted = true
 
 	return nil, nil
 }
 
-func (m *fakeDBaccess) Delete(req *state.DeleteRequest) error {
+func (m *fakeDBaccess) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	m.deleteExecuted = true
 
 	return nil
 }
 
-func (m *fakeDBaccess) BulkSet(req []state.SetRequest) error {
+func (m *fakeDBaccess) BulkSet(ctx context.Context, req []state.SetRequest) error {
 	return nil
 }
 
-func (m *fakeDBaccess) BulkDelete(req []state.DeleteRequest) error {
+func (m *fakeDBaccess) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
 	return nil
 }
 
@@ -79,7 +80,7 @@ func (m *fakeDBaccess) Close() error {
 	return nil
 }
 
-func (m *fakeDBaccess) Ping() error {
+func (m *fakeDBaccess) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/cockroachdb/dbaccess.go
+++ b/state/cockroachdb/dbaccess.go
@@ -13,18 +13,22 @@ limitations under the License.
 
 package cockroachdb
 
-import "github.com/dapr/components-contrib/state"
+import (
+	"context"
+
+	"github.com/dapr/components-contrib/state"
+)
 
 // dbAccess is a private interface which enables unit testing of CockroachDB.
 type dbAccess interface {
 	Init(metadata state.Metadata) error
-	Set(req *state.SetRequest) error
-	BulkSet(req []state.SetRequest) error
-	Get(req *state.GetRequest) (*state.GetResponse, error)
-	Delete(req *state.DeleteRequest) error
-	BulkDelete(req []state.DeleteRequest) error
+	Set(ctx context.Context, req *state.SetRequest) error
+	BulkSet(ctx context.Context, req []state.SetRequest) error
+	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
+	Delete(ctx context.Context, req *state.DeleteRequest) error
+	BulkDelete(ctx context.Context, req []state.DeleteRequest) error
 	ExecuteMulti(req *state.TransactionalStateRequest) error
 	Query(req *state.QueryRequest) (*state.QueryResponse, error)
-	Ping() error
+	Ping(ctx context.Context) error
 	Close() error
 }

--- a/state/couchbase/couchbase.go
+++ b/state/couchbase/couchbase.go
@@ -14,6 +14,7 @@ limitations under the License.
 package couchbase
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -144,7 +145,7 @@ func (cbs *Couchbase) Features() []state.Feature {
 }
 
 // Set stores value for a key to couchbase. It honors ETag (for concurrency) and consistency settings.
-func (cbs *Couchbase) Set(req *state.SetRequest) error {
+func (cbs *Couchbase) Set(ctx context.Context, req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -188,7 +189,7 @@ func (cbs *Couchbase) Set(req *state.SetRequest) error {
 }
 
 // Get retrieves state from couchbase with a key.
-func (cbs *Couchbase) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (cbs *Couchbase) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	var data interface{}
 	cas, err := cbs.bucket.Get(req.Key, &data)
 	if err != nil {
@@ -206,7 +207,7 @@ func (cbs *Couchbase) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // Delete performs a delete operation.
-func (cbs *Couchbase) Delete(req *state.DeleteRequest) error {
+func (cbs *Couchbase) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -236,7 +237,7 @@ func (cbs *Couchbase) Delete(req *state.DeleteRequest) error {
 	return nil
 }
 
-func (cbs *Couchbase) Ping() error {
+func (cbs *Couchbase) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -93,7 +93,7 @@ func (f *Firestore) Features() []state.Feature {
 }
 
 // Get retrieves state from Firestore with a key (Always strong consistency).
-func (f *Firestore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (f *Firestore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	key := req.Key
 
 	entityKey := datastore.NameKey(f.entityKind, key, nil)
@@ -111,7 +111,7 @@ func (f *Firestore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}, nil
 }
 
-func (f *Firestore) setValue(req *state.SetRequest) error {
+func (f *Firestore) setValue(ctx context.Context, req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -128,7 +128,6 @@ func (f *Firestore) setValue(req *state.SetRequest) error {
 	entity := &StateEntity{
 		Value: v,
 	}
-	ctx := context.Background()
 	key := datastore.NameKey(f.entityKind, req.Key, nil)
 
 	_, err = f.client.Put(ctx, key, entity)
@@ -141,16 +140,15 @@ func (f *Firestore) setValue(req *state.SetRequest) error {
 }
 
 // Set saves state into Firestore with retry.
-func (f *Firestore) Set(req *state.SetRequest) error {
-	return state.SetWithOptions(f.setValue, req)
+func (f *Firestore) Set(ctx context.Context, req *state.SetRequest) error {
+	return state.SetWithOptions(f.setValue, ctx, req)
 }
 
-func (f *Firestore) Ping() error {
+func (f *Firestore) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
-	ctx := context.Background()
+func (f *Firestore) deleteValue(ctx context.Context, req *state.DeleteRequest) error {
 	key := datastore.NameKey(f.entityKind, req.Key, nil)
 
 	err := f.client.Delete(ctx, key)
@@ -162,8 +160,8 @@ func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
 }
 
 // Delete performs a delete operation.
-func (f *Firestore) Delete(req *state.DeleteRequest) error {
-	return state.DeleteWithOptions(f.deleteValue, req)
+func (f *Firestore) Delete(ctx context.Context, req *state.DeleteRequest) error {
+	return state.DeleteWithOptions(f.deleteValue, ctx, req)
 }
 
 func getFirestoreMetadata(metadata state.Metadata) (*firestoreMetadata, error) {

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -14,6 +14,7 @@ limitations under the License.
 package consul
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -102,7 +103,7 @@ func metadataToConfig(connInfo map[string]string) (*consulConfig, error) {
 }
 
 // Get retrieves a Consul KV item.
-func (c *Consul) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (c *Consul) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	queryOpts := &api.QueryOptions{}
 	if req.Options.Consistency == state.Strong {
 		queryOpts.RequireConsistent = true
@@ -124,7 +125,7 @@ func (c *Consul) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // Set saves a Consul KV item.
-func (c *Consul) Set(req *state.SetRequest) error {
+func (c *Consul) Set(ctx context.Context, req *state.SetRequest) error {
 	var reqValByte []byte
 	b, ok := req.Value.([]byte)
 	if ok {
@@ -146,12 +147,12 @@ func (c *Consul) Set(req *state.SetRequest) error {
 	return nil
 }
 
-func (c *Consul) Ping() error {
+func (c *Consul) Ping(ctx context.Context) error {
 	return nil
 }
 
 // Delete performes a Consul KV delete operation.
-func (c *Consul) Delete(req *state.DeleteRequest) error {
+func (c *Consul) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	keyWithPath := fmt.Sprintf("%s/%s", c.keyPrefixPath, req.Key)
 	_, err := c.client.KV().Delete(keyWithPath, nil)
 	if err != nil {

--- a/state/hazelcast/hazelcast.go
+++ b/state/hazelcast/hazelcast.go
@@ -14,6 +14,7 @@ limitations under the License.
 package hazelcast
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -91,7 +92,7 @@ func (store *Hazelcast) Features() []state.Feature {
 }
 
 // Set stores value for a key to Hazelcast.
-func (store *Hazelcast) Set(req *state.SetRequest) error {
+func (store *Hazelcast) Set(ctx context.Context, req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req)
 	if err != nil {
 		return err
@@ -117,7 +118,7 @@ func (store *Hazelcast) Set(req *state.SetRequest) error {
 }
 
 // Get retrieves state from Hazelcast with a key.
-func (store *Hazelcast) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (store *Hazelcast) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	resp, err := store.hzMap.Get(req.Key)
 	if err != nil {
 		return nil, fmt.Errorf("hazelcast error: failed to get value for %s: %s", req.Key, err)
@@ -137,12 +138,12 @@ func (store *Hazelcast) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}, nil
 }
 
-func (store *Hazelcast) Ping() error {
+func (store *Hazelcast) Ping(ctx context.Context) error {
 	return nil
 }
 
 // Delete performs a delete operation.
-func (store *Hazelcast) Delete(req *state.DeleteRequest) error {
+func (store *Hazelcast) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err

--- a/state/in-memory/in_memory.go
+++ b/state/in-memory/in_memory.go
@@ -69,7 +69,7 @@ func (store *inMemoryStore) Close() error {
 	return nil
 }
 
-func (store *inMemoryStore) Ping() error {
+func (store *inMemoryStore) Ping(ctx context.Context) error {
 	return nil
 }
 
@@ -77,7 +77,7 @@ func (store *inMemoryStore) Features() []state.Feature {
 	return []state.Feature{state.FeatureETag, state.FeatureTransactional}
 }
 
-func (store *inMemoryStore) Delete(req *state.DeleteRequest) error {
+func (store *inMemoryStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	// step1: validate parameters
 	if err := store.doDeleteValidateParameters(req); err != nil {
 		return err
@@ -125,7 +125,7 @@ func (store *inMemoryStore) doDelete(key string) {
 	delete(store.items, key)
 }
 
-func (store *inMemoryStore) BulkDelete(req []state.DeleteRequest) error {
+func (store *inMemoryStore) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
 	if len(req) == 0 {
 		return nil
 	}
@@ -157,7 +157,7 @@ func (store *inMemoryStore) BulkDelete(req []state.DeleteRequest) error {
 	return nil
 }
 
-func (store *inMemoryStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (store *inMemoryStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	item := store.doGetWithReadLock(req.Key)
 	if item != nil && isExpired(item.expire) {
 		item = store.doGetWithWriteLock(req.Key)
@@ -198,11 +198,11 @@ func isExpired(expire int64) bool {
 	return time.Now().UnixMilli() > expire
 }
 
-func (store *inMemoryStore) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (store *inMemoryStore) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	return false, nil, nil
 }
 
-func (store *inMemoryStore) Set(req *state.SetRequest) error {
+func (store *inMemoryStore) Set(ctx context.Context, req *state.SetRequest) error {
 	// step1: validate parameters
 	ttlInSeconds, err := store.doSetValidateParameters(req)
 	if err != nil {
@@ -272,7 +272,7 @@ type innerSetRequest struct {
 	data         []byte
 }
 
-func (store *inMemoryStore) BulkSet(req []state.SetRequest) error {
+func (store *inMemoryStore) BulkSet(ctx context.Context, req []state.SetRequest) error {
 	if len(req) == 0 {
 		return nil
 	}

--- a/state/in-memory/in_memory_test.go
+++ b/state/in-memory/in_memory_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package inmemory
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -43,13 +44,13 @@ func TestReadAndWrite(t *testing.T) {
 			Value: valueA,
 			ETag:  ptr.String("the etag"),
 		}
-		err := store.Set(setReq)
+		err := store.Set(context.Background(), setReq)
 		assert.Nil(t, err)
 		// get after set
 		getReq := &state.GetRequest{
 			Key: keyA,
 		}
-		resp, err := store.Get(getReq)
+		resp, err := store.Get(context.Background(), getReq)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, valueA, string(resp.Data))
@@ -62,7 +63,7 @@ func TestReadAndWrite(t *testing.T) {
 			Value:    valueA,
 			Metadata: map[string]string{"ttlInSeconds": "1"},
 		}
-		err := store.Set(setReq)
+		err := store.Set(context.Background(), setReq)
 		assert.Nil(t, err)
 		// simulate expiration
 		time.Sleep(2 * time.Second)
@@ -70,7 +71,7 @@ func TestReadAndWrite(t *testing.T) {
 		getReq := &state.GetRequest{
 			Key: keyA,
 		}
-		resp, err := store.Get(getReq)
+		resp, err := store.Get(context.Background(), getReq)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp)
 		assert.Nil(t, resp.Data)
@@ -84,20 +85,20 @@ func TestReadAndWrite(t *testing.T) {
 			Value: "1234",
 			ETag:  ptr.String("the etag"),
 		}
-		err := store.Set(setReq)
+		err := store.Set(context.Background(), setReq)
 		assert.Nil(t, err)
 		// get
 		getReq := &state.GetRequest{
 			Key: "theSecondKey",
 		}
-		resp, err := store.Get(getReq)
+		resp, err := store.Get(context.Background(), getReq)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, "1234", string(resp.Data))
 	})
 
 	t.Run("BulkSet two keys", func(t *testing.T) {
-		err := store.BulkSet([]state.SetRequest{{
+		err := store.BulkSet(context.Background(), []state.SetRequest{{
 			Key:   "theFirstKey",
 			Value: "666",
 		}, {
@@ -109,7 +110,7 @@ func TestReadAndWrite(t *testing.T) {
 	})
 
 	t.Run("BulkGet fails when not supported", func(t *testing.T) {
-		supportBulk, _, err := store.BulkGet([]state.GetRequest{{
+		supportBulk, _, err := store.BulkGet(context.Background(), []state.GetRequest{{
 			Key: "theFirstKey",
 		}, {
 			Key: "theSecondKey",
@@ -123,7 +124,7 @@ func TestReadAndWrite(t *testing.T) {
 		req := &state.DeleteRequest{
 			Key: "theFirstKey",
 		}
-		err := store.Delete(req)
+		err := store.Delete(context.Background(), req)
 		assert.Nil(t, err)
 	})
 }

--- a/state/jetstream/jetstream.go
+++ b/state/jetstream/jetstream.go
@@ -14,6 +14,7 @@ limitations under the License.
 package jetstream
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -92,7 +93,7 @@ func (js *StateStore) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (js *StateStore) Ping() error {
+func (js *StateStore) Ping(ctx context.Context) error {
 	return nil
 }
 
@@ -101,7 +102,7 @@ func (js *StateStore) Features() []state.Feature {
 }
 
 // Get retrieves state with a key.
-func (js *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (js *StateStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	entry, err := js.bucket.Get(escape(req.Key))
 	if err != nil {
 		return nil, err
@@ -113,14 +114,14 @@ func (js *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // Set stores value for a key.
-func (js *StateStore) Set(req *state.SetRequest) error {
+func (js *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	bt, _ := utils.Marshal(req.Value, js.json.Marshal)
 	_, err := js.bucket.Put(escape(req.Key), bt)
 	return err
 }
 
 // Delete performs a delete operation.
-func (js *StateStore) Delete(req *state.DeleteRequest) error {
+func (js *StateStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return js.bucket.Delete(escape(req.Key))
 }
 

--- a/state/jetstream/jetstream_test.go
+++ b/state/jetstream/jetstream_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package jetstream
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -110,8 +111,8 @@ func TestSetGetAndDelete(t *testing.T) {
 	tData := map[string]string{
 		"dkey": "dvalue",
 	}
-
-	err = store.Set(&state.SetRequest{
+	ctx := context.Background()
+	err = store.Set(ctx, &state.SetRequest{
 		Key:   tkey,
 		Value: tData,
 	})
@@ -120,7 +121,7 @@ func TestSetGetAndDelete(t *testing.T) {
 		return
 	}
 
-	resp, err := store.Get(&state.GetRequest{
+	resp, err := store.Get(ctx, &state.GetRequest{
 		Key: tkey,
 	})
 	if err != nil {
@@ -133,7 +134,7 @@ func TestSetGetAndDelete(t *testing.T) {
 		t.Fatal("Response data does not match written data\n")
 	}
 
-	err = store.Delete(&state.DeleteRequest{
+	err = store.Delete(ctx, &state.DeleteRequest{
 		Key: tkey,
 	})
 	if err != nil {
@@ -141,7 +142,7 @@ func TestSetGetAndDelete(t *testing.T) {
 		return
 	}
 
-	_, err = store.Get(&state.GetRequest{
+	_, err = store.Get(ctx, &state.GetRequest{
 		Key: tkey,
 	})
 	if err == nil {

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -14,6 +14,7 @@ limitations under the License.
 package memcached
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -131,7 +132,7 @@ func (m *Memcached) parseTTL(req *state.SetRequest) (*int32, error) {
 	return nil, nil
 }
 
-func (m *Memcached) setValue(req *state.SetRequest) error {
+func (m *Memcached) setValue(ctx context.Context, req *state.SetRequest) error {
 	var bt []byte
 	ttl, err := m.parseTTL(req)
 	if err != nil {
@@ -151,7 +152,7 @@ func (m *Memcached) setValue(req *state.SetRequest) error {
 	return nil
 }
 
-func (m *Memcached) Delete(req *state.DeleteRequest) error {
+func (m *Memcached) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	err := m.client.Delete(req.Key)
 	if err != nil {
 		return err
@@ -160,7 +161,7 @@ func (m *Memcached) Delete(req *state.DeleteRequest) error {
 	return nil
 }
 
-func (m *Memcached) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (m *Memcached) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	item, err := m.client.Get(req.Key)
 	if err != nil {
 		// Return nil for status 204
@@ -176,10 +177,10 @@ func (m *Memcached) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}, nil
 }
 
-func (m *Memcached) Set(req *state.SetRequest) error {
-	return state.SetWithOptions(m.setValue, req)
+func (m *Memcached) Set(ctx context.Context, req *state.SetRequest) error {
+	return state.SetWithOptions(m.setValue, ctx, req)
 }
 
-func (m *Memcached) Ping() error {
+func (m *Memcached) Ping(ctx context.Context) error {
 	return nil
 }

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -159,8 +159,8 @@ func (m *MongoDB) Features() []state.Feature {
 }
 
 // Set saves state into MongoDB.
-func (m *MongoDB) Set(req *state.SetRequest) error {
-	ctx, cancel := context.WithTimeout(context.Background(), m.operationTimeout)
+func (m *MongoDB) Set(ctx context.Context, req *state.SetRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, m.operationTimeout)
 	defer cancel()
 
 	err := m.setInternal(ctx, req)
@@ -171,8 +171,8 @@ func (m *MongoDB) Set(req *state.SetRequest) error {
 	return nil
 }
 
-func (m *MongoDB) Ping() error {
-	if err := m.client.Ping(context.Background(), nil); err != nil {
+func (m *MongoDB) Ping(ctx context.Context) error {
+	if err := m.client.Ping(ctx, nil); err != nil {
 		return fmt.Errorf("mongoDB store: error connecting to mongoDB at %s: %s", m.metadata.host, err)
 	}
 
@@ -205,10 +205,10 @@ func (m *MongoDB) setInternal(ctx context.Context, req *state.SetRequest) error 
 }
 
 // Get retrieves state from MongoDB with a key.
-func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (m *MongoDB) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	var result Item
 
-	ctx, cancel := context.WithTimeout(context.Background(), m.operationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, m.operationTimeout)
 	defer cancel()
 
 	filter := bson.M{id: req.Key}
@@ -264,8 +264,8 @@ func (m *MongoDB) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // Delete performs a delete operation.
-func (m *MongoDB) Delete(req *state.DeleteRequest) error {
-	ctx, cancel := context.WithTimeout(context.Background(), m.operationTimeout)
+func (m *MongoDB) Delete(ctx context.Context, req *state.DeleteRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, m.operationTimeout)
 	defer cancel()
 
 	err := m.deleteInternal(ctx, req)

--- a/state/mysql/mysql_integration_test.go
+++ b/state/mysql/mysql_integration_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -268,7 +269,7 @@ func deleteItemThatDoesNotExist(t *testing.T, mys *MySQL) {
 		Key: randomKey(),
 	}
 
-	err := mys.Delete(deleteReq)
+	err := mys.Delete(context.Background(), deleteReq)
 	assert.Nil(t, err)
 }
 
@@ -277,7 +278,7 @@ func deleteWithNoKeyFails(t *testing.T, mys *MySQL) {
 		Key: "",
 	}
 
-	err := mys.Delete(deleteReq)
+	err := mys.Delete(context.Background(), deleteReq)
 	assert.NotNil(t, err)
 }
 
@@ -295,7 +296,7 @@ func deleteWithInvalidEtagFails(t *testing.T, mys *MySQL) {
 		ETag: &eTag,
 	}
 
-	err := mys.Delete(deleteReq)
+	err := mys.Delete(context.Background(), deleteReq)
 	assert.NotNil(t, err)
 }
 
@@ -311,7 +312,7 @@ func newItemWithEtagFails(t *testing.T, mys *MySQL) {
 		Value: value,
 	}
 
-	err := mys.Set(setReq)
+	err := mys.Set(context.Background(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -340,7 +341,7 @@ func updateWithOldETagFails(t *testing.T, mys *MySQL) {
 		Value: newValue,
 	}
 
-	err := mys.Set(setReq)
+	err := mys.Set(context.Background(), setReq)
 	assert.NotNil(t, err, "Error was not thrown using old eTag")
 }
 
@@ -379,7 +380,7 @@ func testBulkSetAndBulkDelete(t *testing.T, mys *MySQL) {
 		},
 	}
 
-	err := mys.BulkSet(setReq)
+	err := mys.BulkSet(context.Background(), setReq)
 	assert.Nil(t, err)
 	assert.True(t, storeItemExists(t, setReq[0].Key))
 	assert.True(t, storeItemExists(t, setReq[1].Key))
@@ -393,7 +394,7 @@ func testBulkSetAndBulkDelete(t *testing.T, mys *MySQL) {
 		},
 	}
 
-	err = mys.BulkDelete(deleteReq)
+	err = mys.BulkDelete(context.Background(), deleteReq)
 	assert.Nil(t, err)
 	assert.False(t, storeItemExists(t, setReq[0].Key))
 	assert.False(t, storeItemExists(t, setReq[1].Key))
@@ -404,7 +405,7 @@ func setItemWithNoKey(t *testing.T, mys *MySQL) {
 		Key: "",
 	}
 
-	err := mys.Set(setReq)
+	err := mys.Set(context.Background(), setReq)
 	assert.NotNil(t, err, "Error was not nil when setting item with no key.")
 }
 
@@ -438,7 +439,7 @@ func getItemWithNoKey(t *testing.T, mys *MySQL) {
 		Key: "",
 	}
 
-	response, getErr := mys.Get(getReq)
+	response, getErr := mys.Get(context.Background(), getReq)
 	assert.NotNil(t, getErr)
 	assert.Nil(t, response)
 }
@@ -566,7 +567,7 @@ func setItem(t *testing.T, mys *MySQL, key string, value interface{}, eTag *stri
 		Value: value,
 	}
 
-	err := mys.Set(setReq)
+	err := mys.Set(context.Background(), setReq)
 	assert.Nil(t, err, "Error setting an item")
 	itemExists := storeItemExists(t, key)
 	assert.True(t, itemExists, "Item does not exist after being set")
@@ -578,7 +579,7 @@ func getItem(t *testing.T, mys *MySQL, key string) (*state.GetResponse, *fakeIte
 		Options: state.GetStateOption{},
 	}
 
-	response, getErr := mys.Get(getReq)
+	response, getErr := mys.Get(context.Background(), getReq)
 	assert.Nil(t, getErr)
 	assert.NotNil(t, response)
 	outputObject := &fakeItem{}
@@ -594,7 +595,7 @@ func deleteItem(t *testing.T, mys *MySQL, key string, eTag *string) {
 		Options: state.DeleteStateOption{},
 	}
 
-	deleteErr := mys.Delete(deleteReq)
+	deleteErr := mys.Delete(context.Background(), deleteReq)
 	assert.Nil(t, deleteErr, "There was an error deleting a record")
 	assert.False(t, storeItemExists(t, key), "Item still exists after delete")
 }

--- a/state/mysql/mysql_test.go
+++ b/state/mysql/mysql_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -190,7 +191,7 @@ func TestMySQLBulkDeleteRollbackDeletes(t *testing.T) {
 	deletes := []state.DeleteRequest{createDeleteRequest()}
 
 	// Act
-	err := m.mySQL.BulkDelete(deletes)
+	err := m.mySQL.BulkDelete(context.Background(), deletes)
 
 	// Assert
 	assert.NotNil(t, err, "no error returned")
@@ -209,7 +210,7 @@ func TestMySQLBulkSetRollbackSets(t *testing.T) {
 	sets := []state.SetRequest{createSetRequest()}
 
 	// Act
-	err := m.mySQL.BulkSet(sets)
+	err := m.mySQL.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.NotNil(t, err, "no error returned")
@@ -258,7 +259,7 @@ func TestSetHandlesOptionsError(t *testing.T) {
 	request.Options.Consistency = "Invalid"
 
 	// Act
-	err := m.mySQL.setValue(&request)
+	err := m.mySQL.setValue(context.Background(), &request)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -273,7 +274,7 @@ func TestSetHandlesNoKey(t *testing.T) {
 	request.Key = ""
 
 	// Act
-	err := m.mySQL.Set(&request)
+	err := m.mySQL.Set(context.Background(), &request)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -293,7 +294,7 @@ func TestSetHandlesUpdate(t *testing.T) {
 	request.ETag = &eTag
 
 	// Act
-	err := m.mySQL.setValue(&request)
+	err := m.mySQL.setValue(context.Background(), &request)
 
 	// Assert
 	assert.Nil(t, err)
@@ -312,7 +313,7 @@ func TestSetHandlesErr(t *testing.T) {
 		request.ETag = &eTag
 
 		// Act
-		err := m.mySQL.setValue(&request)
+		err := m.mySQL.setValue(context.Background(), &request)
 
 		// Assert
 		assert.NotNil(t, err)
@@ -325,7 +326,7 @@ func TestSetHandlesErr(t *testing.T) {
 		request := createSetRequest()
 
 		// Act
-		err := m.mySQL.setValue(&request)
+		err := m.mySQL.setValue(context.Background(), &request)
 
 		// Assert
 		assert.NotNil(t, err)
@@ -337,7 +338,7 @@ func TestSetHandlesErr(t *testing.T) {
 		request := createSetRequest()
 
 		// Act
-		err := m.mySQL.setValue(&request)
+		err := m.mySQL.setValue(context.Background(), &request)
 
 		// Assert
 		assert.Nil(t, err)
@@ -348,7 +349,7 @@ func TestSetHandlesErr(t *testing.T) {
 		request := createSetRequest()
 
 		// Act
-		err := m.mySQL.setValue(&request)
+		err := m.mySQL.setValue(context.Background(), &request)
 
 		// Assert
 		assert.NotNil(t, err)
@@ -362,7 +363,7 @@ func TestSetHandlesErr(t *testing.T) {
 		request.ETag = &eTag
 
 		// Act
-		err := m.mySQL.setValue(&request)
+		err := m.mySQL.setValue(context.Background(), &request)
 
 		// Assert
 		assert.NotNil(t, err)
@@ -379,7 +380,7 @@ func TestMySQLDeleteHandlesNoKey(t *testing.T) {
 	request.Key = ""
 
 	// Act
-	err := m.mySQL.Delete(&request)
+	err := m.mySQL.Delete(context.Background(), &request)
 
 	// Asset
 	assert.NotNil(t, err)
@@ -398,7 +399,7 @@ func TestDeleteWithETag(t *testing.T) {
 	request.ETag = &eTag
 
 	// Act
-	err := m.mySQL.deleteValue(&request)
+	err := m.mySQL.deleteValue(context.Background(), &request)
 
 	// Assert
 	assert.Nil(t, err)
@@ -415,7 +416,7 @@ func TestDeleteWithErr(t *testing.T) {
 		request := createDeleteRequest()
 
 		// Act
-		err := m.mySQL.deleteValue(&request)
+		err := m.mySQL.deleteValue(context.Background(), &request)
 
 		// Assert
 		assert.NotNil(t, err)
@@ -430,7 +431,7 @@ func TestDeleteWithErr(t *testing.T) {
 		request.ETag = &eTag
 
 		// Act
-		err := m.mySQL.deleteValue(&request)
+		err := m.mySQL.deleteValue(context.Background(), &request)
 
 		// Assert
 		assert.NotNil(t, err)
@@ -451,7 +452,7 @@ func TestGetHandlesNoRows(t *testing.T) {
 	}
 
 	// Act
-	response, err := m.mySQL.Get(request)
+	response, err := m.mySQL.Get(context.Background(), request)
 
 	// Assert
 	assert.Nil(t, err, "returned error")
@@ -468,7 +469,7 @@ func TestGetHandlesNoKey(t *testing.T) {
 	}
 
 	// Act
-	response, err := m.mySQL.Get(request)
+	response, err := m.mySQL.Get(context.Background(), request)
 
 	// Assert
 	assert.NotNil(t, err, "returned error")
@@ -488,7 +489,7 @@ func TestGetHandlesGenericError(t *testing.T) {
 	}
 
 	// Act
-	response, err := m.mySQL.Get(request)
+	response, err := m.mySQL.Get(context.Background(), request)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -509,7 +510,7 @@ func TestGetSucceeds(t *testing.T) {
 		}
 
 		// Act
-		response, err := m.mySQL.Get(request)
+		response, err := m.mySQL.Get(context.Background(), request)
 
 		// Assert
 		assert.Nil(t, err)
@@ -527,7 +528,7 @@ func TestGetSucceeds(t *testing.T) {
 		}
 
 		// Act
-		response, err := m.mySQL.Get(request)
+		response, err := m.mySQL.Get(context.Background(), request)
 
 		// Assert
 		assert.Nil(t, err)
@@ -689,7 +690,7 @@ func TestBulkGetReturnsNil(t *testing.T) {
 	m, _ := mockDatabase(t)
 
 	// Act
-	supported, response, err := m.mySQL.BulkGet(nil)
+	supported, response, err := m.mySQL.BulkGet(context.Background(), nil)
 
 	// Assert
 	assert.Nil(t, err, `returned err`)

--- a/state/oci/objectstorage/objectstorage_integration_test.go
+++ b/state/oci/objectstorage/objectstorage_integration_test.go
@@ -4,6 +4,7 @@ package objectstorage
 // go test -v github.com/dapr/components-contrib/state/oci/objectstorage.
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -84,20 +85,20 @@ func testGet(t *testing.T, ociProperties map[string]string) {
 	statestore := NewOCIObjectStorageStore(logger.NewLogger("logger"))
 	meta := state.Metadata{}
 	meta.Properties = ociProperties
-
+	ctx := context.Background()
 	t.Run("Get an non-existing key", func(t *testing.T) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		getResponse, err := statestore.Get(&state.GetRequest{Key: "xyzq"})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: "xyzq"})
 		assert.Equal(t, &state.GetResponse{}, getResponse, "Response must be empty")
 		assert.NoError(t, err, "Non-existing key must not be treated as error")
 	})
 	t.Run("Get an existing key", func(t *testing.T) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		err = statestore.Set(&state.SetRequest{Key: "test-key", Value: []byte("test-value")})
+		err = statestore.Set(ctx, &state.SetRequest{Key: "test-key", Value: []byte("test-value")})
 		assert.Nil(t, err)
-		getResponse, err := statestore.Get(&state.GetRequest{Key: "test-key"})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: "test-key"})
 		assert.Nil(t, err)
 		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
 		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
@@ -105,9 +106,9 @@ func testGet(t *testing.T, ociProperties map[string]string) {
 	t.Run("Get an existing composed key", func(t *testing.T) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		err = statestore.Set(&state.SetRequest{Key: "test-app||test-key", Value: []byte("test-value")})
+		err = statestore.Set(ctx, &state.SetRequest{Key: "test-app||test-key", Value: []byte("test-value")})
 		assert.Nil(t, err)
-		getResponse, err := statestore.Get(&state.GetRequest{Key: "test-app||test-key"})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: "test-app||test-key"})
 		assert.Nil(t, err)
 		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
 	})
@@ -115,11 +116,11 @@ func testGet(t *testing.T, ociProperties map[string]string) {
 		testKey := "unexpired-ttl-test-key"
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
 			"ttlInSeconds": "100",
 		})})
 		assert.Nil(t, err)
-		getResponse, err := statestore.Get(&state.GetRequest{Key: testKey})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: testKey})
 		assert.Nil(t, err)
 		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set despite TTL setting")
 	})
@@ -127,23 +128,23 @@ func testGet(t *testing.T, ociProperties map[string]string) {
 		testKey := "never-expiring-ttl-test-key"
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
 			"ttlInSeconds": "-1",
 		})})
 		assert.Nil(t, err)
-		getResponse, err := statestore.Get(&state.GetRequest{Key: testKey})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: testKey})
 		assert.Nil(t, err)
 		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal (TTL setting of -1 means never expire)")
 	})
 	t.Run("Get an expired (TTL in the past) state element", func(t *testing.T) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		err = statestore.Set(&state.SetRequest{Key: "ttl-test-key", Value: []byte("test-value"), Metadata: (map[string]string{
+		err = statestore.Set(ctx, &state.SetRequest{Key: "ttl-test-key", Value: []byte("test-value"), Metadata: (map[string]string{
 			"ttlInSeconds": "1",
 		})})
 		assert.Nil(t, err)
 		time.Sleep(time.Second * 2)
-		getResponse, err := statestore.Get(&state.GetRequest{Key: "ttl-test-key"})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: "ttl-test-key"})
 		assert.Equal(t, &state.GetResponse{}, getResponse, "Response must be empty")
 		assert.NoError(t, err, "Expired element must not be treated as error")
 	})
@@ -153,10 +154,11 @@ func testSet(t *testing.T, ociProperties map[string]string) {
 	meta := state.Metadata{}
 	meta.Properties = ociProperties
 	statestore := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	ctx := context.Background()
 	t.Run("Set without a key", func(t *testing.T) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
-		err = statestore.Set(&state.SetRequest{Value: []byte("test-value")})
+		err = statestore.Set(ctx, &state.SetRequest{Value: []byte("test-value")})
 		assert.Equal(t, err, fmt.Errorf("key for value to set was missing from request"), "Lacking Key results in error")
 	})
 	t.Run("Regular Set Operation", func(t *testing.T) {
@@ -164,9 +166,9 @@ func testSet(t *testing.T, ociProperties map[string]string) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
 
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value")})
 		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		getResponse, err := statestore.Get(&state.GetRequest{Key: testKey})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: testKey})
 		assert.Nil(t, err)
 		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
 		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
@@ -176,20 +178,20 @@ func testSet(t *testing.T, ociProperties map[string]string) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
 
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value")})
 		assert.Nil(t, err, "Setting a value with a proper composite key should be errorfree")
-		getResponse, err := statestore.Get(&state.GetRequest{Key: testKey})
+		getResponse, err := statestore.Get(ctx, &state.GetRequest{Key: testKey})
 		assert.Nil(t, err)
 		assert.Equal(t, "test-value", string(getResponse.Data), "Value retrieved should be equal to value set")
 		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
 	})
 	t.Run("Regular Set Operation with TTL", func(t *testing.T) {
 		testKey := "test-key-with-ttl"
-		err := statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
+		err := statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
 			"ttlInSeconds": "500",
 		})})
 		assert.Nil(t, err, "Setting a value with a proper key and a correct TTL value should be errorfree")
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value"), Metadata: (map[string]string{
 			"ttlInSeconds": "XXX",
 		})})
 		assert.NotNil(t, err, "Setting a value with a proper key and a incorrect TTL value should be produce an error")
@@ -200,25 +202,25 @@ func testSet(t *testing.T, ociProperties map[string]string) {
 		err := statestore.Init(meta)
 		assert.Nil(t, err)
 
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value")})
 		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		getResponse, _ := statestore.Get(&state.GetRequest{Key: testKey})
+		getResponse, _ := statestore.Get(ctx, &state.GetRequest{Key: testKey})
 		etag := getResponse.ETag
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: etag, Options: state.SetStateOption{
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("overwritten-value"), ETag: etag, Options: state.SetStateOption{
 			Concurrency: state.FirstWrite,
 		}})
 		assert.Nil(t, err, "Updating value with proper etag should go fine")
 
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
 			Concurrency: state.FirstWrite,
 		}})
 		assert.NotNil(t, err, "Updating value with the old etag should be refused")
 
 		// retrieve the latest etag - assigned by the previous set operation.
-		getResponse, _ = statestore.Get(&state.GetRequest{Key: testKey})
+		getResponse, _ = statestore.Get(ctx, &state.GetRequest{Key: testKey})
 		assert.NotNil(t, *getResponse.ETag, "ETag should be set")
 		etag = getResponse.ETag
-		err = statestore.Set(&state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
+		err = statestore.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("more-overwritten-value"), ETag: etag, Options: state.SetStateOption{
 			Concurrency: state.FirstWrite,
 		}})
 		assert.Nil(t, err, "Updating value with the latest etag should be accepted")
@@ -229,10 +231,11 @@ func testDelete(t *testing.T, ociProperties map[string]string) {
 	m := state.Metadata{}
 	m.Properties = ociProperties
 	s := NewOCIObjectStorageStore(logger.NewLogger("logger"))
+	ctx := context.Background()
 	t.Run("Delete without a key", func(t *testing.T) {
 		err := s.Init(m)
 		assert.Nil(t, err)
-		err = s.Delete(&state.DeleteRequest{})
+		err = s.Delete(ctx, &state.DeleteRequest{})
 		assert.Equal(t, err, fmt.Errorf("key for value to delete was missing from request"), "Lacking Key results in error")
 	})
 	t.Run("Regular Delete Operation", func(t *testing.T) {
@@ -240,9 +243,9 @@ func testDelete(t *testing.T, ociProperties map[string]string) {
 		err := s.Init(m)
 		assert.Nil(t, err)
 
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		err = s.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value")})
 		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		err = s.Delete(&state.DeleteRequest{Key: testKey})
+		err = s.Delete(ctx, &state.DeleteRequest{Key: testKey})
 		assert.Nil(t, err, "Deleting an existing value with a proper key should be errorfree")
 	})
 	t.Run("Regular Delete Operation for composite key", func(t *testing.T) {
@@ -250,13 +253,13 @@ func testDelete(t *testing.T, ociProperties map[string]string) {
 		err := s.Init(m)
 		assert.Nil(t, err)
 
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		err = s.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value")})
 		assert.Nil(t, err, "Setting a value with a proper composite key should be errorfree")
-		err = s.Delete(&state.DeleteRequest{Key: testKey})
+		err = s.Delete(ctx, &state.DeleteRequest{Key: testKey})
 		assert.Nil(t, err, "Deleting an existing value with a proper composite key should be errorfree")
 	})
 	t.Run("Delete with an unknown key", func(t *testing.T) {
-		err := s.Delete(&state.DeleteRequest{Key: "unknownKey"})
+		err := s.Delete(ctx, &state.DeleteRequest{Key: "unknownKey"})
 		assert.Contains(t, err.Error(), "404", "Unknown Key results in error: http status code 404, object not found")
 	})
 
@@ -265,18 +268,18 @@ func testDelete(t *testing.T, ociProperties map[string]string) {
 		err := s.Init(m)
 		assert.Nil(t, err)
 		// create document.
-		err = s.Set(&state.SetRequest{Key: testKey, Value: []byte("test-value")})
+		err = s.Set(ctx, &state.SetRequest{Key: testKey, Value: []byte("test-value")})
 		assert.Nil(t, err, "Setting a value with a proper key should be errorfree")
-		getResponse, _ := s.Get(&state.GetRequest{Key: testKey})
+		getResponse, _ := s.Get(ctx, &state.GetRequest{Key: testKey})
 		etag := getResponse.ETag
 
 		incorrectETag := "someRandomETag"
-		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: &incorrectETag, Options: state.DeleteStateOption{
+		err = s.Delete(ctx, &state.DeleteRequest{Key: testKey, ETag: &incorrectETag, Options: state.DeleteStateOption{
 			Concurrency: state.FirstWrite,
 		}})
 		assert.NotNil(t, err, "Deleting value with an incorrect etag should be prevented")
 
-		err = s.Delete(&state.DeleteRequest{Key: testKey, ETag: etag, Options: state.DeleteStateOption{
+		err = s.Delete(ctx, &state.DeleteRequest{Key: testKey, ETag: etag, Options: state.DeleteStateOption{
 			Concurrency: state.FirstWrite,
 		}})
 		assert.Nil(t, err, "Deleting value with proper etag should go fine")
@@ -290,7 +293,7 @@ func testPing(t *testing.T, ociProperties map[string]string) {
 	t.Run("Ping", func(t *testing.T) {
 		err := s.Init(m)
 		assert.Nil(t, err)
-		err = s.Ping()
+		err = s.Ping(context.Background())
 		assert.Nil(t, err, "Ping should be successful")
 	})
 }

--- a/state/oracledatabase/dbaccess.go
+++ b/state/oracledatabase/dbaccess.go
@@ -14,16 +14,18 @@ limitations under the License.
 package oracledatabase
 
 import (
+	"context"
+
 	"github.com/dapr/components-contrib/state"
 )
 
 // dbAccess is a private interface which enables unit testing of Oracle Database.
 type dbAccess interface {
 	Init(metadata state.Metadata) error
-	Ping() error
-	Set(req *state.SetRequest) error
-	Get(req *state.GetRequest) (*state.GetResponse, error)
-	Delete(req *state.DeleteRequest) error
-	ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error
+	Ping(ctx context.Context) error
+	Set(ctx context.Context, req *state.SetRequest) error
+	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
+	Delete(ctx context.Context, req *state.DeleteRequest) error
+	ExecuteMulti(ctx context.Context, sets []state.SetRequest, deletes []state.DeleteRequest) error
 	Close() error // io.Closer.
 }

--- a/state/oracledatabase/oracledatabase.go
+++ b/state/oracledatabase/oracledatabase.go
@@ -14,6 +14,7 @@ limitations under the License.
 package oracledatabase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dapr/components-contrib/state"
@@ -49,8 +50,8 @@ func (o *OracleDatabase) Init(metadata state.Metadata) error {
 	return o.dbaccess.Init(metadata)
 }
 
-func (o *OracleDatabase) Ping() error {
-	return o.dbaccess.Ping()
+func (o *OracleDatabase) Ping(ctx context.Context) error {
+	return o.dbaccess.Ping(ctx)
 }
 
 // Features returns the features available in this state store.
@@ -59,38 +60,38 @@ func (o *OracleDatabase) Features() []state.Feature {
 }
 
 // Delete removes an entity from the store.
-func (o *OracleDatabase) Delete(req *state.DeleteRequest) error {
-	return o.dbaccess.Delete(req)
+func (o *OracleDatabase) Delete(ctx context.Context, req *state.DeleteRequest) error {
+	return o.dbaccess.Delete(ctx, req)
 }
 
 // BulkDelete removes multiple entries from the store.
-func (o *OracleDatabase) BulkDelete(req []state.DeleteRequest) error {
-	return o.dbaccess.ExecuteMulti(nil, req)
+func (o *OracleDatabase) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
+	return o.dbaccess.ExecuteMulti(ctx, nil, req)
 }
 
 // Get returns an entity from store.
-func (o *OracleDatabase) Get(req *state.GetRequest) (*state.GetResponse, error) {
-	return o.dbaccess.Get(req)
+func (o *OracleDatabase) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
+	return o.dbaccess.Get(ctx, req)
 }
 
 // BulkGet performs a bulks get operations.
-func (o *OracleDatabase) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (o *OracleDatabase) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	// TODO: replace with ExecuteMulti for performance.
 	return false, nil, nil
 }
 
 // Set adds/updates an entity on store.
-func (o *OracleDatabase) Set(req *state.SetRequest) error {
-	return o.dbaccess.Set(req)
+func (o *OracleDatabase) Set(ctx context.Context, req *state.SetRequest) error {
+	return o.dbaccess.Set(ctx, req)
 }
 
 // BulkSet adds/updates multiple entities on store.
-func (o *OracleDatabase) BulkSet(req []state.SetRequest) error {
-	return o.dbaccess.ExecuteMulti(req, nil)
+func (o *OracleDatabase) BulkSet(ctx context.Context, req []state.SetRequest) error {
+	return o.dbaccess.ExecuteMulti(ctx, req, nil)
 }
 
 // Multi handles multiple transactions. Implements TransactionalStore.
-func (o *OracleDatabase) Multi(request *state.TransactionalStateRequest) error {
+func (o *OracleDatabase) Multi(ctx context.Context, request *state.TransactionalStateRequest) error {
 	var deletes []state.DeleteRequest
 	var sets []state.SetRequest
 	for _, req := range request.Operations {
@@ -115,7 +116,7 @@ func (o *OracleDatabase) Multi(request *state.TransactionalStateRequest) error {
 	}
 
 	if len(sets) > 0 || len(deletes) > 0 {
-		return o.dbaccess.ExecuteMulti(sets, deletes)
+		return o.dbaccess.ExecuteMulti(ctx, sets, deletes)
 	}
 
 	return nil

--- a/state/oracledatabase/oracledatabase_test.go
+++ b/state/oracledatabase/oracledatabase_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package oracledatabase
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ type fakeDBaccess struct {
 	getExecuted  bool
 }
 
-func (m *fakeDBaccess) Ping() error {
+func (m *fakeDBaccess) Ping(ctx context.Context) error {
 	m.pingExecuted = true
 	return nil
 }
@@ -45,23 +46,23 @@ func (m *fakeDBaccess) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (m *fakeDBaccess) Set(req *state.SetRequest) error {
+func (m *fakeDBaccess) Set(ctx context.Context, req *state.SetRequest) error {
 	m.setExecuted = true
 
 	return nil
 }
 
-func (m *fakeDBaccess) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (m *fakeDBaccess) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	m.getExecuted = true
 
 	return nil, nil
 }
 
-func (m *fakeDBaccess) Delete(req *state.DeleteRequest) error {
+func (m *fakeDBaccess) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return nil
 }
 
-func (m *fakeDBaccess) ExecuteMulti(sets []state.SetRequest, deletes []state.DeleteRequest) error {
+func (m *fakeDBaccess) ExecuteMulti(ctx context.Context, sets []state.SetRequest, deletes []state.DeleteRequest) error {
 	return nil
 }
 
@@ -73,7 +74,7 @@ func (m *fakeDBaccess) Close() error {
 func TestInitRunsDBAccessInit(t *testing.T) {
 	t.Parallel()
 	ods, fake := createOracleDatabaseWithFake(t)
-	ods.Ping()
+	ods.Ping(context.Background())
 	assert.True(t, fake.initExecuted)
 }
 
@@ -81,7 +82,7 @@ func TestMultiWithNoRequestsReturnsNil(t *testing.T) {
 	t.Parallel()
 	var operations []state.TransactionalStateOperation
 	ods := createOracleDatabase(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
+	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: operations,
 	})
 	assert.Nil(t, err)
@@ -97,7 +98,7 @@ func TestInvalidMultiAction(t *testing.T) {
 	})
 
 	ods := createOracleDatabase(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
+	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: operations,
 	})
 	assert.NotNil(t, err)
@@ -113,7 +114,7 @@ func TestValidSetRequest(t *testing.T) {
 	})
 
 	ods := createOracleDatabase(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
+	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: operations,
 	})
 	assert.Nil(t, err)
@@ -129,7 +130,7 @@ func TestInvalidMultiSetRequest(t *testing.T) {
 	})
 
 	ods := createOracleDatabase(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
+	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: operations,
 	})
 	assert.NotNil(t, err)
@@ -145,7 +146,7 @@ func TestValidMultiDeleteRequest(t *testing.T) {
 	})
 
 	ods := createOracleDatabase(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
+	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: operations,
 	})
 	assert.Nil(t, err)
@@ -161,7 +162,7 @@ func TestInvalidMultiDeleteRequest(t *testing.T) {
 	})
 
 	ods := createOracleDatabase(t)
-	err := ods.Multi(&state.TransactionalStateRequest{
+	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: operations,
 	})
 	assert.NotNil(t, err)
@@ -190,7 +191,7 @@ func createOracleDatabaseWithFake(t *testing.T) (*OracleDatabase, *fakeDBaccess)
 func TestPingRunsDBAccessPing(t *testing.T) {
 	t.Parallel()
 	odb, fake := createOracleDatabaseWithFake(t)
-	odb.Ping()
+	odb.Ping(context.Background())
 	assert.True(t, fake.pingExecuted)
 }
 

--- a/state/postgresql/dbaccess.go
+++ b/state/postgresql/dbaccess.go
@@ -14,17 +14,19 @@ limitations under the License.
 package postgresql
 
 import (
+	"context"
+
 	"github.com/dapr/components-contrib/state"
 )
 
 // dbAccess is a private interface which enables unit testing of PostgreSQL.
 type dbAccess interface {
 	Init(metadata state.Metadata) error
-	Set(req *state.SetRequest) error
-	BulkSet(req []state.SetRequest) error
-	Get(req *state.GetRequest) (*state.GetResponse, error)
-	Delete(req *state.DeleteRequest) error
-	BulkDelete(req []state.DeleteRequest) error
+	Set(ctx context.Context, req *state.SetRequest) error
+	BulkSet(ctx context.Context, req []state.SetRequest) error
+	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
+	Delete(ctx context.Context, req *state.DeleteRequest) error
+	BulkDelete(ctx context.Context, req []state.DeleteRequest) error
 	ExecuteMulti(req *state.TransactionalStateRequest) error
 	Query(req *state.QueryRequest) (*state.QueryResponse, error)
 	Close() error // io.Closer

--- a/state/postgresql/postgresdbaccess_test.go
+++ b/state/postgresql/postgresdbaccess_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package postgresql
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -333,7 +334,7 @@ func TestInvalidBulkSetNoKey(t *testing.T) {
 	})
 
 	// Act
-	err := m.pgDba.BulkSet(sets)
+	err := m.pgDba.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -355,7 +356,7 @@ func TestInvalidBulkSetEmptyValue(t *testing.T) {
 	})
 
 	// Act
-	err := m.pgDba.BulkSet(sets)
+	err := m.pgDba.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -378,7 +379,7 @@ func TestValidBulkSet(t *testing.T) {
 	})
 
 	// Act
-	err := m.pgDba.BulkSet(sets)
+	err := m.pgDba.BulkSet(context.Background(), sets)
 
 	// Assert
 	assert.Nil(t, err)
@@ -399,7 +400,7 @@ func TestInvalidBulkDeleteNoKey(t *testing.T) {
 	})
 
 	// Act
-	err := m.pgDba.BulkDelete(deletes)
+	err := m.pgDba.BulkDelete(context.Background(), deletes)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -421,7 +422,7 @@ func TestValidBulkDelete(t *testing.T) {
 	})
 
 	// Act
-	err := m.pgDba.BulkDelete(deletes)
+	err := m.pgDba.BulkDelete(context.Background(), deletes)
 
 	// Assert
 	assert.Nil(t, err)

--- a/state/postgresql/postgresql.go
+++ b/state/postgresql/postgresql.go
@@ -14,6 +14,8 @@ limitations under the License.
 package postgresql
 
 import (
+	"context"
+
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
 )
@@ -47,7 +49,7 @@ func (p *PostgreSQL) Init(metadata state.Metadata) error {
 	return p.dbaccess.Init(metadata)
 }
 
-func (p *PostgreSQL) Ping() error {
+func (p *PostgreSQL) Ping(ctx context.Context) error {
 	return nil
 }
 
@@ -57,34 +59,34 @@ func (p *PostgreSQL) Features() []state.Feature {
 }
 
 // Delete removes an entity from the store.
-func (p *PostgreSQL) Delete(req *state.DeleteRequest) error {
-	return p.dbaccess.Delete(req)
+func (p *PostgreSQL) Delete(ctx context.Context, req *state.DeleteRequest) error {
+	return p.dbaccess.Delete(ctx, req)
 }
 
 // BulkDelete removes multiple entries from the store.
-func (p *PostgreSQL) BulkDelete(req []state.DeleteRequest) error {
-	return p.dbaccess.BulkDelete(req)
+func (p *PostgreSQL) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
+	return p.dbaccess.BulkDelete(ctx, req)
 }
 
 // Get returns an entity from store.
-func (p *PostgreSQL) Get(req *state.GetRequest) (*state.GetResponse, error) {
-	return p.dbaccess.Get(req)
+func (p *PostgreSQL) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
+	return p.dbaccess.Get(ctx, req)
 }
 
 // BulkGet performs a bulks get operations.
-func (p *PostgreSQL) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (p *PostgreSQL) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	// TODO: replace with ExecuteMulti for performance
 	return false, nil, nil
 }
 
 // Set adds/updates an entity on store.
-func (p *PostgreSQL) Set(req *state.SetRequest) error {
-	return p.dbaccess.Set(req)
+func (p *PostgreSQL) Set(ctx context.Context, req *state.SetRequest) error {
+	return p.dbaccess.Set(ctx, req)
 }
 
 // BulkSet adds/updates multiple entities on store.
-func (p *PostgreSQL) BulkSet(req []state.SetRequest) error {
-	return p.dbaccess.BulkSet(req)
+func (p *PostgreSQL) BulkSet(ctx context.Context, req []state.SetRequest) error {
+	return p.dbaccess.BulkSet(ctx, req)
 }
 
 // Multi handles multiple transactions. Implements TransactionalStore.

--- a/state/postgresql/postgresql_integration_test.go
+++ b/state/postgresql/postgresql_integration_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package postgresql
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -189,7 +190,7 @@ func deleteItemThatDoesNotExist(t *testing.T, pgs *PostgreSQL) {
 	deleteReq := &state.DeleteRequest{
 		Key: randomKey(),
 	}
-	err := pgs.Delete(deleteReq)
+	err := pgs.Delete(context.Background(), deleteReq)
 	assert.Nil(t, err)
 }
 
@@ -308,7 +309,7 @@ func deleteWithInvalidEtagFails(t *testing.T, pgs *PostgreSQL) {
 		Key:  key,
 		ETag: &etag,
 	}
-	err := pgs.Delete(deleteReq)
+	err := pgs.Delete(context.Background(), deleteReq)
 	assert.NotNil(t, err)
 }
 
@@ -316,7 +317,7 @@ func deleteWithNoKeyFails(t *testing.T, pgs *PostgreSQL) {
 	deleteReq := &state.DeleteRequest{
 		Key: "",
 	}
-	err := pgs.Delete(deleteReq)
+	err := pgs.Delete(context.Background(), deleteReq)
 	assert.NotNil(t, err)
 }
 
@@ -331,7 +332,7 @@ func newItemWithEtagFails(t *testing.T, pgs *PostgreSQL) {
 		Value: value,
 	}
 
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.Background(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -357,7 +358,7 @@ func updateWithOldEtagFails(t *testing.T, pgs *PostgreSQL) {
 		ETag:  originalEtag,
 		Value: newValue,
 	}
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.Background(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -399,7 +400,7 @@ func getItemWithNoKey(t *testing.T, pgs *PostgreSQL) {
 		Key: "",
 	}
 
-	response, getErr := pgs.Get(getReq)
+	response, getErr := pgs.Get(context.Background(), getReq)
 	assert.NotNil(t, getErr)
 	assert.Nil(t, response)
 }
@@ -430,7 +431,7 @@ func setItemWithNoKey(t *testing.T, pgs *PostgreSQL) {
 		Key: "",
 	}
 
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.Background(), setReq)
 	assert.NotNil(t, err)
 }
 
@@ -447,7 +448,7 @@ func testBulkSetAndBulkDelete(t *testing.T, pgs *PostgreSQL) {
 		},
 	}
 
-	err := pgs.BulkSet(setReq)
+	err := pgs.BulkSet(context.Background(), setReq)
 	assert.Nil(t, err)
 	assert.True(t, storeItemExists(t, setReq[0].Key))
 	assert.True(t, storeItemExists(t, setReq[1].Key))
@@ -461,7 +462,7 @@ func testBulkSetAndBulkDelete(t *testing.T, pgs *PostgreSQL) {
 		},
 	}
 
-	err = pgs.BulkDelete(deleteReq)
+	err = pgs.BulkDelete(context.Background(), deleteReq)
 	assert.Nil(t, err)
 	assert.False(t, storeItemExists(t, setReq[0].Key))
 	assert.False(t, storeItemExists(t, setReq[1].Key))
@@ -518,7 +519,7 @@ func setItem(t *testing.T, pgs *PostgreSQL, key string, value interface{}, etag 
 		Value: value,
 	}
 
-	err := pgs.Set(setReq)
+	err := pgs.Set(context.Background(), setReq)
 	assert.Nil(t, err)
 	itemExists := storeItemExists(t, key)
 	assert.True(t, itemExists)
@@ -530,7 +531,7 @@ func getItem(t *testing.T, pgs *PostgreSQL, key string) (*state.GetResponse, *fa
 		Options: state.GetStateOption{},
 	}
 
-	response, getErr := pgs.Get(getReq)
+	response, getErr := pgs.Get(context.Background(), getReq)
 	assert.Nil(t, getErr)
 	assert.NotNil(t, response)
 	outputObject := &fakeItem{}
@@ -546,7 +547,7 @@ func deleteItem(t *testing.T, pgs *PostgreSQL, key string, etag *string) {
 		Options: state.DeleteStateOption{},
 	}
 
-	deleteErr := pgs.Delete(deleteReq)
+	deleteErr := pgs.Delete(context.Background(), deleteReq)
 	assert.Nil(t, deleteErr)
 	assert.False(t, storeItemExists(t, key))
 }

--- a/state/postgresql/postgresql_test.go
+++ b/state/postgresql/postgresql_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package postgresql
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,29 +41,29 @@ func (m *fakeDBaccess) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (m *fakeDBaccess) Set(req *state.SetRequest) error {
+func (m *fakeDBaccess) Set(ctx context.Context, req *state.SetRequest) error {
 	m.setExecuted = true
 
 	return nil
 }
 
-func (m *fakeDBaccess) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (m *fakeDBaccess) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	m.getExecuted = true
 
 	return nil, nil
 }
 
-func (m *fakeDBaccess) Delete(req *state.DeleteRequest) error {
+func (m *fakeDBaccess) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	m.deleteExecuted = true
 
 	return nil
 }
 
-func (m *fakeDBaccess) BulkSet(req []state.SetRequest) error {
+func (m *fakeDBaccess) BulkSet(ctx context.Context, req []state.SetRequest) error {
 	return nil
 }
 
-func (m *fakeDBaccess) BulkDelete(req []state.DeleteRequest) error {
+func (m *fakeDBaccess) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
 	return nil
 }
 

--- a/state/redis/redis_test.go
+++ b/state/redis/redis_test.go
@@ -273,7 +273,7 @@ func TestTransactionalDelete(t *testing.T) {
 	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	// Insert a record first.
-	ss.Set(&state.SetRequest{
+	ss.Set(context.Background(), &state.SetRequest{
 		Key:   "weapon",
 		Value: "deathstar",
 	})
@@ -307,12 +307,12 @@ func TestPing(t *testing.T) {
 		clientSettings: &rediscomponent.Settings{},
 	}
 
-	err := ss.Ping()
+	err := ss.Ping(context.Background())
 	assert.NoError(t, err)
 
 	s.Close()
 
-	err = ss.Ping()
+	err = ss.Ping(context.Background())
 	assert.Error(t, err)
 }
 
@@ -331,7 +331,7 @@ func TestRequestsWithGlobalTTL(t *testing.T) {
 	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	t.Run("TTL: Only global specified", func(t *testing.T) {
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon100",
 			Value: "deathstar100",
 		})
@@ -342,7 +342,7 @@ func TestRequestsWithGlobalTTL(t *testing.T) {
 
 	t.Run("TTL: Global and Request specified", func(t *testing.T) {
 		requestTTL := 200
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon100",
 			Value: "deathstar100",
 			Metadata: map[string]string{
@@ -424,7 +424,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 
 	t.Run("TTL specified", func(t *testing.T) {
 		ttlInSeconds := 100
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon100",
 			Value: "deathstar100",
 			Metadata: map[string]string{
@@ -438,7 +438,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 	})
 
 	t.Run("TTL not specified", func(t *testing.T) {
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon200",
 			Value: "deathstar200",
 		})
@@ -449,7 +449,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 	})
 
 	t.Run("TTL Changed for Existing Key", func(t *testing.T) {
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon300",
 			Value: "deathstar300",
 		})
@@ -458,7 +458,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 
 		// make the key no longer persistent
 		ttlInSeconds := 123
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon300",
 			Value: "deathstar300",
 			Metadata: map[string]string{
@@ -469,7 +469,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 		assert.Equal(t, time.Duration(ttlInSeconds)*time.Second, ttl)
 
 		// make the key persistent again
-		ss.Set(&state.SetRequest{
+		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon300",
 			Value: "deathstar301",
 			Metadata: map[string]string{
@@ -493,7 +493,7 @@ func TestTransactionalDeleteNoEtag(t *testing.T) {
 	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	// Insert a record first.
-	ss.Set(&state.SetRequest{
+	ss.Set(context.Background(), &state.SetRequest{
 		Key:   "weapon100",
 		Value: "deathstar100",
 	})

--- a/state/request_options.go
+++ b/state/request_options.go
@@ -14,6 +14,7 @@ limitations under the License.
 package state
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -68,11 +69,11 @@ func validateConsistencyOption(c string) error {
 }
 
 // SetWithOptions handles SetRequest with request options.
-func SetWithOptions(method func(req *SetRequest) error, req *SetRequest) error {
-	return method(req)
+func SetWithOptions(method func(ctx context.Context, req *SetRequest) error, ctx context.Context, req *SetRequest) error {
+	return method(ctx, req)
 }
 
 // DeleteWithOptions handles DeleteRequest with options.
-func DeleteWithOptions(method func(req *DeleteRequest) error, req *DeleteRequest) error {
-	return method(req)
+func DeleteWithOptions(method func(ctx context.Context, req *DeleteRequest) error, ctx context.Context, req *DeleteRequest) error {
+	return method(ctx, req)
 }

--- a/state/request_options_test.go
+++ b/state/request_options_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package state
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,21 +24,21 @@ import (
 func TestSetRequestWithOptions(t *testing.T) {
 	t.Run("set with default options", func(t *testing.T) {
 		counter := 0
-		SetWithOptions(func(req *SetRequest) error {
+		SetWithOptions(func(ctx context.Context, req *SetRequest) error {
 			counter++
 
 			return nil
-		}, &SetRequest{})
+		}, context.Background(), &SetRequest{})
 		assert.Equal(t, 1, counter, "should execute only once")
 	})
 
 	t.Run("set with no explicit options", func(t *testing.T) {
 		counter := 0
-		SetWithOptions(func(req *SetRequest) error {
+		SetWithOptions(func(ctx context.Context, req *SetRequest) error {
 			counter++
 
 			return nil
-		}, &SetRequest{
+		}, context.Background(), &SetRequest{
 			Options: SetStateOption{},
 		})
 		assert.Equal(t, 1, counter, "should execute only once")

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/agrea/ptr"
 	mssql "github.com/denisenkom/go-mssqldb"
+	"golang.org/x/net/context"
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/components-contrib/state/utils"
@@ -332,7 +333,7 @@ func (s *SQLServer) getTable(metadata state.Metadata) error {
 	return nil
 }
 
-func (s *SQLServer) Ping() error {
+func (s *SQLServer) Ping(ctx context.Context) error {
 	return nil
 }
 
@@ -414,7 +415,7 @@ func (s *SQLServer) getDeletes(req state.TransactionalStateOperation) (state.Del
 }
 
 // Delete removes an entity from the store.
-func (s *SQLServer) Delete(req *state.DeleteRequest) error {
+func (s *SQLServer) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return s.executeDelete(s.db, req)
 }
 
@@ -460,7 +461,7 @@ type TvpDeleteTableStringKey struct {
 }
 
 // BulkDelete removes multiple entries from the store.
-func (s *SQLServer) BulkDelete(req []state.DeleteRequest) error {
+func (s *SQLServer) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -517,7 +518,7 @@ func (s *SQLServer) executeBulkDelete(db dbExecutor, req []state.DeleteRequest) 
 }
 
 // Get returns an entity from store.
-func (s *SQLServer) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (s *SQLServer) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	rows, err := s.db.Query(s.getCommand, sql.Named(keyColumnName, req.Key))
 	if err != nil {
 		return nil, err
@@ -549,12 +550,12 @@ func (s *SQLServer) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // BulkGet performs a bulks get operations.
-func (s *SQLServer) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (s *SQLServer) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	return false, nil, nil
 }
 
 // Set adds/updates an entity on store.
-func (s *SQLServer) Set(req *state.SetRequest) error {
+func (s *SQLServer) Set(ctx context.Context, req *state.SetRequest) error {
 	return s.executeSet(s.db, req)
 }
 
@@ -608,7 +609,7 @@ func (s *SQLServer) executeSet(db dbExecutor, req *state.SetRequest) error {
 }
 
 // BulkSet adds/updates multiple entities on store.
-func (s *SQLServer) BulkSet(req []state.SetRequest) error {
+func (s *SQLServer) BulkSet(ctx context.Context, req []state.SetRequest) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err

--- a/state/store.go
+++ b/state/store.go
@@ -13,22 +13,24 @@ limitations under the License.
 
 package state
 
+import "context"
+
 // Store is an interface to perform operations on store.
 type Store interface {
 	BulkStore
 	Init(metadata Metadata) error
 	Features() []Feature
-	Delete(req *DeleteRequest) error
-	Get(req *GetRequest) (*GetResponse, error)
-	Set(req *SetRequest) error
-	Ping() error
+	Delete(ctx context.Context, req *DeleteRequest) error
+	Get(ctx context.Context, req *GetRequest) (*GetResponse, error)
+	Set(ctx context.Context, req *SetRequest) error
+	Ping(ctx context.Context) error
 }
 
 // BulkStore is an interface to perform bulk operations on store.
 type BulkStore interface {
-	BulkDelete(req []DeleteRequest) error
-	BulkGet(req []GetRequest) (bool, []BulkGetResponse, error)
-	BulkSet(req []SetRequest) error
+	BulkDelete(ctx context.Context, req []DeleteRequest) error
+	BulkGet(ctx context.Context, req []GetRequest) (bool, []BulkGetResponse, error)
+	BulkSet(ctx context.Context, req []SetRequest) error
 }
 
 // DefaultBulkStore is a default implementation of BulkStore.
@@ -50,16 +52,16 @@ func (b *DefaultBulkStore) Features() []Feature {
 }
 
 // BulkGet performs a bulks get operations.
-func (b *DefaultBulkStore) BulkGet(req []GetRequest) (bool, []BulkGetResponse, error) {
+func (b *DefaultBulkStore) BulkGet(ctx context.Context, req []GetRequest) (bool, []BulkGetResponse, error) {
 	// by default, the store doesn't support bulk get
 	// return false so daprd will fallback to call get() method one by one
 	return false, nil, nil
 }
 
 // BulkSet performs a bulks save operation.
-func (b *DefaultBulkStore) BulkSet(req []SetRequest) error {
+func (b *DefaultBulkStore) BulkSet(ctx context.Context, req []SetRequest) error {
 	for i := range req {
-		err := b.s.Set(&req[i])
+		err := b.s.Set(ctx, &req[i])
 		if err != nil {
 			return err
 		}
@@ -69,9 +71,9 @@ func (b *DefaultBulkStore) BulkSet(req []SetRequest) error {
 }
 
 // BulkDelete performs a bulk delete operation.
-func (b *DefaultBulkStore) BulkDelete(req []DeleteRequest) error {
+func (b *DefaultBulkStore) BulkDelete(ctx context.Context, req []DeleteRequest) error {
 	for i := range req {
-		err := b.s.Delete(&req[i])
+		err := b.s.Delete(ctx, &req[i])
 		if err != nil {
 			return err
 		}

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package state
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,23 +26,23 @@ func TestStore_withDefaultBulkImpl(t *testing.T) {
 	var store Store = s
 	require.Equal(t, s.count, 0)
 	require.Equal(t, s.bulkCount, 0)
-
-	store.Get(&GetRequest{})
-	store.Set(&SetRequest{})
-	store.Delete(&DeleteRequest{})
+	ctx := context.Background()
+	store.Get(ctx, &GetRequest{})
+	store.Set(ctx, &SetRequest{})
+	store.Delete(ctx, &DeleteRequest{})
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 0, s.bulkCount)
 
-	bulkGet, responses, err := store.BulkGet([]GetRequest{{}, {}, {}})
+	bulkGet, responses, err := store.BulkGet(ctx, []GetRequest{{}, {}, {}})
 	require.Equal(t, false, bulkGet)
 	require.Equal(t, 0, len(responses))
 	require.NoError(t, err)
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 0, s.bulkCount)
-	store.BulkSet([]SetRequest{{}, {}, {}, {}})
+	store.BulkSet(ctx, []SetRequest{{}, {}, {}, {}})
 	require.Equal(t, 3+4, s.count)
 	require.Equal(t, 0, s.bulkCount)
-	store.BulkDelete([]DeleteRequest{{}, {}, {}, {}, {}})
+	store.BulkDelete(ctx, []DeleteRequest{{}, {}, {}, {}, {}})
 	require.Equal(t, 3+4+5, s.count)
 	require.Equal(t, 0, s.bulkCount)
 }
@@ -51,21 +52,21 @@ func TestStore_withCustomisedBulkImpl_notSupportBulkGet(t *testing.T) {
 	var store Store = s
 	require.Equal(t, s.count, 0)
 	require.Equal(t, s.bulkCount, 0)
-
-	store.Get(&GetRequest{})
-	store.Set(&SetRequest{})
-	store.Delete(&DeleteRequest{})
+	ctx := context.Background()
+	store.Get(ctx, &GetRequest{})
+	store.Set(ctx, &SetRequest{})
+	store.Delete(ctx, &DeleteRequest{})
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 0, s.bulkCount)
 
-	bulkGet, _, _ := store.BulkGet([]GetRequest{{}, {}, {}})
+	bulkGet, _, _ := store.BulkGet(ctx, []GetRequest{{}, {}, {}})
 	require.Equal(t, false, bulkGet)
 	require.Equal(t, 6, s.count)
 	require.Equal(t, 0, s.bulkCount)
-	store.BulkSet([]SetRequest{{}, {}, {}, {}})
+	store.BulkSet(ctx, []SetRequest{{}, {}, {}, {}})
 	require.Equal(t, 6, s.count)
 	require.Equal(t, 1, s.bulkCount)
-	store.BulkDelete([]DeleteRequest{{}, {}, {}, {}, {}})
+	store.BulkDelete(ctx, []DeleteRequest{{}, {}, {}, {}, {}})
 	require.Equal(t, 6, s.count)
 	require.Equal(t, 2, s.bulkCount)
 }
@@ -75,21 +76,21 @@ func TestStore_withCustomisedBulkImpl_supportBulkGet(t *testing.T) {
 	var store Store = s
 	require.Equal(t, s.count, 0)
 	require.Equal(t, s.bulkCount, 0)
-
-	store.Get(&GetRequest{})
-	store.Set(&SetRequest{})
-	store.Delete(&DeleteRequest{})
+	ctx := context.Background()
+	store.Get(ctx, &GetRequest{})
+	store.Set(ctx, &SetRequest{})
+	store.Delete(ctx, &DeleteRequest{})
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 0, s.bulkCount)
 
-	bulkGet, _, _ := store.BulkGet([]GetRequest{{}, {}, {}})
+	bulkGet, _, _ := store.BulkGet(ctx, []GetRequest{{}, {}, {}})
 	require.Equal(t, true, bulkGet)
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 1, s.bulkCount)
-	store.BulkSet([]SetRequest{{}, {}, {}, {}})
+	store.BulkSet(ctx, []SetRequest{{}, {}, {}, {}})
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 2, s.bulkCount)
-	store.BulkDelete([]DeleteRequest{{}, {}, {}, {}, {}})
+	store.BulkDelete(ctx, []DeleteRequest{{}, {}, {}, {}, {}})
 	require.Equal(t, 3, s.count)
 	require.Equal(t, 3, s.bulkCount)
 }
@@ -110,25 +111,25 @@ func (s *Store1) Init(metadata Metadata) error {
 	return nil
 }
 
-func (s *Store1) Delete(req *DeleteRequest) error {
+func (s *Store1) Delete(ctx context.Context, req *DeleteRequest) error {
 	s.count++
 
 	return nil
 }
 
-func (s *Store1) Get(req *GetRequest) (*GetResponse, error) {
+func (s *Store1) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
 	s.count++
 
 	return &GetResponse{}, nil
 }
 
-func (s *Store1) Set(req *SetRequest) error {
+func (s *Store1) Set(ctx context.Context, req *SetRequest) error {
 	s.count++
 
 	return nil
 }
 
-func (s *Store1) Ping() error {
+func (s *Store1) Ping(ctx context.Context) error {
 	return nil
 }
 
@@ -149,29 +150,29 @@ func (s *Store2) Features() []Feature {
 	return nil
 }
 
-func (s *Store2) Delete(req *DeleteRequest) error {
+func (s *Store2) Delete(ctx context.Context, req *DeleteRequest) error {
 	s.count++
 
 	return nil
 }
 
-func (s *Store2) Get(req *GetRequest) (*GetResponse, error) {
+func (s *Store2) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
 	s.count++
 
 	return &GetResponse{}, nil
 }
 
-func (s *Store2) Set(req *SetRequest) error {
+func (s *Store2) Set(ctx context.Context, req *SetRequest) error {
 	s.count++
 
 	return nil
 }
 
-func (s *Store2) Ping() error {
+func (s *Store2) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store2) BulkGet(req []GetRequest) (bool, []BulkGetResponse, error) {
+func (s *Store2) BulkGet(ctx context.Context, req []GetRequest) (bool, []BulkGetResponse, error) {
 	if s.supportBulkGet {
 		s.bulkCount++
 
@@ -183,13 +184,13 @@ func (s *Store2) BulkGet(req []GetRequest) (bool, []BulkGetResponse, error) {
 	return false, nil, nil
 }
 
-func (s *Store2) BulkSet(req []SetRequest) error {
+func (s *Store2) BulkSet(ctx context.Context, req []SetRequest) error {
 	s.bulkCount++
 
 	return nil
 }
 
-func (s *Store2) BulkDelete(req []DeleteRequest) error {
+func (s *Store2) BulkDelete(ctx context.Context, req []DeleteRequest) error {
 	s.bulkCount++
 
 	return nil

--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -14,6 +14,7 @@ limitations under the License.
 package zookeeper
 
 import (
+	"context"
 	"errors"
 	"path"
 	"strconv"
@@ -161,7 +162,7 @@ func (s *StateStore) Features() []state.Feature {
 }
 
 // Get retrieves state from Zookeeper with a key.
-func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (s *StateStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	value, stat, err := s.conn.Get(s.prefixedKey(req.Key))
 	if err != nil {
 		if errors.Is(err, zk.ErrNoNode) {
@@ -178,19 +179,19 @@ func (s *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 }
 
 // BulkGet performs a bulks get operations.
-func (s *StateStore) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (s *StateStore) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	// TODO: replace with Multi for performance
 	return false, nil, nil
 }
 
 // Delete performs a delete operation.
-func (s *StateStore) Delete(req *state.DeleteRequest) error {
+func (s *StateStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	r, err := s.newDeleteRequest(req)
 	if err != nil {
 		return err
 	}
 
-	return state.DeleteWithOptions(func(req *state.DeleteRequest) error {
+	return state.DeleteWithOptions(func(ctx context.Context, req *state.DeleteRequest) error {
 		err := s.conn.Delete(r.Path, r.Version)
 		if errors.Is(err, zk.ErrNoNode) {
 			return nil
@@ -205,11 +206,11 @@ func (s *StateStore) Delete(req *state.DeleteRequest) error {
 		}
 
 		return nil
-	}, req)
+	}, ctx, req)
 }
 
 // BulkDelete performs a bulk delete operation.
-func (s *StateStore) BulkDelete(reqs []state.DeleteRequest) error {
+func (s *StateStore) BulkDelete(ctx context.Context, reqs []state.DeleteRequest) error {
 	ops := make([]interface{}, 0, len(reqs))
 
 	for i := range reqs {
@@ -236,13 +237,13 @@ func (s *StateStore) BulkDelete(reqs []state.DeleteRequest) error {
 }
 
 // Set saves state into Zookeeper.
-func (s *StateStore) Set(req *state.SetRequest) error {
+func (s *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	r, err := s.newSetDataRequest(req)
 	if err != nil {
 		return err
 	}
 
-	return state.SetWithOptions(func(req *state.SetRequest) error {
+	return state.SetWithOptions(func(ctx context.Context, req *state.SetRequest) error {
 		_, err = s.conn.Set(r.Path, r.Data, r.Version)
 
 		if errors.Is(err, zk.ErrNoNode) {
@@ -258,11 +259,11 @@ func (s *StateStore) Set(req *state.SetRequest) error {
 		}
 
 		return nil
-	}, req)
+	}, ctx, req)
 }
 
 // BulkSet performs a bulks save operation.
-func (s *StateStore) BulkSet(reqs []state.SetRequest) error {
+func (s *StateStore) BulkSet(ctx context.Context, reqs []state.SetRequest) error {
 	ops := make([]interface{}, 0, len(reqs))
 
 	for i := range reqs {
@@ -303,7 +304,7 @@ func (s *StateStore) BulkSet(reqs []state.SetRequest) error {
 	}
 }
 
-func (s *StateStore) Ping() error {
+func (s *StateStore) Ping(ctx context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: pigletfly <wangbing.adam@gmail.com>

# Description

add context in state interface:

```
type Store interface {
	BulkStore
	Init(metadata Metadata) error
	Features() []Feature
	Delete(ctx context.Context, req *DeleteRequest) error
	Get(ctx context.Context, req *GetRequest) (*GetResponse, error)
	Set(ctx context.Context, req *SetRequest) error
	Ping(ctx context.Context) error
}
```


## Issue reference

https://github.com/dapr/dapr/issues/2716
https://github.com/dapr/components-contrib/issues/1601

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
