### PR TITLE
Tweaks for ASB pubsub

### DIFF
--- a/bindings/azure/servicebusqueues/servicebusqueues_test.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues_test.go
@@ -39,14 +39,14 @@ func TestParseMetadata(t *testing.T) {
 			properties:               map[string]string{"connectionString": "connString", "queueName": "queue1"},
 			expectedConnectionString: "connString",
 			expectedQueueName:        "queue1",
-			expectedTTL:              AzureServiceBusDefaultMessageTimeToLive,
+			expectedTTL:              azureServiceBusDefaultMessageTimeToLive,
 		},
 		{
 			name:                     "Empty TTL",
 			properties:               map[string]string{"connectionString": "connString", "queueName": "queue1", metadata.TTLMetadataKey: ""},
 			expectedConnectionString: "connString",
 			expectedQueueName:        "queue1",
-			expectedTTL:              AzureServiceBusDefaultMessageTimeToLive,
+			expectedTTL:              azureServiceBusDefaultMessageTimeToLive,
 		},
 		{
 			name:                     "With TTL",

--- a/go.mod
+++ b/go.mod
@@ -162,6 +162,7 @@ require (
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.87
 	github.com/labd/commercetools-go-sdk v0.3.2
 	github.com/nacos-group/nacos-sdk-go/v2 v2.0.1
+	go.uber.org/ratelimit v0.2.0
 	gopkg.in/couchbase/gocb.v1 v1.6.4
 )
 
@@ -171,6 +172,7 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.1.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 // indirect
+	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/appscode/go-querystring v0.0.0-20170504095604-0126cfb3f1dc // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/aliyun/credentials-go v1.1.2 h1:qU1vwGIBb3UJ8BwunHDRFtAhS6jnQLnde/yk0
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=
 github.com/aliyunmq/mq-http-go-sdk v1.0.3 h1:/uhH7DUoaw9XTtsPgDp7zdPUyG5FBKj2GmJJph9z+6o=
 github.com/aliyunmq/mq-http-go-sdk v1.0.3/go.mod h1:JYfRMQoPexERvnNNBcal0ZQ2TVQ5ialDiW9ScjaadEM=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.2 h1:JKnhI/XQ75uFBTiuzXpzFrUriDPiZjlOSzh6wXogP0E=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
@@ -1402,6 +1404,8 @@ go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKY
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -25,6 +25,7 @@ type metadata struct {
 	MaxReconnectionAttempts         int    `json:"maxReconnectionAttempts"`
 	ConnectionRecoveryInSec         int    `json:"connectionRecoveryInSec"`
 	DisableEntityManagement         bool   `json:"disableEntityManagement"`
+	MaxRetriableErrorsPerSec        int    `json:"MaxRetriableErrorsPerSec"`
 	MaxDeliveryCount                *int   `json:"maxDeliveryCount"`
 	LockDurationInSec               *int   `json:"lockDurationInSec"`
 	DefaultMessageTimeToLiveInSec   *int   `json:"defaultMessageTimeToLiveInSec"`
@@ -34,3 +35,39 @@ type metadata struct {
 	PublishInitialRetryIntervalInMs int    `json:"publishInitialRetryInternalInMs"`
 	NamespaceName                   string `json:"namespaceName,omitempty"`
 }
+
+const (
+	// Keys.
+	connectionString                = "connectionString"
+	consumerID                      = "consumerID"
+	timeoutInSec                    = "timeoutInSec"
+	handlerTimeoutInSec             = "handlerTimeoutInSec"
+	lockRenewalInSec                = "lockRenewalInSec"
+	maxActiveMessages               = "maxActiveMessages"
+	maxReconnectionAttempts         = "maxReconnectionAttempts"
+	connectionRecoveryInSec         = "connectionRecoveryInSec"
+	disableEntityManagement         = "disableEntityManagement"
+	maxRetriableErrorsPerSec        = "maxRetriableErrorsPerSec"
+	maxDeliveryCount                = "maxDeliveryCount"
+	lockDurationInSec               = "lockDurationInSec"
+	defaultMessageTimeToLiveInSec   = "defaultMessageTimeToLiveInSec"
+	autoDeleteOnIdleInSec           = "autoDeleteOnIdleInSec"
+	maxConcurrentHandlers           = "maxConcurrentHandlers"
+	publishMaxRetries               = "publishMaxRetries"
+	publishInitialRetryInternalInMs = "publishInitialRetryInternalInMs"
+	namespaceName                   = "namespaceName"
+
+	// Defaults.
+	defaultTimeoutInSec             = 60
+	defaultHandlerTimeoutInSec      = 60
+	defaultLockRenewalInSec         = 20
+	defaultMaxRetriableErrorsPerSec = 10
+	// ASB Messages can be up to 256Kb. 10000 messages at this size would roughly use 2.56Gb.
+	// We should change this if performance testing suggests a more sensible default.
+	defaultMaxActiveMessages               = 10000
+	defaultDisableEntityManagement         = false
+	defaultMaxReconnectionAttempts         = 30
+	defaultConnectionRecoveryInSec         = 2
+	defaultPublishMaxRetries               = 5
+	defaultPublishInitialRetryInternalInMs = 500
+)

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -463,6 +463,12 @@ func (a *azureServiceBus) Subscribe(req pubsub.SubscribeRequest, handler pubsub.
 			sub.close(ctx)
 			cancel()
 
+			// If context was canceled, do not attempt to reconnect
+			if a.ctx.Err() != nil {
+				a.logger.Debug("Context canceled; will not try to reconnect")
+				return
+			}
+
 			attempts := readAttemptsStale()
 			if attempts == 0 {
 				a.logger.Errorf("Subscription to topic %s lost connection, unable to recover after %d attempts", sub.topic, a.metadata.MaxReconnectionAttempts)

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -42,6 +42,7 @@ func getFakeProperties() map[string]string {
 		maxActiveMessages:             "100",
 		maxReconnectionAttempts:       "30",
 		connectionRecoveryInSec:       "5",
+		maxRetriableErrorsPerSec:      "50",
 	}
 }
 
@@ -72,6 +73,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 30, m.MaxReconnectionAttempts)
 		assert.NotNil(t, m.ConnectionRecoveryInSec)
 		assert.Equal(t, 5, m.ConnectionRecoveryInSec)
+		assert.Equal(t, 50, m.MaxRetriableErrorsPerSec)
 
 		assert.NotNil(t, m.AutoDeleteOnIdleInSec)
 		assert.Equal(t, 240, *m.AutoDeleteOnIdleInSec)
@@ -182,7 +184,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		m, err := parseAzureServiceBusMetadata(fakeMetaData)
 
 		// assert.
-		assert.Equal(t, 60, m.TimeoutInSec)
+		assert.Equal(t, defaultTimeoutInSec, m.TimeoutInSec)
 		assert.Nil(t, err)
 	})
 
@@ -246,7 +248,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		m, err := parseAzureServiceBusMetadata(fakeMetaData)
 
 		// assert.
-		assert.Equal(t, 60, m.HandlerTimeoutInSec)
+		assert.Equal(t, defaultHandlerTimeoutInSec, m.HandlerTimeoutInSec)
 		assert.Nil(t, err)
 	})
 
@@ -278,7 +280,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		m, err := parseAzureServiceBusMetadata(fakeMetaData)
 
 		// assert.
-		assert.Equal(t, 20, m.LockRenewalInSec)
+		assert.Equal(t, defaultLockRenewalInSec, m.LockRenewalInSec)
 		assert.Nil(t, err)
 	})
 
@@ -292,6 +294,54 @@ func TestParseServiceBusMetadata(t *testing.T) {
 
 		// act.
 		_, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert.
+		assert.Error(t, err)
+		assertValidErrorMessage(t, err)
+	})
+
+	t.Run("missing optional MaxRetriableErrorsPerSec", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[maxRetriableErrorsPerSec] = ""
+
+		// act.
+		m, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert.
+		assert.Equal(t, defaultMaxRetriableErrorsPerSec, m.MaxRetriableErrorsPerSec)
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid optional MaxRetriableErrorsPerSec", func(t *testing.T) {
+		// NaN: Not a Number
+		fakeProperties := getFakeProperties()
+
+		fakeMetaData := pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[maxRetriableErrorsPerSec] = invalidNumber
+
+		// act.
+		_, err := parseAzureServiceBusMetadata(fakeMetaData)
+
+		// assert.
+		assert.Error(t, err)
+		assertValidErrorMessage(t, err)
+
+		// Negative number
+		fakeProperties = getFakeProperties()
+
+		fakeMetaData = pubsub.Metadata{
+			Properties: fakeProperties,
+		}
+		fakeMetaData.Properties[maxRetriableErrorsPerSec] = "-1"
+
+		// act.
+		_, err = parseAzureServiceBusMetadata(fakeMetaData)
 
 		// assert.
 		assert.Error(t, err)

--- a/pubsub/azure/servicebus/subscription.go
+++ b/pubsub/azure/servicebus/subscription.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 
 	"github.com/dapr/components-contrib/pubsub"
@@ -246,6 +247,8 @@ func (s *subscription) tryRenewLocks() {
 
 func (s *subscription) abandonMessage(ctx context.Context, m *azservicebus.ReceivedMessage) error {
 	s.logger.Debugf("Abandoning message %s on topic %s", m.MessageID, s.topic)
+	// Add a lock (of a fixed duration) to prevent the messages from being redelivered right away
+	m.LockedUntil = to.Ptr(time.Now().Add(2 * time.Second))
 	return s.receiver.AbandonMessage(ctx, m, nil)
 }
 

--- a/pubsub/azure/servicebus/subscription.go
+++ b/pubsub/azure/servicebus/subscription.go
@@ -99,6 +99,7 @@ func (s *subscription) ReceiveAndBlock(handler pubsub.Handler, lockRenewalInSec 
 		select {
 		// This blocks if there are too many active messages already
 		case s.activeMessagesChan <- struct{}{}:
+		// Return if context is canceled
 		case <-s.ctx.Done():
 			s.logger.Debugf("Receive context for topic %s done", s.topic)
 			return s.ctx.Err()
@@ -157,7 +158,7 @@ func (s *subscription) getHandlerFunc(handler pubsub.Handler) func(ctx context.C
 
 		// This context is used for the calls to service bus to finalize (i.e. complete/abandon) the message.
 		// If we fail to finalize the message, this message will eventually be reprocessed (at-least once delivery).
-		finalizeCtx, finalizeCancel := context.WithTimeout(ctx, timeout)
+		finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), timeout)
 		defer finalizeCancel()
 
 		if appErr != nil {

--- a/pubsub/azure/servicebus/subscription.go
+++ b/pubsub/azure/servicebus/subscription.go
@@ -65,7 +65,7 @@ func newSubscription(
 		cancel:             cancel,
 	}
 
-	if maxRetriableEPS > 1 {
+	if maxRetriableEPS > 0 {
 		s.retriableErrLimit = ratelimit.New(maxRetriableEPS)
 	} else {
 		s.retriableErrLimit = ratelimit.NewUnlimited()

--- a/tests/certification/bindings/azure/servicebusqueues/go.mod
+++ b/tests/certification/bindings/azure/servicebusqueues/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/andybalholm/brotli v1.0.2 // indirect
 	github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f // indirect
 	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 // indirect
@@ -111,6 +112,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v0.20.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect

--- a/tests/certification/bindings/azure/servicebusqueues/go.sum
+++ b/tests/certification/bindings/azure/servicebusqueues/go.sum
@@ -124,6 +124,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.2 h1:JKnhI/XQ75uFBTiuzXpzFrUriDPiZjlOSzh6wXogP0E=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
@@ -716,6 +718,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=


### PR DESCRIPTION
1. Implement a rate limit when messages are retried, as per conversation with @artursouza . Because when a message is abandoned in ASB it gets re-queued immediately and sent to someone else, we need to slow down or in certain situations we can consume all max retries of messages too quickly (possibly at the rate of 100's per second)
   - This required adding a new metadata key `maxRetriableErrorsPerSec` in both pubsub and binding
1. Binding: previously, the binding was reconnecting to ASB after receiving every single message. Now the connection is kept open to avoid wasting resources. (I should have noticed that earlier).
1. Do not attempt to reconnect when context was canceled
1. Message finalization uses a background context and not the running ctx, in case the app is shutting down