### PR TITLE
Fixed typo in metadata JSON key

### DIFF
--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -25,7 +25,7 @@ type metadata struct {
 	MaxReconnectionAttempts         int    `json:"maxReconnectionAttempts"`
 	ConnectionRecoveryInSec         int    `json:"connectionRecoveryInSec"`
 	DisableEntityManagement         bool   `json:"disableEntityManagement"`
-	MaxRetriableErrorsPerSec        int    `json:"MaxRetriableErrorsPerSec"`
+	MaxRetriableErrorsPerSec        int    `json:"maxRetriableErrorsPerSec"`
 	MaxDeliveryCount                *int   `json:"maxDeliveryCount"`
 	LockDurationInSec               *int   `json:"lockDurationInSec"`
 	DefaultMessageTimeToLiveInSec   *int   `json:"defaultMessageTimeToLiveInSec"`

--- a/pubsub/azure/servicebus/servicebus_test.go
+++ b/pubsub/azure/servicebus/servicebus_test.go
@@ -300,7 +300,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assertValidErrorMessage(t, err)
 	})
 
-	t.Run("missing optional MaxRetriableErrorsPerSec", func(t *testing.T) {
+	t.Run("missing optional maxRetriableErrorsPerSec", func(t *testing.T) {
 		fakeProperties := getFakeProperties()
 
 		fakeMetaData := pubsub.Metadata{
@@ -316,7 +316,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("invalid optional MaxRetriableErrorsPerSec", func(t *testing.T) {
+	t.Run("invalid optional maxRetriableErrorsPerSec", func(t *testing.T) {
 		// NaN: Not a Number
 		fakeProperties := getFakeProperties()
 


### PR DESCRIPTION
Small typo in the JSON key for the `maxRetriableErrorsPerSec` for Azure Service Bus.