### PR TITLE
Updated sendgrid binding to add the option to add names for the to an…

### DIFF
--- a/bindings/twilio/sendgrid/sendgrid.go
+++ b/bindings/twilio/sendgrid/sendgrid.go
@@ -106,42 +106,48 @@ func (sg *SendGrid) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*b
 	// We allow two possible sources of the properties we need,
 	// the component metadata or request metadata, request takes priority if present
 
-	// Set the email from name, this is optional
-	fromName := ""
-	if sg.metadata.EmailFromName != "" {
-		fromName = sg.metadata.EmailFromName
-	}
-	if req.Metadata["emailFromName"] != "" {
-		fromName = req.Metadata["emailFromName"]
-	}
-
 	// Build email from address, this is required
 	var fromAddress *mail.Email
 	if sg.metadata.EmailFrom != "" {
+		// Optionally set the email from name
+		fromName := ""
+		if sg.metadata.EmailFromName != "" {
+			fromName = sg.metadata.EmailFromName
+		}
+
 		fromAddress = mail.NewEmail(fromName, sg.metadata.EmailFrom)
 	}
 	if req.Metadata["emailFrom"] != "" {
+		// Optionally set the email from name
+		fromName := ""
+		if req.Metadata["emailFromName"] != "" {
+			fromName = req.Metadata["emailFromName"]
+		}
+
 		fromAddress = mail.NewEmail(fromName, req.Metadata["emailFrom"])
 	}
 	if fromAddress == nil {
 		return nil, fmt.Errorf("error SendGrid from email not supplied")
 	}
 
-	// Set the email to name, this is optional
-	toName := ""
-	if sg.metadata.EmailToName != "" {
-		toName = sg.metadata.EmailToName
-	}
-	if req.Metadata["emailToName"] != "" {
-		toName = req.Metadata["emailToName"]
-	}
-
 	// Build email to address, this is required
 	var toAddress *mail.Email
 	if sg.metadata.EmailTo != "" {
+		// Optionally set the email to name
+		toName := ""
+		if sg.metadata.EmailToName != "" {
+			toName = sg.metadata.EmailToName
+		}
+
 		toAddress = mail.NewEmail(toName, sg.metadata.EmailTo)
 	}
 	if req.Metadata["emailTo"] != "" {
+		// Optionally set the email to name
+		toName := ""
+		if req.Metadata["emailToName"] != "" {
+			toName = req.Metadata["emailToName"]
+		}
+
 		toAddress = mail.NewEmail(toName, req.Metadata["emailTo"])
 	}
 	if toAddress == nil {

--- a/bindings/twilio/sendgrid/sendgrid.go
+++ b/bindings/twilio/sendgrid/sendgrid.go
@@ -36,12 +36,14 @@ type SendGrid struct {
 
 // Our metadata holds standard email properties.
 type sendGridMetadata struct {
-	APIKey    string `json:"apiKey"`
-	EmailFrom string `json:"emailFrom"`
-	EmailTo   string `json:"emailTo"`
-	Subject   string `json:"subject"`
-	EmailCc   string `json:"emailCc"`
-	EmailBcc  string `json:"emailBcc"`
+	APIKey        string `json:"apiKey"`
+	EmailFrom     string `json:"emailFrom"`
+	EmailFromName string `json:"emailFromName"`
+	EmailTo       string `json:"emailTo"`
+	EmailToName   string `json:"emailToName"`
+	Subject       string `json:"subject"`
+	EmailCc       string `json:"emailCc"`
+	EmailBcc      string `json:"emailBcc"`
 }
 
 // Wrapper to help decode SendGrid API errors.
@@ -71,7 +73,9 @@ func (sg *SendGrid) parseMetadata(meta bindings.Metadata) (sendGridMetadata, err
 
 	// Optional properties, these can be set on a per request basis
 	sgMeta.EmailTo = meta.Properties["emailTo"]
+	sgMeta.EmailToName = meta.Properties["emailToName"]
 	sgMeta.EmailFrom = meta.Properties["emailFrom"]
+	sgMeta.EmailFromName = meta.Properties["emailFromName"]
 	sgMeta.Subject = meta.Properties["subject"]
 	sgMeta.EmailCc = meta.Properties["emailCc"]
 	sgMeta.EmailBcc = meta.Properties["emailBcc"]
@@ -102,25 +106,43 @@ func (sg *SendGrid) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*b
 	// We allow two possible sources of the properties we need,
 	// the component metadata or request metadata, request takes priority if present
 
+	// Set the email from name, this is optional
+	fromName := ""
+	if sg.metadata.EmailFromName != "" {
+		fromName = sg.metadata.EmailFromName
+	}
+	if req.Metadata["emailFromName"] != "" {
+		fromName = req.Metadata["emailFromName"]
+	}
+
 	// Build email from address, this is required
 	var fromAddress *mail.Email
 	if sg.metadata.EmailFrom != "" {
-		fromAddress = mail.NewEmail("", sg.metadata.EmailFrom)
+		fromAddress = mail.NewEmail(fromName, sg.metadata.EmailFrom)
 	}
 	if req.Metadata["emailFrom"] != "" {
-		fromAddress = mail.NewEmail("", req.Metadata["emailFrom"])
+		fromAddress = mail.NewEmail(fromName, req.Metadata["emailFrom"])
 	}
 	if fromAddress == nil {
 		return nil, fmt.Errorf("error SendGrid from email not supplied")
 	}
 
+	// Set the email to name, this is optional
+	toName := ""
+	if sg.metadata.EmailToName != "" {
+		toName = sg.metadata.EmailToName
+	}
+	if req.Metadata["emailToName"] != "" {
+		toName = req.Metadata["emailToName"]
+	}
+
 	// Build email to address, this is required
 	var toAddress *mail.Email
 	if sg.metadata.EmailTo != "" {
-		toAddress = mail.NewEmail("", sg.metadata.EmailTo)
+		toAddress = mail.NewEmail(toName, sg.metadata.EmailTo)
 	}
 	if req.Metadata["emailTo"] != "" {
-		toAddress = mail.NewEmail("", req.Metadata["emailTo"])
+		toAddress = mail.NewEmail(toName, req.Metadata["emailTo"])
 	}
 	if toAddress == nil {
 		return nil, fmt.Errorf("error SendGrid to email not supplied")

--- a/bindings/twilio/sendgrid/sendgrid_test.go
+++ b/bindings/twilio/sendgrid/sendgrid_test.go
@@ -37,3 +37,21 @@ func TestParseMetadata(t *testing.T) {
 		assert.Equal(t, "hello", sgMeta.Subject)
 	})
 }
+
+func TestParseMetadataWithOptionalNames(t *testing.T) {
+	logger := logger.NewLogger("test")
+
+	t.Run("Has correct metadata", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{"apiKey": "123", "emailFrom": "test1@example.net", "emailFromName": "test 1", "emailTo": "test2@example.net", "emailToName": "test 2", "subject": "hello"}
+		r := SendGrid{logger: logger}
+		sgMeta, err := r.parseMetadata(m)
+		assert.Nil(t, err)
+		assert.Equal(t, "123", sgMeta.APIKey)
+		assert.Equal(t, "test1@example.net", sgMeta.EmailFrom)
+		assert.Equal(t, "test 1", sgMeta.EmailFromName)
+		assert.Equal(t, "test2@example.net", sgMeta.EmailTo)
+		assert.Equal(t, "test 2", sgMeta.EmailToName)
+		assert.Equal(t, "hello", sgMeta.Subject)
+	})
+}


### PR DESCRIPTION
Updated sendgrid binding to add the option to add names for the to and from addresses.

Signed-off-by: Adam Rahja <adam@resolve.com>

# Description

Updated the twilio sendgrid binding to add the ability to define the email to name and the email from name.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1749

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: [dapr/docs#2452](https://github.com/dapr/docs/issues/2452)
