### PR TITLE
Components capabilities: adding query api to the feature list

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -106,7 +106,7 @@ const (
 // NewCosmosDBStateStore returns a new CosmosDB state store.
 func NewCosmosDBStateStore(logger logger.Logger) *StateStore {
 	s := &StateStore{
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureETag, state.FeatureTransactional, state.FeatureQueryAPI},
 		logger:   logger,
 	}
 	s.DefaultBulkStore = state.NewDefaultBulkStore(s)

--- a/state/cockroachdb/cockroachdb.go
+++ b/state/cockroachdb/cockroachdb.go
@@ -36,7 +36,7 @@ func New(logger logger.Logger) *CockroachDB {
 // This unexported constructor allows injecting a dbAccess instance for unit testing.
 func internalNew(logger logger.Logger, dba dbAccess) *CockroachDB {
 	return &CockroachDB{
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureETag, state.FeatureTransactional, state.FeatureQueryAPI},
 		logger:   logger,
 		dbaccess: dba,
 	}

--- a/state/feature.go
+++ b/state/feature.go
@@ -18,6 +18,8 @@ const (
 	FeatureETag Feature = "ETAG"
 	// FeatureTransactional is the feature that performs transactional operations.
 	FeatureTransactional Feature = "TRANSACTIONAL"
+	// FeatureQueryAPI is the feature that performs query operations.
+	FeatureQueryAPI Feature = "QUERY_API"
 )
 
 // Feature names a feature that can be implemented by PubSub components.

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -104,7 +104,7 @@ type Item struct {
 // NewMongoDB returns a new MongoDB state store.
 func NewMongoDB(logger logger.Logger) *MongoDB {
 	s := &MongoDB{
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureETag, state.FeatureTransactional, state.FeatureQueryAPI},
 		logger:   logger,
 	}
 	s.DefaultBulkStore = state.NewDefaultBulkStore(s)

--- a/state/postgresql/postgresql.go
+++ b/state/postgresql/postgresql.go
@@ -36,7 +36,7 @@ func NewPostgreSQLStateStore(logger logger.Logger) *PostgreSQL {
 // This unexported constructor allows injecting a dbAccess instance for unit testing.
 func newPostgreSQLStateStore(logger logger.Logger, dba dbAccess) *PostgreSQL {
 	return &PostgreSQL{
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureETag, state.FeatureTransactional, state.FeatureQueryAPI},
 		logger:   logger,
 		dbaccess: dba,
 	}

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -109,7 +109,7 @@ type StateStore struct {
 func NewRedisStateStore(logger logger.Logger) *StateStore {
 	s := &StateStore{
 		json:     jsoniter.ConfigFastest,
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureETag, state.FeatureTransactional, state.FeatureQueryAPI},
 		logger:   logger,
 	}
 	s.DefaultBulkStore = state.NewDefaultBulkStore(s)


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

- Adding Query API to the list of features.
- Pass "query API" while doing init for components where this API is supported.
- Goal is make this info available in the Sidecar Metadata API
- Related Runtime PR - https://github.com/dapr/dapr/pull/4696
