### PR TITLE
Add file upload to s3

### DIFF
--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -64,6 +64,7 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 		request.Metadata = map[string]string{
 			"decodeBase64": "true",
 			"encodeBase64": "false",
+			"filePath":     "/usr/vader.darth",
 		}
 
 		mergedMeta, err := meta.mergeWithRequestMetadata(&request)
@@ -80,6 +81,7 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 		assert.Equal(t, true, meta.ForcePathStyle)
 		assert.Equal(t, true, mergedMeta.DecodeBase64)
 		assert.Equal(t, false, mergedMeta.EncodeBase64)
+		assert.Equal(t, "/usr/vader.darth", mergedMeta.FilePath)
 	})
 
 	t.Run("Has invalid merged metadata decodeBase64", func(t *testing.T) {


### PR DESCRIPTION
This PR adds the ability to have Dapr read a file and upload the contents instead of having the user write boilerplate code to read the file and then send the data over the wire, which can be problematic for large file uploads.
