### PR TITLE
Update certification workflow

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -18,7 +18,7 @@ on:
     types: [certification-test]
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '5 */12 * * *'
   pull_request:
     branches:
       - master
@@ -215,14 +215,14 @@ jobs:
 
         set +e
         gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.json \
-          --junitfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.xml --format standard-verbose -- \
+          --junitfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.xml --format standard-quiet -- \
           -count=1 -timeout=15m
 
         status=$?
         echo "Completed certification tests for ${{ matrix.component }} ... "
         if test $status -ne 0; then
           echo "Setting CERTIFICATION_FAILURE"
-          echo "CERTIFICATION_FAILURE=true" >> $GITHUB_ENV
+          export CERTIFICATION_FAILURE=true
         fi
         set -e
 
@@ -232,11 +232,6 @@ jobs:
           exit -1
         fi
 
-    # Delete any certs downloaded locally
-    - name: Clean up certs
-      if: matrix.required-certs != ''
-      working-directory: ${{ env.TEST_PATH }}
-      run: |
         for CERT_NAME in $(echo "${{ matrix.required-certs }}" | sed 's/,/ /g'); do
           CERT_FILE=$(printenv $CERT_NAME)
 
@@ -244,10 +239,6 @@ jobs:
           rm $CERT_FILE
         done
 
-    - name: Check certification test passed
-      continue-on-error: false
-      run: |
-        echo "CERTIFICATION_FAILURE=$CERTIFICATION_FAILURE"
         if [[ -v CERTIFICATION_FAILURE ]]; then
           exit 1
         fi


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

- Moves to scheduled certification workflow to run every 12 hours instead of 30 minutes to avoid overlapping test runs. `/ok-to-test` is preferred to evaluate PRs.
- Does not print test logs for tests that pass without error -- avoid verbose mode.
- Combines several test steps such that the "Run tests" step is the step which will fail -- this is much more intuitive for users / developers of Dapr.