### PR TITLE
add id when registering services to consul

### DIFF
--- a/nameresolution/consul/consul.go
+++ b/nameresolution/consul/consul.go
@@ -244,12 +244,13 @@ func getRegistrationConfig(cfg configSpec, props map[string]string) (*consul.Age
 		return nil, fmt.Errorf("error parsing %s: %w", nr.DaprHTTPPort, err)
 	}
 
+	id := appID + "-" + host + "-" + httpPort
 	// if no health checks configured add dapr sidecar health check by default
 	if len(cfg.Checks) == 0 {
 		cfg.Checks = []*consul.AgentServiceCheck{
 			{
 				Name:     "Dapr Health Status",
-				CheckID:  fmt.Sprintf("daprHealth:%s", appID),
+				CheckID:  fmt.Sprintf("daprHealth:%s", id),
 				Interval: "15s",
 				HTTP:     fmt.Sprintf("http://%s:%s/v1.0/healthz", host, httpPort),
 			},
@@ -262,6 +263,7 @@ func getRegistrationConfig(cfg configSpec, props map[string]string) (*consul.Age
 	}
 
 	return &consul.AgentServiceRegistration{
+		ID:      id,
 		Name:    appID,
 		Address: host,
 		Port:    appPortInt,

--- a/nameresolution/consul/consul_test.go
+++ b/nameresolution/consul/consul_test.go
@@ -501,7 +501,7 @@ func TestGetConfig(t *testing.T) {
 				assert.Equal(t, 1, len(actual.Registration.Checks))
 				check := actual.Registration.Checks[0]
 				assert.Equal(t, "Dapr Health Status", check.Name)
-				assert.Equal(t, "daprHealth:test-app", check.CheckID)
+				assert.Equal(t, "daprHealth:test-app-"+metadata.Properties[nr.HostAddress]+"-"+metadata.Properties[nr.DaprHTTPPort], check.CheckID)
 				assert.Equal(t, "15s", check.Interval)
 				assert.Equal(t, fmt.Sprintf("http://%s:%s/v1.0/healthz", metadata.Properties[nr.HostAddress], metadata.Properties[nr.DaprHTTPPort]), check.HTTP)
 


### PR DESCRIPTION
Signed-off-by: wisdom <153594697@qq.com>

# Description

In the absence of an id, different instances of the same service registered to consul will be overwritten.
So, new id is added to distinguish them.

## Issue reference

https://github.com/dapr/components-contrib/issues/1513
https://github.com/dapr/components-contrib/issues/1199

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
