### PR TITLE
Fix kafka binding consumer rebalance

### DIFF
--- a/bindings/kafka/kafka.go
+++ b/bindings/kafka/kafka.go
@@ -38,7 +38,7 @@ type Binding struct {
 	logger       logger.Logger
 }
 
-// NewKafka returns a new kafka pubsub instance.
+// NewKafka returns a new kafka binding instance.
 func NewKafka(logger logger.Logger) *Binding {
 	k := kafka.NewKafka(logger)
 	// in kafka binding component, disable consumer retry by default
@@ -70,6 +70,10 @@ func (b *Binding) Init(metadata bindings.Metadata) error {
 
 func (b *Binding) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{bindings.CreateOperation}
+}
+
+func (p *Binding) Close() (err error) {
+	return p.kafka.Close()
 }
 
 func (b *Binding) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {

--- a/internal/component/kafka/consumer.go
+++ b/internal/component/kafka/consumer.go
@@ -48,7 +48,9 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 			}
 		} else {
 			err := consumer.doCallback(session, message)
-			consumer.k.logger.Errorf("Error processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
+			if err != nil {
+				consumer.k.logger.Errorf("Error processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
+			}
 		}
 	}
 

--- a/tests/certification/bindings/kafka/kafka_test.go
+++ b/tests/certification/bindings/kafka/kafka_test.go
@@ -143,7 +143,6 @@ func TestKafka(t *testing.T) {
 			// Send events that the application above will observe.
 			ctx.Log("Sending messages!")
 			for _, msg := range msgs {
-				ctx.Logf("Sending: %q", msg)
 				err := client.InvokeOutputBinding(ctx, &dapr.InvokeBindingRequest{
 					Name:      bindingName,
 					Operation: string(bindings.CreateOperation),

--- a/tests/certification/bindings/kafka/kafka_test.go
+++ b/tests/certification/bindings/kafka/kafka_test.go
@@ -96,13 +96,14 @@ func TestKafka(t *testing.T) {
 	consumerGroup2 := watcher.NewUnordered()
 
 	// Application logic that tracks messages from a topic.
-	application := func(messages *watcher.Watcher) app.SetupFn {
+	application := func(appName string, watcher *watcher.Watcher) app.SetupFn {
 		return func(ctx flow.Context, s common.Service) error {
 			// Setup the /orders event handler.
 			return multierr.Combine(
-				s.AddBindingInvocationHandler(bindingName, func(ctx context.Context, in *common.BindingEvent) (out []byte, err error) {
+				s.AddBindingInvocationHandler(bindingName, func(_ context.Context, in *common.BindingEvent) (out []byte, err error) {
 					// Track/Observe the data of the event.
-					messages.Observe(string(in.Data))
+					watcher.Observe(string(in.Data))
+					ctx.Logf("======== %s received event: %s\n", appName, string(in.Data))
 					return in.Data, nil
 				}),
 			)
@@ -118,7 +119,7 @@ func TestKafka(t *testing.T) {
 
 	// Test logic that sends messages to a topic and
 	// verifies the application has received them.
-	sendRecvTest := func(metadata map[string]string, messages ...*watcher.Watcher) flow.Runnable {
+	sendRecvTest := func(metadata map[string]string, watchers ...*watcher.Watcher) flow.Runnable {
 		_, hasKey := metadata[messageKey]
 		return func(ctx flow.Context) error {
 			client := sidecar.GetClient(ctx, sidecarName1)
@@ -129,7 +130,7 @@ func TestKafka(t *testing.T) {
 			for i := range msgs {
 				msgs[i] = fmt.Sprintf("Hello, Messages %03d", i)
 			}
-			for _, m := range messages {
+			for _, m := range watchers {
 				m.ExpectStrings(msgs...)
 			}
 			// If no key it provided, create a random one.
@@ -153,7 +154,7 @@ func TestKafka(t *testing.T) {
 			}
 
 			// Do the messages we observed match what we expect?
-			for _, m := range messages {
+			for _, m := range watchers {
 				m.Assert(ctx, time.Minute)
 			}
 
@@ -166,10 +167,10 @@ func TestKafka(t *testing.T) {
 	// messages reliably when infrastructure and network
 	// interruptions occur.
 	var task flow.AsyncTask
-	sendMessagesInBackground := func(messages ...*watcher.Watcher) flow.Runnable {
+	sendMessagesInBackground := func(watchers ...*watcher.Watcher) flow.Runnable {
 		return func(ctx flow.Context) error {
 			client := sidecar.GetClient(ctx, sidecarName1)
-			for _, m := range messages {
+			for _, m := range watchers {
 				m.Reset()
 			}
 
@@ -183,7 +184,7 @@ func TestKafka(t *testing.T) {
 					return nil
 				case <-t.C:
 					msg := fmt.Sprintf("Background message - %03d", counter)
-					for _, m := range messages {
+					for _, m := range watchers {
 						m.Prepare(msg) // Track for observation
 					}
 
@@ -199,12 +200,12 @@ func TestKafka(t *testing.T) {
 					}, bo, func(err error, t time.Duration) {
 						ctx.Logf("Error outpub binding message, retrying in %s", t)
 					}, func() {}); err == nil {
-						for _, m := range messages {
+						for _, m := range watchers {
 							m.Add(msg) // Success
 						}
 						counter++
 					} else {
-						for _, m := range messages {
+						for _, m := range watchers {
 							m.Remove(msg) // Remove from Tracking
 						}
 					}
@@ -212,11 +213,11 @@ func TestKafka(t *testing.T) {
 			}
 		}
 	}
-	assertMessages := func(messages ...*watcher.Watcher) flow.Runnable {
+	assertMessages := func(watchers ...*watcher.Watcher) flow.Runnable {
 		return func(ctx flow.Context) error {
 			// Signal sendMessagesInBackground to stop and wait for it to complete.
 			task.CancelAndWait()
-			for _, m := range messages {
+			for _, m := range watchers {
 				m.Assert(ctx, 5*time.Minute)
 			}
 
@@ -269,7 +270,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Run the application logic above.
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
-			application(consumerGroup1))).
+			application(appID1, consumerGroup1))).
 		//
 		// Run the Dapr sidecar with the Kafka component.
 		Step(sidecar.Run(sidecarName1,
@@ -282,7 +283,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Run the second application.
 		Step(app.Run(appID2, fmt.Sprintf(":%d", appPort+portOffset),
-			application(consumerGroup2))).
+			application(appID2, consumerGroup2))).
 		//
 		// Run the Dapr sidecar with the Kafka component.
 		Step(sidecar.Run(sidecarName2,
@@ -299,7 +300,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Run the third application.
 		Step(app.Run(appID3, fmt.Sprintf(":%d", appPort+portOffset*2),
-			application(consumerGroup2))).
+			application(appID3, consumerGroup2))).
 		//
 		// Run the Dapr sidecar with the Kafka component.
 		Step(sidecar.Run(sidecarName3,
@@ -313,7 +314,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Send messages with random keys to test message consumption
 		// across more than one consumer group and consumers per group.
-		Step("send and wait(consumer groups)", sendRecvTest(map[string]string{}, consumerGroup2)).
+		Step("send and wait(no-order)", sendRecvTest(map[string]string{}, consumerGroup2)).
 		//
 		// Gradually stop each broker.
 		// This tests the components ability to handle reconnections

--- a/tests/certification/pubsub/kafka/kafka_test.go
+++ b/tests/certification/pubsub/kafka/kafka_test.go
@@ -294,7 +294,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Send messages using the same metadata/message key so we can expect
 		// in-order processing.
-		Step("send and wait", sendRecvTest(metadata, consumerGroup1, consumerGroup2)).
+		Step("send and wait(in-order)", sendRecvTest(metadata, consumerGroup1, consumerGroup2)).
 		//
 		// Run the third application.
 		Step(app.Run(appID3, fmt.Sprintf(":%d", appPort+portOffset*2),
@@ -312,7 +312,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Send messages with random keys to test message consumption
 		// across more than one consumer group and consumers per group.
-		Step("send and wait", sendRecvTest(map[string]string{}, consumerGroup2)).
+		Step("send and wait(no-order)", sendRecvTest(map[string]string{}, consumerGroup2)).
 		//
 		// Gradually stop each broker.
 		// This tests the components ability to handle reconnections
@@ -336,7 +336,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Component should recover at this point.
 		Step("wait", flow.Sleep(30*time.Second)).
-		Step("assert messages", assertMessages(consumerGroup1, consumerGroup2)).
+		Step("assert messages(Component reconnect)", assertMessages(consumerGroup1, consumerGroup2)).
 		//
 		// Simulate a network interruption.
 		// This tests the components ability to handle reconnections
@@ -351,7 +351,7 @@ func TestKafka(t *testing.T) {
 		//
 		// Component should recover at this point.
 		Step("wait", flow.Sleep(30*time.Second)).
-		Step("assert messages", assertMessages(consumerGroup1, consumerGroup2)).
+		Step("assert messages(network interruption)", assertMessages(consumerGroup1, consumerGroup2)).
 		//
 		// Reset and test that all messages are received during a
 		// consumer rebalance.
@@ -363,6 +363,6 @@ func TestKafka(t *testing.T) {
 		Step("wait", flow.Sleep(3*time.Second)).
 		Step("stop app 2", app.Stop(appID2)).
 		Step("wait", flow.Sleep(30*time.Second)).
-		Step("assert messages", assertMessages(consumerGroup2)).
+		Step("assert messages(consumer rebalance)", assertMessages(consumerGroup2)).
 		Run()
 }


### PR DESCRIPTION
# Description

kafka binding component  doesn't implement io.Closer interface, so when sidecar is stopped and dapr runtime is closed, kafka binding component won't be closed. 

This will cause a bug in kafka cert test because we want to stop one the kafka sidecar and let other kafka sidecar to continue to consumer kakfa event by kafka consumer rebalance.

BTW:  in an actual daprd sidecar, after the sidecar process is quit kafka binding component will also quit and loss the connection with kafka, so this bug only appears in cert test and not in real sidecar. 

## Issue reference

https://github.com/dapr/components-contrib/issues/1799

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
