### PR TITLE
change some parameters to wait for kafka ready

### DIFF
--- a/tests/certification/bindings/kafka/kafka_retry_test.go
+++ b/tests/certification/bindings/kafka/kafka_retry_test.go
@@ -214,7 +214,8 @@ func TestKafka_with_retry(t *testing.T) {
 		Step(dockercompose.Run(clusterName, dockerComposeYAML)).
 		Step("wait for broker sockets",
 			network.WaitForAddresses(5*time.Minute, brokers...)).
-		Step("wait for kafka readiness", retry.Do(time.Second, 30, func(ctx flow.Context) error {
+		Step("wait", flow.Sleep(5*time.Second)).
+		Step("wait for kafka readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
 			config := sarama.NewConfig()
 			config.ClientID = "test-consumer"
 			config.Consumer.Return.Errors = true
@@ -232,7 +233,7 @@ func TestKafka_with_retry(t *testing.T) {
 
 			return err
 		})).
-		Step("wait for Dapr OAuth client", retry.Do(10*time.Second, 6, func(ctx flow.Context) error {
+		Step("wait for Dapr OAuth client", retry.Do(20*time.Second, 6, func(ctx flow.Context) error {
 			httpClient := &http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Signed-off-by: Sky Ao <aoxiaojian@gmail.com>

# Description

To fix the problem found in github action:

```bash
    flow.go:228: Completed step: wait for kafka readiness
    flow.go:220: Running step: wait for Dapr OAuth client
    retry.go:32: Failure: oauth client query for 'dapr' not successful; Retrying in 10s
    flow.go:228: Completed step: wait for Dapr OAuth client
    flow.go:230: oauth client query for 'dapr' not successful
    dockercompose.go:72: Stopping kafka-2   ... 
```

## Issue reference

https://github.com/dapr/components-contrib/issues/1799

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
