### PR TITLE
More sane defaults for default values in MQTT metadata

### DIFF
--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -48,10 +48,10 @@ const (
 	errorMsgPrefix = "mqtt pub sub error:"
 
 	// Defaults.
-	defaultQOS          = 0
-	defaultRetain       = false
+	defaultQOS          = 1
+	defaultRetain       = true
 	defaultWait         = 30 * time.Second
-	defaultCleanSession = true
+	defaultCleanSession = false
 )
 
 // mqttPubSub type allows sending and receiving data to/from MQTT broker.


### PR DESCRIPTION
# Description

Changes the default values for `pubsub.mqtt` to:

- `qos` = 1 (was 0)
- `retain` = true (was false)
- `cleanSession` = false (was true)

These are more sane defaults that ensure more reliability when operating MQTT as pubsub component. The behavior is now more aligned with other pubsub components'.

## Issue reference

Fixes #1809

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
