### PR TITLE
MQTT: re-set "retain" to false as default

### DIFF
--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -49,7 +49,7 @@ const (
 
 	// Defaults.
 	defaultQOS          = 1
-	defaultRetain       = true
+	defaultRetain       = false
 	defaultWait         = 30 * time.Second
 	defaultCleanSession = false
 )

--- a/pubsub/mqtt/mqtt_test.go
+++ b/pubsub/mqtt/mqtt_test.go
@@ -92,7 +92,7 @@ func TestParseMetadata(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, fakeProperties[mqttURL], m.url)
 		assert.Equal(t, byte(1), m.qos)
-		assert.Equal(t, true, m.retain)
+		assert.Equal(t, false, m.retain)
 	})
 
 	t.Run("invalid clean session field", func(t *testing.T) {


### PR DESCRIPTION
Partially reverts #1810 because support for "retain" is currently broken (working on it for 1.9). Unit tests are passing