### PR TITLE
Add contexts to input bindings

### DIFF
--- a/bindings/alicloud/dingtalk/webhook/webhook.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook.go
@@ -93,7 +93,7 @@ func (t *DingTalkWebhook) Init(metadata bindings.Metadata) error {
 }
 
 // Read triggers the outgoing webhook, not yet production ready.
-func (t *DingTalkWebhook) Read(handler bindings.Handler) error {
+func (t *DingTalkWebhook) Read(ctx context.Context, handler bindings.Handler) error {
 	t.logger.Debugf("dingtalk webhook: start read input binding")
 
 	webhooks.Lock()
@@ -218,9 +218,7 @@ func getPostURL(urlPath, secret string) (string, error) {
 func sign(secret, timestamp string) (string, error) {
 	stringToSign := fmt.Sprintf("%s\n%s", timestamp, secret)
 	h := hmac.New(sha256.New, []byte(secret))
-	if _, err := io.WriteString(h, stringToSign); err != nil {
-		return "", fmt.Errorf("sign failed. %w", err)
-	}
-
-	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+	_, _ = h.Write([]byte(stringToSign))
+	dgst := h.Sum(nil)
+	return base64.StdEncoding.EncodeToString(dgst), nil
 }

--- a/bindings/alicloud/dingtalk/webhook/webhook_test.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook_test.go
@@ -91,7 +91,7 @@ func TestBindingReadAndInvoke(t *testing.T) { //nolint:paralleltest
 		return nil, nil
 	}
 
-	err = d.Read(handler)
+	err = d.Read(context.Background(), handler)
 	require.NoError(t, err)
 
 	req := &bindings.InvokeRequest{Data: []byte(msg), Operation: bindings.GetOperation, Metadata: map[string]string{}}

--- a/bindings/alicloud/nacos/nacos.go
+++ b/bindings/alicloud/nacos/nacos.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/clients"
@@ -49,6 +50,7 @@ type configParam struct {
 type Nacos struct {
 	settings     Settings
 	config       configParam
+	watchesLock  sync.Mutex
 	watches      []configParam
 	servers      []constant.ServerConfig
 	logger       logger.Logger
@@ -58,7 +60,10 @@ type Nacos struct {
 
 // NewNacos returns a new Nacos instance.
 func NewNacos(logger logger.Logger) *Nacos {
-	return &Nacos{logger: logger} //nolint:exhaustivestruct
+	return &Nacos{
+		logger:      logger,
+		watchesLock: sync.Mutex{},
+	}
 }
 
 // Init implements InputBinding/OutputBinding's Init method.
@@ -140,19 +145,27 @@ func (n *Nacos) createConfigClient() error {
 }
 
 // Read implements InputBinding's Read method.
-func (n *Nacos) Read(handler bindings.Handler) error {
+func (n *Nacos) Read(ctx context.Context, handler bindings.Handler) error {
 	n.readHandler = handler
 
+	n.watchesLock.Lock()
 	for _, watch := range n.watches {
-		go n.startListen(watch)
+		go n.startListen(ctx, watch)
 	}
+	n.watchesLock.Unlock()
+
+	go func() {
+		// Cancel all listeners when the context is done
+		<-ctx.Done()
+		n.cancelAllListeners()
+	}()
 
 	return nil
 }
 
 // Close implements cancel all listeners, see https://github.com/dapr/components-contrib/issues/779
 func (n *Nacos) Close() error {
-	n.cancelListener()
+	n.cancelAllListeners()
 
 	return nil
 }
@@ -161,9 +174,9 @@ func (n *Nacos) Close() error {
 func (n *Nacos) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	switch req.Operation {
 	case bindings.CreateOperation:
-		return n.publish(req)
+		return n.publish(ctx, req)
 	case bindings.GetOperation:
-		return n.fetch(req)
+		return n.fetch(ctx, req)
 	case bindings.DeleteOperation, bindings.ListOperation:
 		return nil, fmt.Errorf("nacos error: unsupported operation %s", req.Operation)
 	default:
@@ -176,12 +189,12 @@ func (n *Nacos) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{bindings.CreateOperation, bindings.GetOperation}
 }
 
-func (n *Nacos) startListen(config configParam) {
-	n.fetchAndNotify(config)
-	n.addListener(config)
+func (n *Nacos) startListen(ctx context.Context, config configParam) {
+	n.fetchAndNotify(ctx, config)
+	n.addListener(ctx, config)
 }
 
-func (n *Nacos) fetchAndNotify(config configParam) {
+func (n *Nacos) fetchAndNotify(ctx context.Context, config configParam) {
 	content, err := n.configClient.GetConfig(vo.ConfigParam{
 		DataId:   config.dataID,
 		Group:    config.group,
@@ -190,30 +203,31 @@ func (n *Nacos) fetchAndNotify(config configParam) {
 	})
 	if err != nil {
 		n.logger.Warnf("failed to receive nacos config %s:%s, error: %v", config.dataID, config.group, err)
-	} else {
-		n.notifyApp(config.group, config.dataID, content)
+		return
 	}
+	n.notifyApp(ctx, config.group, config.dataID, content)
 }
 
-func (n *Nacos) addListener(config configParam) {
+func (n *Nacos) addListener(ctx context.Context, config configParam) {
 	err := n.configClient.ListenConfig(vo.ConfigParam{
 		DataId:   config.dataID,
 		Group:    config.group,
 		Content:  "",
-		OnChange: n.listener,
+		OnChange: n.listener(ctx),
 	})
 	if err != nil {
 		n.logger.Warnf("failed to add nacos listener for %s:%s, error: %v", config.dataID, config.group, err)
+		return
 	}
 }
 
-func (n *Nacos) addListener4InputBinding(config configParam) {
+func (n *Nacos) addListenerFoInputBinding(ctx context.Context, config configParam) {
 	if n.addToWatches(config) {
-		go n.addListener(config)
+		go n.addListener(ctx, config)
 	}
 }
 
-func (n *Nacos) publish(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (n *Nacos) publish(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	nacosConfigParam, err := n.findConfig(req.Metadata)
 	if err != nil {
 		return nil, err
@@ -231,7 +245,7 @@ func (n *Nacos) publish(req *bindings.InvokeRequest) (*bindings.InvokeResponse, 
 	return nil, nil
 }
 
-func (n *Nacos) fetch(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (n *Nacos) fetch(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	nacosConfigParam, err := n.findConfig(req.Metadata)
 	if err != nil {
 		return nil, err
@@ -248,13 +262,15 @@ func (n *Nacos) fetch(req *bindings.InvokeRequest) (*bindings.InvokeResponse, er
 	}
 
 	if onchange := req.Metadata[metadataConfigOnchange]; strings.EqualFold(onchange, "true") {
-		n.addListener4InputBinding(*nacosConfigParam)
+		n.addListenerFoInputBinding(ctx, *nacosConfigParam)
 	}
 
 	return &bindings.InvokeResponse{Data: []byte(rst), Metadata: map[string]string{}}, nil
 }
 
 func (n *Nacos) addToWatches(c configParam) bool {
+	n.watchesLock.Lock()
+	defer n.watchesLock.Unlock()
 	if n.watches != nil {
 		for _, watch := range n.watches {
 			if c.dataID == watch.dataID && c.group == watch.group {
@@ -286,22 +302,30 @@ func (n *Nacos) findConfig(md map[string]string) (*configParam, error) {
 	return &nacosConfigParam, nil
 }
 
-func (n *Nacos) listener(_, group, dataID, data string) {
-	n.notifyApp(group, dataID, data)
+func (n *Nacos) listener(ctx context.Context) func(_, group, dataID, data string) {
+	return func(_, group, dataID, data string) {
+		n.notifyApp(ctx, group, dataID, data)
+	}
 }
 
-func (n *Nacos) cancelListener() {
+func (n *Nacos) cancelAllListeners() {
+	n.watchesLock.Lock()
+	defer n.watchesLock.Unlock()
 	for _, configParam := range n.watches {
-		if err := n.configClient.CancelListenConfig(vo.ConfigParam{ //nolint:exhaustivestruct
-			DataId: configParam.dataID,
-			Group:  configParam.group,
-		}); err != nil {
+		if err := n.cancelListener(configParam); err != nil {
 			n.logger.Warnf("nacos cancel listener failed err: %v", err)
 		}
 	}
 }
 
-func (n *Nacos) notifyApp(group, dataID, content string) {
+func (n *Nacos) cancelListener(configParam configParam) error {
+	return n.configClient.CancelListenConfig(vo.ConfigParam{
+		DataId: configParam.dataID,
+		Group:  configParam.group,
+	})
+}
+
+func (n *Nacos) notifyApp(ctx context.Context, group, dataID, content string) {
 	metadata := map[string]string{
 		metadataConfigID:    dataID,
 		metadataConfigGroup: group,
@@ -309,7 +333,7 @@ func (n *Nacos) notifyApp(group, dataID, content string) {
 	var err error
 	if n.readHandler != nil {
 		n.logger.Debugf("binding-nacos read content to app")
-		_, err = n.readHandler(context.TODO(), &bindings.ReadResponse{Data: []byte(content), Metadata: metadata})
+		_, err = n.readHandler(ctx, &bindings.ReadResponse{Data: []byte(content), Metadata: metadata})
 	} else {
 		err = errors.New("nacos error: the InputBinding.Read handler not init")
 	}
@@ -372,7 +396,7 @@ func convertServers(ss string) ([]constant.ServerConfig, error) {
 }
 
 func parseServerURL(s string) (*constant.ServerConfig, error) {
-	if !strings.HasPrefix(s, "http") {
+	if !strings.HasPrefix(s, "http://") {
 		s = "http://" + s
 	}
 	u, err := url.Parse(s)

--- a/bindings/alicloud/nacos/nacos_test.go
+++ b/bindings/alicloud/nacos/nacos_test.go
@@ -47,10 +47,8 @@ func TestInputBindingRead(t *testing.T) { //nolint:paralleltest
 		return nil, nil
 	}
 
-	go func() {
-		err = n.Read(handler)
-		require.NoError(t, err)
-	}()
+	err = n.Read(context.Background(), handler)
+	require.NoError(t, err)
 
 	select {
 	case <-ch:

--- a/bindings/alicloud/oss/oss.go
+++ b/bindings/alicloud/oss/oss.go
@@ -16,10 +16,10 @@ package oss
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
@@ -33,10 +33,10 @@ type AliCloudOSS struct {
 }
 
 type ossMetadata struct {
-	Endpoint    string `json:"endpoint"`
-	AccessKeyID string `json:"accessKeyID"`
-	AccessKey   string `json:"accessKey"`
-	Bucket      string `json:"bucket"`
+	Endpoint    string `json:"endpoint" mapstructure:"endpoint"`
+	AccessKeyID string `json:"accessKeyID" mapstructure:"accessKeyID"`
+	AccessKey   string `json:"accessKey" mapstructure:"accessKey"`
+	Bucket      string `json:"bucket" mapstructure:"bucket"`
 }
 
 // NewAliCloudOSS returns a new  instance.
@@ -64,7 +64,7 @@ func (s *AliCloudOSS) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{bindings.CreateOperation}
 }
 
-func (s *AliCloudOSS) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (s *AliCloudOSS) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	key := ""
 	if val, ok := req.Metadata["key"]; ok && val != "" {
 		key = val
@@ -88,13 +88,8 @@ func (s *AliCloudOSS) Invoke(ctx context.Context, req *bindings.InvokeRequest) (
 }
 
 func (s *AliCloudOSS) parseMetadata(metadata bindings.Metadata) (*ossMetadata, error) {
-	b, err := json.Marshal(metadata.Properties)
-	if err != nil {
-		return nil, err
-	}
-
 	var m ossMetadata
-	err = json.Unmarshal(b, &m)
+	err := mapstructure.WeakDecode(metadata.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/alicloud/rocketmq/rocketmq.go
+++ b/bindings/alicloud/rocketmq/rocketmq.go
@@ -17,14 +17,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	mqc "github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/cenkalti/backoff/v4"
 	mqw "github.com/cinience/go_rocketmq"
 
 	"github.com/dapr/components-contrib/bindings"
@@ -36,7 +34,6 @@ type AliCloudRocketMQ struct {
 	logger   logger.Logger
 	settings Settings
 	producer mqw.Producer
-	consumer mqw.PushConsumer
 
 	ctx           context.Context
 	cancel        context.CancelFunc
@@ -47,7 +44,6 @@ func NewAliCloudRocketMQ(l logger.Logger) *AliCloudRocketMQ {
 	return &AliCloudRocketMQ{ //nolint:exhaustivestruct
 		logger:   l,
 		producer: nil,
-		consumer: nil,
 	}
 }
 
@@ -78,11 +74,10 @@ func (a *AliCloudRocketMQ) Init(metadata bindings.Metadata) error {
 }
 
 // Read triggers the rocketmq subscription.
-func (a *AliCloudRocketMQ) Read(handler bindings.Handler) error {
+func (a *AliCloudRocketMQ) Read(ctx context.Context, handler bindings.Handler) error {
 	a.logger.Debugf("binding rocketmq: start read input binding")
 
-	var err error
-	a.consumer, err = a.setupConsumer()
+	consumer, err := a.setupConsumer()
 	if err != nil {
 		return fmt.Errorf("binding-rocketmq error: %w", err)
 	}
@@ -99,7 +94,7 @@ func (a *AliCloudRocketMQ) Read(handler bindings.Handler) error {
 		if err != nil {
 			return err
 		}
-		if err := a.consumer.Subscribe(
+		if err := consumer.Subscribe(
 			topic,
 			mqc.MessageSelector{
 				Type:       mqc.ExpressionType(mqType),
@@ -111,14 +106,24 @@ func (a *AliCloudRocketMQ) Read(handler bindings.Handler) error {
 		}
 	}
 
-	if err := a.consumer.Start(); err != nil {
+	if err := consumer.Start(); err != nil {
 		return fmt.Errorf("binding-rocketmq: consumer start failed. %w", err)
 	}
 
-	exitChan := make(chan os.Signal, 1)
-	signal.Notify(exitChan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
-	<-exitChan
-	a.logger.Info("binding-rocketmq: shutdown.")
+	a.logger.Debugf("binding-rocketmq: consumer started")
+
+	// Listen for context cancelation to stop the subscription
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-a.ctx.Done():
+		}
+
+		innerErr := consumer.Shutdown()
+		if innerErr != nil && !errors.Is(innerErr, context.Canceled) {
+			a.logger.Warnf("binding-rocketmq: error while shutting down consumer: %v")
+		}
+	}()
 
 	return nil
 }
@@ -126,10 +131,6 @@ func (a *AliCloudRocketMQ) Read(handler bindings.Handler) error {
 // Close implements cancel all listeners, see https://github.com/dapr/components-contrib/issues/779
 func (a *AliCloudRocketMQ) Close() error {
 	a.cancel()
-
-	if a.consumer != nil {
-		_ = a.consumer.Shutdown()
-	}
 
 	return nil
 }
@@ -272,10 +273,14 @@ func (a *AliCloudRocketMQ) adaptCallback(_, consumerGroup, mqType, mqExpr string
 				Metadata: metadata,
 			}
 
-			b := a.backOffConfig.NewBackOffWithContext(a.ctx)
+			b := a.backOffConfig.NewBackOffWithContext(ctx)
 
 			rerr := retry.NotifyRecover(func() error {
-				_, herr := handler(a.ctx, msg)
+				herr := ctx.Err()
+				if herr != nil {
+					return backoff.Permanent(herr)
+				}
+				_, herr = handler(ctx, msg)
 				if herr != nil {
 					a.logger.Errorf("rocketmq error: fail to send message to dapr application. topic:%s data-length:%d err:%v ", v.Topic, len(v.Body), herr)
 					success = false

--- a/bindings/alicloud/rocketmq/rocketmq_test.go
+++ b/bindings/alicloud/rocketmq/rocketmq_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestInputBindingRead(t *testing.T) { //nolint:paralleltest
 	if !isLiveTest() {
+		t.Skip()
 		return
 	}
 	m := bindings.Metadata{} //nolint:exhaustivestruct
@@ -44,10 +45,8 @@ func TestInputBindingRead(t *testing.T) { //nolint:paralleltest
 
 		return nil, nil
 	}
-	go func() {
-		err = r.Read(handler)
-		require.NoError(t, err)
-	}()
+	err = r.Read(context.Background(), handler)
+	require.NoError(t, err)
 
 	time.Sleep(5 * time.Second)
 	atomic.StoreInt32(&count, 0)

--- a/bindings/alicloud/tablestore/tablestore.go
+++ b/bindings/alicloud/tablestore/tablestore.go
@@ -70,12 +70,12 @@ func (s *AliCloudTableStore) Init(metadata bindings.Metadata) error {
 	return nil
 }
 
-func (s *AliCloudTableStore) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (s *AliCloudTableStore) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	if req == nil {
 		return nil, errors.Errorf("invoke request required")
 	}
 
-	startTime := time.Now().UTC()
+	startTime := time.Now()
 	resp := &bindings.InvokeResponse{
 		Metadata: map[string]string{
 			invokeStartTimeKey: startTime.Format(time.RFC3339Nano),
@@ -108,7 +108,7 @@ func (s *AliCloudTableStore) Invoke(ctx context.Context, req *bindings.InvokeReq
 			req.Operation, bindings.GetOperation, bindings.ListOperation, bindings.CreateOperation, bindings.DeleteOperation)
 	}
 
-	endTime := time.Now().UTC()
+	endTime := time.Now()
 	resp.Metadata[invokeEndTimeKey] = endTime.Format(time.RFC3339Nano)
 	resp.Metadata[invokeDurationKey] = endTime.Sub(startTime).String()
 

--- a/bindings/alicloud/tablestore/tablestore_test.go
+++ b/bindings/alicloud/tablestore/tablestore_test.go
@@ -69,7 +69,7 @@ func TestDataEncodeAndDecode(t *testing.T) {
 		Data: data,
 	}
 
-	putInvokeResp, err := aliCloudTableStore.Invoke(context.TODO(), putRowReq)
+	putInvokeResp, err := aliCloudTableStore.Invoke(context.Background(), putRowReq)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, putInvokeResp)
@@ -80,7 +80,7 @@ func TestDataEncodeAndDecode(t *testing.T) {
 		"column2": int64(2),
 	})
 
-	putInvokeResp, err = aliCloudTableStore.Invoke(context.TODO(), putRowReq)
+	putInvokeResp, err = aliCloudTableStore.Invoke(context.Background(), putRowReq)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, putInvokeResp)
@@ -100,7 +100,7 @@ func TestDataEncodeAndDecode(t *testing.T) {
 		Data: getData,
 	}
 
-	getInvokeResp, err := aliCloudTableStore.Invoke(context.TODO(), getInvokeReq)
+	getInvokeResp, err := aliCloudTableStore.Invoke(context.Background(), getInvokeReq)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, getInvokeResp)
@@ -134,7 +134,7 @@ func TestDataEncodeAndDecode(t *testing.T) {
 		Data: listData,
 	}
 
-	listResp, err := aliCloudTableStore.Invoke(context.TODO(), listReq)
+	listResp, err := aliCloudTableStore.Invoke(context.Background(), listReq)
 	assert.Nil(t, err)
 	assert.NotNil(t, listResp)
 
@@ -162,12 +162,12 @@ func TestDataEncodeAndDecode(t *testing.T) {
 		Data: deleteData,
 	}
 
-	deleteResp, err := aliCloudTableStore.Invoke(context.TODO(), deleteReq)
+	deleteResp, err := aliCloudTableStore.Invoke(context.Background(), deleteReq)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, deleteResp)
 
-	getInvokeResp, err = aliCloudTableStore.Invoke(context.TODO(), getInvokeReq)
+	getInvokeResp, err = aliCloudTableStore.Invoke(context.Background(), getInvokeReq)
 
 	assert.Nil(t, err)
 	assert.Nil(t, getInvokeResp.Data)

--- a/bindings/apns/apns.go
+++ b/bindings/apns/apns.go
@@ -20,6 +20,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 
@@ -121,7 +122,11 @@ func (a *APNS) sendPushNotification(ctx context.Context, req *bindings.InvokeReq
 		return nil, err
 	}
 
-	defer httpResponse.Body.Close()
+	defer func() {
+		// Drain before closing
+		_, _ = io.Copy(io.Discard, httpResponse.Body)
+		_ = httpResponse.Body.Close()
+	}()
 
 	if httpResponse.StatusCode == http.StatusOK {
 		return makeSuccessResponse(httpResponse)

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -15,19 +15,16 @@ package kinesis
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/config"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/interfaces"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/worker"
@@ -51,35 +48,35 @@ type AWSKinesis struct {
 }
 
 type kinesisMetadata struct {
-	StreamName          string              `json:"streamName"`
-	ConsumerName        string              `json:"consumerName"`
-	Region              string              `json:"region"`
-	Endpoint            string              `json:"endpoint"`
-	AccessKey           string              `json:"accessKey"`
-	SecretKey           string              `json:"secretKey"`
-	SessionToken        string              `json:"sessionToken"`
-	KinesisConsumerMode kinesisConsumerMode `json:"mode"`
+	StreamName          string `json:"streamName"`
+	ConsumerName        string `json:"consumerName"`
+	Region              string `json:"region"`
+	Endpoint            string `json:"endpoint"`
+	AccessKey           string `json:"accessKey"`
+	SecretKey           string `json:"secretKey"`
+	SessionToken        string `json:"sessionToken"`
+	KinesisConsumerMode string `json:"mode" mapstructure:"mode"`
 }
-
-type kinesisConsumerMode string
 
 const (
 	// ExtendedFanout - dedicated throughput through data stream api.
-	ExtendedFanout kinesisConsumerMode = "extended"
+	ExtendedFanout = "extended"
 
 	// SharedThroughput - shared throughput using checkpoint and monitoring.
-	SharedThroughput kinesisConsumerMode = "shared"
+	SharedThroughput = "shared"
 
 	partitionKeyName = "partitionKey"
 )
 
 // recordProcessorFactory.
 type recordProcessorFactory struct {
+	ctx     context.Context
 	logger  logger.Logger
 	handler bindings.Handler
 }
 
 type recordProcessor struct {
+	ctx     context.Context
 	logger  logger.Logger
 	handler bindings.Handler
 }
@@ -140,7 +137,7 @@ func (a *AWSKinesis) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*
 	if partitionKey == "" {
 		partitionKey = uuid.New().String()
 	}
-	_, err := a.client.PutRecord(&kinesis.PutRecordInput{
+	_, err := a.client.PutRecordWithContext(ctx, &kinesis.PutRecordInput{
 		StreamName:   &a.metadata.StreamName,
 		Data:         req.Data,
 		PartitionKey: &partitionKey,
@@ -149,63 +146,72 @@ func (a *AWSKinesis) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*
 	return nil, err
 }
 
-func (a *AWSKinesis) Read(handler bindings.Handler) error {
+func (a *AWSKinesis) Read(ctx context.Context, handler bindings.Handler) (err error) {
 	if a.metadata.KinesisConsumerMode == SharedThroughput {
-		a.worker = worker.NewWorker(a.recordProcessorFactory(handler), a.workerConfig)
-		err := a.worker.Start()
+		a.worker = worker.NewWorker(a.recordProcessorFactory(ctx, handler), a.workerConfig)
+		err = a.worker.Start()
 		if err != nil {
 			return err
 		}
 	} else if a.metadata.KinesisConsumerMode == ExtendedFanout {
-		ctx := context.Background()
-		stream, err := a.client.DescribeStream(&kinesis.DescribeStreamInput{StreamName: &a.metadata.StreamName})
+		var stream *kinesis.DescribeStreamOutput
+		stream, err = a.client.DescribeStream(&kinesis.DescribeStreamInput{StreamName: &a.metadata.StreamName})
 		if err != nil {
 			return err
 		}
-		go a.Subscribe(ctx, *stream.StreamDescription, handler)
+		err = a.Subscribe(ctx, *stream.StreamDescription, handler)
+		if err != nil {
+			return err
+		}
 	}
 
-	exitChan := make(chan os.Signal, 1)
-	signal.Notify(exitChan, os.Interrupt, syscall.SIGTERM)
-	<-exitChan
-
-	if a.metadata.KinesisConsumerMode == SharedThroughput {
-		go a.worker.Shutdown()
-	} else if a.metadata.KinesisConsumerMode == ExtendedFanout {
-		go a.deregisterConsumer(a.streamARN, a.consumerARN)
-	}
+	// Wait for context cancelation then stop
+	go func() {
+		<-ctx.Done()
+		if a.metadata.KinesisConsumerMode == SharedThroughput {
+			a.worker.Shutdown()
+		} else if a.metadata.KinesisConsumerMode == ExtendedFanout {
+			a.deregisterConsumer(a.streamARN, a.consumerARN)
+		}
+	}()
 
 	return nil
 }
 
 // Subscribe to all shards.
 func (a *AWSKinesis) Subscribe(ctx context.Context, streamDesc kinesis.StreamDescription, handler bindings.Handler) error {
-	consumerARN, err := a.ensureConsumer(streamDesc.StreamARN)
+	consumerARN, err := a.ensureConsumer(ctx, streamDesc.StreamARN)
 	if err != nil {
 		a.logger.Error(err)
-
 		return err
 	}
 
 	a.consumerARN = consumerARN
 
-	for {
-		var wg sync.WaitGroup
-		wg.Add(len(streamDesc.Shards))
-		for i, shard := range streamDesc.Shards {
-			go func(idx int, s *kinesis.Shard) error {
-				defer wg.Done()
+	for i, shard := range streamDesc.Shards {
+		go func(idx int, s *kinesis.Shard) error {
+			// Reconnection backoff
+			bo := backoff.NewExponentialBackOff()
+			bo.InitialInterval = 2 * time.Second
+
+			// Repeat until context is canceled
+			for ctx.Err() == nil {
 				sub, err := a.client.SubscribeToShardWithContext(ctx, &kinesis.SubscribeToShardInput{
 					ConsumerARN:      consumerARN,
 					ShardId:          s.ShardId,
 					StartingPosition: &kinesis.StartingPosition{Type: aws.String(kinesis.ShardIteratorTypeLatest)},
 				})
 				if err != nil {
-					a.logger.Error(err)
-
-					return err
+					wait := bo.NextBackOff()
+					a.logger.Errorf("Error while reading from shard %v: %v. Attempting to reconnect in %s...", s.ShardId, err, wait)
+					time.Sleep(wait)
+					continue
 				}
 
+				// Reset the backoff on connection success
+				bo.Reset()
+
+				// Process events
 				for event := range sub.EventStream.Events() {
 					switch e := event.(type) {
 					case *kinesis.SubscribeToShardEvent:
@@ -216,31 +222,30 @@ func (a *AWSKinesis) Subscribe(ctx context.Context, streamDesc kinesis.StreamDes
 						}
 					}
 				}
-
-				return nil
-			}(i, shard)
-		}
-		wg.Wait()
-		time.Sleep(time.Minute * 5)
+			}
+			return nil
+		}(i, shard)
 	}
+
+	return nil
 }
 
-func (a *AWSKinesis) ensureConsumer(streamARN *string) (*string, error) {
-	consumer, err := a.client.DescribeStreamConsumer(&kinesis.DescribeStreamConsumerInput{
+func (a *AWSKinesis) ensureConsumer(parentCtx context.Context, streamARN *string) (*string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	consumer, err := a.client.DescribeStreamConsumerWithContext(ctx, &kinesis.DescribeStreamConsumerInput{
 		ConsumerName: &a.metadata.ConsumerName,
 		StreamARN:    streamARN,
 	})
+	cancel()
 	if err != nil {
-		arn, err := a.registerConsumer(streamARN)
-
-		return arn, err
+		return a.registerConsumer(parentCtx, streamARN)
 	}
 
 	return consumer.ConsumerDescription.ConsumerARN, nil
 }
 
-func (a *AWSKinesis) registerConsumer(streamARN *string) (*string, error) {
-	consumer, err := a.client.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+func (a *AWSKinesis) registerConsumer(ctx context.Context, streamARN *string) (*string, error) {
+	consumer, err := a.client.RegisterStreamConsumerWithContext(ctx, &kinesis.RegisterStreamConsumerInput{
 		ConsumerName: &a.metadata.ConsumerName,
 		StreamARN:    streamARN,
 	})
@@ -248,7 +253,7 @@ func (a *AWSKinesis) registerConsumer(streamARN *string) (*string, error) {
 		return nil, err
 	}
 
-	err = a.waitUntilConsumerExists(context.Background(), &kinesis.DescribeStreamConsumerInput{
+	err = a.waitUntilConsumerExists(ctx, &kinesis.DescribeStreamConsumerInput{
 		ConsumerName: &a.metadata.ConsumerName,
 		StreamARN:    streamARN,
 	})
@@ -262,11 +267,14 @@ func (a *AWSKinesis) registerConsumer(streamARN *string) (*string, error) {
 
 func (a *AWSKinesis) deregisterConsumer(streamARN *string, consumerARN *string) error {
 	if a.consumerARN != nil {
-		_, err := a.client.DeregisterStreamConsumer(&kinesis.DeregisterStreamConsumerInput{
+		// Use a background context because the running context may have been canceled already
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err := a.client.DeregisterStreamConsumerWithContext(ctx, &kinesis.DeregisterStreamConsumerInput{
 			ConsumerARN:  consumerARN,
 			StreamARN:    streamARN,
 			ConsumerName: &a.metadata.ConsumerName,
 		})
+		cancel()
 
 		return err
 	}
@@ -315,26 +323,28 @@ func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, err
 }
 
 func (a *AWSKinesis) parseMetadata(metadata bindings.Metadata) (*kinesisMetadata, error) {
-	b, err := json.Marshal(metadata.Properties)
-	if err != nil {
-		return nil, err
-	}
-
 	var m kinesisMetadata
-	err = json.Unmarshal(b, &m)
+	err := mapstructure.WeakDecode(metadata.Properties, &m)
 	if err != nil {
 		return nil, err
 	}
-
 	return &m, nil
 }
 
-func (a *AWSKinesis) recordProcessorFactory(handler bindings.Handler) interfaces.IRecordProcessorFactory {
-	return &recordProcessorFactory{logger: a.logger, handler: handler}
+func (a *AWSKinesis) recordProcessorFactory(ctx context.Context, handler bindings.Handler) interfaces.IRecordProcessorFactory {
+	return &recordProcessorFactory{
+		ctx:     ctx,
+		logger:  a.logger,
+		handler: handler,
+	}
 }
 
 func (r *recordProcessorFactory) CreateProcessor() interfaces.IRecordProcessor {
-	return &recordProcessor{logger: r.logger, handler: r.handler}
+	return &recordProcessor{
+		ctx:     r.ctx,
+		logger:  r.logger,
+		handler: r.handler,
+	}
 }
 
 func (p *recordProcessor) Initialize(input *interfaces.InitializationInput) {
@@ -348,7 +358,7 @@ func (p *recordProcessor) ProcessRecords(input *interfaces.ProcessRecordsInput) 
 	}
 
 	for _, v := range input.Records {
-		p.handler(context.TODO(), &bindings.ReadResponse{
+		p.handler(p.ctx, &bindings.ReadResponse{
 			Data: v.Data,
 		})
 	}

--- a/bindings/aws/kinesis/kinesis_test.go
+++ b/bindings/aws/kinesis/kinesis_test.go
@@ -24,14 +24,14 @@ import (
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{
-		"AccessKey":    "key",
-		"Region":       "region",
-		"SecretKey":    "secret",
-		"ConsumerName": "test",
-		"StreamName":   "stream",
-		"Mode":         "extended",
-		"Endpoint":     "endpoint",
-		"SessionToken": "token",
+		"accessKey":    "key",
+		"region":       "region",
+		"secretKey":    "secret",
+		"consumerName": "test",
+		"streamName":   "stream",
+		"mode":         "extended",
+		"endpoint":     "endpoint",
+		"sessionToken": "token",
 	}
 	kinesis := AWSKinesis{}
 	meta, err := kinesis.parseMetadata(m)
@@ -43,5 +43,5 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, "stream", meta.StreamName)
 	assert.Equal(t, "endpoint", meta.Endpoint)
 	assert.Equal(t, "token", meta.SessionToken)
-	assert.Equal(t, kinesisConsumerMode("extended"), meta.KinesisConsumerMode)
+	assert.Equal(t, "extended", meta.KinesisConsumerMode)
 }

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -153,7 +153,6 @@ func (a *AzureBlobStorage) Init(metadata bindings.Metadata) error {
 
 func (a *AzureBlobStorage) parseMetadata(metadata bindings.Metadata) (*blobStorageMetadata, error) {
 	var m blobStorageMetadata
-
 	if val, ok := mdutils.GetMetadataProperty(metadata.Properties, azauth.StorageAccountNameKeys...); ok && val != "" {
 		m.AccountName = val
 	} else {

--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -135,7 +135,7 @@ func (c *CosmosDB) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{bindings.CreateOperation}
 }
 
-func (c *CosmosDB) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (c *CosmosDB) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	switch req.Operation {
 	case bindings.CreateOperation:
 		var obj interface{}

--- a/bindings/azure/cosmosdbgremlinapi/cosmosdbgremlinapi.go
+++ b/bindings/azure/cosmosdbgremlinapi/cosmosdbgremlinapi.go
@@ -98,7 +98,7 @@ func (c *CosmosDBGremlinAPI) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{queryOperation}
 }
 
-func (c *CosmosDBGremlinAPI) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (c *CosmosDBGremlinAPI) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	var jsonPoint map[string]interface{}
 	err := json.Unmarshal(req.Data, &jsonPoint)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c *CosmosDBGremlinAPI) Invoke(ctx context.Context, req *bindings.InvokeReq
 	if gq == "" {
 		return nil, errors.New("CosmosDBGremlinAPI Error: missing data - gremlin query not set")
 	}
-	startTime := time.Now().UTC()
+	startTime := time.Now()
 	resp := &bindings.InvokeResponse{
 		Metadata: map[string]string{
 			respOpKey:        string(req.Operation),
@@ -125,7 +125,7 @@ func (c *CosmosDBGremlinAPI) Invoke(ctx context.Context, req *bindings.InvokeReq
 	if len(d) > 0 {
 		resp.Data = d[0].Result.Data
 	}
-	endTime := time.Now().UTC()
+	endTime := time.Now()
 	resp.Metadata[respEndTimeKey] = endTime.Format(time.RFC3339Nano)
 	resp.Metadata[respDurationKey] = endTime.Sub(startTime).String()
 

--- a/bindings/azure/eventgrid/eventgrid.go
+++ b/bindings/azure/eventgrid/eventgrid.go
@@ -74,13 +74,13 @@ func (a *AzureEventGrid) Init(metadata bindings.Metadata) error {
 	return nil
 }
 
-func (a *AzureEventGrid) Read(handler bindings.Handler) error {
+func (a *AzureEventGrid) Read(ctx context.Context, handler bindings.Handler) error {
 	err := a.ensureInputBindingMetadata()
 	if err != nil {
 		return err
 	}
 
-	err = a.createSubscription()
+	err = a.createSubscription(ctx)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (a *AzureEventGrid) Read(handler bindings.Handler) error {
 			case "POST":
 				bodyBytes := ctx.PostBody()
 
-				_, err = handler(context.TODO(), &bindings.ReadResponse{
+				_, err = handler(ctx, &bindings.ReadResponse{
 					Data: bodyBytes,
 				})
 				if err != nil {
@@ -110,11 +110,27 @@ func (a *AzureEventGrid) Read(handler bindings.Handler) error {
 		}
 	}
 
-	a.logger.Debugf("About to start listening for Event Grid events at http://localhost:%s/api/events", a.metadata.HandshakePort)
-	err = fasthttp.ListenAndServe(fmt.Sprintf(":%s", a.metadata.HandshakePort), m)
-	if err != nil {
-		return err
+	srv := &fasthttp.Server{
+		Handler: m,
 	}
+
+	// Run the server in background
+	go func() {
+		a.logger.Debugf("About to start listening for Event Grid events at http://localhost:%s/api/events", a.metadata.HandshakePort)
+		err := srv.ListenAndServe(fmt.Sprintf(":%s", a.metadata.HandshakePort))
+		if err != nil {
+			a.logger.Errorf("Error starting server: %v", err)
+		}
+	}()
+
+	// Close the server when context is canceled
+	go func() {
+		<-ctx.Done()
+		err := srv.Shutdown()
+		if err != nil {
+			a.logger.Errorf("Error shutting down server: %v", err)
+		}
+	}()
 
 	return nil
 }
@@ -229,7 +245,7 @@ func (a *AzureEventGrid) parseMetadata(metadata bindings.Metadata) (*azureEventG
 	return &eventGridMetadata, nil
 }
 
-func (a *AzureEventGrid) createSubscription() error {
+func (a *AzureEventGrid) createSubscription(ctx context.Context) error {
 	clientCredentialsConfig := auth.NewClientCredentialsConfig(a.metadata.ClientID, a.metadata.ClientSecret, a.metadata.TenantID)
 
 	subscriptionClient := eventgrid.NewEventSubscriptionsClient(a.metadata.SubscriptionID)
@@ -253,7 +269,7 @@ func (a *AzureEventGrid) createSubscription() error {
 	}
 
 	a.logger.Debugf("Attempting to create or update Event Grid subscription. scope=%s endpointURL=%s", a.metadata.Scope, a.metadata.SubscriberEndpoint)
-	result, err := subscriptionClient.CreateOrUpdate(context.Background(), a.metadata.Scope, a.metadata.EventSubscriptionName, eventInfo)
+	result, err := subscriptionClient.CreateOrUpdate(ctx, a.metadata.Scope, a.metadata.EventSubscriptionName, eventInfo)
 	if err != nil {
 		a.logger.Debugf("Failed to create or update Event Grid subscription: %v", err)
 

--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -17,10 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/aad"
@@ -76,7 +73,7 @@ const (
 	sysPropMessageID                  = "message-id"
 )
 
-func readHandler(e *eventhub.Event, handler bindings.Handler) error {
+func readHandler(ctx context.Context, e *eventhub.Event, handler bindings.Handler) error {
 	res := bindings.ReadResponse{Data: e.Data, Metadata: map[string]string{}}
 	if e.SystemProperties.SequenceNumber != nil {
 		res.Metadata[sysPropSequenceNumber] = strconv.FormatInt(*e.SystemProperties.SequenceNumber, 10)
@@ -114,7 +111,7 @@ func readHandler(e *eventhub.Event, handler bindings.Handler) error {
 	if e.ID != "" {
 		res.Metadata[sysPropMessageID] = e.ID
 	}
-	_, err := handler(context.TODO(), &res)
+	_, err := handler(ctx, &res)
 
 	return err
 }
@@ -304,43 +301,39 @@ func (a *AzureEventHubs) Invoke(ctx context.Context, req *bindings.InvokeRequest
 	return nil, nil
 }
 
-// Read gets messages from eventhubs in a non-blocking fashion.
-func (a *AzureEventHubs) Read(handler bindings.Handler) error {
+// Read gets messages from eventhubs in a non-blocking way.
+func (a *AzureEventHubs) Read(ctx context.Context, handler bindings.Handler) error {
 	if !a.metadata.partitioned() {
-		if err := a.RegisterEventProcessor(handler); err != nil {
+		if err := a.RegisterEventProcessor(ctx, handler); err != nil {
 			return err
 		}
 	} else {
-		if err := a.RegisterPartitionedEventProcessor(handler); err != nil {
+		if err := a.RegisterPartitionedEventProcessor(ctx, handler); err != nil {
 			return err
 		}
 	}
 
-	// close Event Hubs when application exits.
-	exitChan := make(chan os.Signal, 1)
-	signal.Notify(exitChan, os.Interrupt, syscall.SIGTERM)
-	<-exitChan
-
-	a.Close()
+	go func() {
+		// Wait for context to be canceled then close the connection
+		<-ctx.Done()
+		a.Close()
+	}()
 
 	return nil
 }
 
 // RegisterPartitionedEventProcessor - receive eventhub messages by partitionID.
-func (a *AzureEventHubs) RegisterPartitionedEventProcessor(handler bindings.Handler) error {
-	ctx := context.Background()
-
+func (a *AzureEventHubs) RegisterPartitionedEventProcessor(ctx context.Context, handler bindings.Handler) error {
 	runtimeInfo, err := a.hub.GetRuntimeInformation(ctx)
 	if err != nil {
 		return err
 	}
 
 	callback := func(c context.Context, event *eventhub.Event) error {
-		if event != nil {
-			return readHandler(event, handler)
+		if event == nil {
+			return nil
 		}
-
-		return nil
+		return readHandler(c, event, handler)
 	}
 
 	ops := []eventhub.ReceiveOption{
@@ -364,6 +357,47 @@ func (a *AzureEventHubs) RegisterPartitionedEventProcessor(handler bindings.Hand
 	return nil
 }
 
+// RegisterEventProcessor - receive eventhub messages by eventprocessor
+// host by balancing partitions.
+func (a *AzureEventHubs) RegisterEventProcessor(ctx context.Context, handler bindings.Handler) error {
+	leaserCheckpointer, err := storage.NewStorageLeaserCheckpointer(a.storageCredential, a.metadata.storageAccountName, a.metadata.storageContainerName, *a.azureEnvironment)
+	if err != nil {
+		return err
+	}
+
+	var processor *eph.EventProcessorHost
+	if a.metadata.connectionString != "" {
+		processor, err = eph.NewFromConnectionString(ctx, a.metadata.connectionString, leaserCheckpointer, leaserCheckpointer, eph.WithNoBanner(), eph.WithConsumerGroup(a.metadata.consumerGroup))
+		if err != nil {
+			return err
+		}
+	} else {
+		// AAD connection.
+		processor, err = eph.New(ctx, a.metadata.eventHubNamespaceName, a.metadata.eventHubName, a.tokenProvider, leaserCheckpointer, leaserCheckpointer, eph.WithNoBanner(), eph.WithConsumerGroup(a.metadata.consumerGroup))
+		if err != nil {
+			return err
+		}
+		a.logger.Debugf("processor initialized via AAD for eventHubName %s", a.metadata.eventHubName)
+	}
+
+	_, err = processor.RegisterHandler(
+		ctx,
+		func(c context.Context, event *eventhub.Event) error {
+			return readHandler(c, event, handler)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = processor.StartNonBlocking(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func contains(arr []string, str string) bool {
 	for _, a := range arr {
 		if a == str {
@@ -374,45 +408,10 @@ func contains(arr []string, str string) bool {
 	return false
 }
 
-// RegisterEventProcessor - receive eventhub messages by eventprocessor
-// host by balancing partitions.
-func (a *AzureEventHubs) RegisterEventProcessor(handler bindings.Handler) error {
-	leaserCheckpointer, err := storage.NewStorageLeaserCheckpointer(a.storageCredential, a.metadata.storageAccountName, a.metadata.storageContainerName, *a.azureEnvironment)
-	if err != nil {
-		return err
-	}
-
-	var processor *eph.EventProcessorHost
-	if a.metadata.connectionString != "" {
-		processor, err = eph.NewFromConnectionString(context.Background(), a.metadata.connectionString, leaserCheckpointer, leaserCheckpointer, eph.WithNoBanner(), eph.WithConsumerGroup(a.metadata.consumerGroup))
-		if err != nil {
-			return err
-		}
-	} else {
-		// AAD connection.
-		processor, err = eph.New(context.Background(), a.metadata.eventHubNamespaceName, a.metadata.eventHubName, a.tokenProvider, leaserCheckpointer, leaserCheckpointer, eph.WithNoBanner(), eph.WithConsumerGroup(a.metadata.consumerGroup))
-		if err != nil {
-			return err
-		}
-		a.logger.Debugf("processor initialized via AAD for eventHubName %s", a.metadata.eventHubName)
-	}
-
-	_, err = processor.RegisterHandler(context.Background(),
-		func(c context.Context, e *eventhub.Event) error {
-			return readHandler(e, handler)
-		})
-	if err != nil {
-		return err
-	}
-
-	err = processor.StartNonBlocking(context.Background())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (a *AzureEventHubs) Close() error {
-	return a.hub.Close(context.Background())
+func (a *AzureEventHubs) Close() (err error) {
+	// Use a background context because the connection context may be canceled already
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	err = a.hub.Close(ctx)
+	cancel()
+	return err
 }

--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -138,8 +138,6 @@ func (a *AzureServiceBusQueues) Operations() []bindings.OperationKind {
 
 func (a *AzureServiceBusQueues) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	var err error
-	ctx, cancel := context.WithTimeout(ctx, a.timeout)
-	defer cancel()
 
 	a.senderLock.RLock()
 	sender := a.sender
@@ -173,79 +171,82 @@ func (a *AzureServiceBusQueues) Invoke(ctx context.Context, req *bindings.Invoke
 		msg.TimeToLive = &ttl
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, a.timeout)
+	defer cancel()
+
 	return nil, sender.SendMessage(ctx, msg, nil)
 }
 
-func (a *AzureServiceBusQueues) Read(handler bindings.Handler) error {
-	subscribeCtx := context.Background()
-
+func (a *AzureServiceBusQueues) Read(subscribeCtx context.Context, handler bindings.Handler) error {
 	// Reconnection backoff policy
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = 0
 	bo.InitialInterval = time.Duration(a.metadata.MinConnectionRecoveryInSec) * time.Second
 	bo.MaxInterval = time.Duration(a.metadata.MaxConnectionRecoveryInSec) * time.Second
 
-	// Reconnect loop.
-	for {
-		sub := impl.NewSubscription(
-			subscribeCtx,
-			a.metadata.MaxActiveMessages,
-			a.metadata.TimeoutInSec,
-			*a.metadata.MaxRetriableErrorsPerSec,
-			&a.metadata.MaxConcurrentHandlers,
-			"queue "+a.metadata.QueueName,
-			a.logger,
-		)
+	go func() {
+		// Reconnect loop.
+		for {
+			sub := impl.NewSubscription(
+				subscribeCtx,
+				a.metadata.MaxActiveMessages,
+				a.metadata.TimeoutInSec,
+				*a.metadata.MaxRetriableErrorsPerSec,
+				&a.metadata.MaxConcurrentHandlers,
+				"queue "+a.metadata.QueueName,
+				a.logger,
+			)
 
-		// Blocks until a successful connection (or until context is canceled)
-		err := sub.Connect(func() (*servicebus.Receiver, error) {
-			return a.client.NewReceiverForQueue(a.metadata.QueueName, nil)
-		})
-		if err != nil {
-			// Realistically, the only time we should get to this point is if the context was canceled, but let's log any other error we may get.
-			if err != context.Canceled {
-				a.logger.Warnf("Error reading from Azure Service Bus Queue binding: %s", err.Error())
+			// Blocks until a successful connection (or until context is canceled)
+			err := sub.Connect(func() (*servicebus.Receiver, error) {
+				return a.client.NewReceiverForQueue(a.metadata.QueueName, nil)
+			})
+			if err != nil {
+				// Realistically, the only time we should get to this point is if the context was canceled, but let's log any other error we may get.
+				if err != context.Canceled {
+					a.logger.Warnf("Error reading from Azure Service Bus Queue binding: %s", err.Error())
+				}
+				return
 			}
-			break
-		}
 
-		// ReceiveAndBlock will only return with an error that it cannot handle internally. The subscription connection is closed when this method returns.
-		// If that occurs, we will log the error and attempt to re-establish the subscription connection until we exhaust the number of reconnect attempts.
-		err = sub.ReceiveAndBlock(
-			a.getHandlerFunc(handler),
-			a.metadata.LockRenewalInSec,
-			func() {
-				// Reset the backoff when the subscription is successful and we have received the first message
-				bo.Reset()
-			},
-		)
-		if err != nil {
-			var detachError *amqp.DetachError
-			var amqpError *amqp.Error
-			if errors.Is(err, detachError) ||
-				(errors.As(err, &amqpError) && amqpError.Condition == amqp.ErrorDetachForced) {
-				a.logger.Debug(err)
-			} else {
-				a.logger.Error(err)
+			// ReceiveAndBlock will only return with an error that it cannot handle internally. The subscription connection is closed when this method returns.
+			// If that occurs, we will log the error and attempt to re-establish the subscription connection until we exhaust the number of reconnect attempts.
+			err = sub.ReceiveAndBlock(
+				a.getHandlerFunc(handler),
+				a.metadata.LockRenewalInSec,
+				func() {
+					// Reset the backoff when the subscription is successful and we have received the first message
+					bo.Reset()
+				},
+			)
+			if err != nil {
+				var detachError *amqp.DetachError
+				var amqpError *amqp.Error
+				if errors.Is(err, detachError) ||
+					(errors.As(err, &amqpError) && amqpError.Condition == amqp.ErrorDetachForced) {
+					a.logger.Debug(err)
+				} else {
+					a.logger.Error(err)
+				}
 			}
+
+			// Gracefully close the connection (in case it's not closed already)
+			// Use a background context here (with timeout) because ctx may be closed already
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second*time.Duration(a.metadata.TimeoutInSec))
+			sub.Close(closeCtx)
+			closeCancel()
+
+			// If context was canceled, do not attempt to reconnect
+			if subscribeCtx.Err() != nil {
+				a.logger.Debug("Context canceled; will not reconnect")
+				return
+			}
+
+			wait := bo.NextBackOff()
+			a.logger.Warnf("Subscription to queue %s lost connection, attempting to reconnect in %s...", a.metadata.QueueName, wait)
+			time.Sleep(wait)
 		}
-
-		// Gracefully close the connection (in case it's not closed already)
-		// Use a background context here (with timeout) because ctx may be closed already
-		closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second*time.Duration(a.metadata.TimeoutInSec))
-		sub.Close(closeCtx)
-		closeCancel()
-
-		// If context was canceled, do not attempt to reconnect
-		if subscribeCtx.Err() != nil {
-			a.logger.Debug("Context canceled; will not reconnect")
-			break
-		}
-
-		wait := bo.NextBackOff()
-		a.logger.Warnf("Subscription to queue %s lost connection, attempting to reconnect in %s...", a.metadata.QueueName, wait)
-		time.Sleep(wait)
-	}
+	}()
 
 	return nil
 }

--- a/bindings/azure/servicebusqueues/servicebusqueues_integration_test.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues_integration_test.go
@@ -120,6 +120,8 @@ func TestQueueWithTTL(t *testing.T) {
 }
 
 func TestPublishingWithTTL(t *testing.T) {
+	ctx := context.Background()
+
 	serviceBusConnectionString := getTestServiceBusConnectionString()
 	assert.NotEmpty(t, serviceBusConnectionString, fmt.Sprintf("Azure ServiceBus connection string must set in environment variable '%s'", testServiceBusEnvKey))
 
@@ -138,9 +140,9 @@ func TestPublishingWithTTL(t *testing.T) {
 	assert.Nil(t, err)
 
 	qmr := ns.NewQueueManager()
-	defer qmr.Delete(context.Background(), queueName)
+	defer qmr.Delete(ctx, queueName)
 
-	queueEntity, err := qmr.Get(context.Background(), queueName)
+	queueEntity, err := qmr.Get(ctx, queueName)
 	assert.Nil(t, err)
 	const defaultAzureServiceBusMessageTimeToLive = "P14D"
 	assert.Equal(t, defaultAzureServiceBusMessageTimeToLive, *queueEntity.DefaultMessageTimeToLive)
@@ -152,7 +154,7 @@ func TestPublishingWithTTL(t *testing.T) {
 			metadata.TTLMetadataKey: fmt.Sprintf("%d", ttlInSeconds),
 		},
 	}
-	_, err = queueBinding1.Invoke(&writeRequest)
+	_, err = queueBinding1.Invoke(ctx, &writeRequest)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second * (ttlInSeconds + 2))
@@ -175,7 +177,7 @@ func TestPublishingWithTTL(t *testing.T) {
 			metadata.TTLMetadataKey: fmt.Sprintf("%d", ttlInSeconds),
 		},
 	}
-	_, err = queueBinding2.Invoke(&writeRequest)
+	_, err = queueBinding2.Invoke(ctx, &writeRequest)
 	assert.Nil(t, err)
 
 	msg, ok, err := getMessageWithRetries(queue, maxGetDuration)

--- a/bindings/commercetools/commercetools.go
+++ b/bindings/commercetools/commercetools.go
@@ -84,11 +84,13 @@ func (ct *Binding) Operations() []bindings.OperationKind {
 // Invoke is triggered from Dapr.
 func (ct *Binding) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	var reqData Data
-	json.Unmarshal(req.Data, &reqData)
+	err := json.Unmarshal(req.Data, &reqData)
+	if err != nil {
+		return nil, err
+	}
 	query := reqData.Query
 
 	res := &bindings.InvokeResponse{Data: nil, Metadata: nil}
-	var err error
 
 	if len(reqData.CommercetoolsAPI) > 0 {
 		ct.logger.Infof("commercetoolsAPI: %s", reqData.CommercetoolsAPI)

--- a/bindings/cron/cron.go
+++ b/bindings/cron/cron.go
@@ -27,16 +27,13 @@ import (
 
 // Binding represents Cron input binding.
 type Binding struct {
-	logger   logger.Logger
-	name     string
-	schedule string
-	parser   cron.Parser
+	logger        logger.Logger
+	name          string
+	schedule      string
+	parser        cron.Parser
+	runningCtx    context.Context
+	runningCancel context.CancelFunc
 }
-
-var (
-	_      = bindings.InputBinding(&Binding{})
-	stopCh = make(map[string]chan bool)
-)
 
 // NewCron returns a new Cron event input binding.
 func NewCron(logger logger.Logger) *Binding {
@@ -53,9 +50,6 @@ func NewCron(logger logger.Logger) *Binding {
 //   "15 * * * * *" - Every 15 sec
 //   "0 30 * * * *" - Every 30 min
 func (b *Binding) Init(metadata bindings.Metadata) error {
-	if _, ok := stopCh[metadata.Name]; !ok {
-		stopCh[metadata.Name] = make(chan bool)
-	}
 	b.name = metadata.Name
 	s, f := metadata.Properties["schedule"]
 	if !f || s == "" {
@@ -67,15 +61,17 @@ func (b *Binding) Init(metadata bindings.Metadata) error {
 	}
 	b.schedule = s
 
+	b.resetContext()
+
 	return nil
 }
 
 // Read triggers the Cron scheduler.
-func (b *Binding) Read(handler bindings.Handler) error {
+func (b *Binding) Read(ctx context.Context, handler bindings.Handler) error {
 	c := cron.New(cron.WithParser(b.parser))
 	id, err := c.AddFunc(b.schedule, func() {
 		b.logger.Debugf("name: %s, schedule fired: %v", b.name, time.Now())
-		handler(context.TODO(), &bindings.ReadResponse{
+		handler(ctx, &bindings.ReadResponse{
 			Metadata: map[string]string{
 				"timeZone":    c.Location().String(),
 				"readTimeUTC": time.Now().UTC().String(),
@@ -87,9 +83,18 @@ func (b *Binding) Read(handler bindings.Handler) error {
 	}
 	c.Start()
 	b.logger.Debugf("name: %s, next run: %v", b.name, time.Until(c.Entry(id).Next))
-	<-stopCh[b.name]
-	b.logger.Debugf("name: %s, stopping schedule: %s", b.name, b.schedule)
-	c.Stop()
+
+	go func() {
+		// Wait for a context to be canceled or a message on the stopCh
+		select {
+		case <-b.runningCtx.Done():
+			// Do nothing
+		case <-ctx.Done():
+			b.runningCancel()
+		}
+		b.logger.Debugf("name: %s, stopping schedule: %s", b.name, b.schedule)
+		c.Stop()
+	}()
 
 	return nil
 }
@@ -97,18 +102,20 @@ func (b *Binding) Read(handler bindings.Handler) error {
 // Invoke exposes way to stop previously started cron.
 func (b *Binding) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	b.logger.Debugf("name: %s, operation: %v", b.name, req.Operation)
-	if req.Operation != bindings.DeleteOperation {
+
+	switch req.Operation {
+	case bindings.DeleteOperation:
+		b.resetContext()
+		return &bindings.InvokeResponse{
+			Metadata: map[string]string{
+				"schedule":    b.schedule,
+				"stopTimeUTC": time.Now().UTC().String(),
+			},
+		}, nil
+	default:
 		return nil, fmt.Errorf("invalid operation: '%v', only '%v' supported",
 			req.Operation, bindings.DeleteOperation)
 	}
-	stopCh[b.name] <- true
-
-	return &bindings.InvokeResponse{
-		Metadata: map[string]string{
-			"schedule":    b.schedule,
-			"stopTimeUTC": time.Now().UTC().String(),
-		},
-	}, nil
 }
 
 // Operations method returns the supported operations by this binding.
@@ -116,4 +123,12 @@ func (b *Binding) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{
 		bindings.DeleteOperation,
 	}
+}
+
+// Resets the runningCtx
+func (b *Binding) resetContext() {
+	if b.runningCancel != nil {
+		b.runningCancel()
+	}
+	b.runningCtx, b.runningCancel = context.WithCancel(context.Background())
 }

--- a/bindings/gcp/bucket/bucket_test.go
+++ b/bindings/gcp/bucket/bucket_test.go
@@ -166,8 +166,9 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 
 		mergedMeta, err := meta.mergeWithRequestMetadata(&request)
 
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, mergedMeta)
+		assert.False(t, mergedMeta.DecodeBase64)
 	})
 	t.Run("Has invalid merged metadata encodeBase64", func(t *testing.T) {
 		m := bindings.Metadata{}
@@ -211,8 +212,9 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 
 		mergedMeta, err := meta.mergeWithRequestMetadata(&request)
 
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, mergedMeta)
+		assert.False(t, mergedMeta.EncodeBase64)
 	})
 }
 

--- a/bindings/gcp/pubsub/pubsub.go
+++ b/bindings/gcp/pubsub/pubsub.go
@@ -84,24 +84,29 @@ func (g *GCPPubSub) Init(metadata bindings.Metadata) error {
 }
 
 func (g *GCPPubSub) parseMetadata(metadata bindings.Metadata) ([]byte, error) {
-	b, err := json.Marshal(metadata.Properties)
-
-	return b, err
+	return json.Marshal(metadata.Properties)
 }
 
-func (g *GCPPubSub) Read(handler bindings.Handler) error {
-	sub := g.client.Subscription(g.metadata.Subscription)
-	err := sub.Receive(context.Background(), func(ctx context.Context, m *pubsub.Message) {
-		_, err := handler(ctx, &bindings.ReadResponse{
-			Data:     m.Data,
-			Metadata: map[string]string{id: m.ID, publishTime: m.PublishTime.String()},
-		})
-		if err == nil {
+func (g *GCPPubSub) Read(ctx context.Context, handler bindings.Handler) error {
+	go func() {
+		sub := g.client.Subscription(g.metadata.Subscription)
+		err := sub.Receive(ctx, func(c context.Context, m *pubsub.Message) {
+			_, err := handler(c, &bindings.ReadResponse{
+				Data:     m.Data,
+				Metadata: map[string]string{id: m.ID, publishTime: m.PublishTime.String()},
+			})
+			if err != nil {
+				m.Nack()
+				return
+			}
 			m.Ack()
+		})
+		if err != nil {
+			g.logger.Errorf("error receiving messages: %v", err)
 		}
-	})
+	}()
 
-	return err
+	return nil
 }
 
 func (g *GCPPubSub) Operations() []bindings.OperationKind {

--- a/bindings/huawei/obs/obs.go
+++ b/bindings/huawei/obs/obs.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/huaweicloud/huaweicloud-sdk-go-obs/obs"
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
@@ -92,13 +93,8 @@ func (o *HuaweiOBS) Init(metadata bindings.Metadata) error {
 }
 
 func (o *HuaweiOBS) parseMetadata(metadata bindings.Metadata) (*obsMetadata, error) {
-	b, err := json.Marshal(metadata.Properties)
-	if err != nil {
-		return nil, err
-	}
-
 	var m obsMetadata
-	err = json.Unmarshal(b, &m)
+	err := mapstructure.WeakDecode(metadata.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/influx/influx.go
+++ b/bindings/influx/influx.go
@@ -20,6 +20,7 @@ import (
 
 	influxdb2 "github.com/influxdata/influxdb-client-go"
 	"github.com/influxdata/influxdb-client-go/api"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/bindings"
@@ -40,8 +41,6 @@ var (
 	ErrMetadataMissing         = errors.New("metadata required")
 	ErrMetadataRawNotFound     = errors.Errorf("required metadata not set: %s", rawQueryKey)
 )
-
-var _ bindings.OutputBinding = &Influx{}
 
 // Influx allows writing to InfluxDB.
 type Influx struct {
@@ -98,13 +97,8 @@ func (i *Influx) Init(metadata bindings.Metadata) error {
 
 // GetInfluxMetadata returns new Influx metadata.
 func (i *Influx) getInfluxMetadata(metadata bindings.Metadata) (*influxMetadata, error) {
-	b, err := json.Marshal(metadata.Properties)
-	if err != nil {
-		return nil, err
-	}
-
 	var iMetadata influxMetadata
-	err = json.Unmarshal(b, &iMetadata)
+	err := mapstructure.WeakDecode(metadata.Properties, &iMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/input_binding.go
+++ b/bindings/input_binding.go
@@ -22,10 +22,10 @@ import (
 
 // InputBinding is the interface to define a binding that triggers on incoming events.
 type InputBinding interface {
-	// Init passes connection and properties metadata to the binding implementation
+	// Init passes connection and properties metadata to the binding implementation.
 	Init(metadata Metadata) error
-	// Read is a blocking method that triggers the callback function whenever an event arrives
-	Read(handler Handler) error
+	// Read is a method that runs in background and triggers the callback function whenever an event arrives.
+	Read(ctx context.Context, handler Handler) error
 }
 
 // Handler is the handler used to invoke the app handler.

--- a/bindings/kubernetes/kubernetes.go
+++ b/bindings/kubernetes/kubernetes.go
@@ -17,10 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -45,8 +42,6 @@ type EventResponse struct {
 	OldVal v1.Event `json:"oldVal"`
 	NewVal v1.Event `json:"newVal"`
 }
-
-var _ = bindings.InputBinding(&kubernetesInput{})
 
 // NewKubernetes returns a new Kubernetes event input binding.
 func NewKubernetes(logger logger.Logger) bindings.InputBinding {
@@ -82,12 +77,13 @@ func (k *kubernetesInput) parseMetadata(metadata bindings.Metadata) error {
 	return nil
 }
 
-func (k *kubernetesInput) Read(handler bindings.Handler) error {
+func (k *kubernetesInput) Read(ctx context.Context, handler bindings.Handler) error {
 	watchlist := cache.NewListWatchFromClient(
 		k.kubeClient.CoreV1().RESTClient(),
 		"events",
 		k.namespace,
-		fields.Everything())
+		fields.Everything(),
+	)
 	var resultChan chan EventResponse = make(chan EventResponse)
 	_, controller := cache.NewInformer(
 		watchlist,
@@ -129,27 +125,35 @@ func (k *kubernetesInput) Read(handler bindings.Handler) error {
 			},
 		},
 	)
+
+	// Start the controller in backgound
 	stopCh := make(chan struct{})
-	sigterm := make(chan os.Signal, 1)
-	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM)
 	go controller.Run(stopCh)
-	done := false
-	for !done {
-		select {
-		case obj := <-resultChan:
-			data, err := json.Marshal(obj)
-			if err != nil {
-				k.logger.Errorf("Error marshalling event %w", err)
-			} else {
-				handler(context.TODO(), &bindings.ReadResponse{
-					Data: data,
-				})
+
+	// Watch for new messages and for context cancellation
+	go func() {
+		var (
+			obj  EventResponse
+			data []byte
+			err  error
+		)
+		for {
+			select {
+			case obj = <-resultChan:
+				data, err = json.Marshal(obj)
+				if err != nil {
+					k.logger.Errorf("Error marshalling event %w", err)
+				} else {
+					handler(ctx, &bindings.ReadResponse{
+						Data: data,
+					})
+				}
+			case <-ctx.Done():
+				close(stopCh)
+				return
 			}
-		case <-sigterm:
-			done = true
-			close(stopCh)
 		}
-	}
+	}()
 
 	return nil
 }

--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -26,6 +26,7 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
@@ -72,14 +73,8 @@ func (ls *LocalStorage) Init(metadata bindings.Metadata) error {
 }
 
 func (ls *LocalStorage) parseMetadata(metadata bindings.Metadata) (*Metadata, error) {
-	lsInfo := metadata.Properties
-	b, err := json.Marshal(lsInfo)
-	if err != nil {
-		return nil, err
-	}
-
 	var m Metadata
-	err = json.Unmarshal(b, &m)
+	err := mapstructure.WeakDecode(metadata.Properties, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +242,7 @@ func walkPath(root string) ([]string, error) {
 }
 
 // Invoke is called for output bindings.
-func (ls *LocalStorage) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (ls *LocalStorage) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	filename := ""
 	if val, ok := req.Metadata[fileNameMetadataKey]; ok && val != "" {
 		filename = val

--- a/bindings/mqtt/mqtt_integration_test.go
+++ b/bindings/mqtt/mqtt_integration_test.go
@@ -88,7 +88,7 @@ func TestInvokeWithTopic(t *testing.T) {
 	}()
 
 	// Test invoke with default topic configured for component.
-	_, err = r.Invoke(context.TODO(), &bindings.InvokeRequest{Data: dataDefault})
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{Data: dataDefault})
 	assert.Nil(t, err)
 
 	m := <-msgCh
@@ -98,7 +98,7 @@ func TestInvokeWithTopic(t *testing.T) {
 	assert.Equal(t, topicDefault, mqttMessage.Topic())
 
 	// Test invoke with customized topic.
-	_, err = r.Invoke(context.TODO(), &bindings.InvokeRequest{
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{
 		Data: dataCustomized,
 		Metadata: map[string]string{
 			mqttTopic: topicCustomized,

--- a/bindings/mqtt/mqtt_test.go
+++ b/bindings/mqtt/mqtt_test.go
@@ -113,7 +113,8 @@ func TestParseMetadata(t *testing.T) {
 		m, err := parseMQTTMetaData(fakeMetaData)
 
 		// assert
-		assert.Contains(t, err.Error(), "invalid clean session")
+		assert.NoError(t, err)
+		assert.Equal(t, m.cleanSession, false)
 		assert.Equal(t, fakeProperties[mqttURL], m.url)
 	})
 
@@ -200,7 +201,7 @@ func TestParseMetadata(t *testing.T) {
 		m := NewMQTT(logger)
 		m.ctx, m.cancel = context.WithCancel(context.Background())
 
-		m.handleMessage(func(ctx context.Context, r *bindings.ReadResponse) ([]byte, error) {
+		m.handleMessage(context.Background(), func(ctx context.Context, r *bindings.ReadResponse) ([]byte, error) {
 			assert.Equal(t, payload, r.Data)
 			metadata := r.Metadata
 			responseTopic, ok := metadata[mqttTopic]

--- a/bindings/postgres/postgres.go
+++ b/bindings/postgres/postgres.go
@@ -42,8 +42,6 @@ type Postgres struct {
 	db     *pgxpool.Pool
 }
 
-var _ = bindings.OutputBinding(&Postgres{})
-
 // NewPostgres returns a new PostgreSQL output binding.
 func NewPostgres(logger logger.Logger) *Postgres {
 	return &Postgres{logger: logger}

--- a/bindings/postmark/postmark.go
+++ b/bindings/postmark/postmark.go
@@ -93,7 +93,7 @@ func (p *Postmark) Operations() []bindings.OperationKind {
 }
 
 // Invoke does the work of sending message to Postmark API.
-func (p *Postmark) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (p *Postmark) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	// We allow two possible sources of the properties we need,
 	// the component metadata or request metadata, request takes priority if present
 

--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -24,6 +24,7 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/internal/utils"
 	contrib_metadata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
@@ -161,19 +162,11 @@ func (r *RabbitMQ) parseMetadata(metadata bindings.Metadata) error {
 	}
 
 	if val, ok := metadata.Properties[durable]; ok && val != "" {
-		d, err := strconv.ParseBool(val)
-		if err != nil {
-			return fmt.Errorf("rabbitMQ binding error: can't parse durable field: %s", err)
-		}
-		m.Durable = d
+		m.Durable = utils.IsTruthy(val)
 	}
 
 	if val, ok := metadata.Properties[deleteWhenUnused]; ok && val != "" {
-		d, err := strconv.ParseBool(val)
-		if err != nil {
-			return fmt.Errorf("rabbitMQ binding error: can't parse deleteWhenUnused field: %s", err)
-		}
-		m.DeleteWhenUnused = d
+		m.DeleteWhenUnused = utils.IsTruthy(val)
 	}
 
 	if val, ok := metadata.Properties[prefetchCount]; ok && val != "" {
@@ -185,11 +178,7 @@ func (r *RabbitMQ) parseMetadata(metadata bindings.Metadata) error {
 	}
 
 	if val, ok := metadata.Properties[exclusive]; ok && val != "" {
-		d, err := strconv.ParseBool(val)
-		if err != nil {
-			return fmt.Errorf("rabbitMQ binding error: can't parse exclusive field: %s", err)
-		}
-		m.Exclusive = d
+		m.Exclusive = utils.IsTruthy(val)
 	}
 
 	if val, ok := metadata.Properties[maxPriority]; ok && val != "" {
@@ -236,7 +225,7 @@ func (r *RabbitMQ) declareQueue() (amqp.Queue, error) {
 	return r.channel.QueueDeclare(r.metadata.QueueName, r.metadata.Durable, r.metadata.DeleteWhenUnused, r.metadata.Exclusive, false, args)
 }
 
-func (r *RabbitMQ) Read(handler bindings.Handler) error {
+func (r *RabbitMQ) Read(ctx context.Context, handler bindings.Handler) error {
 	msgs, err := r.channel.Consume(
 		r.queue.Name,
 		"",
@@ -250,20 +239,24 @@ func (r *RabbitMQ) Read(handler bindings.Handler) error {
 		return err
 	}
 
-	forever := make(chan bool)
-
 	go func() {
-		for d := range msgs {
-			_, err := handler(context.TODO(), &bindings.ReadResponse{
-				Data: d.Body,
-			})
-			if err == nil {
-				r.channel.Ack(d.DeliveryTag, false)
+		var err error
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case d := <-msgs:
+				_, err = handler(ctx, &bindings.ReadResponse{
+					Data: d.Body,
+				})
+				if err != nil {
+					r.channel.Nack(d.DeliveryTag, false, true)
+				} else {
+					r.channel.Ack(d.DeliveryTag, false)
+				}
 			}
 		}
 	}()
-
-	<-forever
 
 	return nil
 }

--- a/bindings/rabbitmq/rabbitmq_integration_test.go
+++ b/bindings/rabbitmq/rabbitmq_integration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rabbitmq
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -95,7 +96,7 @@ func TestQueuesWithTTL(t *testing.T) {
 	defer ch.Close()
 
 	const tooLateMsgContent = "too_late_msg"
-	_, err = r.Invoke(&bindings.InvokeRequest{Data: []byte(tooLateMsgContent)})
+	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{Data: []byte(tooLateMsgContent)})
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second + (ttlInSeconds * time.Second))
@@ -106,7 +107,7 @@ func TestQueuesWithTTL(t *testing.T) {
 
 	// Getting before it is expired, should return it
 	const testMsgContent = "test_msg"
-	_, err = r.Invoke(&bindings.InvokeRequest{Data: []byte(testMsgContent)})
+	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{Data: []byte(testMsgContent)})
 	assert.Nil(t, err)
 
 	msg, ok, err := getMessageWithRetries(ch, queueName, maxGetDuration)
@@ -159,7 +160,7 @@ func TestPublishingWithTTL(t *testing.T) {
 		},
 	}
 
-	_, err = rabbitMQBinding1.Invoke(&writeRequest)
+	_, err = rabbitMQBinding1.Invoke(context.Backgound(), &writeRequest)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second + (ttlInSeconds * time.Second))
@@ -180,7 +181,7 @@ func TestPublishingWithTTL(t *testing.T) {
 			contrib_metadata.TTLMetadataKey: strconv.Itoa(ttlInSeconds * 1000),
 		},
 	}
-	_, err = rabbitMQBinding2.Invoke(&writeRequest)
+	_, err = rabbitMQBinding2.Invoke(context.Backgound(), &writeRequest)
 	assert.Nil(t, err)
 
 	msg, ok, err := getMessageWithRetries(ch, queueName, maxGetDuration)
@@ -280,7 +281,7 @@ func TestPublishWithPriority(t *testing.T) {
 	defer ch.Close()
 
 	const middlePriorityMsgContent = "middle"
-	_, err = r.Invoke(&bindings.InvokeRequest{
+	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{
 		Metadata: map[string]string{
 			contrib_metadata.PriorityMetadataKey: "5",
 		},
@@ -289,7 +290,7 @@ func TestPublishWithPriority(t *testing.T) {
 	assert.Nil(t, err)
 
 	const lowPriorityMsgContent = "low"
-	_, err = r.Invoke(&bindings.InvokeRequest{
+	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{
 		Metadata: map[string]string{
 			contrib_metadata.PriorityMetadataKey: "1",
 		},
@@ -298,7 +299,7 @@ func TestPublishWithPriority(t *testing.T) {
 	assert.Nil(t, err)
 
 	const highPriorityMsgContent = "high"
-	_, err = r.Invoke(&bindings.InvokeRequest{
+	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{
 		Metadata: map[string]string{
 			contrib_metadata.PriorityMetadataKey: "10",
 		},

--- a/bindings/redis/redis.go
+++ b/bindings/redis/redis.go
@@ -58,7 +58,7 @@ func (r *Redis) Init(meta bindings.Metadata) (err error) {
 }
 
 func (r *Redis) Ping() error {
-	if _, err := r.client.Ping(context.Background()).Result(); err != nil {
+	if _, err := r.client.Ping(r.ctx).Result(); err != nil {
 		return fmt.Errorf("redis binding: error connecting to redis at %s: %s", r.clientSettings.Host, err)
 	}
 

--- a/bindings/rethinkdb/statechange/statechange.go
+++ b/bindings/rethinkdb/statechange/statechange.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/internal/utils"
 	"github.com/dapr/kit/logger"
 )
 
@@ -33,7 +34,6 @@ type Binding struct {
 	logger  logger.Logger
 	session *r.Session
 	config  StateConfig
-	stopCh  chan bool
 }
 
 // StateConfig is the binding config.
@@ -42,13 +42,10 @@ type StateConfig struct {
 	Table string `json:"table"`
 }
 
-var _ = bindings.InputBinding(&Binding{})
-
 // NewRethinkDBStateChangeBinding returns a new RethinkDB actor event input binding.
 func NewRethinkDBStateChangeBinding(logger logger.Logger) *Binding {
 	return &Binding{
 		logger: logger,
-		stopCh: make(chan bool),
 	}
 }
 
@@ -70,23 +67,27 @@ func (b *Binding) Init(metadata bindings.Metadata) error {
 }
 
 // Read triggers the RethinkDB scheduler.
-func (b *Binding) Read(handler bindings.Handler) error {
+func (b *Binding) Read(ctx context.Context, handler bindings.Handler) error {
 	b.logger.Infof("subscribing to state changes in %s.%s...", b.config.Database, b.config.Table)
-	cursor, err := r.DB(b.config.Database).Table(b.config.Table).Changes(r.ChangesOpts{
-		IncludeTypes: true,
-	}).Run(b.session)
+	cursor, err := r.DB(b.config.Database).
+		Table(b.config.Table).
+		Changes(r.ChangesOpts{
+			IncludeTypes: true,
+		}).
+		Run(b.session, r.RunOpts{
+			Context: ctx,
+		})
 	if err != nil {
 		errors.Wrapf(err, "error connecting to table %s", b.config.Table)
 	}
 
 	go func() {
-		for {
+		for ctx.Err() == nil {
 			var change interface{}
 			ok := cursor.Next(&change)
 			if !ok {
 				b.logger.Errorf("error detecting change: %v", cursor.Err())
-
-				break
+				continue
 			}
 
 			data, err := json.Marshal(change)
@@ -104,17 +105,14 @@ func (b *Binding) Read(handler bindings.Handler) error {
 				},
 			}
 
-			if _, err := handler(context.TODO(), resp); err != nil {
+			if _, err := handler(ctx, resp); err != nil {
 				b.logger.Errorf("error invoking change handler: %v", err)
-
 				continue
 			}
 		}
-	}()
 
-	done := <-b.stopCh
-	b.logger.Errorf("done: %b", done)
-	defer cursor.Close()
+		cursor.Close()
+	}()
 
 	return nil
 }
@@ -174,17 +172,9 @@ func metadataToConfig(cfg map[string]string, logger logger.Logger) (StateConfig,
 			}
 			c.MaxOpen = i
 		case "discover_hosts": // bool
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return c, errors.Wrapf(err, "invalid discover hosts format: %v", v)
-			}
-			c.DiscoverHosts = b
+			c.DiscoverHosts = utils.IsTruthy(v)
 		case "use-open-tracing": // bool
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return c, errors.Wrapf(err, "invalid use open tracing format: %v", v)
-			}
-			c.UseOpentracing = b
+			c.UseOpentracing = utils.IsTruthy(v)
 		case "max_idle": // int
 			i, err := strconv.Atoi(v)
 			if err != nil {

--- a/bindings/rethinkdb/statechange/statechange_test.go
+++ b/bindings/rethinkdb/statechange/statechange_test.go
@@ -73,20 +73,18 @@ func TestBinding(t *testing.T) {
 	err := b.Init(m)
 	assert.NoErrorf(t, err, "error initializing")
 
-	go func() {
-		err = b.Read(func(ctx context.Context, res *bindings.ReadResponse) ([]byte, error) {
-			assert.NotNil(t, res)
-			t.Logf("state change event:\n%s", string(res.Data))
+	ctx, cancel := context.WithCancel(context.Background())
+	err = b.Read(ctx, func(_ context.Context, res *bindings.ReadResponse) ([]byte, error) {
+		assert.NotNil(t, res)
+		t.Logf("state change event:\n%s", string(res.Data))
 
-			return nil, nil
-		})
-		assert.NoErrorf(t, err, "error on read")
-	}()
+		return nil, nil
+	})
+	assert.NoErrorf(t, err, "error on read")
 
 	testTimer := time.AfterFunc(testDuration, func() {
 		t.Log("done")
-		b.stopCh <- true
+		cancel()
 	})
 	defer testTimer.Stop()
-	<-b.stopCh
 }

--- a/bindings/smtp/smtp.go
+++ b/bindings/smtp/smtp.go
@@ -78,7 +78,7 @@ func (s *Mailer) Operations() []bindings.OperationKind {
 }
 
 // Invoke sends an email message.
-func (s *Mailer) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (s *Mailer) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	// Merge config metadata with request metadata
 	metadata, err := s.metadata.mergeWithRequestMetadata(req)
 	if err != nil {

--- a/bindings/twilio/sms/sms_test.go
+++ b/bindings/twilio/sms/sms_test.go
@@ -84,7 +84,7 @@ func TestWriteShouldSucceed(t *testing.T) {
 
 	t.Run("Should succeed with expected url and headers", func(t *testing.T) {
 		httpTransport.reset()
-		_, err := tw.Invoke(context.TODO(), &bindings.InvokeRequest{
+		_, err := tw.Invoke(context.Background(), &bindings.InvokeRequest{
 			Data: []byte("hello world"),
 			Metadata: map[string]string{
 				toNumber: "toNumber",
@@ -121,7 +121,7 @@ func TestWriteShouldFail(t *testing.T) {
 
 	t.Run("Missing 'to' should fail", func(t *testing.T) {
 		httpTransport.reset()
-		_, err := tw.Invoke(context.TODO(), &bindings.InvokeRequest{
+		_, err := tw.Invoke(context.Background(), &bindings.InvokeRequest{
 			Data:     []byte("hello world"),
 			Metadata: map[string]string{},
 		})
@@ -133,7 +133,7 @@ func TestWriteShouldFail(t *testing.T) {
 		httpTransport.reset()
 		httpErr := errors.New("twilio fake error")
 		httpTransport.errToReturn = httpErr
-		_, err := tw.Invoke(context.TODO(), &bindings.InvokeRequest{
+		_, err := tw.Invoke(context.Background(), &bindings.InvokeRequest{
 			Data: []byte("hello world"),
 			Metadata: map[string]string{
 				toNumber: "toNumber",
@@ -147,7 +147,7 @@ func TestWriteShouldFail(t *testing.T) {
 	t.Run("Twilio call returns status not >=200 and <300", func(t *testing.T) {
 		httpTransport.reset()
 		httpTransport.response.StatusCode = 401
-		_, err := tw.Invoke(context.TODO(), &bindings.InvokeRequest{
+		_, err := tw.Invoke(context.Background(), &bindings.InvokeRequest{
 			Data: []byte("hello world"),
 			Metadata: map[string]string{
 				toNumber: "toNumber",

--- a/bindings/twitter/twitter.go
+++ b/bindings/twitter/twitter.go
@@ -17,10 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/dghubble/go-twitter/twitter"
@@ -37,8 +34,6 @@ type Binding struct {
 	query  string
 	logger logger.Logger
 }
-
-var _ = bindings.InputBinding(&Binding{})
 
 // NewTwitter returns a new Twitter event input binding.
 func NewTwitter(logger logger.Logger) *Binding {
@@ -86,9 +81,9 @@ func (t *Binding) Operations() []bindings.OperationKind {
 }
 
 // Read triggers the Twitter search and events on each result tweet.
-func (t *Binding) Read(handler bindings.Handler) error {
+func (t *Binding) Read(ctx context.Context, handler bindings.Handler) error {
 	if t.query == "" {
-		return nil
+		return errors.New("metadata property 'query' is empty")
 	}
 
 	demux := twitter.NewSwitchDemux()
@@ -100,7 +95,7 @@ func (t *Binding) Read(handler bindings.Handler) error {
 
 			return
 		}
-		handler(context.TODO(), &bindings.ReadResponse{
+		handler(ctx, &bindings.ReadResponse{
 			Data: data,
 			Metadata: map[string]string{
 				"query": t.query,
@@ -126,30 +121,15 @@ func (t *Binding) Read(handler bindings.Handler) error {
 	if err != nil {
 		return errors.Wrapf(err, "error executing stream filter: %+v", filterParams)
 	}
-	defer stream.Stop()
 
 	t.logger.Debug("starting handler...")
 	go demux.HandleChan(stream.Messages)
 
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-
-	done := false
-	for !done {
-		s := <-signalChan
-		switch s {
-		case syscall.SIGHUP:
-			t.logger.Info("stopping, component hung up")
-			done = true
-		case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
-			t.logger.Info("stopping, component terminated")
-			done = true
-		}
-	}
+	go func() {
+		<-ctx.Done()
+		t.logger.Debug("stopping handler...")
+		stream.Stop()
+	}()
 
 	return nil
 }

--- a/bindings/zeebe/client.go
+++ b/bindings/zeebe/client.go
@@ -14,13 +14,13 @@ limitations under the License.
 package zeebe
 
 import (
-	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 
 	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/config"
 	"github.com/dapr/kit/logger"
 )
 
@@ -37,10 +37,10 @@ type ClientFactoryImpl struct {
 
 // https://docs.zeebe.io/operations/authentication.html
 type clientMetadata struct {
-	GatewayAddr            string            `json:"gatewayAddr"`
-	GatewayKeepAlive       metadata.Duration `json:"gatewayKeepAlive"`
-	CaCertificatePath      string            `json:"caCertificatePath"`
-	UsePlaintextConnection bool              `json:"usePlainTextConnection,string"`
+	GatewayAddr            string        `json:"gatewayAddr" mapstructure:"gatewayAddr"`
+	GatewayKeepAlive       time.Duration `json:"gatewayKeepAlive" mapstructure:"gatewayKeepAlive"`
+	CaCertificatePath      string        `json:"caCertificatePath" mapstructure:"caCertificatePath"`
+	UsePlaintextConnection bool          `json:"usePlainTextConnection,string" mapstructure:"usePlainTextConnection"`
 }
 
 // NewClientFactoryImpl returns a new ClientFactory instance.
@@ -58,7 +58,7 @@ func (c *ClientFactoryImpl) Get(metadata bindings.Metadata) (zbc.Client, error) 
 		GatewayAddress:         meta.GatewayAddr,
 		UsePlaintextConnection: meta.UsePlaintextConnection,
 		CaCertificatePath:      meta.CaCertificatePath,
-		KeepAlive:              meta.GatewayKeepAlive.Duration,
+		KeepAlive:              meta.GatewayKeepAlive,
 	})
 	if err != nil {
 		return nil, err
@@ -68,13 +68,8 @@ func (c *ClientFactoryImpl) Get(metadata bindings.Metadata) (zbc.Client, error) 
 }
 
 func (c *ClientFactoryImpl) parseMetadata(metadata bindings.Metadata) (*clientMetadata, error) {
-	b, err := json.Marshal(metadata.Properties)
-	if err != nil {
-		return nil, err
-	}
-
 	var m clientMetadata
-	err = json.Unmarshal(b, &m)
+	err := config.Decode(metadata.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/zeebe/client_test.go
+++ b/bindings/zeebe/client_test.go
@@ -34,7 +34,7 @@ func TestParseMetadata(t *testing.T) {
 	meta, err := client.parseMetadata(m)
 	assert.NoError(t, err)
 	assert.Equal(t, "172.0.0.1:1234", meta.GatewayAddr)
-	assert.Equal(t, 5*time.Second, meta.GatewayKeepAlive.Duration)
+	assert.Equal(t, 5*time.Second, meta.GatewayKeepAlive)
 	assert.Equal(t, "/cert/path", meta.CaCertificatePath)
 	assert.Equal(t, true, meta.UsePlaintextConnection)
 }
@@ -53,7 +53,7 @@ func TestParseMetadataDefaultValues(t *testing.T) {
 	client := ClientFactoryImpl{logger: logger.NewLogger("test")}
 	meta, err := client.parseMetadata(m)
 	assert.NoError(t, err)
-	assert.Equal(t, time.Duration(0), meta.GatewayKeepAlive.Duration)
+	assert.Equal(t, time.Duration(0), meta.GatewayKeepAlive)
 	assert.Equal(t, "", meta.CaCertificatePath)
 	assert.Equal(t, false, meta.UsePlaintextConnection)
 }

--- a/pubsub/aws/snssqs/metadata.go
+++ b/pubsub/aws/snssqs/metadata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	mdutils "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 )
 
@@ -51,17 +52,6 @@ type snsSqsMetadata struct {
 	accountID string
 	// processing concurrency mode
 	concurrencyMode pubsub.ConcurrencyMode
-}
-
-func getAliasedProperty(aliases []string, metadata pubsub.Metadata) (string, bool) {
-	props := metadata.Properties
-	for _, s := range aliases {
-		if val, ok := props[s]; ok {
-			return val, true
-		}
-	}
-
-	return "", false
 }
 
 func parseInt64(input string, propertyName string) (int64, error) {
@@ -170,15 +160,15 @@ func (md *snsSqsMetadata) hideDebugPrintedCredentials() string {
 }
 
 func (md *snsSqsMetadata) setCredsAndQueueNameConfig(metadata pubsub.Metadata) error {
-	if val, ok := getAliasedProperty([]string{"Endpoint", "endpoint"}, metadata); ok {
+	if val, ok := mdutils.GetMetadataProperty(metadata.Properties, "Endpoint", "endpoint"); ok {
 		md.Endpoint = val
 	}
 
-	if val, ok := getAliasedProperty([]string{"awsAccountID", "accessKey"}, metadata); ok {
+	if val, ok := mdutils.GetMetadataProperty(metadata.Properties, "awsAccountID", "accessKey"); ok {
 		md.AccessKey = val
 	}
 
-	if val, ok := getAliasedProperty([]string{"awsSecret", "secretKey"}, metadata); ok {
+	if val, ok := mdutils.GetMetadataProperty(metadata.Properties, "awsSecret", "secretKey"); ok {
 		md.SecretKey = val
 	}
 
@@ -186,7 +176,7 @@ func (md *snsSqsMetadata) setCredsAndQueueNameConfig(metadata pubsub.Metadata) e
 		md.SessionToken = val
 	}
 
-	if val, ok := getAliasedProperty([]string{"awsRegion", "region"}, metadata); ok {
+	if val, ok := mdutils.GetMetadataProperty(metadata.Properties, "awsRegion", "region"); ok {
 		md.Region = val
 	}
 

--- a/pubsub/rocketmq/rocketmq.go
+++ b/pubsub/rocketmq/rocketmq.go
@@ -218,12 +218,12 @@ func (r *rocketMQ) adaptCallback(topic, consumerGroup, mqType, mqExpr string, ha
 			if msg.Queue != nil {
 				metadata[metadataRocketmqBrokerName] = msg.Queue.BrokerName
 			}
-			newMessage := pubsub.NewMessage{
+			newMessage := &pubsub.NewMessage{
 				Topic:    topic,
 				Data:     dataBytes,
 				Metadata: metadata,
 			}
-			err = handler(ctx, &newMessage)
+			err = handler(ctx, newMessage)
 			if err != nil {
 				r.logger.Errorf("rocketmq error: fail to process message. topic:%s cloudEventsMap-length:%d err:%v.", newMessage.Topic, len(msg.Body), err)
 				success = false

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pkg/errors"
 
 	azauth "github.com/dapr/components-contrib/internal/authentication/azure"
+	"github.com/dapr/components-contrib/internal/utils"
 	mdutils "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
@@ -237,14 +238,7 @@ func getTablesMetadata(metadata map[string]string) (*tablesMetadata, error) {
 	}
 
 	if val, ok := metadata[cosmosDbModeKey]; ok && val != "" {
-		switch strings.ToLower(strings.TrimSpace(val)) {
-		case "y", "yes", "true", "t", "on", "1":
-			meta.cosmosDbMode = true
-		default:
-			meta.cosmosDbMode = false
-		}
-	} else {
-		meta.cosmosDbMode = false
+		meta.cosmosDbMode = utils.IsTruthy(val)
 	}
 
 	if val, ok := metadata[serviceURLKey]; ok && val != "" {
@@ -254,14 +248,7 @@ func getTablesMetadata(metadata map[string]string) (*tablesMetadata, error) {
 	}
 
 	if val, ok := metadata[skipCreateTableKey]; ok && val != "" {
-		switch strings.ToLower(strings.TrimSpace(val)) {
-		case "y", "yes", "true", "t", "on", "1":
-			meta.skipCreateTable = true
-		default:
-			meta.skipCreateTable = false
-		}
-	} else {
-		meta.skipCreateTable = false
+		meta.skipCreateTable = utils.IsTruthy(val)
 	}
 
 	return &meta, nil

--- a/tests/certification/bindings/alicloud/dubbo/go.mod
+++ b/tests/certification/bindings/alicloud/dubbo/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -154,3 +154,6 @@ replace github.com/dapr/components-contrib => ../../../../..
 replace github.com/dapr/components-contrib/tests/certification => ../../..
 
 replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/alicloud/dubbo/go.sum
+++ b/tests/certification/bindings/alicloud/dubbo/go.sum
@@ -195,8 +195,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creasty/defaults v1.5.2 h1:/VfB6uxpyp6h0fr7SPp7n8WJBoV8jfxQXPCnkVSjyls=
 github.com/creasty/defaults v1.5.2/go.mod h1:FPZ+Y0WNrbqOVw+c6av63eyHUAl6pMHZwqLPvXUZGfY=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -474,8 +472,8 @@ github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -543,6 +541,8 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869/go.mod h1:cJ6Cj7dQo+O6GJNiMx+Pa94qKj+TG8ONdKHgMNIyyag=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
@@ -884,6 +884,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
@@ -1233,6 +1234,7 @@ golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/alicloud/nacos/go.mod
+++ b/tests/certification/bindings/alicloud/nacos/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -127,3 +127,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib => ../../../../..
 
 replace github.com/dapr/components-contrib/tests/certification => ../../..
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/alicloud/nacos/go.sum
+++ b/tests/certification/bindings/alicloud/nacos/go.sum
@@ -140,8 +140,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -343,8 +341,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -389,6 +387,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -619,6 +619,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -895,6 +896,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/azure/blobstorage/go.mod
+++ b/tests/certification/bindings/azure/blobstorage/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -141,3 +141,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib/tests/certification => ../../../
 
 replace github.com/dapr/components-contrib => ../../../../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/azure/blobstorage/go.sum
+++ b/tests/certification/bindings/azure/blobstorage/go.sum
@@ -180,8 +180,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -391,8 +389,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -437,6 +435,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -666,6 +666,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -943,6 +944,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/azure/cosmosdb/go.mod
+++ b/tests/certification/bindings/azure/cosmosdb/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -141,3 +141,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib/tests/certification => ../../../
 
 replace github.com/dapr/components-contrib => ../../../../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/azure/cosmosdb/go.sum
+++ b/tests/certification/bindings/azure/cosmosdb/go.sum
@@ -180,8 +180,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -391,8 +389,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -437,6 +435,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -667,6 +667,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -944,6 +945,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/azure/eventhubs/go.mod
+++ b/tests/certification/bindings/azure/eventhubs/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -150,3 +150,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib => ../../../../..
 
 replace github.com/dapr/components-contrib/tests/certification => ../../..
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/azure/eventhubs/go.sum
+++ b/tests/certification/bindings/azure/eventhubs/go.sum
@@ -196,8 +196,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -410,8 +408,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -456,6 +454,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -689,6 +689,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -969,6 +970,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/azure/servicebusqueues/go.mod
+++ b/tests/certification/bindings/azure/servicebusqueues/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -147,3 +147,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib => ../../../../..
 
 replace github.com/dapr/components-contrib/tests/certification => ../../..
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/azure/servicebusqueues/go.sum
+++ b/tests/certification/bindings/azure/servicebusqueues/go.sum
@@ -186,8 +186,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -399,8 +397,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -445,6 +443,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -675,6 +675,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -957,6 +958,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/azure/storagequeues/go.mod
+++ b/tests/certification/bindings/azure/storagequeues/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -143,3 +143,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib => ../../../../..
 
 replace github.com/dapr/components-contrib/tests/certification => ../../..
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/azure/storagequeues/go.sum
+++ b/tests/certification/bindings/azure/storagequeues/go.sum
@@ -178,8 +178,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -389,8 +387,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -435,6 +433,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -664,6 +664,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -944,6 +945,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/bindings/kafka/go.mod
+++ b/tests/certification/bindings/kafka/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -144,3 +144,6 @@ replace github.com/dapr/components-contrib => ../../../../
 // in the Dapr runtime. Don't commit with this uncommented!
 //
 // replace github.com/dapr/dapr => ../../../../../dapr
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/bindings/kafka/go.sum
+++ b/tests/certification/bindings/kafka/go.sum
@@ -140,8 +140,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20220420235722-15a34b12afe5 h1:OSMIDCk5l89mnwiri6h6821n/IN8iZ2NwE80D+Zp0JA=
@@ -347,8 +345,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -394,6 +392,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -627,6 +627,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -911,6 +912,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b // indirect
@@ -119,3 +119,6 @@ require (
 replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 
 replace github.com/dapr/components-contrib => ../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -134,8 +134,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -333,8 +331,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -379,6 +377,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -600,6 +600,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -871,6 +872,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/pubsub/azure/eventhubs/go.mod
+++ b/tests/certification/pubsub/azure/eventhubs/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -154,3 +154,6 @@ replace github.com/dapr/components-contrib => ../../../../../
 // in the Dapr runtime. Don't commit with this uncommented!
 //
 // replace github.com/dapr/dapr => ../../../../../dapr
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/pubsub/azure/eventhubs/go.sum
+++ b/tests/certification/pubsub/azure/eventhubs/go.sum
@@ -196,8 +196,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -410,8 +408,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -456,6 +454,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -689,6 +689,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -967,6 +968,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/pubsub/kafka/go.mod
+++ b/tests/certification/pubsub/kafka/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -144,3 +144,6 @@ replace github.com/dapr/components-contrib => ../../../../
 // in the Dapr runtime. Don't commit with this uncommented!
 //
 // replace github.com/dapr/dapr => ../../../../../dapr
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/pubsub/kafka/go.sum
+++ b/tests/certification/pubsub/kafka/go.sum
@@ -140,8 +140,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20220420235722-15a34b12afe5 h1:OSMIDCk5l89mnwiri6h6821n/IN8iZ2NwE80D+Zp0JA=
@@ -347,8 +345,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -394,6 +392,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -627,6 +627,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -911,6 +912,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/pubsub/mqtt/go.mod
+++ b/tests/certification/pubsub/mqtt/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -132,3 +132,6 @@ replace github.com/eclipse/paho.mqtt.golang => github.com/shivamkm07/paho.mqtt.g
 // in the Dapr runtime. Don't commit with this uncommented!
 //
 // replace github.com/dapr/dapr => ../../../../../dapr
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/pubsub/mqtt/go.sum
+++ b/tests/certification/pubsub/mqtt/go.sum
@@ -136,8 +136,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -336,8 +334,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -382,6 +380,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -605,6 +605,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -880,6 +881,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/pubsub/rabbitmq/go.mod
+++ b/tests/certification/pubsub/rabbitmq/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -126,3 +126,6 @@ replace github.com/dapr/components-contrib => ../../../../
 // in the Dapr runtime. Don't commit with this uncommented!
 //
 // replace github.com/dapr/dapr => ../../../../../dapr
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/pubsub/rabbitmq/go.sum
+++ b/tests/certification/pubsub/rabbitmq/go.sum
@@ -134,8 +134,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -333,8 +331,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -379,6 +377,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -602,6 +602,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -874,6 +875,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/secretstores/azure/keyvault/go.mod
+++ b/tests/certification/secretstores/azure/keyvault/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -142,3 +142,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib/tests/certification => ../../../
 
 replace github.com/dapr/components-contrib => ../../../../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/secretstores/azure/keyvault/go.sum
+++ b/tests/certification/secretstores/azure/keyvault/go.sum
@@ -182,8 +182,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -393,8 +391,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -439,6 +437,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -668,6 +668,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -945,6 +946,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/state/azure/tablestorage/go.mod
+++ b/tests/certification/state/azure/tablestorage/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -141,3 +141,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib => ../../../../..
 
 replace github.com/dapr/components-contrib/tests/certification => ../../..
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/state/azure/tablestorage/go.sum
+++ b/tests/certification/state/azure/tablestorage/go.sum
@@ -180,8 +180,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -391,8 +389,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -437,6 +435,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -666,6 +666,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -943,6 +944,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/state/postgresql/go.mod
+++ b/tests/certification/state/postgresql/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -127,3 +127,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib/tests/certification => ../../
 
 replace github.com/dapr/components-contrib => ../../../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/state/postgresql/go.sum
+++ b/tests/certification/state/postgresql/go.sum
@@ -140,8 +140,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -341,8 +339,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -387,6 +385,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -674,6 +674,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -961,6 +962,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/tests/certification/state/redis/go.mod
+++ b/tests/certification/state/redis/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -124,3 +124,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib/tests/certification => ../../
 
 replace github.com/dapr/components-contrib => ../../../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/state/redis/go.sum
+++ b/tests/certification/state/redis/go.sum
@@ -136,8 +136,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -339,8 +337,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -385,6 +383,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -606,6 +606,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -878,6 +879,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/certification/state/sqlserver/go.mod
+++ b/tests/certification/state/sqlserver/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.0.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -122,3 +122,6 @@ replace go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 replace github.com/dapr/components-contrib/tests/certification => ../../
 
 replace github.com/dapr/components-contrib => ../../../../
+
+// TODO: TEMPORARY CHANGE UNTIL PR IS MERGED IN dapr/dapr
+replace github.com/dapr/dapr => github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb

--- a/tests/certification/state/sqlserver/go.sum
+++ b/tests/certification/state/sqlserver/go.sum
@@ -134,8 +134,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.8.0 h1:ZAAoBe6wuFp7k4tIHB7ajZXVTtGeDeVqIPrldzo3dF0=
-github.com/dapr/dapr v1.8.0/go.mod h1:yAsDiK5oecG0htw2S8JG9RFaeHJVdlTfZyOrL57AvRM=
 github.com/dapr/go-sdk v1.4.0 h1:Bbk2p9XhrTTZLwb7A8t1z3iQtiINAmpVLlQHFqZX17s=
 github.com/dapr/go-sdk v1.4.0/go.mod h1:t3hylW10Sf2ByFWGpD2IiqnCTAOI0O6kzg4ZkS8CbJw=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
@@ -337,8 +335,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
-github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.1 h1:YQsLlGDJgwhXFpucSPyVbCBviQtjlHv3jLTlp8YmtEw=
+github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -383,6 +381,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb h1:Pv6EnSTd9p1K52APLb9w23oD2bfvmb61VObT2GQJzA0=
+github.com/italypaleale/dapr v1.6.1-0.20220712175237-1bdf5e5592eb/go.mod h1:ICgweINgLS0pHUV3ltOFICBudqlBIBDFtUO3LhxEd8A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
@@ -604,6 +604,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -878,6 +879,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tests/conformance/bindings/bindings.go
+++ b/tests/conformance/bindings/bindings.go
@@ -186,20 +186,18 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 
 	inputBindingCall := 0
 	readChan := make(chan int)
+	readCtx, readCancel := context.WithCancel(context.Background())
+	defer readCancel()
 	if config.HasOperation("read") {
 		t.Run("read", func(t *testing.T) {
 			testLogger.Info("Read test running ...")
-			go func() {
-				testLogger.Info("Read callback invoked ...")
-				err := inputBinding.Read(func(ctx context.Context, r *bindings.ReadResponse) ([]byte, error) {
-					inputBindingCall++
-					readChan <- inputBindingCall
+			err := inputBinding.Read(readCtx, func(ctx context.Context, r *bindings.ReadResponse) ([]byte, error) {
+				inputBindingCall++
+				readChan <- inputBindingCall
 
-					return nil, nil
-				})
-				assert.True(t, err == nil || errors.Is(err, context.Canceled), "expected Read canceled on Close")
-			}()
-			testLogger.Info("Read test done.")
+				return nil, nil
+			})
+			assert.True(t, err == nil || errors.Is(err, context.Canceled), "expected Read canceled on Close")
 		})
 		// Special case for message brokers that are also bindings
 		// Need a small wait here because with brokers like MQTT
@@ -216,7 +214,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 			testLogger.Info("Create test running ...")
 			req := config.createInvokeRequest()
 			req.Operation = bindings.CreateOperation
-			_, err := outputBinding.Invoke(context.TODO(), &req)
+			_, err := outputBinding.Invoke(context.Background(), &req)
 			assert.NoError(t, err, "expected no error invoking output binding")
 			createPerformed = true
 			testLogger.Info("Create test done.")
@@ -229,7 +227,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 			testLogger.Info("Get test running ...")
 			req := config.createInvokeRequest()
 			req.Operation = bindings.GetOperation
-			resp, err := outputBinding.Invoke(context.TODO(), &req)
+			resp, err := outputBinding.Invoke(context.Background(), &req)
 			assert.Nil(t, err, "expected no error invoking output binding")
 			if createPerformed {
 				assert.Equal(t, req.Data, resp.Data)
@@ -244,7 +242,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 			testLogger.Info("List test running ...")
 			req := config.createInvokeRequest()
 			req.Operation = bindings.ListOperation
-			_, err := outputBinding.Invoke(context.TODO(), &req)
+			_, err := outputBinding.Invoke(context.Background(), &req)
 			assert.NoError(t, err, "expected no error invoking output binding")
 			testLogger.Info("List test done.")
 		})
@@ -272,12 +270,12 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 			testLogger.Info("Delete test running ...")
 			req := config.createInvokeRequest()
 			req.Operation = bindings.DeleteOperation
-			_, err := outputBinding.Invoke(context.TODO(), &req)
+			_, err := outputBinding.Invoke(context.Background(), &req)
 			assert.Nil(t, err, "expected no error invoking output binding")
 
 			if createPerformed && config.HasOperation(string(bindings.GetOperation)) {
 				req.Operation = bindings.GetOperation
-				resp, err := outputBinding.Invoke(context.TODO(), &req)
+				resp, err := outputBinding.Invoke(context.Background(), &req)
 				assert.NoError(t, err, "expected no error invoking output binding")
 				assert.NotNil(t, resp)
 				assert.Nil(t, resp.Data)

--- a/tests/e2e/bindings/zeebe/helper.go
+++ b/tests/e2e/bindings/zeebe/helper.go
@@ -191,7 +191,7 @@ func DeployProcess(
 
 	metadata := map[string]string{"fileName": fileName}
 	req := &bindings.InvokeRequest{Data: data, Metadata: metadata, Operation: command.DeployProcessOperation}
-	res, err := cmd.Invoke(context.TODO(), req)
+	res, err := cmd.Invoke(context.Background(), req)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func CreateProcessInstance(
 	}
 
 	req := &bindings.InvokeRequest{Data: data, Operation: command.CreateInstanceOperation}
-	res, err := cmd.Invoke(context.TODO(), req)
+	res, err := cmd.Invoke(context.Background(), req)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func ActicateJob(
 	}
 
 	req := &bindings.InvokeRequest{Data: data, Operation: command.ActivateJobsOperation}
-	res, err := cmd.Invoke(context.TODO(), req)
+	res, err := cmd.Invoke(context.Background(), req)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func InitTestProcess(
 		return err
 	}
 
-	go ackJob.Read(testWorker)
+	ackJob.Read(context.Background(), testWorker)
 
 	return nil
 }


### PR DESCRIPTION
# Description

Adds support for contexts in input bindings.

This is the last part of the "shutdown sequence fix": it allows shutting down input bindings before output ones.

## Corresponding PR in dapr/dapr

https://github.com/dapr/dapr/pull/4846

## Pending actions

This PR is marked as "draft" until the following things are done. Note that for most PRs listed below from components-contrib, I've already merged the commits in this branch (so please do not squash those PRs before merging them!):

- [X] Open corresponding PR in dapr/dapr
- [x] Update certification tests with new APIs
- [x] https://github.com/dapr/components-contrib/pull/1820
- [x] https://github.com/dapr/components-contrib/pull/1821
- [x] https://github.com/dapr/components-contrib/pull/1822
- [x] https://github.com/dapr/components-contrib/pull/1823
- [x] https://github.com/dapr/components-contrib/pull/1824
- [x] https://github.com/dapr/components-contrib/pull/1825
- [x] https://github.com/dapr/components-contrib/pull/1826
- [x] https://github.com/dapr/components-contrib/pull/1827
- [x] https://github.com/dapr/components-contrib/pull/1828
- [x] https://github.com/dapr/components-contrib/pull/1829
- [x] https://github.com/dapr/components-contrib/pull/1830
- [x] https://github.com/dapr/components-contrib/pull/1837