### PR TITLE
Actually let all contrib maintainers use automerge label

### DIFF
--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install PyGithub
       - name: Automerge and update
         env:
-          MAINTAINERS: yaron2,youngbupark,artursouza
+          MAINTAINERS: yaron2,artursouza,berndverst
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
         run: python ./.github/scripts/automerge.py
   prune_stale:


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

I added the automerge label to contrib some time ago, but this label only can be used by maintainers as indicated here. The maintainer list was wrong and is now updated to include myself.