### PR TITLE
Cherry-pick "Do not hardcode specific testTopicName" into release-1.8

### DIFF
--- a/.github/infrastructure/conformance/azure/conf-test-azure-eventhubs.bicep
+++ b/.github/infrastructure/conformance/azure/conf-test-azure-eventhubs.bicep
@@ -16,11 +16,11 @@ param rgLocation string = resourceGroup().location
 param confTestTags object = {}
 
 var eventHubsNamespacePolicy = '${eventHubsNamespaceName}-namespace-policy'
-var eventHubBindingsName = '${eventHubsNamespaceName}-bindings-topic'
+var eventHubBindingsName = 'eventhubs-bindings-topic'
 var eventHubBindingsPolicyName = '${eventHubBindingsName}-policy'
 var eventHubBindingsConsumerGroupName = '${eventHubBindingsName}-cg'
 
-var eventHubPubsubName = '${eventHubsNamespaceName}-pubsub-topic'
+var eventHubPubsubName = 'eventhubs-pubsub-topic'
 var eventHubPubsubPolicyName = '${eventHubPubsubName}-policy'
 var eventHubPubsubConsumerGroupName = '${eventHubPubsubName}-cg'
 

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -13,7 +13,7 @@ components:
     allOperations: true
     config:
       pubsubName: azure-eventhubs
-      testTopicName: dapr3-conf-test-eventhubs-pubsub-topic
+      testTopicName: eventhubs-pubsub-topic
       testMultiTopic1Name: certification-pubsub-multi-topic1
       testMultiTopic2Name: certification-pubsub-multi-topic2
       ## with partition key set, inorder processing is guaranteed.


### PR DESCRIPTION
Cherry-picking 15f99b0b61e5338c69eec99e1287d883b44abc4a into the release-1.8 branch. This is just an infra change and doesn't impact code in any way.