### PR TITLE
Changed dapr bot to merge without squashing

### DIFF
--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -40,7 +40,7 @@ for pr in pulls:
         # Merge only one PR per run.
         print(f"Merging PR {pr.html_url}")
         try:
-            pr.merge(merge_method='squash')
+            pr.merge(merge_method='merge')
             merged = True
             break
         except:


### PR DESCRIPTION
The behavior of Dapr Bot was to squash merge PRs. Although sometimes useful, squashing rewrites history and is likely to cause merge conflicts if another PR depends on that.

Leaving this here if maintainers think this makes sense :)