### PR TITLE
Added pubsub.FeatureSubscribeWildcards capability

### DIFF
--- a/pubsub/feature.go
+++ b/pubsub/feature.go
@@ -16,6 +16,8 @@ package pubsub
 const (
 	// FeatureMessageTTL is the feature to handle message TTL.
 	FeatureMessageTTL Feature = "MESSAGE_TTL"
+	// FeatureSubscribeWildcards is the feature to allow subscribing to topics/queues using a wildcard.
+	FeatureSubscribeWildcards Feature = "SUBSCRIBE_WILDCARDS"
 )
 
 // Feature names a feature that can be implemented by PubSub components.

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -369,5 +369,5 @@ func (m *mqttPubSub) Close() error {
 }
 
 func (m *mqttPubSub) Features() []pubsub.Feature {
-	return nil
+	return []pubsub.Feature{pubsub.FeatureSubscribeWildcards}
 }


### PR DESCRIPTION
Currently only the MQTT component seems to have support for subscribing to topics/queues with a wildcard in the name. This adds the capability.