### PR TITLE
Add user agent to AWS requests

### DIFF
--- a/internal/authentication/aws/aws.go
+++ b/internal/authentication/aws/aws.go
@@ -16,7 +16,9 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/dapr/kit/logger"
 )
 
 func GetClient(accessKey string, secretKey string, sessionToken string, region string, endpoint string) (*session.Session, error) {
@@ -34,10 +36,19 @@ func GetClient(accessKey string, secretKey string, sessionToken string, region s
 		awsConfig = awsConfig.WithEndpoint(endpoint)
 	}
 
-	awsSession, err := session.NewSession(awsConfig)
+	awsSession, err := session.NewSessionWithOptions(session.Options{
+		Config:            *awsConfig,
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return nil, err
 	}
+
+	userAgentHandler := request.NamedHandler{
+		Name: "UserAgentHandler",
+		Fn:   request.MakeAddToUserAgentHandler("dapr", logger.DaprVersion),
+	}
+	awsSession.Handlers.Build.PushBackNamed(userAgentHandler)
 
 	return awsSession, nil
 }

--- a/internal/authentication/aws/aws.go
+++ b/internal/authentication/aws/aws.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+
 	"github.com/dapr/kit/logger"
 )
 


### PR DESCRIPTION
Signed-off-by: Clare Liguori <liguori@amazon.com>

# Description

Setting the user agent on the AWS SDK helps provide more context in CloudTrail entries about the API calls made by Dapr, especially where the Dapr sidecar may be using the same credentials as the main app container.

Example CloudTrail entry for an SQS CreateQueue API call made by Dapr using the pubsub quickstart, showing the Dapr user agent:

```
{
    "eventVersion": "1.08",
    "userIdentity": {
        "type": "IAMUser",
        "principalId": "XXXXXX",
        "arn": "arn:aws:iam::XXXXXX:user/clare",
        "accountId": "XXXXXX",
        "accessKeyId": "XXXXXX",
        "userName": "clare"
    },
    "eventTime": "2022-07-18T20:31:36Z",
    "eventSource": "sqs.amazonaws.com",
    "eventName": "CreateQueue",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "XXXXXX",
    "userAgent": "aws-sdk-go/1.41.7 (go1.18; linux; amd64) dapr/edge",
    "requestParameters": {
        "queueName": "order-processor",
        "tags": {
            "dapr-queue-name": "order-processor"
        }
    },
    "responseElements": {
        "queueUrl": "https://sqs.us-west-2.amazonaws.com/XXXXXX/order-processor"
    },
    "requestID": "c7da082e-a392-5c45-846e-536166fad6c8",
    "eventID": "1d32e282-d4a6-429b-a967-00b3bd50708b",
    "readOnly": false,
    "eventType": "AwsApiCall",
    "managementEvent": true,
    "recipientAccountId": "XXXXXX",
    "eventCategory": "Management"
}
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
