### PR TITLE
Use unique message key in Azure ServiceBus PubSub

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -156,11 +156,13 @@ jobs:
         export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/test_report
         echo "TEST_OUTPUT_FILE_PREFIX=$TEST_OUTPUT_FILE_PREFIX" >> $GITHUB_ENV
 
-    - name: Configure certification test path
+    - name: Configure certification test and source path
       run: |
         TEST_COMPONENT=$(echo ${{ matrix.component }} | sed -E 's/\./\//g')
         export TEST_PATH="${PROJECT_PATH}/tests/certification/${TEST_COMPONENT}"
         echo "TEST_PATH=$TEST_PATH" >> $GITHUB_ENV
+        export SOURCE_PATH="github.com/dapr/components-contrib/${TEST_COMPONENT}"
+        echo "SOURCE_PATH=$SOURCE_PATH" >> $GITHUB_ENV
 
     - uses: Azure/login@v1
       with:
@@ -201,6 +203,7 @@ jobs:
       run: |
         go mod download
         go install gotest.tools/gotestsum@latest
+        go install github.com/axw/gocov/gocov@v1.1.0
 
     - name: Check that go mod tidy is up-to-date
       working-directory: ${{ env.TEST_PATH }}
@@ -218,7 +221,13 @@ jobs:
         set +e
         gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.json \
           --junitfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.xml --format standard-quiet -- \
-          -count=1 -timeout=15m
+          -coverprofile=cover.out -covermode=set -coverpkg=${{ env.SOURCE_PATH }}
+
+        COVERAGE_REPORT=$(gocov convert cover.out | gocov report)
+        COVERAGE_LINE=$(echo $COVERAGE_REPORT  | grep -oP '(?<=Total Coverage:).*') # example: "80.00% (40/50)"
+        COVERAGE_PERCENTAGE=$(echo $COVERAGE_LINE | grep -oP '([0-9\.]*)' | head -n 1) # example "80.00"
+        echo "COVERAGE_LINE=$COVERAGE_LINE" >> $GITHUB_ENV
+        echo "COMPONENT_PERCENTAGE=$COVERAGE_PERCENTAGE" >> $GITHUB_ENV
 
         status=$?
         echo "Completed certification tests for ${{ matrix.component }} ... "
@@ -245,6 +254,27 @@ jobs:
           exit 1
         fi
 
+    - name: Prepare Cert Coverage Info
+      run: |
+       mkdir -p tmp/cov_files
+       SOURCE_PATH_LINEAR=$(echo ${{ env.SOURCE_PATH }} |sed 's#/#\.#g') # converts slashes to dots in this string, so that it doesn't consider them sub-folders
+       echo "${{ env.COVERAGE_LINE }}" >> tmp/cov_files/$SOURCE_PATH_LINEAR.txt
+
+    - name: Upload Cert Coverage Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: certtest_cov
+        path: tmp/cov_files
+        retention-days: 1
+
+    - name: Component Coverage Discord Notification 
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_WEBHOOK_URL }}
+      uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
+      continue-on-error: true
+      with:
+        args: 'Cert Test Coverage for {{ SOURCE_PATH }} is {{ COVERAGE_LINE }}'
+
     # Upload logs for test analytics to consume
     - name: Upload test results
       if: always()
@@ -252,3 +282,41 @@ jobs:
       with:
         name: ${{ matrix.component }}_certification_test
         path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.*
+
+  post_job:
+    name: Notify Total coverage
+    runs-on: ubuntu-latest
+    needs: certification
+    if: always()
+    steps:
+      - name: Download Cert Coverage Artifact
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        id: download
+        with:
+          name: certtest_cov
+          path: tmp/cov_files
+
+      - name: Calculate total coverage
+        run: |
+          ls "${{steps.download.outputs.download-path}}" | while read f; do
+          while read LINE;
+              do
+              ratio=$(echo $LINE | cut -d "(" -f2 | cut -d ")" -f1)
+              tempNumerator=$(echo $ratio | cut -d'/' -f1)
+              tempDenominator=$(echo $ratio | cut -d'/' -f2)
+              export numerator=$(($numerator+$tempNumerator))
+              export denominator=$(($denominator+$tempDenominator))
+              totalPer=$(awk "BEGIN { print (($numerator / $denominator) * 100) }")
+              echo "totalPer=$totalPer" >> $GITHUB_ENV
+            done < ${{steps.download.outputs.download-path}}/$f
+          done
+        continue-on-error: true
+      
+      - name: Final Coverage Discord Notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_WEBHOOK_URL }}
+        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
+        continue-on-error: true
+        with:
+          args: 'Total Coverage for Certification Tests is {{ totalPer }}%'


### PR DESCRIPTION
Signed-off-by: Joni Collinge <jonathancollinge@live.com>

# Description

Instead of using the message ID which is not guarenteed to be unique as a key in the map to track the active messages this PR changes to use the messages sequence 
number which is guarenteed to be unique per message.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1892

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
