### PR TITLE
Add auto-completion flag for Zeebe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/camunda/zeebe/clients/go/v8 v8.0.3
+	github.com/camunda/zeebe/clients/go/v8 v8.0.4
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/cinience/go_rocketmq v0.0.2
 	github.com/coreos/go-oidc v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -190,7 +190,6 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Flaque/filet v0.0.0-20201012163910-45f684403088/go.mod h1:TK+jB3mBs+8ZMWhU5BqZKnZWJ1MrLo8etNVg51ueTBo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -410,8 +409,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bytecodealliance/wasmtime-go v0.35.0 h1:VZjaZ0XOY0qp9TQfh0CQj9zl/AbdeXePVTALy8V1sKs=
 github.com/bytecodealliance/wasmtime-go v0.35.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
-github.com/camunda/zeebe/clients/go/v8 v8.0.3 h1:FUfLgh66CV++P79uNL4IIdDhyhFydbkb2s5FognuTGs=
-github.com/camunda/zeebe/clients/go/v8 v8.0.3/go.mod h1:iOEgFlCYAPdqae6iPp0ajeo2RSxJirU39i+UAN74NOY=
+github.com/camunda/zeebe/clients/go/v8 v8.0.4 h1:8r2InKZDn0jTj8OPtBbKR2CSLgJD8Hgqw/rp3jiLhX8=
+github.com/camunda/zeebe/clients/go/v8 v8.0.4/go.mod h1:vqeNO1EphExqC15spP56PNXQ6SB8sMjhEfO16bfFRPo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
@@ -651,7 +650,6 @@ github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.11+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.14+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -740,7 +738,6 @@ github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebP
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
@@ -820,7 +817,6 @@ github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
-github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
@@ -1434,7 +1430,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
-github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
@@ -1442,7 +1437,6 @@ github.com/moby/sys/signal v0.6.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
-github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -1453,7 +1447,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
-github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/moul/http2curl v1.0.0 h1:dRMWoAtb+ePxMlLkrCbAqh4TlPHXvoGUSQ323/9Zahs=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -1553,7 +1546,6 @@ github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
-github.com/opencontainers/runc v1.0.3/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1831,7 +1823,6 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
-github.com/testcontainers/testcontainers-go v0.12.0/go.mod h1:SIndOQXZng0IW8iWU1Js0ynrfZ8xcxrTtDfF6rD2pxs=
 github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43 h1:o/PS34ksCpw72GtxUKad1jDMPsgGn6zVRG0BFIOUrsU=
 github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tevid/gohamcrest v1.1.1/go.mod h1:3UvtWlqm8j5JbwYZh80D/PVBt0mJ1eJiYgZMibh0H/k=
@@ -2195,7 +2186,6 @@ golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211105192438-b53810dc28af/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211108170745-6635138e15ea/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -2369,7 +2359,6 @@ golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211106132015-ebca88c72f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211109184856-51b60fd695b3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tests/e2e/bindings/zeebe/command/activate_jobs_test.go
+++ b/tests/e2e/bindings/zeebe/command/activate_jobs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ func TestActivateJobs(t *testing.T) {
 
 	deployment, err := zeebe.DeployProcess(
 		cmd,
+		context.Background(),
 		zeebe.TestProcessFile,
 		zeebe.ProcessIDModifier(id),
 		zeebe.JobTypeModifier("test", jobType))
@@ -43,7 +45,7 @@ func TestActivateJobs(t *testing.T) {
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
 	t.Run("activate a job and fetch all variables", func(t *testing.T) {
-		processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"bpmnProcessId": id,
 			"version":       1,
 			"variables": map[string]interface{}{
@@ -54,7 +56,7 @@ func TestActivateJobs(t *testing.T) {
 		assert.NoError(t, err)
 		time.Sleep(5 * time.Second)
 
-		jobs, err := zeebe.ActicateJob(cmd, map[string]interface{}{
+		jobs, err := zeebe.ActicateJob(cmd, context.Background(), map[string]interface{}{
 			"jobType":           jobType,
 			"maxJobsToActivate": 100,
 			"timeout":           "10m",
@@ -81,7 +83,7 @@ func TestActivateJobs(t *testing.T) {
 	})
 
 	t.Run("activate a job and fetch only the foo variable", func(t *testing.T) {
-		processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"bpmnProcessId": id,
 			"version":       1,
 			"variables": map[string]interface{}{
@@ -92,7 +94,7 @@ func TestActivateJobs(t *testing.T) {
 		assert.NoError(t, err)
 		time.Sleep(5 * time.Second)
 
-		jobs, err := zeebe.ActicateJob(cmd, map[string]interface{}{
+		jobs, err := zeebe.ActicateJob(cmd, context.Background(), map[string]interface{}{
 			"jobType":           jobType,
 			"maxJobsToActivate": 100,
 			"timeout":           "10m",

--- a/tests/e2e/bindings/zeebe/command/cancel_instance_test.go
+++ b/tests/e2e/bindings/zeebe/command/cancel_instance_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -34,12 +35,12 @@ func TestCancelInstance(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Deploy process
-	deployment, err := zeebe.DeployProcess(cmd, zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
+	deployment, err := zeebe.DeployProcess(cmd, context.Background(), zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
 	assert.NoError(t, err)
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
 	// Create instance
-	processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+	processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 		"bpmnProcessId": id,
 	})
 	assert.NoError(t, err)
@@ -54,7 +55,7 @@ func TestCancelInstance(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.CancelInstanceOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Data)
 		assert.Nil(t, res.Metadata)
@@ -70,7 +71,7 @@ func TestCancelInstance(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.CancelInstanceOperation}
-		_, err = cmd.Invoke(req)
+		_, err = cmd.Invoke(context.Background(), req)
 		assert.Error(t, err)
 	})
 }

--- a/tests/e2e/bindings/zeebe/command/complete_job_test.go
+++ b/tests/e2e/bindings/zeebe/command/complete_job_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -39,13 +40,14 @@ func TestCompleteJob(t *testing.T) {
 
 	deployment, err := zeebe.DeployProcess(
 		cmd,
+		context.Background(),
 		zeebe.TestProcessFile,
 		zeebe.ProcessIDModifier(id),
 		zeebe.JobTypeModifier("test", jobType))
 	assert.NoError(t, err)
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
-	_, err = zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+	_, err = zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 		"bpmnProcessId": id,
 		"version":       1,
 		"variables": map[string]interface{}{
@@ -56,7 +58,7 @@ func TestCompleteJob(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 
-	jobs, err := zeebe.ActicateJob(cmd, map[string]interface{}{
+	jobs, err := zeebe.ActicateJob(cmd, context.Background(), map[string]interface{}{
 		"jobType":           jobType,
 		"maxJobsToActivate": 100,
 		"timeout":           "10m",
@@ -81,7 +83,7 @@ func TestCompleteJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.CompleteJobOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Data)
 		assert.Nil(t, res.Metadata)
@@ -98,7 +100,7 @@ func TestCompleteJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.CompleteJobOperation}
-		_, err = cmd.Invoke(req)
+		_, err = cmd.Invoke(context.Background(), req)
 		assert.Error(t, err)
 	})
 }

--- a/tests/e2e/bindings/zeebe/command/create_instance_test.go
+++ b/tests/e2e/bindings/zeebe/command/create_instance_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dapr/components-contrib/tests/e2e/bindings/zeebe"
@@ -35,7 +36,7 @@ func TestCreateInstance(t *testing.T) {
 	}
 
 	// Deploy version 1
-	firstDeployment, err := zeebe.DeployProcess(cmd, zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
+	firstDeployment, err := zeebe.DeployProcess(cmd, context.Background(), zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
 	assert.NoError(t, err)
 	assert.Equal(t, id, firstDeployment.BpmnProcessId)
 	assert.Equal(t, int32(1), firstDeployment.Version)
@@ -43,7 +44,7 @@ func TestCreateInstance(t *testing.T) {
 	// Deploy version 2
 	secondDeployment, err := zeebe.DeployProcess(
 		// changing the name results in a new version
-		cmd, zeebe.TestProcessFile, zeebe.ProcessIDModifier(id), zeebe.NameModifier(id))
+		cmd, context.Background(), zeebe.TestProcessFile, zeebe.ProcessIDModifier(id), zeebe.NameModifier(id))
 	assert.NoError(t, err)
 	assert.Equal(t, id, secondDeployment.BpmnProcessId)
 	assert.Equal(t, int32(2), secondDeployment.Version)
@@ -51,7 +52,7 @@ func TestCreateInstance(t *testing.T) {
 	t.Run("create instance by BPMN process ID for version 1", func(t *testing.T) {
 		t.Parallel()
 
-		processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"bpmnProcessId": id,
 			"version":       1,
 			"variables":     variables,
@@ -66,7 +67,7 @@ func TestCreateInstance(t *testing.T) {
 	t.Run("create instance by BPMN process ID for latest version (version 2)", func(t *testing.T) {
 		t.Parallel()
 
-		processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"bpmnProcessId": id,
 			"variables":     variables,
 		})
@@ -80,7 +81,7 @@ func TestCreateInstance(t *testing.T) {
 	t.Run("return error for not existing BPMN process ID", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		_, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"bpmnProcessId": "not-existing",
 			"variables":     variables,
 		})
@@ -90,7 +91,7 @@ func TestCreateInstance(t *testing.T) {
 	t.Run("create instance by process definition key (version 1)", func(t *testing.T) {
 		t.Parallel()
 
-		processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"processDefinitionKey": firstDeployment.ProcessDefinitionKey,
 			"variables":            variables,
 		})
@@ -104,7 +105,7 @@ func TestCreateInstance(t *testing.T) {
 	t.Run("create instance by process definition key (version 2)", func(t *testing.T) {
 		t.Parallel()
 
-		processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"processDefinitionKey": secondDeployment.ProcessDefinitionKey,
 			"variables":            variables,
 		})
@@ -118,7 +119,7 @@ func TestCreateInstance(t *testing.T) {
 	t.Run("return error for not existing process definition key", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+		_, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 			"processDefinitionKey": 0,
 			"variables":            variables,
 		})

--- a/tests/e2e/bindings/zeebe/command/deploy_process_test.go
+++ b/tests/e2e/bindings/zeebe/command/deploy_process_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dapr/components-contrib/tests/e2e/bindings/zeebe"
@@ -29,7 +30,7 @@ func TestDeployProcess(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("deploy a new process", func(t *testing.T) {
-		deployment, err := zeebe.DeployProcess(cmd, zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
+		deployment, err := zeebe.DeployProcess(cmd, context.Background(), zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
 		assert.NoError(t, err)
 		assert.Equal(t, id, deployment.BpmnProcessId)
 		assert.Equal(t, int32(1), deployment.Version)
@@ -40,7 +41,7 @@ func TestDeployProcess(t *testing.T) {
 	t.Run("override an existing process with another version", func(t *testing.T) {
 		deployment, err := zeebe.DeployProcess(
 			// changing the name results in a new version
-			cmd, zeebe.TestProcessFile, zeebe.ProcessIDModifier(id), zeebe.NameModifier(id))
+			cmd, context.Background(), zeebe.TestProcessFile, zeebe.ProcessIDModifier(id), zeebe.NameModifier(id))
 		assert.NoError(t, err)
 		assert.Equal(t, id, deployment.BpmnProcessId)
 		assert.Equal(t, int32(2), deployment.Version)

--- a/tests/e2e/bindings/zeebe/command/fail_job_test.go
+++ b/tests/e2e/bindings/zeebe/command/fail_job_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -39,13 +40,14 @@ func TestFailJob(t *testing.T) {
 
 	deployment, err := zeebe.DeployProcess(
 		cmd,
+		context.Background(),
 		zeebe.TestProcessFile,
 		zeebe.ProcessIDModifier(id),
 		zeebe.JobTypeModifier("test", jobType))
 	assert.NoError(t, err)
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
-	_, err = zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+	_, err = zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 		"bpmnProcessId": id,
 		"version":       1,
 		"variables": map[string]interface{}{
@@ -56,7 +58,7 @@ func TestFailJob(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 
-	jobs, err := zeebe.ActicateJob(cmd, map[string]interface{}{
+	jobs, err := zeebe.ActicateJob(cmd, context.Background(), map[string]interface{}{
 		"jobType":           jobType,
 		"maxJobsToActivate": 100,
 		"timeout":           "10m",
@@ -79,7 +81,7 @@ func TestFailJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.FailJobOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Data)
 		assert.Nil(t, res.Metadata)
@@ -94,7 +96,7 @@ func TestFailJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.FailJobOperation}
-		_, err = cmd.Invoke(req)
+		_, err = cmd.Invoke(context.Background(), req)
 		assert.Error(t, err)
 	})
 }

--- a/tests/e2e/bindings/zeebe/command/publish_message_test.go
+++ b/tests/e2e/bindings/zeebe/command/publish_message_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestPublishMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.PublishMessageOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		variableResponse := &pb.PublishMessageResponse{}
@@ -62,7 +63,7 @@ func TestPublishMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.PublishMessageOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		variableResponse := &pb.PublishMessageResponse{}
@@ -82,7 +83,7 @@ func TestPublishMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.PublishMessageOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		variableResponse := &pb.PublishMessageResponse{}
@@ -104,7 +105,7 @@ func TestPublishMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.PublishMessageOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		variableResponse := &pb.PublishMessageResponse{}
@@ -128,7 +129,7 @@ func TestPublishMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.PublishMessageOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		variableResponse := &pb.PublishMessageResponse{}

--- a/tests/e2e/bindings/zeebe/command/set_variables_test.go
+++ b/tests/e2e/bindings/zeebe/command/set_variables_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -35,12 +36,12 @@ func TestSetVariables(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Deploy process
-	deployment, err := zeebe.DeployProcess(cmd, zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
+	deployment, err := zeebe.DeployProcess(cmd, context.Background(), zeebe.TestProcessFile, zeebe.ProcessIDModifier(id))
 	assert.NoError(t, err)
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
 	// Create instance
-	processInstance, err := zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+	processInstance, err := zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 		"bpmnProcessId": id,
 		"variables": map[string]interface{}{
 			"foo": "bar",
@@ -61,7 +62,7 @@ func TestSetVariables(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.SetVariablesOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		variableResponse := &pb.SetVariablesResponse{}
@@ -83,7 +84,7 @@ func TestSetVariables(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.SetVariablesOperation}
-		_, err = cmd.Invoke(req)
+		_, err = cmd.Invoke(context.Background(), req)
 		assert.Error(t, err)
 	})
 }

--- a/tests/e2e/bindings/zeebe/command/throw_error_test.go
+++ b/tests/e2e/bindings/zeebe/command/throw_error_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -39,13 +40,14 @@ func TestThrowError(t *testing.T) {
 
 	deployment, err := zeebe.DeployProcess(
 		cmd,
+		context.Background(),
 		zeebe.TestProcessFile,
 		zeebe.ProcessIDModifier(id),
 		zeebe.JobTypeModifier("test", jobType))
 	assert.NoError(t, err)
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
-	_, err = zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+	_, err = zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 		"bpmnProcessId": id,
 		"version":       1,
 		"variables": map[string]interface{}{
@@ -56,7 +58,7 @@ func TestThrowError(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 
-	jobs, err := zeebe.ActicateJob(cmd, map[string]interface{}{
+	jobs, err := zeebe.ActicateJob(cmd, context.Background(), map[string]interface{}{
 		"jobType":           jobType,
 		"maxJobsToActivate": 100,
 		"timeout":           "10m",
@@ -79,7 +81,7 @@ func TestThrowError(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.ThrowErrorOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Data)
 		assert.Nil(t, res.Metadata)
@@ -94,7 +96,7 @@ func TestThrowError(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.ThrowErrorOperation}
-		_, err = cmd.Invoke(req)
+		_, err = cmd.Invoke(context.Background(), req)
 		assert.Error(t, err)
 	})
 }

--- a/tests/e2e/bindings/zeebe/command/topology_test.go
+++ b/tests/e2e/bindings/zeebe/command/topology_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"testing"
@@ -40,7 +41,7 @@ func TestTopology(t *testing.T) {
 		t.Parallel()
 
 		req := &bindings.InvokeRequest{Operation: command.TopologyOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 
 		topology := &pb.TopologyResponse{}

--- a/tests/e2e/bindings/zeebe/command/update_job_retries_test.go
+++ b/tests/e2e/bindings/zeebe/command/update_job_retries_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -39,13 +40,14 @@ func TestUpdateJobRetries(t *testing.T) {
 
 	deployment, err := zeebe.DeployProcess(
 		cmd,
+		context.Background(),
 		zeebe.TestProcessFile,
 		zeebe.ProcessIDModifier(id),
 		zeebe.JobTypeModifier("test", jobType))
 	assert.NoError(t, err)
 	assert.Equal(t, id, deployment.BpmnProcessId)
 
-	_, err = zeebe.CreateProcessInstance(cmd, map[string]interface{}{
+	_, err = zeebe.CreateProcessInstance(cmd, context.Background(), map[string]interface{}{
 		"bpmnProcessId": id,
 		"version":       1,
 		"variables": map[string]interface{}{
@@ -56,7 +58,7 @@ func TestUpdateJobRetries(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 
-	jobs, err := zeebe.ActicateJob(cmd, map[string]interface{}{
+	jobs, err := zeebe.ActicateJob(cmd, context.Background(), map[string]interface{}{
 		"jobType":           jobType,
 		"maxJobsToActivate": 100,
 		"timeout":           "10m",
@@ -78,7 +80,7 @@ func TestUpdateJobRetries(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.UpdateJobRetriesOperation}
-		res, err := cmd.Invoke(req)
+		res, err := cmd.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Data)
 		assert.Nil(t, res.Metadata)
@@ -92,7 +94,7 @@ func TestUpdateJobRetries(t *testing.T) {
 		assert.NoError(t, err)
 
 		req := &bindings.InvokeRequest{Data: data, Operation: command.UpdateJobRetriesOperation}
-		_, err = cmd.Invoke(req)
+		_, err = cmd.Invoke(context.Background(), req)
 		assert.Error(t, err)
 	})
 }

--- a/tests/e2e/bindings/zeebe/docker-compose.yml
+++ b/tests/e2e/bindings/zeebe/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "${ZEEBE_BROKER_GATEWAY_NETWORK_PORT}:${ZEEBE_BROKER_GATEWAY_NETWORK_PORT}"
 
   dapr:
-    image: daprio/dapr-dev:0.1.7
+    image: daprio/dapr-dev:0.1.8
     privileged: true
     init: true
     security_opt:

--- a/tests/e2e/bindings/zeebe/helper.go
+++ b/tests/e2e/bindings/zeebe/helper.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"github.com/google/uuid"
@@ -50,16 +49,6 @@ type EnvVars struct {
 
 type MetadataPair struct {
 	Key, Value string
-}
-
-type CalcVariables struct {
-	Operator      string  `json:"operator"`
-	FirstOperand  float64 `json:"firstOperand"`
-	SecondOperand float64 `json:"secondOperand"`
-}
-
-type CalcResult struct {
-	Result float64 `json:"result"`
 }
 
 // GetEnvVars returns the Zeebe environment vars.
@@ -181,6 +170,7 @@ func GetTestFile(fileName string, modifiers ...func(string) string) ([]byte, err
 // a JSON with the deployment information.
 func DeployProcess(
 	cmd *command.ZeebeCommand,
+	ctx context.Context,
 	fileName string,
 	modifiers ...func(string) string,
 ) (*pb.ProcessMetadata, error) {
@@ -191,7 +181,7 @@ func DeployProcess(
 
 	metadata := map[string]string{"fileName": fileName}
 	req := &bindings.InvokeRequest{Data: data, Metadata: metadata, Operation: command.DeployProcessOperation}
-	res, err := cmd.Invoke(context.Background(), req)
+	res, err := cmd.Invoke(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -221,6 +211,7 @@ func DeployProcess(
 // CreateProcessInstance creates a process instance and returns the process instance data.
 func CreateProcessInstance(
 	cmd *command.ZeebeCommand,
+	ctx context.Context,
 	payload map[string]interface{},
 ) (*pb.CreateProcessInstanceResponse, error) {
 	data, err := json.Marshal(payload)
@@ -229,7 +220,7 @@ func CreateProcessInstance(
 	}
 
 	req := &bindings.InvokeRequest{Data: data, Operation: command.CreateInstanceOperation}
-	res, err := cmd.Invoke(context.Background(), req)
+	res, err := cmd.Invoke(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -245,6 +236,7 @@ func CreateProcessInstance(
 
 func ActicateJob(
 	cmd *command.ZeebeCommand,
+	ctx context.Context,
 	payload map[string]interface{},
 ) (*[]pb.ActivatedJob, error) {
 	data, err := json.Marshal(payload)
@@ -253,7 +245,7 @@ func ActicateJob(
 	}
 
 	req := &bindings.InvokeRequest{Data: data, Operation: command.ActivateJobsOperation}
-	res, err := cmd.Invoke(context.Background(), req)
+	res, err := cmd.Invoke(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -267,39 +259,10 @@ func ActicateJob(
 	return activatedJobs, nil
 }
 
-// CalcWorker is a simple calculation worker.
-func CalcWorker(request *bindings.ReadResponse) ([]byte, error) {
-	variables := &CalcVariables{}
-	err := json.Unmarshal(request.Data, variables)
-	if err != nil {
-		return nil, err
-	}
-
-	result := CalcResult{}
-	switch variables.Operator {
-	case "+":
-		result.Result = variables.FirstOperand + variables.SecondOperand
-	case "-":
-		result.Result = variables.FirstOperand - variables.SecondOperand
-	case "/":
-		result.Result = variables.FirstOperand / variables.SecondOperand
-	case "*":
-		result.Result = variables.FirstOperand * variables.SecondOperand
-	default:
-		return nil, fmt.Errorf("unexpected operator: %s", variables.Operator)
-	}
-
-	response, err := json.Marshal(result)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
 // InitTestProcess initializes a test process.
 func InitTestProcess(
 	cmd *command.ZeebeCommand,
+	ctx context.Context,
 	id string,
 	testWorker bindings.Handler,
 	additionalMetadata ...MetadataPair,
@@ -308,6 +271,7 @@ func InitTestProcess(
 
 	_, err := DeployProcess(
 		cmd,
+		ctx,
 		TestProcessFile,
 		ProcessIDModifier(id),
 		RetryModifier("test", 3),
@@ -321,14 +285,7 @@ func InitTestProcess(
 		return err
 	}
 
-	ackJob.Read(context.Background(), testWorker)
+	ackJob.Read(ctx, testWorker)
 
 	return nil
-}
-
-// InterruptProcess interrupts a process.
-func InterruptProcess() {
-	pid := syscall.Getpid()
-	proc, _ := os.FindProcess(pid)
-	proc.Signal(os.Interrupt)
 }

--- a/tests/e2e/bindings/zeebe/processes/calc.bpmn
+++ b/tests/e2e/bindings/zeebe/processes/calc.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0z68obe" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0z68obe" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="zeebe-test" name="Test" isExecutable="true">
     <bpmn:startEvent id="StartEvent_calc">
       <bpmn:outgoing>Flow_1ie08zg</bpmn:outgoing>
@@ -9,7 +9,7 @@
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1ie08zg" sourceRef="StartEvent_calc" targetRef="Activity_calc" />
     <bpmn:sequenceFlow id="Flow_0nxk85w" sourceRef="Activity_calc" targetRef="Activity_ack" />
-    <bpmn:serviceTask id="Activity_calc" name="Caluculate">
+    <bpmn:serviceTask id="Activity_calc" name="Calculate">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="calc" retries="1" />
         <zeebe:taskHeaders>
@@ -42,6 +42,10 @@
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="zeebe-test">
+      <bpmndi:BPMNEdge id="Flow_1vpdzvm_di" bpmnElement="Flow_1vpdzvm">
+        <di:waypoint x="670" y="117" />
+        <di:waypoint x="772" y="117" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_09ovgve_di" bpmnElement="Flow_09ovgve">
         <di:waypoint x="390" y="302" />
         <di:waypoint x="390" y="157" />
@@ -54,15 +58,15 @@
         <di:waypoint x="215" y="117" />
         <di:waypoint x="340" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vpdzvm_di" bpmnElement="Flow_1vpdzvm">
-        <di:waypoint x="670" y="117" />
-        <di:waypoint x="772" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_calc">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1uulfg3_di" bpmnElement="EndEvent_calc">
+        <dc:Bounds x="772" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1eoj541_di" bpmnElement="Activity_calc">
         <dc:Bounds x="340" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_07y36b6_di" bpmnElement="Event_Message">
         <dc:Bounds x="372" y="302" width="36" height="36" />
@@ -72,9 +76,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_19z6izv_di" bpmnElement="Activity_ack">
         <dc:Bounds x="570" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1uulfg3_di" bpmnElement="EndEvent_calc">
-        <dc:Bounds x="772" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
# Description

The actual implementation of the Zeebe job worker binding auto-completes a job automatically if a success response will be returned or if an error occurs. In case of an error, the binding will create an incident. But there is also a case that a process can throw a business error. This can actually not be handled, because of this auto-completion functionality. 

This change introduces a new flag "autocomplete" which is enabled by default to keep backward compatibility. Auto-completion is also the most common way to handle worker results. If a worker should return a business error, then this flag can be set to false and the worker can complete the job itself with either an incident, business error or a success response.

The PR adds also new tests to test this behavior and fixes also the tests which were broken during recent Dapr changes. Maybe it makes sense to run the tests also in the pipeline.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#2673
