### PR TITLE
Allow metadata to flow through service bus queue

### DIFF
--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -154,8 +154,11 @@ func (a *AzureServiceBusQueues) Invoke(ctx context.Context, req *bindings.Invoke
 		a.senderLock.Unlock()
 	}
 
+	a.logger.Infof("Invoke Binding incoming metadata: %+v", req.Metadata)
+
 	msg := &servicebus.Message{
-		Body: req.Data,
+		Body:                  req.Data,
+		ApplicationProperties: make(map[string]interface{}),
 	}
 	if val, ok := req.Metadata[id]; ok && val != "" {
 		msg.MessageID = &val
@@ -163,6 +166,12 @@ func (a *AzureServiceBusQueues) Invoke(ctx context.Context, req *bindings.Invoke
 	if val, ok := req.Metadata[correlationID]; ok && val != "" {
 		msg.CorrelationID = &val
 	}
+
+	// Include incoming metadata in the message to be used when it is read.
+	for k, v := range req.Metadata {
+		msg.ApplicationProperties[k] = v
+	}
+
 	ttl, ok, err := contrib_metadata.TryGetTTL(req.Metadata)
 	if err != nil {
 		return nil, err
@@ -260,6 +269,13 @@ func (a *AzureServiceBusQueues) getHandlerFunc(handler bindings.Handler) impl.Ha
 		}
 		if msg.Subject != nil {
 			metadata[label] = *msg.Subject
+		}
+
+		// Passthrough any custom metadata to the handler.
+		for key, val := range msg.ApplicationProperties {
+			if stringVal, ok := val.(string); ok {
+				metadata[key] = stringVal
+			}
 		}
 
 		_, err := handler(a.ctx, &bindings.ReadResponse{

--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -154,8 +154,6 @@ func (a *AzureServiceBusQueues) Invoke(ctx context.Context, req *bindings.Invoke
 		a.senderLock.Unlock()
 	}
 
-	a.logger.Infof("Invoke Binding incoming metadata: %+v", req.Metadata)
-
 	msg := &servicebus.Message{
 		Body:                  req.Data,
 		ApplicationProperties: make(map[string]interface{}),
@@ -169,6 +167,10 @@ func (a *AzureServiceBusQueues) Invoke(ctx context.Context, req *bindings.Invoke
 
 	// Include incoming metadata in the message to be used when it is read.
 	for k, v := range req.Metadata {
+		// Don't include the values that are saved in MessageID or CorrelationID.
+		if k == id || k == correlationID {
+			continue
+		}
 		msg.ApplicationProperties[k] = v
 	}
 

--- a/tests/certification/bindings/azure/servicebusqueues/README.md
+++ b/tests/certification/bindings/azure/servicebusqueues/README.md
@@ -31,6 +31,11 @@ The purpose of this module is to provide tests that certify the Azure Service Bu
    - Start an application that is guaranteed to fail
    - Ensure the binding continues to read incoming messages
    - Ensure the messages that are failed are retried
+- Verify Metadata flows through event
+   - Create an output/input binding
+   - Run dapr application with components
+   - Invoke the output binding providing metadata
+   - Receive the message and validate the metadata
 
 ### Future Tests
 1. Provide iterations around the different auth mechanisms supported by Azure Service Bus.


### PR DESCRIPTION
# Description

This commit lets metadata bind to a message and be read when
the message is received. This allows for the distributed tracing
of events.

This is required for https://github.com/dapr/dapr/issues/4884.

Other binding/pubsubs will need to be examined but this was chosen
as the first attempt. Once the dapr changes are committed, we can go
through the other input bindings.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

This PR starts to address https://github.com/dapr/dapr/issues/4884 but requires changes in dapr/dapr after.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
