### PR TITLE
[pubsub/jetstream]: allow tls client authentication

### DIFF
--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -54,6 +54,9 @@ func (js *jetstreamPubSub) Init(metadata pubsub.Metadata) error {
 		}, func(nonce []byte) ([]byte, error) {
 			return sigHandler(js.meta.seedKey, nonce)
 		}))
+	} else if js.meta.tls_client_cert != "" && js.meta.tls_client_key != "" {
+		js.l.Debug("Configure nats for tls client authentication")
+		opts = append(opts, nats.ClientCert(js.meta.tls_client_cert, js.meta.tls_client_key))
 	}
 
 	js.nc, err = nats.Connect(js.meta.natsURL, opts...)

--- a/pubsub/jetstream/metadata.go
+++ b/pubsub/jetstream/metadata.go
@@ -23,8 +23,12 @@ import (
 
 type metadata struct {
 	natsURL string
+
 	jwt     string
 	seedKey string
+
+	tls_client_cert string
+	tls_client_key  string
 
 	name           string
 	durableName    string
@@ -53,6 +57,17 @@ func parseMetadata(psm pubsub.Metadata) (metadata, error) {
 
 	if m.jwt == "" && m.seedKey != "" {
 		return metadata{}, fmt.Errorf("missing jwt")
+	}
+
+	m.tls_client_cert = psm.Properties["tls_client_cert"]
+	m.tls_client_key = psm.Properties["tls_client_key"]
+
+	if m.tls_client_cert != "" && m.tls_client_key == "" {
+		return metadata{}, fmt.Errorf("missing tls client key")
+	}
+
+	if m.tls_client_cert == "" && m.tls_client_key != "" {
+		return metadata{}, fmt.Errorf("missing tls client cert")
 	}
 
 	if m.name = psm.Properties["name"]; m.name == "" {

--- a/pubsub/jetstream/metadata_test.go
+++ b/pubsub/jetstream/metadata_test.go
@@ -90,6 +90,42 @@ func TestParseMetadata(t *testing.T) {
 			want:      metadata{},
 			expectErr: true,
 		},
+		{
+			desc: "Invalid metadata with missing tls client key",
+			input: pubsub.Metadata{
+				Properties: map[string]string{
+					"natsURL":         "nats://localhost:4222",
+					"name":            "myName",
+					"durableName":     "myDurable",
+					"queueGroupName":  "myQueue",
+					"startSequence":   "1",
+					"startTime":       "1629328511",
+					"deliverAll":      "true",
+					"flowControl":     "true",
+					"tls_client_cert": "/path/to/tls.pem",
+				},
+			},
+			want:      metadata{},
+			expectErr: true,
+		},
+		{
+			desc: "Invalid metadata with missing tls client client",
+			input: pubsub.Metadata{
+				Properties: map[string]string{
+					"natsURL":        "nats://localhost:4222",
+					"name":           "myName",
+					"durableName":    "myDurable",
+					"queueGroupName": "myQueue",
+					"startSequence":  "1",
+					"startTime":      "1629328511",
+					"deliverAll":     "true",
+					"flowControl":    "true",
+					"tls_client_key": "/path/to/tls.key",
+				},
+			},
+			want:      metadata{},
+			expectErr: true,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {


### PR DESCRIPTION
# Description

- Configure the NATS client for TLS Client Authentication if a key pair is supplied.

## Issue reference

- Closes #1923

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#2697
