### PR TITLE
Attempt to validate azure/gcp credentials for pubsub and firestore components

### DIFF
--- a/pubsub/azure/servicebus/metadata.go
+++ b/pubsub/azure/servicebus/metadata.go
@@ -34,6 +34,7 @@ type metadata struct {
 	PublishMaxRetries               int    `json:"publishMaxRetries"`
 	PublishInitialRetryIntervalInMs int    `json:"publishInitialRetryInternalInMs"`
 	NamespaceName                   string `json:"namespaceName,omitempty"`
+	InitialTopic                    string `json:"initialTopic"`
 }
 
 const (
@@ -56,6 +57,7 @@ const (
 	publishMaxRetries               = "publishMaxRetries"
 	publishInitialRetryInternalInMs = "publishInitialRetryInternalInMs"
 	namespaceName                   = "namespaceName"
+	initialTopic                    = "initialTopic"
 
 	// Deprecated keys.
 	maxReconnectionAttempts = "maxReconnectionAttempts"

--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -31,4 +31,5 @@ type metadata struct {
 	EnableMessageOrdering   bool
 	MaxReconnectionAttempts int
 	ConnectionRecoveryInSec int
+	InitialTopic            string
 }

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -84,6 +84,14 @@ func (f *Firestore) Init(metadata state.Metadata) error {
 	f.client = client
 	f.entityKind = meta.EntityKind
 
+	//Check datastore to validate component, ErrNoSuchEntity is suppressed
+	req := state.GetRequest{
+		Key: "initDaprTestKey",
+	}
+	_, err = f.Get(&req)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
# Description

Attempted to add credential checks in the init() methods of azure service bus and gcp pubsub/firestore components. 

For GCP Pubsub and Azure Service bus it currently involves adding an optional metadata field "initialTopic". The user would add a topic or possibly topics that we could make get/create calls on during init and could validate if the credentials were correctly configured and have sufficient permissions. We could also simplify the approach and do only a getTopic() call on a random string to see if we have permissions to read from the service.

For firestore we do a query on a dummy string. The entry should not exist and we should get a ErrNoSuchEntity if configured correctly. Any other errors would result in failure.

## Issue reference

#1752 One of multiple PRs for this issue

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
