### PR TITLE
Updated codecov Action to v3

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -11,5 +11,5 @@ coverage:
       # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
       default: false
 comment:
-  # Delete old comment and post new one for new coverage information.
-  behavior: new
+  # Update old comment with new coverage information if the PR is changed. Avoids triggering multiple emails.
+  behavior: once

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -106,4 +106,4 @@ jobs:
         run: make test
       - name: Codecov
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
v1 is deprecated per https://github.com/codecov/codecov-action