### PR TITLE
binding.eventhub: use same name schema for storage leases like on pubsub.eventhub

### DIFF
--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/aad"
@@ -152,6 +153,28 @@ func NewAzureEventHubs(logger logger.Logger) *AzureEventHubs {
 func validate(connectionString string) error {
 	_, err := conn.ParsedConnectionFromStr(connectionString)
 	return err
+}
+
+func (aeh *AzureEventHubs) getStoragePrefixString() (string, error) {
+	hubName, err := aeh.validateAndGetHubName()
+	if err != nil {
+		return "", err
+	}
+
+	// empty string in the end of slice to have a suffix "-".
+	return strings.Join([]string{"dapr", hubName, aeh.metadata.consumerGroup, ""}, "-"), nil
+}
+
+func (aeh *AzureEventHubs) validateAndGetHubName() (string, error) {
+	hubName := aeh.metadata.eventHubName
+	if hubName == "" {
+		parsed, err := conn.ParsedConnectionFromStr(aeh.metadata.connectionString)
+		if err != nil {
+			return "", err
+		}
+		hubName = parsed.HubName
+	}
+	return hubName, nil
 }
 
 // Init performs metadata init.
@@ -360,7 +383,13 @@ func (a *AzureEventHubs) RegisterPartitionedEventProcessor(ctx context.Context, 
 // RegisterEventProcessor - receive eventhub messages by eventprocessor
 // host by balancing partitions.
 func (a *AzureEventHubs) RegisterEventProcessor(ctx context.Context, handler bindings.Handler) error {
-	leaserCheckpointer, err := storage.NewStorageLeaserCheckpointer(a.storageCredential, a.metadata.storageAccountName, a.metadata.storageContainerName, *a.azureEnvironment)
+	storagePrefix, err := a.getStoragePrefixString()
+	if err != nil {
+		return err
+	}
+
+	leaserPrefixOpt := storage.WithPrefixInBlobPath(storagePrefix)
+	leaserCheckpointer, err := storage.NewStorageLeaserCheckpointer(a.storageCredential, a.metadata.storageAccountName, a.metadata.storageContainerName, *a.azureEnvironment, leaserPrefixOpt)
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -155,20 +155,20 @@ func validate(connectionString string) error {
 	return err
 }
 
-func (aeh *AzureEventHubs) getStoragePrefixString() (string, error) {
-	hubName, err := aeh.validateAndGetHubName()
+func (a *AzureEventHubs) getStoragePrefixString() (string, error) {
+	hubName, err := a.validateAndGetHubName()
 	if err != nil {
 		return "", err
 	}
 
 	// empty string in the end of slice to have a suffix "-".
-	return strings.Join([]string{"dapr", hubName, aeh.metadata.consumerGroup, ""}, "-"), nil
+	return strings.Join([]string{"dapr", hubName, a.metadata.consumerGroup, ""}, "-"), nil
 }
 
-func (aeh *AzureEventHubs) validateAndGetHubName() (string, error) {
-	hubName := aeh.metadata.eventHubName
+func (a *AzureEventHubs) validateAndGetHubName() (string, error) {
+	hubName := a.metadata.eventHubName
 	if hubName == "" {
-		parsed, err := conn.ParsedConnectionFromStr(aeh.metadata.connectionString)
+		parsed, err := conn.ParsedConnectionFromStr(a.metadata.connectionString)
 		if err != nil {
 			return "", err
 		}

--- a/bindings/azure/eventhubs/eventhubs_test.go
+++ b/bindings/azure/eventhubs/eventhubs_test.go
@@ -17,9 +17,44 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/kit/logger"
 )
+
+var testLogger = logger.NewLogger("test")
+
+func TestGetStoragePrefixString(t *testing.T) {
+	props := map[string]string{"storageAccountName": "fake", "storageAccountKey": "fake", "consumerGroup": "default", "storageContainerName": "test", "eventHub": "hubName", "eventHubNamespace": "fake"}
+
+	metadata := bindings.Metadata{Properties: props}
+	m, err := parseMetadata(metadata)
+
+	require.NoError(t, err)
+
+	aeh := &AzureEventHubs{logger: testLogger, metadata: m}
+
+	actual, _ := aeh.getStoragePrefixString()
+
+	assert.Equal(t, "dapr-hubName-default-", actual)
+}
+
+func TestGetStoragePrefixStringWithHubNameFromConnectionString(t *testing.T) {
+	connectionString := "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=fakeKey;SharedAccessKey=key;EntityPath=hubName"
+	props := map[string]string{"storageAccountName": "fake", "storageAccountKey": "fake", "consumerGroup": "default", "storageContainerName": "test", "connectionString": connectionString}
+
+	metadata := bindings.Metadata{Properties: props}
+	m, err := parseMetadata(metadata)
+
+	require.NoError(t, err)
+
+	aeh := &AzureEventHubs{logger: testLogger, metadata: m}
+
+	actual, _ := aeh.getStoragePrefixString()
+
+	assert.Equal(t, "dapr-hubName-default-", actual)
+}
 
 func TestParseMetadata(t *testing.T) {
 	t.Run("test valid configuration", func(t *testing.T) {


### PR DESCRIPTION
Hi,

We are currently adopting the naming change from this PR #1292 to the KEDA Eventhub Scaler. But the naming change includes only the pubsub component and not the eventhub binding. So there are two different naming schemas for storage leases, and this makes it more difficult to integrate that in the KEDA Scaler.

See  this discussion on KEDA: [https://github.com/kedacore/keda/issues/3022](https://github.com/kedacore/keda/issues/3022)

Before doing the KEDA change, it makes sense to use a unique naming schema for pubsub and binding. So I've made a proposal for it.

What do you think?