### PR TITLE
bindings.cron: ensure it can resume correctly after context cancellation

### DIFF
--- a/bindings/cron/cron.go
+++ b/bindings/cron/cron.go
@@ -85,12 +85,12 @@ func (b *Binding) Read(ctx context.Context, handler bindings.Handler) error {
 	b.logger.Debugf("name: %s, next run: %v", b.name, time.Until(c.Entry(id).Next))
 
 	go func() {
-		// Wait for a context to be canceled or a message on the stopCh
+		// Wait for a context to be canceled
 		select {
 		case <-b.runningCtx.Done():
 			// Do nothing
 		case <-ctx.Done():
-			b.runningCancel()
+			b.resetContext()
 		}
 		b.logger.Debugf("name: %s, stopping schedule: %s", b.name, b.schedule)
 		c.Stop()


### PR DESCRIPTION
The cron binding did not resume correctly after a context cancellation and a new context. This is currently not (yet) used in Dapr so no end-user impact yet.
