### PR TITLE
Allow more folks to run `/ok-to-test`

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -45,7 +45,12 @@ jobs:
               "shubham1172",
               "skyao",
               "msfussell",
-              "Taction"
+              "Taction",
+              "RyanLettieri",
+              "DeepanshuA",
+              "yash-nisar,
+              "addjuarez",
+              "tmacam",
             ];
             const payload = context.payload;
             const issue = context.issue;


### PR DESCRIPTION
Give access to `/ok-to-test` to several more people working on certification tests.

Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>