### PR TITLE
Enable CosmosDB Binding conformance test

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -122,6 +122,8 @@ jobs:
           required-certs: AzureKeyVaultSecretStoreCert
         - component: secretstores.azure.keyvault.serviceprincipal
           required-secrets: AzureKeyVaultName,AzureKeyVaultSecretStoreTenantId,AzureKeyVaultSecretStoreServicePrincipalClientId,AzureKeyVaultSecretStoreServicePrincipalClientSecret
+        - component: bindings.azure.cosmosdb
+          required-secrets: AzureCosmosDBMasterKey,AzureCosmosDBUrl,AzureCosmosDB,AzureCosmosDBCollection
         EOF
         )
         echo "::set-output name=cron-components::$CRON_COMPONENTS"


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Ensures the CosmosDB Binding conformance test is actually run. Manually verified test passes against Master and #1876 from @RyanLettieri 