### PR TITLE
optimize: add e2etests buildtags for e2e

### DIFF
--- a/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
+++ b/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
@@ -1,7 +1,9 @@
+//go:build e2etests
+// +build e2etests
+
 package authentication_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/dapr/components-contrib/pubsub"
@@ -54,11 +56,6 @@ func TestAuthentication(t *testing.T) {
 			}
 			err := js.Init(md)
 			if err != nil && !tC.expectError {
-				if strings.Contains(err.Error(), "network is unreachable") ||
-					strings.Contains(err.Error(), "no servers available for connection") {
-					log.Warn("jetstream server is unreachable")
-					return
-				}
 				t.Fatal("Did not expect error during connect", err.Error())
 			}
 			if err == nil && tC.expectError {

--- a/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
+++ b/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
@@ -54,7 +54,8 @@ func TestAuthentication(t *testing.T) {
 			}
 			err := js.Init(md)
 			if err != nil && !tC.expectError {
-				if strings.Contains(err.Error(), "network is unreachable") {
+				if strings.Contains(err.Error(), "network is unreachable") ||
+					strings.Contains(err.Error(), "no servers available for connection") {
 					log.Warn("jetstream server is unreachable")
 					return
 				}

--- a/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
+++ b/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
@@ -53,11 +53,11 @@ func TestAuthentication(t *testing.T) {
 				},
 			}
 			err := js.Init(md)
-			if strings.Contains(err.Error(), "network is unreachable") {
-				log.Warn("jetstream server is unreachable")
-				return
-			}
 			if err != nil && !tC.expectError {
+				if strings.Contains(err.Error(), "network is unreachable") {
+					log.Warn("jetstream server is unreachable")
+					return
+				}
 				t.Fatal("Did not expect error during connect", err.Error())
 			}
 			if err == nil && tC.expectError {

--- a/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
+++ b/tests/e2e/pubsub/jetstream/authentication/authentication_test.go
@@ -1,6 +1,7 @@
 package authentication_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dapr/components-contrib/pubsub"
@@ -52,6 +53,10 @@ func TestAuthentication(t *testing.T) {
 				},
 			}
 			err := js.Init(md)
+			if strings.Contains(err.Error(), "network is unreachable") {
+				log.Warn("jetstream server is unreachable")
+				return
+			}
 			if err != nil && !tC.expectError {
 				t.Fatal("Did not expect error during connect", err.Error())
 			}


### PR DESCRIPTION
```shell
=== RUN   TestAuthentication
=== RUN   TestAuthentication/Valid_jwt_and_valid_seed
err: nats: no servers available for connection
    authentication_test.go:56: Did not expect error during connect nats: no servers available for connection
=== RUN   TestAuthentication/Valid_jwt_and_invalid_seed
err: dial tcp [::1]:4222: connect: network is unreachable
=== RUN   TestAuthentication/Invalid_jwt_and_valid_seed
err: nats: no servers available for connection
--- FAIL: TestAuthentication (0.00s)
    --- FAIL: TestAuthentication/Valid_jwt_and_valid_seed (0.00s)
    --- PASS: TestAuthentication/Valid_jwt_and_invalid_seed (0.00s)
    --- PASS: TestAuthentication/Invalid_jwt_and_valid_seed (0.00s)
FAIL
FAIL    github.com/dapr/components-contrib/tests/e2e/pubsub/jetstream/authentication    0.009s
FAIL
```