### PR TITLE
Removing the use of the ioutil package And Fix CVE-2021-42576

### DIFF
--- a/bindings/alicloud/dingtalk/webhook/webhook_test.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook_test.go
@@ -15,7 +15,7 @@ package webhook
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -43,7 +43,7 @@ func TestPublishMsg(t *testing.T) { //nolint:paralleltest
 			t.Errorf("Expected request to '/test', got '%s'", r.URL.EscapedPath())
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.Nil(t, err)
 		assert.Equal(t, msg, string(body))
 	}))

--- a/bindings/apns/apns_test.go
+++ b/bindings/apns/apns_test.go
@@ -16,7 +16,7 @@ package apns
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -316,7 +316,7 @@ func TestInvoke(t *testing.T) {
 
 			return &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(strings.NewReader(body)),
+				Body:       io.NopCloser(strings.NewReader(body)),
 			}
 		})
 		_, err := testBinding.Invoke(context.TODO(), successRequest)

--- a/bindings/azure/eventgrid/eventgrid.go
+++ b/bindings/azure/eventgrid/eventgrid.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/eventgrid/mgmt/2021-12-01/eventgrid"
@@ -279,7 +279,7 @@ func (a *AzureEventGrid) createSubscription(ctx context.Context) error {
 	res := result.FutureAPI.Response()
 
 	if res.StatusCode != fasthttp.StatusCreated {
-		bodyBytes, err := ioutil.ReadAll(res.Body)
+		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			a.logger.Debugf("Failed reading error body when creating or updating Event Grid subscription: %v", err)
 

--- a/bindings/azure/signalr/signalr.go
+++ b/bindings/azure/signalr/signalr.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -213,7 +213,7 @@ func (s *SignalR) sendMessageToSignalR(ctx context.Context, url string, token st
 	defer resp.Body.Close()
 
 	// Read the body regardless to drain it and ensure the connection can be reused
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/signalr/signalr_test.go
+++ b/bindings/azure/signalr/signalr_test.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -284,7 +284,7 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func TestWriteShouldFail(t *testing.T) {
 	httpTransport := &mockTransport{
-		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
+		response: &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))},
 	}
 
 	s := NewSignalR(logger.NewLogger("test"))
@@ -335,7 +335,7 @@ func TestWriteShouldFail(t *testing.T) {
 
 func TestWriteShouldSucceed(t *testing.T) {
 	httpTransport := &mockTransport{
-		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
+		response: &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))},
 	}
 
 	s := NewSignalR(logger.NewLogger("test"))

--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strconv"
 
@@ -214,9 +213,9 @@ func (g *GCPStorage) get(ctx context.Context, req *bindings.InvokeRequest) (*bin
 	}
 	defer rc.Close()
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	if err != nil {
-		return nil, fmt.Errorf("gcp bucketgcp bucket binding error: ioutil.ReadAll: %v", err)
+		return nil, fmt.Errorf("gcp bucketgcp bucket binding error: io.ReadAll: %v", err)
 	}
 
 	if metadata.EncodeBase64 {

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -148,7 +147,7 @@ func (h *HTTPSource) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*
 
 	// Read the response body. For empty responses (e.g. 204 No Content)
 	// `b` will be an empty slice.
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -15,7 +15,7 @@ package http_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -53,7 +53,7 @@ func TestInit(t *testing.T) {
 			input := req.Method
 			if req.Body != nil {
 				defer req.Body.Close()
-				b, _ := ioutil.ReadAll(req.Body)
+				b, _ := io.ReadAll(req.Body)
 				if len(b) > 0 {
 					input = string(b)
 				}

--- a/bindings/huawei/obs/obs.go
+++ b/bindings/huawei/obs/obs.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -228,7 +228,7 @@ func (o *HuaweiOBS) get(ctx context.Context, req *bindings.InvokeRequest) (*bind
 		}
 	}()
 
-	data, err := ioutil.ReadAll(out.Body)
+	data, err := io.ReadAll(out.Body)
 	if err != nil {
 		return nil, fmt.Errorf("obs binding error. error reading obs object content: %w", err)
 	}

--- a/bindings/huawei/obs/obs_test.go
+++ b/bindings/huawei/obs/obs_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -374,7 +374,7 @@ func TestGetOperation(t *testing.T) {
 							},
 							Metadata: map[string]string{},
 						},
-						Body: ioutil.NopCloser(strings.NewReader("Hello Dapr")),
+						Body: io.NopCloser(strings.NewReader("Hello Dapr")),
 					}, nil
 				},
 			},
@@ -447,7 +447,7 @@ func TestGetOperation(t *testing.T) {
 							},
 							Metadata: map[string]string{},
 						},
-						Body: ioutil.NopCloser(iotest.ErrReader(errors.New("unexpected data reading error"))),
+						Body: io.NopCloser(iotest.ErrReader(errors.New("unexpected data reading error"))),
 					}, nil
 				},
 			},
@@ -667,7 +667,7 @@ func TestInvoke(t *testing.T) {
 							},
 							Metadata: map[string]string{},
 						},
-						Body: ioutil.NopCloser(strings.NewReader("Hello Dapr")),
+						Body: io.NopCloser(strings.NewReader("Hello Dapr")),
 					}, nil
 				},
 			},

--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -153,7 +153,7 @@ func (ls *LocalStorage) get(filename string, req *bindings.InvokeRequest) (*bind
 		return nil, err
 	}
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		ls.logger.Debugf("%s", err)
 

--- a/bindings/mysql/mysql.go
+++ b/bindings/mysql/mysql.go
@@ -21,7 +21,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -263,7 +263,7 @@ func initDB(url, pemPath string) (*sql.DB, error) {
 
 	if pemPath != "" {
 		rootCertPool := x509.NewCertPool()
-		pem, err := ioutil.ReadFile(pemPath)
+		pem, err := os.ReadFile(pemPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading PEM file from %s", pemPath)
 		}

--- a/bindings/twilio/sms/sms_test.go
+++ b/bindings/twilio/sms/sms_test.go
@@ -16,7 +16,7 @@ package sms
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -68,7 +68,7 @@ func TestParseDuration(t *testing.T) {
 
 func TestWriteShouldSucceed(t *testing.T) {
 	httpTransport := &mockTransport{
-		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
+		response: &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))},
 	}
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{
@@ -105,7 +105,7 @@ func TestWriteShouldSucceed(t *testing.T) {
 
 func TestWriteShouldFail(t *testing.T) {
 	httpTransport := &mockTransport{
-		response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))},
+		response: &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))},
 	}
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/matryer/is v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.7 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.17 // indirect
 	github.com/miekg/dns v1.1.48 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/moul/http2curl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2184,8 +2184,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
-github.com/microcosm-cc/bluemonday v1.0.7 h1:6yAQfk4XT+PI/dk1ZeBp1gr3Q2Hd1DR0O3aEyPUJVTE=
-github.com/microcosm-cc/bluemonday v1.0.7/go.mod h1:HOT/6NaBlR0f9XlxD3zolN6Z3N8Lp4pvhp+jLS5ihnI=
+github.com/microcosm-cc/bluemonday v1.0.17 h1:Z1a//hgsQ4yjC+8zEkV8IWySkXnsxmdSY642CTFQb5Y=
+github.com/microcosm-cc/bluemonday v1.0.17/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.12/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -3238,7 +3238,6 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
-golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
@@ -3247,6 +3246,7 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/internal/authentication/azure/auth.go
+++ b/internal/authentication/azure/auth.go
@@ -18,7 +18,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -331,7 +331,7 @@ func (c CertConfig) GetTokenCredential() (token azcore.TokenCredential, err erro
 	// If we have a certificate path, load it
 	if c.ClientCertificateConfig.CertificatePath != "" {
 		var errB error
-		data, errB = ioutil.ReadFile(ccc.CertificatePath)
+		data, errB = os.ReadFile(ccc.CertificatePath)
 		if errB != nil {
 			return nil, fmt.Errorf("failed to read the certificate file (%s): %v", ccc.CertificatePath, errB)
 		}

--- a/internal/authentication/azure/auth_test.go
+++ b/internal/authentication/azure/auth_test.go
@@ -15,7 +15,6 @@ package azure
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -60,7 +59,7 @@ func TestGetClientCert(t *testing.T) {
 func TestAuthorizorWithCertFile(t *testing.T) {
 	testCertFileName := "./.cert.pfx"
 	certBytes := getTestCert()
-	err := ioutil.WriteFile(testCertFileName, certBytes, 0o644)
+	err := os.WriteFile(testCertFileName, certBytes, 0o644)
 	assert.NoError(t, err)
 
 	settings, err := NewEnvironmentSettings(

--- a/middleware/http/nethttpadaptor/nethttpadaptor.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor.go
@@ -29,7 +29,7 @@ func NewNetHTTPHandlerFunc(logger logger.Logger, h fasthttp.RequestHandler) http
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := fasthttp.RequestCtx{}
 		remoteIP := net.ParseIP(r.RemoteAddr)
-		remoteAddr := net.IPAddr{remoteIP, ""} // nolint
+		remoteAddr := net.IPAddr{remoteIP, ""} //nolint
 		c.Init(&fasthttp.Request{}, &remoteAddr, nil)
 
 		if r.Body != nil {

--- a/middleware/http/nethttpadaptor/nethttpadaptor.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor.go
@@ -14,7 +14,7 @@ limitations under the License.
 package nethttpadaptor
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -29,11 +29,11 @@ func NewNetHTTPHandlerFunc(logger logger.Logger, h fasthttp.RequestHandler) http
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := fasthttp.RequestCtx{}
 		remoteIP := net.ParseIP(r.RemoteAddr)
-		remoteAddr := net.IPAddr{remoteIP, ""} //nolint
+		remoteAddr := net.IPAddr{remoteIP, ""} // nolint
 		c.Init(&fasthttp.Request{}, &remoteAddr, nil)
 
 		if r.Body != nil {
-			reqBody, err := ioutil.ReadAll(r.Body)
+			reqBody, err := io.ReadAll(r.Body)
 			if err != nil {
 				logger.Errorf("error reading request body, %+v", err)
 

--- a/middleware/http/nethttpadaptor/nethttpadaptor_test.go
+++ b/middleware/http/nethttpadaptor/nethttpadaptor_test.go
@@ -15,7 +15,7 @@ package nethttpadaptor
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -422,7 +422,7 @@ func TestNewNetHTTPHandlerFuncResponses(t *testing.T) {
 				return httptest.NewRequest("GET", "http://localhost:8080/test", nil)
 			},
 			func(t *testing.T, res *http.Response) {
-				body, _ := ioutil.ReadAll(res.Body)
+				body, _ := io.ReadAll(res.Body)
 				assert.Equal(t, "test body!", string(body))
 			},
 		},

--- a/secretstores/hashicorp/vault/vault.go
+++ b/secretstores/hashicorp/vault/vault.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -247,7 +246,7 @@ func (v *vaultSecretStore) getSecret(secret, version string) (*vaultKVResponse, 
 		}
 	} else {
 		// treat the secret as string
-		b, err := ioutil.ReadAll(httpresp.Body)
+		b, err := io.ReadAll(httpresp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't read response: %s", err)
 		}
@@ -394,7 +393,7 @@ func (v *vaultSecretStore) initVaultToken() error {
 		return nil
 	}
 
-	data, err := ioutil.ReadFile(v.vaultTokenMountPath)
+	data, err := os.ReadFile(v.vaultTokenMountPath)
 	if err != nil {
 		return fmt.Errorf("couldn't read vault token from mount path %s err: %s", v.vaultTokenMountPath, err)
 	}
@@ -477,7 +476,7 @@ func (v *vaultSecretStore) getRootCAsPools(vaultCAPem string, vaultCAPath string
 // readCertificateFile reads the certificate at given path.
 func readCertificateFile(certPool *x509.CertPool, path string) error {
 	// Read certificate file
-	pemFile, err := ioutil.ReadFile(path)
+	pemFile, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("couldn't read CA file from disk: %s", err)
 	}

--- a/secretstores/hashicorp/vault/vault_test.go
+++ b/secretstores/hashicorp/vault/vault_test.go
@@ -15,7 +15,6 @@ package vault
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -35,7 +34,7 @@ const (
 func TestReadVaultToken(t *testing.T) {
 	t.Run("read correct token", func(t *testing.T) {
 		dir := os.TempDir()
-		f, err := ioutil.TempFile(dir, "vault-token")
+		f, err := os.CreateTemp(dir, "vault-token")
 		assert.NoError(t, err)
 		fileName := f.Name()
 		defer os.Remove(fileName)
@@ -55,7 +54,7 @@ func TestReadVaultToken(t *testing.T) {
 
 	t.Run("read incorrect token", func(t *testing.T) {
 		dir := os.TempDir()
-		f, err := ioutil.TempFile(dir, "vault-token")
+		f, err := os.CreateTemp(dir, "vault-token")
 		assert.NoError(t, err)
 		fileName := f.Name()
 		defer os.Remove(fileName)

--- a/secretstores/local/file/filestore.go
+++ b/secretstores/local/file/filestore.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"strconv"
@@ -246,7 +246,7 @@ func (j *localSecretStore) readLocalFile(secretsFile string) (map[string]interfa
 
 	defer jsonFile.Close()
 
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return nil, err
 	}

--- a/state/azure/cosmosdb/cosmosdb_query_test.go
+++ b/state/azure/cosmosdb/cosmosdb_query_test.go
@@ -15,7 +15,7 @@ package cosmosdb
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/a8m/documentdb"
@@ -127,7 +127,7 @@ func TestCosmosDbQuery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		data, err := ioutil.ReadFile(test.input)
+		data, err := os.ReadFile(test.input)
 		assert.NoError(t, err)
 		var qq query.Query
 		err = json.Unmarshal(data, &qq)

--- a/state/cockroachdb/cockroachdb_query_test.go
+++ b/state/cockroachdb/cockroachdb_query_test.go
@@ -15,7 +15,7 @@ package cockroachdb
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/agrea/ptr"
@@ -57,7 +57,7 @@ func TestPostgresqlQueryBuildQuery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		data, err := ioutil.ReadFile(test.input)
+		data, err := os.ReadFile(test.input)
 		assert.NoError(t, err)
 		var storeQuery query.Query
 		err = json.Unmarshal(data, &storeQuery)

--- a/state/mongodb/mongodb_query_test.go
+++ b/state/mongodb/mongodb_query_test.go
@@ -15,7 +15,7 @@ package mongodb
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,7 @@ func TestMongoQuery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		data, err := ioutil.ReadFile(test.input)
+		data, err := os.ReadFile(test.input)
 		assert.NoError(t, err)
 		var qq query.Query
 		err = json.Unmarshal(data, &qq)

--- a/state/mysql/mySQLFactory.go
+++ b/state/mysql/mySQLFactory.go
@@ -18,7 +18,7 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-sql-driver/mysql"
 
@@ -41,7 +41,7 @@ func (m *mySQLFactory) Open(connectionString string) (*sql.DB, error) {
 
 func (m *mySQLFactory) RegisterTLSConfig(pemPath string) error {
 	rootCertPool := x509.NewCertPool()
-	pem, readErr := ioutil.ReadFile(pemPath)
+	pem, readErr := os.ReadFile(pemPath)
 
 	if readErr != nil {
 		m.logger.Errorf("Error reading PEM file from $s", pemPath)

--- a/state/mysql/mysql_integration_test.go
+++ b/state/mysql/mysql_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -632,7 +631,7 @@ func connectToDB(t *testing.T) (*sql.DB, error) {
 	val := getPemPath()
 	if val != "" {
 		rootCertPool := x509.NewCertPool()
-		pem, readErr := ioutil.ReadFile(val)
+		pem, readErr := os.ReadFile(val)
 
 		assert.Nil(t, readErr, "Could not read PEM file")
 

--- a/state/oci/objectstorage/objectstorage.go
+++ b/state/oci/objectstorage/objectstorage.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -292,7 +291,7 @@ func (r *StateStore) writeDocument(req *state.SetRequest) error {
 	if req.Options.Concurrency != state.FirstWrite {
 		etag = nil
 	}
-	err = r.client.putObject(ctx, objectName, objectLength, ioutil.NopCloser(bytes.NewReader(content)), metadata, etag)
+	err = r.client.putObject(ctx, objectName, objectLength, io.NopCloser(bytes.NewReader(content)), metadata, etag)
 	if err != nil {
 		r.logger.Debugf("error in writing object to OCI object storage  %s, err %s", req.Key, err)
 		return fmt.Errorf("failed to write object to OCI Object storage : %w", err)

--- a/state/postgresql/postgresql_query_test.go
+++ b/state/postgresql/postgresql_query_test.go
@@ -15,7 +15,7 @@ package postgresql
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,7 +54,7 @@ func TestPostgresqlQueryBuildQuery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		data, err := ioutil.ReadFile(test.input)
+		data, err := os.ReadFile(test.input)
 		assert.NoError(t, err)
 		var qq query.Query
 		err = json.Unmarshal(data, &qq)

--- a/state/query/query_test.go
+++ b/state/query/query_test.go
@@ -15,7 +15,7 @@ package query
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,7 +85,7 @@ func TestQuery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		data, err := ioutil.ReadFile(test.input)
+		data, err := os.ReadFile(test.input)
 		assert.NoError(t, err)
 		var q Query
 		err = json.Unmarshal(data, &q)

--- a/state/redis/redis_query_test.go
+++ b/state/redis/redis_query_test.go
@@ -15,7 +15,7 @@ package redis
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +47,7 @@ func TestMongoQuery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		data, err := ioutil.ReadFile(test.input)
+		data, err := os.ReadFile(test.input)
 		assert.NoError(t, err)
 		var qq query.Query
 		err = json.Unmarshal(data, &qq)

--- a/state/rethinkdb/rethinkdb.go
+++ b/state/rethinkdb/rethinkdb.go
@@ -15,7 +15,7 @@ package rethinkdb
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -66,7 +66,7 @@ func NewRethinkDBStateStore(logger logger.Logger) *RethinkDB {
 
 // Init parses metadata, initializes the RethinkDB client, and ensures the state table exists.
 func (s *RethinkDB) Init(metadata state.Metadata) error {
-	r.Log.Out = ioutil.Discard
+	r.Log.Out = io.Discard
 	r.SetTags("rethinkdb", "json")
 	cfg, err := metadataToConfig(metadata.Properties, s.logger)
 	if err != nil {

--- a/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
+++ b/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -320,7 +320,7 @@ func TestBlobStorage(t *testing.T) {
 			url := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", storageAccountName, containerName, blobName)
 			resp, httpErr := http.Get(url) // nolint:gosec
 			assert.NoError(t, httpErr)
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 
 			if shoudBePublic {

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -225,7 +224,7 @@ func isYaml(fileName string) bool {
 }
 
 func readTestConfiguration(filePath string) ([]byte, error) {
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file %s", filePath)
 	}

--- a/tests/conformance/standalone_loader.go
+++ b/tests/conformance/standalone_loader.go
@@ -17,8 +17,8 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -45,7 +45,7 @@ func NewStandaloneComponents(componentPath string) *StandaloneComponents {
 // LoadComponents loads dapr components from a given directory.
 func (s *StandaloneComponents) LoadComponents() ([]Component, error) {
 	dir := s.componentsPath
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (s *StandaloneComponents) LoadComponents() ([]Component, error) {
 		if !file.IsDir() && s.isYaml(file.Name()) {
 			path := filepath.Join(dir, file.Name())
 
-			b, err := ioutil.ReadFile(path)
+			b, err := os.ReadFile(path)
 			if err != nil {
 				log.Printf("error reading file %s : %s", path, err)
 

--- a/tests/conformance/utils/utils.go
+++ b/tests/conformance/utils/utils.go
@@ -15,7 +15,7 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -118,7 +118,7 @@ func (s *server) handleGet() []byte {
 }
 
 func (s *server) handlePost(r *http.Request) {
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	defer r.Body.Close()
 
 	if err == nil {

--- a/tests/e2e/bindings/zeebe/helper.go
+++ b/tests/e2e/bindings/zeebe/helper.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -151,7 +150,7 @@ func RetryModifier(jobType string, retries int) func(string) string {
 // GetTestFile loads the content of a BPMN process file. The function also accepts a list of
 // modifier functions which allows to manipulate the content of the returned BPMN file.
 func GetTestFile(fileName string, modifiers ...func(string) string) ([]byte, error) {
-	dataBytes, err := ioutil.ReadFile("../processes/" + fileName)
+	dataBytes, err := os.ReadFile("../processes/" + fileName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

1. Fix formation security vulnerability in [CVE-2021-42576](https://nvd.nist.gov/vuln/detail/CVE-2021-42576).
2. The current minimum version of dapr is golang 1.18, which is no longer compatible with the previous version and can remove the marked deprecated functions.
## Issue reference

## Checklist

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
