### PR TITLE
Update code to reflect renaming on UnlockResponse.Status

### DIFF
--- a/lock/redis/standalone.go
+++ b/lock/redis/standalone.go
@@ -173,9 +173,9 @@ func (r *StandaloneRedisLock) Unlock(req *lock.UnlockRequest) (*lock.UnlockRespo
 	if i >= 0 {
 		status = lock.Success
 	} else if i == -1 {
-		status = lock.LockUnexist
+		status = lock.LockDoesNotExist
 	} else if i == -2 {
-		status = lock.LockBelongToOthers
+		status = lock.LockBelongsToOthers
 	}
 	return &lock.UnlockResponse{
 		Status: status,

--- a/lock/responses.go
+++ b/lock/responses.go
@@ -27,8 +27,8 @@ type Status int32
 
 // lock status.
 const (
-	Success            Status = 0
-	LockUnexist        Status = 1
-	LockBelongToOthers Status = 2
-	InternalError      Status = 3
+	Success             Status = 0
+	LockDoesNotExist    Status = 1
+	LockBelongsToOthers Status = 2
+	InternalError       Status = 3
 )


### PR DESCRIPTION
# Description

PR dapr/dapr#4989 (issue dapr/dapr#4988) updated the names of some
enums in `UnlockResponse.Status` ProtoBuff definition:

* `LOCK_UNEXIST` became `LOCK_DOES_NOT_EXIST `
* `LOCK_BELONG_TO_OTHERS`  became `LOCK_BELONGS_TO_OTHERS`

Code implementing Distributed Lock component in components-contrib
needs to be updated to account for this modification.

This PR accomplishes this by updating contants mapping back to the
two enums above to match their new names.

Fixes dapr/components-contrib#1950

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1950 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
