### PR TITLE
fix(kafka): ConsumeClaim should not return err when retry recovery failed

### DIFF
--- a/internal/component/kafka/consumer.go
+++ b/internal/component/kafka/consumer.go
@@ -44,7 +44,7 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 			}, func() {
 				consumer.k.logger.Infof("Successfully processed Kafka message after it previously failed: %s/%d/%d [key=%s]", message.Topic, message.Partition, message.Offset, asBase64String(message.Key))
 			}); err != nil {
-				return err
+				consumer.k.logger.Errorf("Error processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
 			}
 		} else {
 			err := consumer.doCallback(session, message)

--- a/internal/component/kafka/consumer.go
+++ b/internal/component/kafka/consumer.go
@@ -44,7 +44,7 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 			}, func() {
 				consumer.k.logger.Infof("Successfully processed Kafka message after it previously failed: %s/%d/%d [key=%s]", message.Topic, message.Partition, message.Offset, asBase64String(message.Key))
 			}); err != nil {
-				consumer.k.logger.Errorf("Error processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
+				consumer.k.logger.Errorf("Too many failed attempts at processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
 			}
 		} else {
 			err := consumer.doCallback(session, message)


### PR DESCRIPTION
ConsumeClaim should not return err when retry recovery failed.

# Description

`ConsumeClaim` return error will cause restart loop of consume, if initialOffset is oldest, this message will be consumed forever. So we should log error and let it go like no retry does.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
