### PR TITLE
Fix CosmosDB state store handling of nulls 

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -249,7 +249,18 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	if items[0].IsBinary {
-		bytes, _ := base64.StdEncoding.DecodeString(items[0].Value.(string))
+		if items[0].Value == nil || len(items[0].Value.(string)) == 0 {
+			return &state.GetResponse{
+				Data: make([]byte, 0),
+				ETag: ptr.String(items[0].Etag),
+			}, nil
+		}
+
+		bytes, decodeErr := base64.StdEncoding.DecodeString(items[0].Value.(string))
+		if decodeErr != nil {
+			c.logger.Warnf("CosmosDB state store Get request could not decode binary string: %v. Returning raw string instead.", decodeErr)
+			bytes = []byte(items[0].Value.(string))
+		}
 
 		return &state.GetResponse{
 			Data: bytes,
@@ -583,6 +594,9 @@ func (c *StateStore) findCollection() (*documentdb.Collection, error) {
 
 func createUpsertItem(contentType string, req state.SetRequest, partitionKey string) (CosmosItem, error) {
 	byteArray, isBinary := req.Value.([]uint8)
+	if len(byteArray) == 0 {
+		isBinary = false
+	}
 
 	ttl, err := parseTTL(req.Metadata)
 	if err != nil {

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -249,7 +249,7 @@ func (c *StateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}
 
 	if items[0].IsBinary {
-		if items[0].Value == nil || len(items[0].Value.(string)) == 0 {
+		if items[0].Value == nil {
 			return &state.GetResponse{
 				Data: make([]byte, 0),
 				ETag: ptr.String(items[0].Etag),


### PR DESCRIPTION
Addresses some issue related to the handling of nulls / nil values on Cosmos DB State store. #1970 

- No longer treats empty / nil values as binary data on Set operations.
- Allows returning of nil values in Get operation.
- Falls back to returning raw string if a byte string cannot be decoded (in Get operation).

Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
