### PR TITLE
Corrected module name in go mod file

### DIFF
--- a/tests/certification/pubsub/azure/servicebus/go.mod
+++ b/tests/certification/pubsub/azure/servicebus/go.mod
@@ -1,4 +1,4 @@
-module servicebusqueue_test
+module servicebus_test
 
 go 1.19
 


### PR DESCRIPTION
Signed-off-by: Amulya Varote <amulyavarote@microsoft.com>

# Description

Corrected module name from servicebusqueue_test to servicebus_test in go mod file.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
