### PR TITLE
Enable conformance tests for rethinkdb

### DIFF
--- a/.github/infrastructure/docker-compose-rethinkdb.yml
+++ b/.github/infrastructure/docker-compose-rethinkdb.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  rethinkdb:
+    image: rethinkdb:2.4
+    ports:
+      - 8081:8080
+      - 28015:28015
+      - 29015:29015

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -69,6 +69,7 @@ jobs:
         - state.redis
         - state.sqlserver
         - state.cockroachdb
+        - state.rethinkdb
         EOF
         )
         echo "::set-output name=pr-components::$PR_COMPONENTS"
@@ -305,6 +306,11 @@ jobs:
       run: |
         docker-compose -f ./.github/infrastructure/docker-compose-cockroachdb.yml -p cockroachdb up -d
       if: contains(matrix.component, 'cockroachdb')
+
+    - name: Start rethinkdb
+      run: |
+        docker-compose -f ./.github/infrastructure/docker-compose-rethinkdb.yml -p rethinkdb up -d
+      if: contains(matrix.component, 'rethinkdb')
 
     - name: Setup KinD test data
       if: contains(matrix.component, 'kubernetes')

--- a/state/rethinkdb/rethinkdb.go
+++ b/state/rethinkdb/rethinkdb.go
@@ -59,7 +59,7 @@ type stateRecord struct {
 // NewRethinkDBStateStore returns a new RethinkDB state store.
 func NewRethinkDBStateStore(logger logger.Logger) state.Store {
 	return &RethinkDB{
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureTransactional},
 		logger:   logger,
 	}
 }

--- a/tests/config/state/rethinkdb/statestore.yml
+++ b/tests/config/state/rethinkdb/statestore.yml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.rethinkdb
+  version: v1
+  metadata:
+    - name: address
+      value: 127.0.0.1:28015
+    - name: database
+      value: test

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -37,3 +37,6 @@ components:
   - component: cockroachdb
     allOperations: false
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "query" ]
+  - component: rethinkdb
+    allOperations: false
+    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction"]

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -73,6 +73,7 @@ import (
 	s_mysql "github.com/dapr/components-contrib/state/mysql"
 	s_postgresql "github.com/dapr/components-contrib/state/postgresql"
 	s_redis "github.com/dapr/components-contrib/state/redis"
+	s_rethinkdb "github.com/dapr/components-contrib/state/rethinkdb"
 	s_sqlserver "github.com/dapr/components-contrib/state/sqlserver"
 	conf_bindings "github.com/dapr/components-contrib/tests/conformance/bindings"
 	conf_pubsub "github.com/dapr/components-contrib/tests/conformance/pubsub"
@@ -434,6 +435,8 @@ func loadStateStore(tc TestComponent) state.Store {
 		store = s_cockroachdb.New(testLogger)
 	case "memcached":
 		store = s_memcached.NewMemCacheStateStore(testLogger)
+	case "rethinkdb":
+		store = s_rethinkdb.NewRethinkDBStateStore(testLogger)
 	default:
 		return nil
 	}


### PR DESCRIPTION
# Description

This makes RethinkDB a Beta component.

Note:
RethinkDB does **not support ETag**. As such the ETag capability has been removed from the set of returned capabilities.

Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
