### PR TITLE
Rethinkdb state store: Remove falsely advertised transaction support

### DIFF
--- a/state/rethinkdb/rethinkdb.go
+++ b/state/rethinkdb/rethinkdb.go
@@ -59,7 +59,7 @@ type stateRecord struct {
 // NewRethinkDBStateStore returns a new RethinkDB state store.
 func NewRethinkDBStateStore(logger logger.Logger) state.Store {
 	return &RethinkDB{
-		features: []state.Feature{state.FeatureTransactional},
+		features: []state.Feature{},
 		logger:   logger,
 	}
 }

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -39,4 +39,4 @@ components:
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "query" ]
   - component: rethinkdb
     allOperations: false
-    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction"]
+    operations: [ "set", "get", "delete", "bulkset", "bulkdelete"]


### PR DESCRIPTION
# Description

Rethinkdb state store: Remove falsely advertised transaction support

RethinkDB does not support multi-item / multi-document transactions and as such should not advertise transaction support.
