### PR TITLE
Reduce conformance test run frequency

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,7 +18,7 @@ on:
     types: [conformance-test]
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 */8 * * *'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Run conformance tests against master every 8 hours instead of 30 minutes.

Tests will still run on PR of course, and via `/ok-to-test`


Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>
