### PR TITLE
Query API: Set filters when unmarshalling Query Struct

### DIFF
--- a/state/query/query.go
+++ b/state/query/query.go
@@ -106,6 +106,14 @@ func (q *Query) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return err
 		}
+
+		jdata, err := json.Marshal(elem)
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal(jdata, &q.Filters); err != nil {
+			return err
+		}
 	}
 	// setting sorting
 	if elem, ok := m[SORT]; ok {

--- a/state/query/query_test.go
+++ b/state/query/query_test.go
@@ -38,16 +38,33 @@ func TestQuery(t *testing.T) {
 		{
 			input: "../../tests/state/query/q2.json",
 			query: Query{
-				Filters: nil,
-				Sort:    nil,
-				Page:    Pagination{Limit: 2, Token: ""},
-				Filter:  &EQ{Key: "state", Val: "CA"},
+				Filters: map[string]any{
+					"EQ": map[string]any{
+						"state": "CA",
+					},
+				},
+				Sort:   nil,
+				Page:   Pagination{Limit: 2, Token: ""},
+				Filter: &EQ{Key: "state", Val: "CA"},
 			},
 		},
 		{
 			input: "../../tests/state/query/q3.json",
 			query: Query{
-				Filters: nil,
+				Filters: map[string]any{
+					"AND": []any{
+						map[string]any{
+							"EQ": map[string]any{
+								"person.org": "A",
+							},
+						},
+						map[string]any{
+							"IN": map[string]any{
+								"state": []any{"CA", "WA"},
+							},
+						},
+					},
+				},
 				Sort: []Sorting{
 					{Key: "state", Order: "DESC"},
 					{Key: "person.name", Order: ""},
@@ -56,7 +73,7 @@ func TestQuery(t *testing.T) {
 				Filter: &AND{
 					Filters: []Filter{
 						&EQ{Key: "person.org", Val: "A"},
-						&IN{Key: "state", Vals: []interface{}{"CA", "WA"}},
+						&IN{Key: "state", Vals: []any{"CA", "WA"}},
 					},
 				},
 			},
@@ -64,7 +81,29 @@ func TestQuery(t *testing.T) {
 		{
 			input: "../../tests/state/query/q4.json",
 			query: Query{
-				Filters: nil,
+				Filters: map[string]any{
+					"OR": []any{
+						map[string]any{
+							"EQ": map[string]any{
+								"person.org": "A",
+							},
+						},
+						map[string]any{
+							"AND": []any{
+								map[string]any{
+									"EQ": map[string]any{
+										"person.org": "B",
+									},
+								},
+								map[string]any{
+									"IN": map[string]any{
+										"state": []any{"CA", "WA"},
+									},
+								},
+							},
+						},
+					},
+				},
 				Sort: []Sorting{
 					{Key: "state", Order: "DESC"},
 					{Key: "person.name", Order: ""},


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Set filters attribute on query struct when unmarshalling it. This will allow components to serialize the filters further.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2037 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
