### PR TITLE
Cert tests: Use `docker compose` instead of `docker-compose`

### DIFF
--- a/tests/certification/flow/dockercompose/dockercompose.go
+++ b/tests/certification/flow/dockercompose/dockercompose.go
@@ -49,7 +49,8 @@ func Up(project, filename string) flow.Runnable {
 
 func (c Compose) Up(ctx flow.Context) error {
 	out, err := exec.Command(
-		"docker compose",
+		"docker"
+		"compose",
 		"-p", c.project,
 		"-f", c.filename,
 		"up", "-d",
@@ -65,7 +66,8 @@ func Down(project, filename string) flow.Runnable {
 
 func (c Compose) Down(ctx flow.Context) error {
 	out, err := exec.Command(
-		"docker-compose",
+		"docker",
+		"compose",
 		"-p", c.project,
 		"-f", c.filename,
 		"down", "-v").CombinedOutput()
@@ -86,7 +88,7 @@ func (c Compose) Start(services ...string) flow.Runnable {
 			"start",
 		}
 		args = append(args, services...)
-		out, err := exec.Command("docker-compose", args...).CombinedOutput()
+		out, err := exec.Command("docker", "compose", args...).CombinedOutput()
 		ctx.Log(string(out))
 		return err
 	}
@@ -104,7 +106,7 @@ func (c Compose) Stop(services ...string) flow.Runnable {
 			"stop",
 		}
 		args = append(args, services...)
-		out, err := exec.Command("docker-compose", args...).CombinedOutput()
+		out, err := exec.Command("docker", "compose", args...).CombinedOutput()
 		ctx.Log(string(out))
 		return err
 	}

--- a/tests/certification/flow/dockercompose/dockercompose.go
+++ b/tests/certification/flow/dockercompose/dockercompose.go
@@ -49,7 +49,7 @@ func Up(project, filename string) flow.Runnable {
 
 func (c Compose) Up(ctx flow.Context) error {
 	out, err := exec.Command(
-		"docker-compose",
+		"docker compose",
 		"-p", c.project,
 		"-f", c.filename,
 		"up", "-d",


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Cert tests: Use `docker compose` instead of `docker-compose`