### PR TITLE
Fix Zeebe metadata duration issue & provide metadata parsing utility

### DIFF
--- a/bindings/alicloud/dingtalk/webhook/settings.go
+++ b/bindings/alicloud/dingtalk/webhook/settings.go
@@ -20,7 +20,7 @@ package webhook
 import (
 	"errors"
 
-	"github.com/dapr/kit/config"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 type Settings struct {
@@ -30,7 +30,7 @@ type Settings struct {
 }
 
 func (s *Settings) Decode(in interface{}) error {
-	return config.Decode(in, s)
+	return metadata.DecodeMetadata(in, s)
 }
 
 func (s *Settings) Validate() error {

--- a/bindings/alicloud/nacos/settings.go
+++ b/bindings/alicloud/nacos/settings.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dapr/kit/config"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 type Settings struct {
@@ -48,7 +48,7 @@ type Settings struct {
 }
 
 func (s *Settings) Decode(in interface{}) error {
-	return config.Decode(in, s)
+	return metadata.DecodeMetadata(in, s)
 }
 
 func (s *Settings) Validate() error {

--- a/bindings/alicloud/oss/oss.go
+++ b/bindings/alicloud/oss/oss.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -87,9 +87,9 @@ func (s *AliCloudOSS) Invoke(_ context.Context, req *bindings.InvokeRequest) (*b
 	return nil, err
 }
 
-func (s *AliCloudOSS) parseMetadata(metadata bindings.Metadata) (*ossMetadata, error) {
+func (s *AliCloudOSS) parseMetadata(meta bindings.Metadata) (*ossMetadata, error) {
 	var m ossMetadata
-	err := mapstructure.WeakDecode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/alicloud/rocketmq/settings.go
+++ b/bindings/alicloud/rocketmq/settings.go
@@ -19,7 +19,7 @@ import (
 
 	rocketmq "github.com/cinience/go_rocketmq"
 
-	"github.com/dapr/kit/config"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // rocketmq.
@@ -63,7 +63,7 @@ type Settings struct {
 }
 
 func (s *Settings) Decode(in interface{}) error {
-	if err := config.Decode(in, s); err != nil {
+	if err := metadata.DecodeMetadata(in, s); err != nil {
 		return fmt.Errorf("decode error: %w", err)
 	}
 

--- a/bindings/alicloud/sls/sls.go
+++ b/bindings/alicloud/sls/sls.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aliyun/aliyun-log-go-sdk/producer"
 
 	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/kit/config"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -97,9 +97,9 @@ func (s *AliCloudSlsLogstorage) parseLog(req *bindings.InvokeRequest) (*sls.Log,
 	return producer.GenerateLog(uint32(time.Now().Unix()), logInfo), nil
 }
 
-func (s *AliCloudSlsLogstorage) parseMeta(metadata bindings.Metadata) (*SlsLogstorageMetadata, error) {
+func (s *AliCloudSlsLogstorage) parseMeta(meta bindings.Metadata) (*SlsLogstorageMetadata, error) {
 	var m SlsLogstorageMetadata
-	err := config.Decode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -20,10 +20,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
 	awsAuth "github.com/dapr/components-contrib/internal/authentication/aws"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -95,7 +95,7 @@ func (d *DynamoDB) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bi
 
 func (d *DynamoDB) getDynamoDBMetadata(spec bindings.Metadata) (*dynamoDBMetadata, error) {
 	var meta dynamoDBMetadata
-	err := mapstructure.WeakDecode(spec.Properties, &meta)
+	err := metadata.DecodeMetadata(spec.Properties, &meta)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -24,13 +24,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/config"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/interfaces"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/worker"
 
 	"github.com/dapr/components-contrib/bindings"
 	awsAuth "github.com/dapr/components-contrib/internal/authentication/aws"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -322,9 +322,9 @@ func (a *AWSKinesis) getClient(metadata *kinesisMetadata) (*kinesis.Kinesis, err
 	return k, nil
 }
 
-func (a *AWSKinesis) parseMetadata(metadata bindings.Metadata) (*kinesisMetadata, error) {
+func (a *AWSKinesis) parseMetadata(meta bindings.Metadata) (*kinesisMetadata, error) {
 	var m kinesisMetadata
-	err := mapstructure.WeakDecode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/huawei/obs/obs.go
+++ b/bindings/huawei/obs/obs.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/huaweicloud/huaweicloud-sdk-go-obs/obs"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -92,9 +92,9 @@ func (o *HuaweiOBS) Init(metadata bindings.Metadata) error {
 	return nil
 }
 
-func (o *HuaweiOBS) parseMetadata(metadata bindings.Metadata) (*obsMetadata, error) {
+func (o *HuaweiOBS) parseMetadata(meta bindings.Metadata) (*obsMetadata, error) {
 	var m obsMetadata
-	err := mapstructure.WeakDecode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/influx/influx.go
+++ b/bindings/influx/influx.go
@@ -20,10 +20,10 @@ import (
 
 	influxdb2 "github.com/influxdata/influxdb-client-go"
 	"github.com/influxdata/influxdb-client-go/api"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -96,9 +96,9 @@ func (i *Influx) Init(metadata bindings.Metadata) error {
 }
 
 // GetInfluxMetadata returns new Influx metadata.
-func (i *Influx) getInfluxMetadata(metadata bindings.Metadata) (*influxMetadata, error) {
+func (i *Influx) getInfluxMetadata(meta bindings.Metadata) (*influxMetadata, error) {
 	var iMetadata influxMetadata
-	err := mapstructure.WeakDecode(metadata.Properties, &iMetadata)
+	err := metadata.DecodeMetadata(meta.Properties, &iMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/ipfs/metadata.go
+++ b/bindings/ipfs/metadata.go
@@ -23,7 +23,7 @@ import (
 	ipfsFsrepo "github.com/ipfs/kubo/repo/fsrepo"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	"github.com/dapr/kit/config"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 type ipfsMetadata struct {
@@ -64,7 +64,7 @@ type ipfsMetadata struct {
 // FromMap initializes the metadata object from a map.
 func (m *ipfsMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = config.Decode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/ipfs/operation-add.go
+++ b/bindings/ipfs/operation-add.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/multiformats/go-multihash"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // Handler for the "add" operation, which adds a new file
@@ -78,7 +77,7 @@ type addRequestMetadata struct {
 
 func (m *addRequestMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = mapstructure.WeakDecode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/ipfs/operation-get.go
+++ b/bindings/ipfs/operation-get.go
@@ -22,9 +22,8 @@ import (
 	ipfsFiles "github.com/ipfs/go-ipfs-files"
 	ipfsPath "github.com/ipfs/interface-go-ipfs-core/path"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // Handler for the "get" operation, which retrieves a document
@@ -72,7 +71,7 @@ type getRequestMetadata struct {
 
 func (m *getRequestMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = mapstructure.WeakDecode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/ipfs/operation-ls.go
+++ b/bindings/ipfs/operation-ls.go
@@ -21,9 +21,8 @@ import (
 
 	ipfsPath "github.com/ipfs/interface-go-ipfs-core/path"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // Handler for the "ls" operation, which retrieves a document
@@ -83,7 +82,7 @@ type lsRequestMetadata struct {
 
 func (m *lsRequestMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = mapstructure.WeakDecode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/ipfs/operation-pin-add.go
+++ b/bindings/ipfs/operation-pin-add.go
@@ -21,9 +21,8 @@ import (
 	ipfsOptions "github.com/ipfs/interface-go-ipfs-core/options"
 	ipfsPath "github.com/ipfs/interface-go-ipfs-core/path"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // Handler for the "pin-add" operation, which adds a new pin
@@ -65,7 +64,7 @@ type pinAddRequestMetadata struct {
 
 func (m *pinAddRequestMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = mapstructure.WeakDecode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/ipfs/operation-pin-ls.go
+++ b/bindings/ipfs/operation-pin-ls.go
@@ -21,9 +21,8 @@ import (
 
 	ipfsOptions "github.com/ipfs/interface-go-ipfs-core/options"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // Handler for the "pin-ls" operation, which removes a pin
@@ -75,7 +74,7 @@ type pinLsRequestMetadata struct {
 
 func (m *pinLsRequestMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = mapstructure.WeakDecode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/ipfs/operation-pin-rm.go
+++ b/bindings/ipfs/operation-pin-rm.go
@@ -21,9 +21,8 @@ import (
 	ipfsOptions "github.com/ipfs/interface-go-ipfs-core/options"
 	ipfsPath "github.com/ipfs/interface-go-ipfs-core/path"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 )
 
 // Handler for the "pin-rm" operation, which removes a pin
@@ -65,7 +64,7 @@ type pinRmRequestMetadata struct {
 
 func (m *pinRmRequestMetadata) FromMap(mp map[string]string) (err error) {
 	if len(mp) > 0 {
-		err = mapstructure.WeakDecode(mp, m)
+		err = metadata.DecodeMetadata(mp, m)
 		if err != nil {
 			return err
 		}

--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -26,9 +26,9 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -72,9 +72,9 @@ func (ls *LocalStorage) Init(metadata bindings.Metadata) error {
 	return nil
 }
 
-func (ls *LocalStorage) parseMetadata(metadata bindings.Metadata) (*Metadata, error) {
+func (ls *LocalStorage) parseMetadata(meta bindings.Metadata) (*Metadata, error) {
 	var m Metadata
-	err := mapstructure.WeakDecode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/zeebe/client.go
+++ b/bindings/zeebe/client.go
@@ -15,6 +15,7 @@ package zeebe
 
 import (
 	"errors"
+	"time"
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 
@@ -36,10 +37,10 @@ type ClientFactoryImpl struct {
 
 // https://docs.zeebe.io/operations/authentication.html
 type clientMetadata struct {
-	GatewayAddr            string            `json:"gatewayAddr" mapstructure:"gatewayAddr"`
-	GatewayKeepAlive       metadata.Duration `json:"gatewayKeepAlive" mapstructure:"gatewayKeepAlive"`
-	CaCertificatePath      string            `json:"caCertificatePath" mapstructure:"caCertificatePath"`
-	UsePlaintextConnection bool              `json:"usePlainTextConnection,string" mapstructure:"usePlainTextConnection"`
+	GatewayAddr            string        `json:"gatewayAddr" mapstructure:"gatewayAddr"`
+	GatewayKeepAlive       time.Duration `json:"gatewayKeepAlive" mapstructure:"gatewayKeepAlive"`
+	CaCertificatePath      string        `json:"caCertificatePath" mapstructure:"caCertificatePath"`
+	UsePlaintextConnection bool          `json:"usePlainTextConnection,string" mapstructure:"usePlainTextConnection"`
 }
 
 // NewClientFactoryImpl returns a new ClientFactory instance.
@@ -57,7 +58,7 @@ func (c *ClientFactoryImpl) Get(metadata bindings.Metadata) (zbc.Client, error) 
 		GatewayAddress:         meta.GatewayAddr,
 		UsePlaintextConnection: meta.UsePlaintextConnection,
 		CaCertificatePath:      meta.CaCertificatePath,
-		KeepAlive:              meta.GatewayKeepAlive.Duration,
+		KeepAlive:              meta.GatewayKeepAlive,
 	})
 	if err != nil {
 		return nil, err

--- a/bindings/zeebe/client.go
+++ b/bindings/zeebe/client.go
@@ -15,12 +15,11 @@ package zeebe
 
 import (
 	"errors"
-	"time"
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 
 	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/kit/config"
+	metadata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 )
 
@@ -37,10 +36,10 @@ type ClientFactoryImpl struct {
 
 // https://docs.zeebe.io/operations/authentication.html
 type clientMetadata struct {
-	GatewayAddr            string        `json:"gatewayAddr" mapstructure:"gatewayAddr"`
-	GatewayKeepAlive       time.Duration `json:"gatewayKeepAlive" mapstructure:"gatewayKeepAlive"`
-	CaCertificatePath      string        `json:"caCertificatePath" mapstructure:"caCertificatePath"`
-	UsePlaintextConnection bool          `json:"usePlainTextConnection,string" mapstructure:"usePlainTextConnection"`
+	GatewayAddr            string            `json:"gatewayAddr" mapstructure:"gatewayAddr"`
+	GatewayKeepAlive       metadata.Duration `json:"gatewayKeepAlive" mapstructure:"gatewayKeepAlive"`
+	CaCertificatePath      string            `json:"caCertificatePath" mapstructure:"caCertificatePath"`
+	UsePlaintextConnection bool              `json:"usePlainTextConnection,string" mapstructure:"usePlainTextConnection"`
 }
 
 // NewClientFactoryImpl returns a new ClientFactory instance.
@@ -58,7 +57,7 @@ func (c *ClientFactoryImpl) Get(metadata bindings.Metadata) (zbc.Client, error) 
 		GatewayAddress:         meta.GatewayAddr,
 		UsePlaintextConnection: meta.UsePlaintextConnection,
 		CaCertificatePath:      meta.CaCertificatePath,
-		KeepAlive:              meta.GatewayKeepAlive,
+		KeepAlive:              meta.GatewayKeepAlive.Duration,
 	})
 	if err != nil {
 		return nil, err
@@ -67,9 +66,9 @@ func (c *ClientFactoryImpl) Get(metadata bindings.Metadata) (zbc.Client, error) 
 	return client, nil
 }
 
-func (c *ClientFactoryImpl) parseMetadata(metadata bindings.Metadata) (*clientMetadata, error) {
+func (c *ClientFactoryImpl) parseMetadata(meta bindings.Metadata) (*clientMetadata, error) {
 	var m clientMetadata
-	err := config.Decode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/zeebe/client_test.go
+++ b/bindings/zeebe/client_test.go
@@ -35,7 +35,7 @@ func TestParseMetadata(t *testing.T) {
 	meta, err := client.parseMetadata(m)
 	assert.NoError(t, err)
 	assert.Equal(t, "172.0.0.1:1234", meta.GatewayAddr)
-	assert.Equal(t, 5*time.Second, meta.GatewayKeepAlive.Duration)
+	assert.Equal(t, 5*time.Second, meta.GatewayKeepAlive)
 	assert.Equal(t, "/cert/path", meta.CaCertificatePath)
 	assert.Equal(t, true, meta.UsePlaintextConnection)
 }
@@ -54,7 +54,7 @@ func TestParseMetadataDefaultValues(t *testing.T) {
 	client := ClientFactoryImpl{logger: logger.NewLogger("test")}
 	meta, err := client.parseMetadata(m)
 	assert.NoError(t, err)
-	assert.Equal(t, time.Duration(0), meta.GatewayKeepAlive.Duration)
+	assert.Equal(t, time.Duration(0), meta.GatewayKeepAlive)
 	assert.Equal(t, "", meta.CaCertificatePath)
 	assert.Equal(t, false, meta.UsePlaintextConnection)
 }

--- a/bindings/zeebe/client_test.go
+++ b/bindings/zeebe/client_test.go
@@ -35,7 +35,7 @@ func TestParseMetadata(t *testing.T) {
 	meta, err := client.parseMetadata(m)
 	assert.NoError(t, err)
 	assert.Equal(t, "172.0.0.1:1234", meta.GatewayAddr)
-	assert.Equal(t, 5*time.Second, meta.GatewayKeepAlive)
+	assert.Equal(t, 5*time.Second, meta.GatewayKeepAlive.Duration)
 	assert.Equal(t, "/cert/path", meta.CaCertificatePath)
 	assert.Equal(t, true, meta.UsePlaintextConnection)
 }
@@ -54,7 +54,7 @@ func TestParseMetadataDefaultValues(t *testing.T) {
 	client := ClientFactoryImpl{logger: logger.NewLogger("test")}
 	meta, err := client.parseMetadata(m)
 	assert.NoError(t, err)
-	assert.Equal(t, time.Duration(0), meta.GatewayKeepAlive)
+	assert.Equal(t, time.Duration(0), meta.GatewayKeepAlive.Duration)
 	assert.Equal(t, "", meta.CaCertificatePath)
 	assert.Equal(t, false, meta.UsePlaintextConnection)
 }

--- a/bindings/zeebe/jobworker/jobworker.go
+++ b/bindings/zeebe/jobworker/jobworker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/bindings/zeebe"
 	"github.com/dapr/components-contrib/metadata"
-	"github.com/dapr/kit/config"
 	"github.com/dapr/kit/logger"
 )
 
@@ -111,13 +110,12 @@ func (z *ZeebeJobWorker) Read(ctx context.Context, handler bindings.Handler) err
 	return nil
 }
 
-func (z *ZeebeJobWorker) parseMetadata(metadata bindings.Metadata) (*jobWorkerMetadata, error) {
+func (z *ZeebeJobWorker) parseMetadata(meta bindings.Metadata) (*jobWorkerMetadata, error) {
 	var m jobWorkerMetadata
-	err := config.Decode(metadata.Properties, &m)
+	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
 	}
-
 	return &m, nil
 }
 

--- a/metadata/duration.go
+++ b/metadata/duration.go
@@ -18,8 +18,11 @@ package metadata
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type Duration struct {
@@ -50,6 +53,42 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 		return nil
 	default:
 		return errors.New("invalid duration")
+	}
+}
+
+// This helper function is used to decode durations within a map[string]interface{} into a struct.
+// It must be used in conjunction with mapstructure's DecodeHook.
+// This is used in utils.DecodeMetadata to decode durations in metadata.
+//
+//	mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+//	   DecodeHook: mapstructure.ComposeDecodeHookFunc(
+//	     toTimeDurationHookFunc()),
+//	   Metadata: nil,
+//			Result:   result,
+//	})
+func toTimeDurationHookFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{},
+	) (interface{}, error) {
+		if t != reflect.TypeOf(Duration{}) {
+			return data, nil
+		}
+
+		switch f.Kind() {
+		case reflect.String:
+			val, err := time.ParseDuration(data.(string))
+			if err != nil {
+				return nil, err
+			}
+			return Duration{Duration: val}, nil
+		case reflect.Float64:
+			val := time.Duration(data.(float64))
+			return val, nil
+		default:
+			return data, nil
+		}
 	}
 }
 

--- a/metadata/duration.go
+++ b/metadata/duration.go
@@ -72,7 +72,7 @@ func toTimeDurationHookFunc() mapstructure.DecodeHookFunc {
 		t reflect.Type,
 		data interface{},
 	) (interface{}, error) {
-		if t != reflect.TypeOf(Duration{}) {
+		if t != reflect.TypeOf(Duration{}) && t != reflect.TypeOf(time.Duration(0)) {
 			return data, nil
 		}
 
@@ -82,10 +82,22 @@ func toTimeDurationHookFunc() mapstructure.DecodeHookFunc {
 			if err != nil {
 				return nil, err
 			}
+			if t != reflect.TypeOf(Duration{}) {
+				return val, nil
+			}
 			return Duration{Duration: val}, nil
 		case reflect.Float64:
 			val := time.Duration(data.(float64))
-			return val, nil
+			if t != reflect.TypeOf(Duration{}) {
+				return val, nil
+			}
+			return Duration{Duration: val}, nil
+		case reflect.Int64:
+			val := time.Duration(data.(int64))
+			if t != reflect.TypeOf(Duration{}) {
+				return val, nil
+			}
+			return Duration{Duration: val}, nil
 		default:
 			return data, nil
 		}

--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -128,12 +128,13 @@ func GetMetadataProperty(props map[string]string, keys ...string) (val string, o
 
 // DecodeMetadata decodes metadata into a struct
 // This is an extension of mitchellh/mapstructure which also supports decoding durations
-func DecodeMetadata(input map[string]string, result interface{}) error {
+func DecodeMetadata(input interface{}, result interface{}) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			toTimeDurationHookFunc()),
-		Metadata: nil,
-		Result:   &result,
+		Metadata:         nil,
+		Result:           result,
+		WeaklyTypedInput: true,
 	})
 	if err != nil {
 		return err

--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -123,4 +124,20 @@ func GetMetadataProperty(props map[string]string, keys ...string) (val string, o
 		}
 	}
 	return "", false
+}
+
+// DecodeMetadata decodes metadata into a struct
+// This is an extension of mitchellh/mapstructure which also supports decoding durations
+func DecodeMetadata(input map[string]string, result interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			toTimeDurationHookFunc()),
+		Metadata: nil,
+		Result:   &result,
+	})
+	if err != nil {
+		return err
+	}
+	err = decoder.Decode(input)
+	return err
 }

--- a/metadata/utils_test.go
+++ b/metadata/utils_test.go
@@ -96,11 +96,12 @@ func TestTryGetContentType(t *testing.T) {
 func TestMetadataDecode(t *testing.T) {
 	t.Run("Test metadata decoding", func(t *testing.T) {
 		type testMetadata struct {
-			Mystring   string   `json:"mystring"`
-			Myduration Duration `json:"myduration"`
-			Myinteger  int      `json:"myinteger,string"`
-			Myfloat64  float64  `json:"myfloat64,string"`
-			Mybool     *bool    `json:"mybool,omitempty"`
+			Mystring          string        `json:"mystring"`
+			Myduration        Duration      `json:"myduration"`
+			Myinteger         int           `json:"myinteger,string"`
+			Myfloat64         float64       `json:"myfloat64,string"`
+			Mybool            *bool         `json:"mybool,omitempty"`
+			MyRegularDuration time.Duration `json:"myregularduration"`
 		}
 
 		var m testMetadata
@@ -111,6 +112,7 @@ func TestMetadataDecode(t *testing.T) {
 		testData["myinteger"] = "1"
 		testData["myfloat64"] = "1.1"
 		testData["mybool"] = "true"
+		testData["myregularduration"] = "6m"
 
 		err := DecodeMetadata(testData, &m)
 
@@ -119,6 +121,7 @@ func TestMetadataDecode(t *testing.T) {
 		assert.Equal(t, "test", m.Mystring)
 		assert.Equal(t, 1, m.Myinteger)
 		assert.Equal(t, 1.1, m.Myfloat64)
+		assert.Equal(t, 6*time.Minute, m.MyRegularDuration)
 		assert.Equal(t, Duration{Duration: 3 * time.Second}, m.Myduration)
 	})
 }

--- a/metadata/utils_test.go
+++ b/metadata/utils_test.go
@@ -14,7 +14,9 @@ limitations under the License.
 package metadata
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -89,5 +91,36 @@ func TestTryGetContentType(t *testing.T) {
 
 		assert.Equal(t, contentType, val)
 		assert.Equal(t, true, ok)
+	})
+}
+
+func TestMetadataDecode(t *testing.T) {
+	t.Run("Test metadata decoding", func(t *testing.T) {
+		type testMetadata struct {
+			Mystring   string   `json:"mystring"`
+			Myduration Duration `json:"myduration"`
+			Myinteger  int      `json:"myinteger,string"`
+			Myfloat64  float64  `json:"myfloat64,string"`
+			Mybool     *bool    `json:"mybool,omitempty"`
+		}
+
+		var m testMetadata
+
+		testData := make(map[string]string)
+		testData["mystring"] = "test"
+		testData["myduration"] = "3s"
+		testData["myinteger"] = "1"
+		testData["myfloat64"] = "1.1"
+		testData["mybool"] = "true"
+
+		err := DecodeMetadata(testData, &m)
+		fmt.Println(testData)
+
+		assert.Nil(t, err)
+		assert.Equal(t, true, *m.Mybool)
+		assert.Equal(t, "test", m.Mystring)
+		assert.Equal(t, 1, m.Myinteger)
+		assert.Equal(t, 1.1, m.Myfloat64)
+		assert.Equal(t, Duration{Duration: 3 * time.Second}, m.Myduration)
 	})
 }

--- a/metadata/utils_test.go
+++ b/metadata/utils_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package metadata
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -114,7 +113,6 @@ func TestMetadataDecode(t *testing.T) {
 		testData["mybool"] = "true"
 
 		err := DecodeMetadata(testData, &m)
-		fmt.Println(testData)
 
 		assert.Nil(t, err)
 		assert.Equal(t, true, *m.Mybool)

--- a/pubsub/rocketmq/metadata.go
+++ b/pubsub/rocketmq/metadata.go
@@ -17,8 +17,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
-	"github.com/dapr/kit/config"
 )
 
 var (
@@ -74,7 +74,7 @@ func getDefaultRocketMQMetaData() *rocketMQMetaData {
 }
 
 func (s *rocketMQMetaData) Decode(in interface{}) error {
-	if err := config.Decode(in, &s); err != nil {
+	if err := metadata.DecodeMetadata(in, &s); err != nil {
 		return fmt.Errorf("decode failed. %w", err)
 	}
 	return nil

--- a/secretstores/local/file/filestore.go
+++ b/secretstores/local/file/filestore.go
@@ -23,8 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/secretstores"
-	"github.com/dapr/kit/config"
 	"github.com/dapr/kit/logger"
 )
 
@@ -225,7 +225,7 @@ func (j *localSecretStore) combine(values []string) string {
 
 func (j *localSecretStore) getLocalSecretStoreMetadata(spec secretstores.Metadata) (*localSecretStoreMetaData, error) {
 	var meta localSecretStoreMetaData
-	err := config.Decode(spec.Properties, &meta)
+	err := metadata.DecodeMetadata(spec.Properties, &meta)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Fixes #2050

Original issue was introduced when adding request context in bindings. The mitchelh/mapstructure library does not natively support converting of `time.duration` and this PR had to add this.