### PR TITLE
Disable broken go vulnerability check in workflow

### DIFF
--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -99,11 +99,11 @@ jobs:
       - name: Run go mod tidy check diff
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
         run: make modtidy-all check-diff
-      - name: Run Go Vulnerability Check
-        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+#       - name: Run Go Vulnerability Check
+#         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+#         run: |
+#           go install golang.org/x/vuln/cmd/govulncheck@latest
+#           govulncheck ./...
       - name: Run make test
         env:
           COVERAGE_OPTS: "-coverprofile=coverage.txt -covermode=atomic"


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Disable broken go vulnerability check in workflow. Will eventually reenable