### PR TITLE
Add pubsub.redis conformance test accidentally removed in #2058

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -58,6 +58,7 @@ jobs:
         - pubsub.natsstreaming
         - pubsub.pulsar
         - pubsub.rabbitmq
+        - pubsub.redis
         - pubsub.kafka-wurstmeister
         - pubsub.kafka-confluent
         - secretstores.kubernetes


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Add pubsub.redis conformance test accidentally removed in #2058