### PR TITLE
calculate cert test coverage only on scheduled runs

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -284,7 +284,7 @@ jobs:
     name: Notify Total coverage
     runs-on: ubuntu-latest
     needs: certification
-    if: always()
+    if: github.event_name == 'schedule'
     steps:
       - name: Download Cert Coverage Artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

calculate cert test coverage only on scheduled runs