### PR TITLE
Includes image of contributors in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ For documentation on how components are being used in Dapr in a language/platfor
 
 * [Developing new component](docs/developing-component.md)
 
+Thanks to everyone who has contributed!
+
+<a href="https://github.com/dapr/components-contrib/graphs/contributors">
+  <img src="https://contributors-img.web.app/image?repo=dapr/components-contrib" />
+</a>
+
+
 ## Code of Conduct
 
 Please refer to our [Dapr Community Code of Conduct](https://github.com/dapr/community/blob/master/CODE-OF-CONDUCT.md)


### PR DESCRIPTION
Includes image of contributors in Readme.md

This is just for fun. It makes it more apparent that this repo has a lot of contributors.

![Screen Shot 2022-09-14 at 5 13 32 PM](https://user-images.githubusercontent.com/4535280/190284459-c210e0ae-0514-4944-825b-efc65905ccab.png)
