### PR TITLE
pass context to internal kafka producer impl

### DIFF
--- a/internal/component/kafka/producer.go
+++ b/internal/component/kafka/producer.go
@@ -14,6 +14,7 @@ limitations under the License.
 package kafka
 
 import (
+	"context"
 	"errors"
 
 	"github.com/Shopify/sarama"
@@ -77,7 +78,7 @@ func (k *Kafka) Publish(topic string, data []byte, metadata map[string]string) e
 	return nil
 }
 
-func (k *Kafka) BulkPublish(topic string, entries []pubsub.BulkMessageEntry, metadata map[string]string) (pubsub.BulkPublishResponse, error) {
+func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.BulkMessageEntry, metadata map[string]string) (pubsub.BulkPublishResponse, error) {
 	if k.producer == nil {
 		err := errors.New("component is closed")
 		return pubsub.NewBulkPublishResponse(entries, pubsub.PublishFailed, err), err

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -80,7 +80,7 @@ func (p *PubSub) Publish(req *pubsub.PublishRequest) error {
 
 // BatchPublish messages to Kafka cluster.
 func (p *PubSub) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
-	return p.kafka.BulkPublish(req.Topic, req.Entries, req.Metadata)
+	return p.kafka.BulkPublish(ctx, req.Topic, req.Entries, req.Metadata)
 }
 
 func (p *PubSub) Close() (err error) {


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description

Small change to pass in context from BulkPublish call into the producer impl code for kafka.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
