### PR TITLE
Adding conformance for bulk publish and properly map kafka errors on bulk publish

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,8 @@ on:
   pull_request:
     branches:
       - master
-      - release-*
+      - 'release-*'
+      - 'feature/*'
 
 jobs:
   # Based on whether this is a PR or a scheduled run, we will run a different

--- a/internal/component/kafka/producer.go
+++ b/internal/component/kafka/producer.go
@@ -14,6 +14,7 @@ limitations under the License.
 package kafka
 
 import (
+	"context"
 	"errors"
 
 	"github.com/Shopify/sarama"
@@ -77,7 +78,7 @@ func (k *Kafka) Publish(topic string, data []byte, metadata map[string]string) e
 	return nil
 }
 
-func (k *Kafka) BulkPublish(topic string, entries []pubsub.BulkMessageEntry, metadata map[string]string) (pubsub.BulkPublishResponse, error) {
+func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.BulkMessageEntry, metadata map[string]string) (pubsub.BulkPublishResponse, error) {
 	if k.producer == nil {
 		err := errors.New("component is closed")
 		return pubsub.NewBulkPublishResponse(entries, pubsub.PublishFailed, err), err

--- a/internal/component/kafka/producer.go
+++ b/internal/component/kafka/producer.go
@@ -91,6 +91,16 @@ func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.Bu
 			Topic: topic,
 			Value: sarama.ByteEncoder(entry.Event),
 		}
+		// From Sarama documentation
+		// This field is used to hold arbitrary data you wish to include so it
+		// will be available when receiving on the Successes and Errors channels.
+		// Sarama completely ignores this field and is only to be used for
+		// pass-through data.
+		// This pass thorugh field is used for mapping errors, as seen in the mapKafkaProducerErrors method
+		// The EntryID will be unique for this request and the ProducerMessage is returned on the Errros channel,
+		// the metadata in that field is compared to the entry metadata to generate the right response on partial failures
+		msg.Metadata = entry.EntryID
+
 		for name, value := range metadata {
 			if name == key {
 				msg.Key = sarama.StringEncoder(value)
@@ -108,8 +118,55 @@ func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.Bu
 	}
 
 	if err := k.producer.SendMessages(msgs); err != nil {
-		return pubsub.NewBulkPublishResponse(entries, pubsub.PublishFailed, err), err
+		// map the returned error to different entries
+		return k.mapKafkaProducerErrors(err, entries), err
 	}
 
 	return pubsub.NewBulkPublishResponse(entries, pubsub.PublishSucceeded, nil), nil
+}
+
+// mapKafkaProducerErrors to correct response statuses
+func (k *Kafka) mapKafkaProducerErrors(err error, entries []pubsub.BulkMessageEntry) pubsub.BulkPublishResponse {
+	var pErrs sarama.ProducerErrors
+	if !errors.As(err, &pErrs) {
+		// Ideally this condition should not be executed, but in the scenario that the err is not of sarama.ProducerErrors type
+		// return a default error that all messages have failed
+		return pubsub.NewBulkPublishResponse(entries, pubsub.PublishFailed, err)
+	}
+	resp := pubsub.BulkPublishResponse{
+		Statuses: make([]pubsub.BulkPublishResponseEntry, 0, len(entries)),
+	}
+	// used in the case of the partial success scenario
+	alreadySeen := map[string]struct{}{}
+
+	for _, pErr := range pErrs {
+		if entryID, ok := pErr.Msg.Metadata.(string); ok {
+			alreadySeen[entryID] = struct{}{}
+			resp.Statuses = append(resp.Statuses, pubsub.BulkPublishResponseEntry{
+				Status:  pubsub.PublishFailed,
+				EntryID: entryID,
+				Error:   pErr.Err,
+			})
+		} else {
+			// Ideally this condition should not be executed, but in the scenario that the Metadata field
+			// is not of string type return a default error that all messages have failed
+			k.logger.Warnf("error parsing bulk errors from Kafka, returning default error response of all failed")
+			return pubsub.NewBulkPublishResponse(entries, pubsub.PublishFailed, err)
+		}
+	}
+	// Check if all the messages have failed
+	if len(pErrs) != len(entries) {
+		// This is a partial success scenario
+		for _, entry := range entries {
+			// Check if the entryID was not seen in the pErrs list
+			if _, ok := alreadySeen[entry.EntryID]; !ok {
+				// this is a message that has succeeded
+				resp.Statuses = append(resp.Statuses, pubsub.BulkPublishResponseEntry{
+					Status:  pubsub.PublishSucceeded,
+					EntryID: entry.EntryID,
+				})
+			}
+		}
+	}
+	return resp
 }

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -121,7 +121,7 @@ func (p *PubSub) Publish(req *pubsub.PublishRequest) error {
 
 // BatchPublish messages to Kafka cluster.
 func (p *PubSub) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
-	return p.kafka.BulkPublish(req.Topic, req.Entries, req.Metadata)
+	return p.kafka.BulkPublish(ctx, req.Topic, req.Entries, req.Metadata)
 }
 
 func (p *PubSub) Close() (err error) {

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -1,4 +1,5 @@
-# Supported operation: publish, subscribe
+# Supported operation: publish, subscribe, multiplehandlers, bulkpublish
+# bulkpublish is only run for components that implement pubsub.BulkPublisher interface
 # Config map:
 ## pubsubName : name of the pubsub
 ## testTopicName: name of the test topic to use

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -1,5 +1,5 @@
 # Supported operation: publish, subscribe, multiplehandlers, bulkpublish
-# bulkpublish is only run for components that implement pubsub.BulkPublisher interface
+# bulkpublish should only be run for components that implement pubsub.BulkPublisher interface
 # Config map:
 ## pubsubName : name of the pubsub
 ## testTopicName: name of the test topic to use
@@ -11,7 +11,7 @@
 componentType: pubsub
 components:
   - component: azure.eventhubs
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
     config:
       pubsubName: azure-eventhubs
       testTopicName: eventhubs-pubsub-topic
@@ -23,41 +23,41 @@ components:
       publishMetadata:
         partitionKey: abcd
   - component: azure.servicebus
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
     config:
       pubsubName: azure-servicebus
       testTopicName: dapr-conf-test
       checkInOrderProcessing: false
   - component: redis
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
     config:
       checkInOrderProcessing: false
   - component: natsstreaming
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: jetstream
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: kafka
     allOperations: true
   - component: pulsar
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: mqtt
     profile: mosquitto
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: mqtt
     profile: emqx
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: mqtt
     profile: vernemq
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: hazelcast
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: rabbitmq
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
     config:
       checkInOrderProcessing: false
   - component: in-memory
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
   - component: aws.snssqs
-    allOperations: true
+    operations: ["publish", "subscribe", "multiplehandlers"]
     config:
       checkInOrderProcessing: false

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -229,7 +229,7 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 		t.Run("bulkPublish", func(t *testing.T) {
 			bP, ok := ps.(pubsub.BulkPublisher)
 			if !ok {
-				t.Skipf("Bulk publish conformance skipped since component %s does not implement the required interface", config.ComponentName)
+				t.Fatalf("cannot run bulkPublish conformance, BulkPublisher interface not implemented by the component %s", config.ComponentName)
 			}
 			// only run the test if BulkPublish is implemented
 			// Some pubsub, like Kafka need to wait for Subscriber to be up before messages can be consumed.


### PR DESCRIPTION
# Description

Adding conformance for bulk publish. 
This is currently using the existing subscriber to subscribe to the bulk published events as well.

For the mapping of errors from kafka, I was able to manually modify the bulk publish conf test locally and simulate a partial failure for a single message. I did modify the max message size for producer also locally and made the single failure message larger than the accepted size. 

The BulkPublishResponse got from BulkPublish is as following 
```
{[{11 FAILED kafka server: Message was too large, server rejected it to avoid allocation error.} {12 SUCCESS <nil>} {13 SUCCESS <nil>} {14 SUCCESS <nil>} {15 SUCCESS <nil>} {16 SUCCESS <nil>} {17 SUCCESS <nil>} {18 SUCCESS <nil>} {19 SUCCESS <nil>} {20 SUCCESS <nil>}]}
```
Here 11 -> 20 are the entry IDs and the 11 message alone failed with message was too large error.
The overall error was `kafka: Failed to deliver 1 messages.`

This I believe should only be part of certification test later on for kafka as it is too specific to kafka (as in modifying producer message size and simulating partial failure on publish).

Later on will figure out a way to add it to conformance tests.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

related to https://github.com/dapr/dapr/issues/2218

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
