### PR TITLE
Azure Event Hubs bulk publish to use request metadata

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,6 +1,20 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -13,4 +27,22 @@ func IsTruthy(val string) bool {
 	default:
 		return false
 	}
+}
+
+// GetElemOrDefaultFromMap returns the value of a key from a map, or a default value
+// if the key does not exist or the value is not of the expected type.
+func GetElemOrDefaultFromMap[T int | uint64](m map[string]string, key string, def T) T {
+	if val, ok := m[key]; ok {
+		switch any(def).(type) {
+		case int:
+			if ival, err := strconv.ParseInt(val, 10, 64); err == nil {
+				return T(ival)
+			}
+		case uint64:
+			if uval, err := strconv.ParseUint(val, 10, 64); err == nil {
+				return T(uval)
+			}
+		}
+	}
+	return def
 }

--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -44,6 +44,9 @@ const (
 
 	// MaxBulkAwaitDurationKey is the key for the max bulk await duration in the metadata.
 	MaxBulkAwaitDurationMilliSecondsKey string = "maxBulkAwaitDurationMilliSeconds"
+
+	// MaxBulkPubBytesKey defines the maximum bytes to publish in a bulk publish request metadata.
+	MaxBulkPubBytesKey string = "maxBulkPubBytes"
 )
 
 // TryGetTTL tries to get the ttl as a time.Duration value for pubsub, binding and any other building block.

--- a/pubsub/azure/eventhubs/eventhubs_test.go
+++ b/pubsub/azure/eventhubs/eventhubs_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"testing"
 
-	eventhub "github.com/Azure/azure-event-hubs-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -67,18 +66,6 @@ func TestParseEventHubsMetadata(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, missingConnectionStringNamespaceErrorMsg, err.Error())
-	})
-
-	t.Run("test maxBulkSizeInBytes limits", func(t *testing.T) {
-		val := fmt.Sprintf("%d", eventhub.DefaultMaxMessageSizeInBytes+1)
-		props := map[string]string{"connectionString": "fake", "maxBulkSizeInBytes": val}
-
-		metadata := pubsub.Metadata{Base: metadata.Base{Properties: props}}
-		_, err := parseEventHubsMetadata(metadata)
-
-		expected := fmt.Sprintf(maxBulkSizeInBytesTooLargeErrorTmpl, eventhub.DefaultMaxMessageSizeInBytes)
-		assert.Error(t, err)
-		assert.Equal(t, expected, err.Error())
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

For consistency, use request level metadata for bulk publish instead of component level. Note, the util has been copied from #2100.

## Issue reference

Please reference the issue this PR will close: #2090 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
