### PR TITLE
fix(kafka): ConsumeClaim should return when messages channel closed

### DIFF
--- a/internal/component/kafka/consumer.go
+++ b/internal/component/kafka/consumer.go
@@ -38,7 +38,11 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 
 	for {
 		select {
-		case message := <-claim.Messages():
+		case message, ok := <-claim.Messages():
+			if !ok {
+				return nil
+			}
+
 			if consumer.k.consumeRetryEnabled {
 				if err := retry.NotifyRecover(func() error {
 					return consumer.doCallback(session, message)


### PR DESCRIPTION
# Description

ConsumeClaim should also return when messages channel is closed, otherwise we will got nil message from a closed channel. This pr fix https://github.com/dapr/components-contrib/pull/2049#discussion_r978507084

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
