### PR TITLE
Add time to CloudEvent automatically if not present

### DIFF
--- a/pubsub/envelope.go
+++ b/pubsub/envelope.go
@@ -51,6 +51,7 @@ const (
 	SourceField          = "source"
 	IDField              = "id"
 	SubjectField         = "subject"
+	TimeField            = "time"
 )
 
 // unmarshalPrecise is a wrapper around encoding/json's Decoder
@@ -110,6 +111,7 @@ func NewCloudEventsEnvelope(id, source, eventType, subject string, topic string,
 		TraceIDField:         traceParent,
 		TraceParentField:     traceParent,
 		TraceStateField:      traceState,
+		TimeField:            time.Now().Format(time.RFC3339),
 	}
 
 	ce[ceDataField] = ceData
@@ -127,6 +129,14 @@ func FromCloudEvent(cloudEvent []byte, topic, pubsub, traceParent string, traceS
 	err := unmarshalPrecise(cloudEvent, &m)
 	if err != nil {
 		return m, err
+	}
+
+	customTimeVal, keyExists := m[TimeField]
+
+	if keyExists {
+		m[TimeField] = customTimeVal
+	} else {
+		m[TimeField] = time.Now().Format(time.RFC3339)
 	}
 
 	m[TraceIDField] = traceParent

--- a/pubsub/envelope_test.go
+++ b/pubsub/envelope_test.go
@@ -41,6 +41,7 @@ func TestEnvelopeXML(t *testing.T) {
 		assert.Equal(t, "1.0", envelope[SpecVersionField])
 		assert.Equal(t, "routed.topic", envelope[TopicField])
 		assert.Equal(t, "mypubsub", envelope[PubsubField])
+		assert.NotNil(t, envelope[TimeField])
 	})
 
 	t.Run("xml without content-type", func(t *testing.T) {
@@ -52,6 +53,7 @@ func TestEnvelopeXML(t *testing.T) {
 		assert.Equal(t, "1.0", envelope[SpecVersionField])
 		assert.Equal(t, "routed.topic", envelope[TopicField])
 		assert.Equal(t, "mypubsub", envelope[PubsubField])
+		assert.NotNil(t, envelope[TimeField])
 	})
 }
 
@@ -246,6 +248,7 @@ func TestNewFromExisting(t *testing.T) {
 		m := map[string]interface{}{
 			"specversion": "1.0",
 			"customfield": "a",
+			"time":        "2021-08-02T09:00:00Z",
 		}
 		b, _ := json.Marshal(&m)
 
@@ -257,6 +260,7 @@ func TestNewFromExisting(t *testing.T) {
 		assert.Equal(t, "pubsub", n[PubsubField])
 		assert.Equal(t, "1", n[TraceParentField])
 		assert.Equal(t, "key=value", n[TraceStateField])
+		assert.Equal(t, "2021-08-02T09:00:00Z", n[TimeField])
 		assert.Nil(t, n[DataField])
 		assert.Nil(t, n[DataBase64Field])
 	})
@@ -271,6 +275,7 @@ func TestNewFromExisting(t *testing.T) {
 			"specversion": "1.0",
 			"customfield": "a",
 			"data":        "hello world",
+			"time":        "2021-08-02T09:00:00Z",
 		}
 		b, _ := json.Marshal(&m)
 
@@ -282,6 +287,7 @@ func TestNewFromExisting(t *testing.T) {
 		assert.Equal(t, "pubsub", n[PubsubField])
 		assert.Equal(t, "1", n[TraceParentField])
 		assert.Equal(t, "key=value", n[TraceStateField])
+		assert.Equal(t, "2021-08-02T09:00:00Z", n[TimeField])
 		assert.Nil(t, n[DataBase64Field])
 		assert.Equal(t, "hello world", n[DataField])
 	})
@@ -302,6 +308,7 @@ func TestNewFromExisting(t *testing.T) {
 		assert.Equal(t, "pubsub", n[PubsubField])
 		assert.Equal(t, "1", n[TraceParentField])
 		assert.Equal(t, "key=value", n[TraceStateField])
+		assert.NotNil(t, n[TimeField])
 		assert.Nil(t, n[DataField])
 		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte{0x1}), n[DataBase64Field])
 	})
@@ -312,6 +319,7 @@ func TestCreateFromBinaryPayload(t *testing.T) {
 	envelope := NewCloudEventsEnvelope("", "", "", "", "", "",
 		"application/octet-stream", []byte{0x1}, "trace", "")
 	assert.Equal(t, base64Encoding, envelope[DataBase64Field])
+	assert.NotNil(t, envelope[TimeField])
 	assert.Nil(t, envelope[DataField])
 }
 


### PR DESCRIPTION
Closes https://github.com/dapr/dapr/issues/5137

Signed-off-by: Yash Nisar <yashnisar@microsoft.com>

# Description
Add time to CloudEvent automatically if not present

## Issue reference
https://github.com/dapr/dapr/issues/5137

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

Tested with dapr changes: https://github.com/dapr/dapr/commit/7cde7b7e8c0786334eb0e26304fa642a18674c24

### Test evidence: 

#### Without custom timestamp:

Request:
```
dapr publish --publish-app-id order-processor --pubsub orderpubsub --topic orders --data '{"specversion" : "1.0", "type" : "com.dapr.cloudevent.sent", "source" : "testcloudeventspubsub", "subject" : "Cloud Events Test", "id" : "someCloudEventId", "datacontenttype" : "application/cloudevents+json", "data" : {"orderId": "100"}}'
```

Response:
```
INFO[0034] HTTP API Called: POST /v1.0/publish/orderpubsub/orders  app_id=order-processor instance=Yashs-MacBook-Pro.local scope=dapr.runtime.http-info type=log ver=edge
== APP == Dapr pub/sub is subscribed to: [{"pubsubname": "orderpubsub", "topic": "orders", "route": "orders"}]
== APP == Subscriber received : {'attributes': {'specversion': '1.0', 'id': 'someCloudEventId', 'source': 'testcloudeventspubsub', 'type': 'com.dapr.cloudevent.sent', 'datacontenttype': 'application/cloudevents+json', 'subject': 'Cloud Events Test', 'time': '2022-09-23T11:58:41-05:00', 'pubsubname': 'orderpubsub', 'topic': 'orders', 'traceid': '00-12a04ebe04ef75caabfbe51c4b124e1f-ebbc8f4aaba62480-01', 'traceparent': '00-12a04ebe04ef75caabfbe51c4b124e1f-ebbc8f4aaba62480-01', 'tracestate': ''}, 'data': {'orderId': '100'}}
```

Request:
```
curl -X POST [http://localhost:58257/v1.0/publish/orderpubsub/orders](http://localhost:58257/v1.0/publish/orderpubsub/orders) -H "Content-Type: application/cloudevents+json" -d '{"specversion" : "1.0", "type" : "com.dapr.cloudevent.sent", "source" : "testcloudeventspubsub", "subject" : "Cloud Events Test", "id" : "someCloudEventId", "datacontenttype" : "application/cloudevents+json", "data" : {"orderId": "100"}}'
```

Response:
```
INFO[0265] HTTP API Called: POST /v1.0/publish/orderpubsub/orders  app_id=order-processor instance=Yashs-MacBook-Pro.local scope=dapr.runtime.http-info type=log ver=edge
== APP == Subscriber received : {'attributes': {'specversion': '1.0', 'id': 'someCloudEventId', 'source': 'testcloudeventspubsub', 'type': 'com.dapr.cloudevent.sent', 'datacontenttype': 'application/cloudevents+json', 'subject': 'Cloud Events Test', 'time': '2022-09-23T12:02:32-05:00', 'pubsubname': 'orderpubsub', 'topic': 'orders', 'traceid': '00-556b723c238f7f1c49815cedd29b2981-5050fe399a05e7bf-01', 'traceparent': '00-556b723c238f7f1c49815cedd29b2981-5050fe399a05e7bf-01', 'tracestate': ''}, 'data': {'orderId': '100'}}
== APP == 127.0.0.1 - - [23/Sep/2022 12:02:32] "POST /orders HTTP/1.1" 200 -
```

#### With custom timestamp:

Request:
```
dapr publish --publish-app-id order-processor --pubsub orderpubsub --topic orders --data '{"specversion" : "1.0", "type" : "com.dapr.cloudevent.sent", "source" : "testcloudeventspubsub", "subject" : "Cloud Events Test", "id" : "someCloudEventId", "time" : "2021-08-02T09:00:00Z", "datacontenttype" : "application/cloudevents+json", "data" : {"orderId": "100"}}'
```

Response:
```
INFO[0083] HTTP API Called: POST /v1.0/publish/orderpubsub/orders  app_id=order-processor instance=Yashs-MacBook-Pro.local scope=dapr.runtime.http-info type=log ver=edge
== APP == 127.0.0.1 - - [23/Sep/2022 11:59:30] "POST /orders HTTP/1.1" 200 -
== APP == Subscriber received : {'attributes': {'specversion': '1.0', 'id': 'someCloudEventId', 'source': 'testcloudeventspubsub', 'type': 'com.dapr.cloudevent.sent', 'datacontenttype': 'application/cloudevents+json', 'subject': 'Cloud Events Test', 'time': '2021-08-02T09:00:00Z', 'pubsubname': 'orderpubsub', 'topic': 'orders', 'traceid': '00-b2f1362d4c60fbdfac698deafe3ac630-6161e8ae9292906b-01', 'traceparent': '00-b2f1362d4c60fbdfac698deafe3ac630-6161e8ae9292906b-01', 'tracestate': ''}, 'data': {'orderId': '100'}}
```

Request:
```
curl -X POST [http://localhost:58257/v1.0/publish/orderpubsub/orders](http://localhost:58257/v1.0/publish/orderpubsub/orders) -H "Content-Type: application/cloudevents+json" -d '{"specversion" : "1.0", "type" : "com.dapr.cloudevent.sent", "source" : "testcloudeventspubsub", "subject" : "Cloud Events Test", "id" : "someCloudEventId", "time" : "2021-08-02T09:00:00Z", "datacontenttype" : "application/cloudevents+json", "data" : {"orderId": "100"}}'
```

Response:
```
INFO[0230] HTTP API Called: POST /v1.0/publish/orderpubsub/orders  app_id=order-processor instance=Yashs-MacBook-Pro.local scope=dapr.runtime.http-info type=log ver=edge
== APP == Subscriber received : {'attributes': {'specversion': '1.0', 'id': 'someCloudEventId', 'source': 'testcloudeventspubsub', 'type': 'com.dapr.cloudevent.sent', 'datacontenttype': 'application/cloudevents+json', 'subject': 'Cloud Events Test', 'time': '2021-08-02T09:00:00Z', 'pubsubname': 'orderpubsub', 'topic': 'orders', 'traceid': '00-aee739e0a87bb4c15545ef2a04cdff2d-71d1686f64bba3df-01', 'traceparent': '00-aee739e0a87bb4c15545ef2a04cdff2d-71d1686f64bba3df-01', 'tracestate': ''}, 'data': {'orderId': '100'}}
== APP == 127.0.0.1 - - [23/Sep/2022 12:01:57] "POST /orders HTTP/1.1" 200 -
```