### PR TITLE
Added username and password arguments to pubsub.rabbitmq metadata

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -59,7 +59,7 @@ type rabbitMQ struct {
 	ctx               context.Context
 	cancel            context.CancelFunc
 
-	connectionDial func(host string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error)
+	connectionDial func(uri string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error)
 
 	logger logger.Logger
 }
@@ -94,8 +94,8 @@ func NewRabbitMQ(logger logger.Logger) pubsub.PubSub {
 	}
 }
 
-func dial(host string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) {
-	conn, err := amqp.Dial(host)
+func dial(uri string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) {
+	conn, err := amqp.Dial(uri)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -111,7 +111,7 @@ func dial(host string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) 
 
 // Init does metadata parsing and connection creation.
 func (r *rabbitMQ) Init(metadata pubsub.Metadata) error {
-	meta, err := createMetadata(metadata)
+	meta, err := createMetadata(metadata, r.logger)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (r *rabbitMQ) reconnect(connectionCount int) error {
 		return err
 	}
 
-	r.connection, r.channel, err = r.connectionDial(r.metadata.host)
+	r.connection, r.channel, err = r.connectionDial(r.metadata.connectionURI())
 	if err != nil {
 		r.reset()
 

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -37,7 +37,7 @@ func newRabbitMQTest(broker *rabbitMQInMemoryBroker) pubsub.PubSub {
 	return &rabbitMQ{
 		declaredExchanges: make(map[string]bool),
 		logger:            logger.NewLogger("test"),
-		connectionDial: func(host string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) {
+		connectionDial: func(uri string) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error) {
 			broker.connectCount++
 
 			return broker, broker, nil
@@ -45,20 +45,12 @@ func newRabbitMQTest(broker *rabbitMQInMemoryBroker) pubsub.PubSub {
 	}
 }
 
-func TestNoHost(t *testing.T) {
-	broker := newBroker()
-	pubsubRabbitMQ := newRabbitMQTest(broker)
-	err := pubsubRabbitMQ.Init(pubsub.Metadata{})
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "missing RabbitMQ host")
-}
-
 func TestNoConsumer(t *testing.T) {
 	broker := newBroker()
 	pubsubRabbitMQ := newRabbitMQTest(broker)
 	metadata := pubsub.Metadata{Base: mdata.Base{
 		Properties: map[string]string{
-			metadataHostKey: "anyhost",
+			metadataHostnameKey: "anyhost",
 		},
 	}}
 	err := pubsubRabbitMQ.Init(metadata)
@@ -73,7 +65,7 @@ func TestConcurrencyMode(t *testing.T) {
 		pubsubRabbitMQ := newRabbitMQTest(broker)
 		metadata := pubsub.Metadata{Base: mdata.Base{
 			Properties: map[string]string{
-				metadataHostKey:       "anyhost",
+				metadataHostnameKey:   "anyhost",
 				metadataConsumerIDKey: "consumer",
 				pubsub.ConcurrencyKey: string(pubsub.Parallel),
 			},
@@ -88,7 +80,7 @@ func TestConcurrencyMode(t *testing.T) {
 		pubsubRabbitMQ := newRabbitMQTest(broker)
 		metadata := pubsub.Metadata{Base: mdata.Base{
 			Properties: map[string]string{
-				metadataHostKey:       "anyhost",
+				metadataHostnameKey:   "anyhost",
 				metadataConsumerIDKey: "consumer",
 				pubsub.ConcurrencyKey: string(pubsub.Single),
 			},
@@ -103,7 +95,7 @@ func TestConcurrencyMode(t *testing.T) {
 		pubsubRabbitMQ := newRabbitMQTest(broker)
 		metadata := pubsub.Metadata{Base: mdata.Base{
 			Properties: map[string]string{
-				metadataHostKey:       "anyhost",
+				metadataHostnameKey:   "anyhost",
 				metadataConsumerIDKey: "consumer",
 			},
 		}}
@@ -118,7 +110,7 @@ func TestPublishAndSubscribe(t *testing.T) {
 	pubsubRabbitMQ := newRabbitMQTest(broker)
 	metadata := pubsub.Metadata{Base: mdata.Base{
 		Properties: map[string]string{
-			metadataHostKey:       "anyhost",
+			metadataHostnameKey:   "anyhost",
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
@@ -161,7 +153,7 @@ func TestPublishReconnect(t *testing.T) {
 	pubsubRabbitMQ := newRabbitMQTest(broker)
 	metadata := pubsub.Metadata{Base: mdata.Base{
 		Properties: map[string]string{
-			metadataHostKey:       "anyhost",
+			metadataHostnameKey:   "anyhost",
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
@@ -212,7 +204,7 @@ func TestPublishReconnectAfterClose(t *testing.T) {
 	pubsubRabbitMQ := newRabbitMQTest(broker)
 	metadata := pubsub.Metadata{Base: mdata.Base{
 		Properties: map[string]string{
-			metadataHostKey:       "anyhost",
+			metadataHostnameKey:   "anyhost",
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
@@ -262,7 +254,7 @@ func TestSubscribeBindRoutingKeys(t *testing.T) {
 	pubsubRabbitMQ := newRabbitMQTest(broker)
 	metadata := pubsub.Metadata{Base: mdata.Base{
 		Properties: map[string]string{
-			metadataHostKey:       "anyhost",
+			metadataHostnameKey:   "anyhost",
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
@@ -286,7 +278,7 @@ func TestSubscribeReconnect(t *testing.T) {
 	pubsubRabbitMQ := newRabbitMQTest(broker)
 	metadata := pubsub.Metadata{Base: mdata.Base{
 		Properties: map[string]string{
-			metadataHostKey:                 "anyhost",
+			metadataHostnameKey:             "anyhost",
 			metadataConsumerIDKey:           "consumer",
 			metadataAutoAckKey:              "true",
 			metadataReconnectWaitSecondsKey: "0",


### PR DESCRIPTION
# Description

Added `username` and `password` arguments to pubsub.rabbitmq metadata and provide it to `amqp.Dial`.

**Caution:** This is probably a breaking change because the `host` argument was missused to also include credentials.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1719

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
