### PR TITLE
Onboard Azure EH and SB to bulk pub/sub conformance tests

### DIFF
--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -12,7 +12,7 @@
 componentType: pubsub
 components:
   - component: azure.eventhubs
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: ["publish", "subscribe", "multiplehandlers", "bulkpublish"]
     config:
       pubsubName: azure-eventhubs
       testTopicName: eventhubs-pubsub-topic
@@ -24,7 +24,7 @@ components:
       publishMetadata:
         partitionKey: abcd
   - component: azure.servicebus
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    allOperations: true
     config:
       pubsubName: azure-servicebus
       testTopicName: dapr-conf-test
@@ -44,7 +44,7 @@ components:
     allOperations: true
   - component: kafka
     profile: confluent
-    allOperations: true    
+    allOperations: true
   - component: pulsar
     operations: ["publish", "subscribe", "multiplehandlers"]
   - component: mqtt


### PR DESCRIPTION
# Description

Onboard the following conformance tests
1. Azure Event Hubs - Bulk Publish
2. Azure Service Bus - Bulk Publish and Bulk Subscribe

## Issue reference

Main issue: dapr/dapr#2218

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
