### PR TITLE
removing conf workflow run for PR targetting feature branch

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -23,7 +23,6 @@ on:
     branches:
       - master
       - 'release-*'
-      - 'feature/*'
 
 jobs:
   # Based on whether this is a PR or a scheduled run, we will run a different


### PR DESCRIPTION
# Description

Based on comment https://github.com/dapr/components-contrib/pull/2126#discussion_r982685145

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
