### PR TITLE
fix redis subscribe all keys

### DIFF
--- a/configuration/redis/redis.go
+++ b/configuration/redis/redis.go
@@ -299,7 +299,12 @@ func (r *ConfigurationStore) Unsubscribe(ctx context.Context, req *configuration
 func (r *ConfigurationStore) doSubscribe(ctx context.Context, req *configuration.SubscribeRequest, handler configuration.UpdateHandler, redisChannel4revision string, id string, stop chan struct{}) {
 	// enable notify-keyspace-events by redis Set command
 	r.client.ConfigSet(ctx, "notify-keyspace-events", "KA")
-	p := r.client.Subscribe(ctx, redisChannel4revision)
+	var p *redis.PubSub
+	if redisChannel4revision == keySpaceAny {
+		p = r.client.PSubscribe(ctx, redisChannel4revision)
+	} else {
+		p = r.client.Subscribe(ctx, redisChannel4revision)
+	}
 	for {
 		select {
 		case <-stop:


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

Using `PSubscribe` when a pattern is provided, else use `Subscribe`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1999 

