### PR TITLE
Bot doesn't report full table of results

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -337,7 +337,9 @@ jobs:
   post_job:
     name: Post-completion
     runs-on: ubuntu-latest
-    needs: certification
+    needs: 
+      - certification
+      - generate-matrix
     steps:
       - name: Parse repository_dispatch payload
         if: github.event_name == 'repository_dispatch'
@@ -359,38 +361,92 @@ jobs:
 
       - name: Build message
         if: env.PR_NUMBER != ''
-        run: |
-          BASEPATH="${{steps.testresults.outputs.download-path}}"
+        # Abusing of the github-script action to be able to write this in JS
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prComponents = ('${{ needs.generate-matrix.outputs.pr-components }}' && JSON.parse('${{ needs.generate-matrix.outputs.pr-components }}')) || []
+            const cloudComponents = ('${{ needs.generate-matrix.outputs.cloud-components }}' && JSON.parse('${{ needs.generate-matrix.outputs.cloud-components }}')) || []
+            const allComponents = [...prComponents, ...cloudComponents]
+            const basePath = '${{ steps.testresults.outputs.download-path }}'
+            const testType = 'certification'
 
-          mkdir -p tmp/
+            const fs = require('fs')
+            const path = require('path')
 
-          cat << EOT > tmp/message.txt
-          # Components conformance test
+            let message = `# Components ${testType} test
 
-          🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+            🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
 
-          Commit ref: ${{ env.CHECKOUT_REF }}
+            Commit ref: ${{ env.CHECKOUT_REF }}`
 
-          ## Result
+            let allSuccess = true
+            let allFound = true
+            let notSuccess = []
+            let notFound = []
+            for (let i = 0; i < allComponents.length; i++) {
+                const component = allComponents[i]
+                let found = false
+                let success = false
+                try {
+                    let read =fs.readFileSync(path.join(basePath, component + '.txt'), 'utf8')
+                    read = read.split('\n')[0]
+                    switch (read) {
+                        case '1':
+                            found = true
+                            success = true
+                            break
+                        case '0':
+                            found = true
+                            success = false
+                    }
+                } catch (e) {
+                    // ignore errors, leave found = false
+                }
 
-          | Component | Status |
-          | --- | --- |
-          EOT
+                if (!found) {
+                    allFound = false
+                    notFound.push(component)
+                }
+                if (!success) {
+                    allSuccess = false
+                    notSuccess.push(component)
+                }
+            }
 
-          ls "$BASEPATH" | while read f; do
-          while read LINE; do
-              if [[ "$LINE" == "1" ]]; then
-                echo "| ${f%.*} | ✅ |" >> tmp/message.txt
-              elif [[ "$LINE" == "0" ]]; then
-                echo "| ${f%.*} | ❌ |" >> tmp/message.txt
-              else
-                echo "| ${f%.*} | 🤔 |" >> tmp/message.txt
-              fi
-            done < "$BASEPATH/$f"
-          done
+            if (allSuccess) {
+                if (allFound) {
+                    message += '\n\n' + `# ✅ All ${testType} tests passed
 
-          echo "Final message"
-          cat tmp/message.txt
+            All tests have reported a successful status` + '\n\n'
+                } else {
+                    message += '\n\n' + `# ⚠️ Some ${testType} tests did not report status
+
+            Although there were no failures reported, some tests did not report a status:` + '\n\n'
+                    for (let i = 0; i < notFound.length; i++) {
+                        message += '- ' + notFound[i] + '\n'
+                    }
+                    message += '\n'
+                }
+            } else {
+                message += '\n\n' + `# ❌ Some ${testType} tests failed
+
+            These tests failed:` + '\n\n'
+                for (let i = 0; i < notSuccess.length; i++) {
+                    message += '- ' + notSuccess[i] + '\n'
+                }
+                message += '\n'
+
+                if (!allFound) {
+                    message += 'Additionally, some tests did not report a status:\n\n'
+                    for (let i = 0; i < notFound.length; i++) {
+                        message += '- ' + notFound[i] + '\n'
+                    }
+                    message += '\n'
+                }
+            }
+
+            fs.writeFileSync('message.txt', message)
 
       - name: Replace PR comment
         if: env.PR_NUMBER != ''
@@ -399,7 +455,7 @@ jobs:
           header: ${{ github.run_id }}
           number: ${{ env.PR_NUMBER }}
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
-          path: tmp/message.txt
+          path: message.txt
 
       - name: Download Cert Coverage Artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -244,7 +244,6 @@ jobs:
       working-directory: ${{ env.TEST_PATH }}
       run: |
         echo "Running certification tests for ${{ matrix.component }} ... "
-
         export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
         set +e
         gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.json \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -474,7 +474,9 @@ jobs:
   post_job:
     name: Post-completion
     runs-on: ubuntu-latest
-    needs: conformance
+    needs:
+      - conformance
+      - generate-matrix
     steps:
       - name: Parse repository_dispatch payload
         if: github.event_name == 'repository_dispatch'
@@ -496,38 +498,92 @@ jobs:
 
       - name: Build message
         if: env.PR_NUMBER != ''
-        run: |
-          BASEPATH="${{steps.testresults.outputs.download-path}}"
+        # Abusing of the github-script action to be able to write this in JS
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prComponents = ('${{ needs.generate-matrix.outputs.pr-components }}' && JSON.parse('${{ needs.generate-matrix.outputs.pr-components }}')) || []
+            const cronComponents = ('${{ needs.generate-matrix.outputs.cron-components }}' && JSON.parse('${{ needs.generate-matrix.outputs.cron-components }}')) || []
+            const allComponents = [...prComponents, ...cronComponents]
+            const basePath = '${{ steps.testresults.outputs.download-path }}'
+            const testType = 'conformance'
 
-          mkdir -p tmp/
+            const fs = require('fs')
+            const path = require('path')
 
-          cat << EOT > tmp/message.txt
-          # Components conformance test
+            let message = `# Components ${testType} test
 
-          🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+            🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
 
-          Commit ref: ${{ env.CHECKOUT_REF }}
+            Commit ref: ${{ env.CHECKOUT_REF }}`
 
-          ## Result
+            let allSuccess = true
+            let allFound = true
+            let notSuccess = []
+            let notFound = []
+            for (let i = 0; i < allComponents.length; i++) {
+                const component = allComponents[i]
+                let found = false
+                let success = false
+                try {
+                    let read =fs.readFileSync(path.join(basePath, component + '.txt'), 'utf8')
+                    read = read.split('\n')[0]
+                    switch (read) {
+                        case '1':
+                            found = true
+                            success = true
+                            break
+                        case '0':
+                            found = true
+                            success = false
+                    }
+                } catch (e) {
+                    // ignore errors, leave found = false
+                }
 
-          | Component | Status |
-          | --- | --- |
-          EOT
+                if (!found) {
+                    allFound = false
+                    notFound.push(component)
+                }
+                if (!success) {
+                    allSuccess = false
+                    notSuccess.push(component)
+                }
+            }
 
-          ls "$BASEPATH" | while read f; do
-          while read LINE; do
-              if [[ "$LINE" == "1" ]]; then
-                echo "| ${f%.*} | ✅ |" >> tmp/message.txt
-              elif [[ "$LINE" == "0" ]]; then
-                echo "| ${f%.*} | ❌ |" >> tmp/message.txt
-              else
-                echo "| ${f%.*} | 🤔 |" >> tmp/message.txt
-              fi
-            done < "$BASEPATH/$f"
-          done
+            if (allSuccess) {
+                if (allFound) {
+                    message += '\n\n' + `# ✅ All ${testType} tests passed
 
-          echo "Final message"
-          cat tmp/message.txt
+            All tests have reported a successful status` + '\n\n'
+                } else {
+                    message += '\n\n' + `# ⚠️ Some ${testType} tests did not report status
+
+            Although there were no failures reported, some tests did not report a status:` + '\n\n'
+                    for (let i = 0; i < notFound.length; i++) {
+                        message += '- ' + notFound[i] + '\n'
+                    }
+                    message += '\n'
+                }
+            } else {
+                message += '\n\n' + `# ❌ Some ${testType} tests failed
+
+            These tests failed:` + '\n\n'
+                for (let i = 0; i < notSuccess.length; i++) {
+                    message += '- ' + notSuccess[i] + '\n'
+                }
+                message += '\n'
+
+                if (!allFound) {
+                    message += 'Additionally, some tests did not report a status:\n\n'
+                    for (let i = 0; i < notFound.length; i++) {
+                        message += '- ' + notFound[i] + '\n'
+                    }
+                    message += '\n'
+                }
+            }
+
+            fs.writeFileSync('message.txt', message)
 
       - name: Replace PR comment
         if: env.PR_NUMBER != ''
@@ -536,4 +592,4 @@ jobs:
           header: ${{ github.run_id }}
           number: ${{ env.PR_NUMBER }}
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
-          path: tmp/message.txt
+          path: message.txt


### PR DESCRIPTION
This is a follow-up on #2154 and changes how the bot reports the result.

The problem is that in this repo, there are many dozens of tests, so the bot was reporting a table with a lot of results. This could have easily caused information overload, making maintainers/approvers miss important information.

This PR changes how the bot reports the result.

If everything is successful, only a single checkmark is sent:

<img width="933" alt="image" src="https://user-images.githubusercontent.com/43508/194412952-cc7197c3-2c8f-4421-8fef-6c0286833014.png">

If at least one test fails, the status changes and only the list of failed components is shown:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/43508/194413072-d73ea181-f6fa-452c-a51d-40bf6b736561.png">

Likewise, this also changes the bot to actually check that all tests that were triggered reported a status. Before, if a test for a component failed to report a result for whatever reason, it was not included in the output. Now, those are included as missing as well:

<img width="486" alt="image" src="https://user-images.githubusercontent.com/43508/194413303-ebd2a4f2-381c-4006-b3a9-cab237a6a13c.png">
