### PR TITLE
Azure Service Bus: consider receiving 0 messages as an error that requires reconnecting

### DIFF
--- a/internal/component/azure/servicebus/subscription.go
+++ b/internal/component/azure/servicebus/subscription.go
@@ -15,6 +15,7 @@ package servicebus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -138,11 +139,12 @@ func (s *Subscription) ReceiveAndBlock(handler HandlerFunc, lockRenewalInSec int
 	// Receiver loop
 	for {
 		select {
-		// This blocks if there are too many active messages already
-		// This is released by the handler, but if the loop ends before it reaches the handler, make sure to release it with `<-s.activeMessagesChan`
 		case s.activeMessagesChan <- struct{}{}:
-		// Return if context is canceled
+			// No-op
+			// This blocks if there are too many active messages already
+			// This is released by the handler, but if the loop ends before it reaches the handler, make sure to release it with `<-s.activeMessagesChan`
 		case <-ctx.Done():
+			// Return if context is canceled
 			s.logger.Debugf("Receive context for %s done", s.entity)
 			return ctx.Err()
 		}
@@ -158,21 +160,22 @@ func (s *Subscription) ReceiveAndBlock(handler HandlerFunc, lockRenewalInSec int
 			return err
 		}
 
-		// Invoke only once
-		if onFirstSuccess != nil {
-			onFirstSuccess()
-			onFirstSuccess = nil
-		}
-
 		l := len(msgs)
 		if l == 0 {
 			// We got no message, which is unusual too
 			s.logger.Warn("Received 0 messages from Service Bus")
 			<-s.activeMessagesChan
-			continue
+			// Return an error to force the Service Bus component to try and reconnect.
+			return errors.New("received 0 messages from Service Bus")
 		} else if l > 1 {
 			// We are requesting one message only; this should never happen
 			s.logger.Errorf("Expected one message from Service Bus, but received %d", l)
+		}
+
+		// Invoke only once
+		if onFirstSuccess != nil {
+			onFirstSuccess()
+			onFirstSuccess = nil
 		}
 
 		msg := msgs[0]

--- a/pubsub/azure/servicebus/servicebus.go
+++ b/pubsub/azure/servicebus/servicebus.go
@@ -256,11 +256,17 @@ func (a *azureServiceBus) Init(metadata pubsub.Metadata) (err error) {
 		return err
 	}
 
-	userAgent := "dapr-" + logger.DaprVersion
+	clientOpts := &servicebus.ClientOptions{
+		ApplicationID: "dapr-" + logger.DaprVersion,
+		// TODO: Use the built-in retry in the SDK rather than our own on top of that
+		/*RetryOptions: servicebus.RetryOptions{
+			MaxRetries: int32(a.metadata.PublishMaxRetries),
+			RetryDelay: time.Duration(a.metadata.PublishInitialRetryIntervalInMs) * time.Millisecond,
+		},*/
+	}
+
 	if a.metadata.ConnectionString != "" {
-		a.client, err = servicebus.NewClientFromConnectionString(a.metadata.ConnectionString, &servicebus.ClientOptions{
-			ApplicationID: userAgent,
-		})
+		a.client, err = servicebus.NewClientFromConnectionString(a.metadata.ConnectionString, clientOpts)
 		if err != nil {
 			return err
 		}
@@ -280,9 +286,7 @@ func (a *azureServiceBus) Init(metadata pubsub.Metadata) (err error) {
 			return innerErr
 		}
 
-		a.client, innerErr = servicebus.NewClient(a.metadata.NamespaceName, token, &servicebus.ClientOptions{
-			ApplicationID: userAgent,
-		})
+		a.client, innerErr = servicebus.NewClient(a.metadata.NamespaceName, token, clientOpts)
 		if innerErr != nil {
 			return innerErr
 		}


### PR DESCRIPTION
(In draft until we complete validation with @halspang in the long-haul cluster)

In the long-haul clusters, we have seen that the pubsub app sometimes enters into a weird state.

The only relevant log message is that it begins receiving payloads from Azure Service Bus with 0 messages. When that happens, something else gets messed up.

This is an attempt to fix the issue by causing the ASB components to force-reconnect to ASB when they receive 0 messages. This means changing the behavior to assume the connection is down.