### PR TITLE
rollback code to set config.net.tls.enable=true when auth is required and tls is not required

### DIFF
--- a/internal/component/kafka/auth.go
+++ b/internal/component/kafka/auth.go
@@ -54,15 +54,13 @@ func updateTLSConfig(config *sarama.Config, metadata *kafkaMetadata) error {
 		config.Net.TLS.Enable = false
 		return nil
 	}
-	if !metadata.TLSSkipVerify && metadata.TLSCaCert == "" {
-		config.Net.TLS.Enable = false
-		return nil
-	}
-
-	//nolint:gosec
-	config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: metadata.TLSSkipVerify, MinVersion: tls.VersionTLS12}
 	config.Net.TLS.Enable = true
 
+	if !metadata.TLSSkipVerify && metadata.TLSCaCert == "" {
+		return nil
+	}
+	//nolint:gosec
+	config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: metadata.TLSSkipVerify, MinVersion: tls.VersionTLS12}
 	if metadata.TLSCaCert != "" {
 		caCertPool := x509.NewCertPool()
 		if ok := caCertPool.AppendCertsFromPEM([]byte(metadata.TLSCaCert)); !ok {


### PR DESCRIPTION

Signed-off-by: Sky Ao <aoxiaojian@gmail.com>

# Description

When auth is required, even the tls is not required, we need to set config.net.tls.enable=true.

## Issue reference

https://github.com/dapr/components-contrib/issues/2182

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
