### PR TITLE
Remove Fossa test temporarily

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -39,8 +39,9 @@ jobs:
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
 
-      - name: "Run FOSSA Test"
-        uses: fossas/fossa-action@v1.3.1 # Use a specific version if locking is preferred
-        with:
-          api-key: ${{ env.FOSSA_API_KEY }}
-          run-tests: true
+# REMOVING THIS STEP AS FOSSA API HAS BEEN FAILING FOR MONTHS NOW
+#      - name: "Run FOSSA Test"
+#        uses: fossas/fossa-action@v1.3.1 # Use a specific version if locking is preferred
+#        with:
+#          api-key: ${{ env.FOSSA_API_KEY }}
+#          run-tests: true


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Only remove Fossa test temporarily. Results will still be available in the Fossa portal.