### PR TITLE
Pin postgres version in test infra

### DIFF
--- a/.github/infrastructure/docker-compose-postgresql.yml
+++ b/.github/infrastructure/docker-compose-postgresql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: postgres
+    image: postgres:15
     restart: always
     ports:
       - "5432:5432"
@@ -9,3 +9,16 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: example
       POSTGRES_DB: dapr_test
+  # Uncomment for local development
+  #pgadmin:
+  #  image: dpage/pgadmin4
+  #  restart: always
+  #  ports:
+  #    - "9001:9001"
+  #  depends_on:
+  #    - db
+  #  environment:
+  #    - "PGADMIN_LISTEN_PORT=9001"
+  #    - "PGADMIN_DEFAULT_EMAIL=admin@local.dev"
+  #    - "PGADMIN_DEFAULT_PASSWORD=example"
+  #    - "PGADMIN_DISABLE_POSTFIX=1"


### PR DESCRIPTION
Postgres releases a new major version every year or so, and they sometimes have backwards-incompatible changes. When Postgres 15 came out a few days ago, our cert tests started to fail right away (the bug was in our tests making assumptions they should not have made).

This pins postgres to a specific version in our test infra so we can upgrade at our own pace.

Also adds a (commented-out) service for deploying pgadmin, useful for local debugging.