### PR TITLE
Fixes to mDNS resolver

### DIFF
--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -17,10 +17,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -50,8 +52,6 @@ const (
 	// addressTTL is the duration an address has before
 	// becoming stale and being evicted.
 	addressTTL = time.Second * 60
-	// max integer value supported on this architecture.
-	maxInt = int(^uint(0) >> 1)
 )
 
 // address is used to store an ip address along with
@@ -66,7 +66,7 @@ type address struct {
 // data used to control and access said addresses.
 type addressList struct {
 	addresses []address
-	counter   int
+	counter   atomic.Uint32
 	mu        sync.RWMutex
 }
 
@@ -97,7 +97,6 @@ func (a *addressList) add(ip string) {
 	for i := range a.addresses {
 		if a.addresses[i].ip == ip {
 			a.addresses[i].expiresAt = time.Now().Add(addressTTL)
-
 			return
 		}
 	}
@@ -115,16 +114,17 @@ func (a *addressList) next() *string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	if len(a.addresses) == 0 {
+	l := uint32(len(a.addresses))
+	if l == 0 {
 		return nil
 	}
 
-	if a.counter == maxInt {
-		a.counter = 0
+	if a.counter.Load() == math.MaxUint32 {
+		a.counter.CompareAndSwap(math.MaxUint32, 0)
 	}
-	index := a.counter % len(a.addresses)
+	counter := a.counter.Add(1) - 1
+	index := counter % l
 	addr := a.addresses[index]
-	a.counter++
 
 	return &addr.ip
 }
@@ -172,6 +172,8 @@ func NewSubscriber() Subscriber {
 
 // NewResolver creates the instance of mDNS name resolver.
 func NewResolver(logger logger.Logger) nameresolution.Resolver {
+	refreshCtx, refreshCancel := context.WithCancel(context.Background())
+
 	r := &Resolver{
 		subs:             make(map[string]*SubscriberPool),
 		appAddressesIPv4: make(map[string]*addressList),
@@ -189,53 +191,17 @@ func NewResolver(logger logger.Logger) nameresolution.Resolver {
 		// registrations channel to signal the resolver to
 		// stop serving queries for registered app ids.
 		registrations: make(map[string]chan struct{}),
-		// shutdownRefresh channel to signal to stop on-demand refreshes.
-		shutdownRefresh: make(chan struct{}, 1),
-		// shutdownRefreshPeriodic channel to signal to stop periodic refreshes.
-		shutdownRefreshPeridoic: make(chan struct{}, 1),
-		logger:                  logger,
+		// shutdown refreshers
+		refreshCtx:    refreshCtx,
+		refreshCancel: refreshCancel,
+		logger:        logger,
 	}
-
-	// refresh app addresses on demand.
-	go func() {
-		refreshCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		for {
-			select {
-			case appID := <-r.refreshChan:
-				if err := r.refreshApp(refreshCtx, appID); err != nil {
-					r.logger.Warnf(err.Error())
-				}
-			case <-r.shutdownRefresh:
-				r.logger.Debug("stopping on demand cache refreshes.")
-				return
-			}
-		}
-	}()
-
-	// refresh all app addresses periodically.
-	go func() {
-		refreshCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		for {
-			select {
-			case <-time.After(refreshInterval):
-				if err := r.refreshAllApps(refreshCtx); err != nil {
-					r.logger.Warnf(err.Error())
-				}
-			case <-r.shutdownRefreshPeridoic:
-				r.logger.Debug("stopping periodic cache refreshes.")
-				return
-			}
-		}
-	}()
 
 	return r
 }
 
 type Resolver struct {
+	resolver atomic.Pointer[zeroconf.Resolver]
 	// subscribers are used when multiple callers
 	// request the same app ID before it is cached.
 	// Only 1 will fetch the address, the rest will
@@ -259,17 +225,43 @@ type Resolver struct {
 	registrationMu sync.RWMutex
 	registrations  map[string]chan struct{}
 	// shutdown refreshes.
-	shutdownRefresh         chan struct{}
-	shutdownRefreshPeridoic chan struct{}
-	logger                  logger.Logger
+	refreshCtx    context.Context
+	refreshCancel context.CancelFunc
+	logger        logger.Logger
+}
+
+func (r *Resolver) startRefreshers() {
+	// refresh app addresses periodically and on demand
+	go func() {
+		for {
+			select {
+			// Refresh on demand
+			case appID := <-r.refreshChan:
+				if err := r.refreshApp(r.refreshCtx, appID); err != nil {
+					r.logger.Warnf(err.Error())
+				}
+			// Refresh periodically
+			case <-time.After(refreshInterval):
+				if err := r.refreshAllApps(r.refreshCtx); err != nil {
+					r.logger.Warnf(err.Error())
+				}
+			// Stop on context canceled
+			case <-r.refreshCtx.Done():
+				r.logger.Debug("stopping cache refreshes")
+				return
+			}
+		}
+	}()
 }
 
 // Init registers service for mDNS.
 func (m *Resolver) Init(metadata nameresolution.Metadata) error {
-	var appID string
-	var hostAddress string
-	var ok bool
-	var instanceID string
+	var (
+		appID       string
+		hostAddress string
+		ok          bool
+		instanceID  string
+	)
 
 	props := metadata.Properties
 
@@ -300,7 +292,33 @@ func (m *Resolver) Init(metadata nameresolution.Metadata) error {
 	}
 
 	m.logger.Infof("local service entry announced: %s -> %s:%d", appID, hostAddress, port)
+
+	resolver, err := m.getZeroconfResolver()
+	if err != nil {
+		return err
+	}
+	m.resolver.Store(resolver)
+
 	return nil
+}
+
+func (m *Resolver) getZeroconfResolver() (resolver *zeroconf.Resolver, err error) {
+	// Try with IPv4 + IPv6 first, then IPv4-only, then IPv6-only
+	opts := []zeroconf.ClientOption{
+		zeroconf.SelectIPTraffic(zeroconf.IPv4AndIPv6),
+		zeroconf.SelectIPTraffic(zeroconf.IPv4),
+		zeroconf.SelectIPTraffic(zeroconf.IPv6),
+	}
+	for i := 0; i < len(opts); i++ {
+		resolver, err = zeroconf.NewResolver(opts[i])
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize resolver: %w", err)
+	}
+	return resolver, nil
 }
 
 // Close is not formally part of the name resolution interface as proposed
@@ -318,8 +336,9 @@ func (m *Resolver) Close() error {
 	m.registrations = make(map[string]chan struct{})
 
 	// stop all refresh loops
-	m.shutdownRefresh <- struct{}{}
-	m.shutdownRefreshPeridoic <- struct{}{}
+	if m.refreshCancel != nil {
+		m.refreshCancel()
+	}
 
 	return nil
 }
@@ -649,7 +668,6 @@ func (m *Resolver) refreshAllApps(ctx context.Context) error {
 	numApps := numAppIPv4Addr + numAppIPv6Addr
 	if numApps == 0 {
 		m.logger.Debug("no mDNS apps to refresh.")
-
 		return nil
 	}
 
@@ -677,17 +695,12 @@ func (m *Resolver) refreshAllApps(ctx context.Context) error {
 
 // browse will perform a non-blocking mdns network browse for the provided app id.
 func (m *Resolver) browse(ctx context.Context, appID string, onEach func(ip string)) error {
-	resolver, err := zeroconf.NewResolver(nil)
-	if err != nil {
-		return fmt.Errorf("failed to initialize resolver: %w", err)
-	}
 	entries := make(chan *zeroconf.ServiceEntry)
 
 	handleEntry := func(entry *zeroconf.ServiceEntry) {
 		for _, text := range entry.Text {
 			if text != appID {
 				m.logger.Debugf("mDNS response doesn't match app id %s, skipping.", appID)
-
 				break
 			}
 
@@ -698,7 +711,6 @@ func (m *Resolver) browse(ctx context.Context, appID string, onEach func(ip stri
 
 			if !hasIPv4Address && !hasIPv6Address {
 				m.logger.Debugf("mDNS response for app id %s doesn't contain any IPv4 or IPv6 addresses, skipping.", appID)
-
 				break
 			}
 
@@ -709,11 +721,11 @@ func (m *Resolver) browse(ctx context.Context, appID string, onEach func(ip stri
 			// We should understand the cases in which additional addresses
 			// are returned and whether we need to support them.
 			if hasIPv4Address {
-				addr = fmt.Sprintf("%s:%d", entry.AddrIPv4[0].String(), port)
+				addr = entry.AddrIPv4[0].String() + ":" + strconv.Itoa(port)
 				m.addAppAddressIPv4(appID, addr)
 			}
 			if hasIPv6Address {
-				addr = fmt.Sprintf("%s:%d", entry.AddrIPv6[0].String(), port)
+				addr = entry.AddrIPv6[0].String() + ":" + strconv.Itoa(port)
 				m.addAppAddressIPv6(appID, addr)
 			}
 
@@ -749,11 +761,26 @@ func (m *Resolver) browse(ctx context.Context, appID string, onEach func(ip stri
 		}
 	}(entries)
 
-	if err = resolver.Browse(ctx, appID, "local.", entries); err != nil {
-		return fmt.Errorf("failed to browse: %w", err)
+	// Try 2 times, in case the resolver needs to be recreated
+	var err error
+	for i := 0; i < 2; i++ {
+		resolver := m.resolver.Load()
+		resolverErr := resolver.Browse(ctx, appID, "local.", entries)
+		if resolverErr == nil {
+			err = nil
+			break
+		}
+		err = fmt.Errorf("failed to browse: %w", resolverErr)
+
+		// Recreate a client
+		newResolver, resolverErr := m.getZeroconfResolver()
+		if resolverErr == nil {
+			// This may not swap if the resolver has been swapped by another goroutine already, and that's ok
+			m.resolver.CompareAndSwap(resolver, newResolver)
+		}
 	}
 
-	return nil
+	return err
 }
 
 // addAppAddressIPv4 adds an IPv4 address to the
@@ -834,7 +861,6 @@ func (m *Resolver) nextIPv4Address(appID string) *string {
 		addr := addrList.next()
 		if addr != nil {
 			m.logger.Debugf("found mDNS IPv4 address in cache: %s", *addr)
-
 			return addr
 		}
 	}
@@ -852,7 +878,6 @@ func (m *Resolver) nextIPv6Address(appID string) *string {
 		addr := addrList.next()
 		if addr != nil {
 			m.logger.Debugf("found mDNS IPv6 address in cache: %s", *addr)
-
 			return addr
 		}
 	}
@@ -862,16 +887,18 @@ func (m *Resolver) nextIPv6Address(appID string) *string {
 
 // union merges the elements from two lists into a set.
 func union(first []string, second []string) []string {
-	keys := make(map[string]struct{})
+	keys := make(map[string]struct{}, len(first)+len(second))
 	for _, id := range first {
 		keys[id] = struct{}{}
 	}
 	for _, id := range second {
 		keys[id] = struct{}{}
 	}
-	result := make([]string, 0, len(keys))
+	result := make([]string, len(keys))
+	i := 0
 	for id := range keys {
-		result = append(result, id)
+		result[i] = id
+		i++
 	}
 
 	return result


### PR DESCRIPTION
1. If the host doesn't support IPv6 (or supports only IPv6), allow the client to resolve IPs
3. Better concurrency handling with picking an address from the list via round-robin
