### PR TITLE
Add note how to avoid compatibility issues between repos

### DIFF
--- a/docs/developing-component.md
+++ b/docs/developing-component.md
@@ -55,7 +55,8 @@ make lint
 ## Validating with Dapr core
 
 1. Make sure you clone the `dapr/dapr` and `dapr/components-contrib` repositories side-by-side, within the same folder.
-1. Replace `github.com/dapr/components-contrib` with a reference to the locally-cloned `components-contrib`:
+1. In case of compatibility issues between `dapr/dapr` and `dapr/compoments-contrib` `go.mod` files during build, checkout the latest released version of `dapr/dapr`.
+4. Replace `github.com/dapr/components-contrib` with a reference to the locally-cloned `components-contrib`:
    ```bash
    go mod edit -replace github.com/dapr/components-contrib=../components-contrib
    ```

--- a/docs/developing-component.md
+++ b/docs/developing-component.md
@@ -56,7 +56,7 @@ make lint
 
 1. Make sure you clone the `dapr/dapr` and `dapr/components-contrib` repositories side-by-side, within the same folder.
 1. In case of compatibility issues between `dapr/dapr` and `dapr/compoments-contrib` `go.mod` files during build, checkout the latest released version of `dapr/dapr`.
-4. Replace `github.com/dapr/components-contrib` with a reference to the locally-cloned `components-contrib`:
+1. Replace `github.com/dapr/components-contrib` with a reference to the locally-cloned `components-contrib`:
    ```bash
    go mod edit -replace github.com/dapr/components-contrib=../components-contrib
    ```


### PR DESCRIPTION
It's pretty common to get into different errors while tidying or building `dapr/dapr` with local `dapr/components-contrib`. Usually checking out the latest released version helps.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
