### PR TITLE
Run conf tests for state.mysql against MariaDB too

### DIFF
--- a/.github/infrastructure/docker-compose-mariadb.yml
+++ b/.github/infrastructure/docker-compose-mariadb.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  mariadb:
+    image: mariadb:10
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: dapr_state_store
+      MARIADB_USER: dapr
+      MARIADB_PASSWORD: example
+    ports:
+      - "3306:3306"

--- a/.github/infrastructure/docker-compose-mysql.yml
+++ b/.github/infrastructure/docker-compose-mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: mysql
+    image: mysql:8
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -77,7 +77,8 @@ jobs:
         - state.cassandra
         - state.memcached
         - state.mongodb
-        - state.mysql
+        - state.mysql.mysql
+        - state.mysql.mariadb
         - state.postgresql
         - state.redis
         - state.sqlserver
@@ -322,7 +323,12 @@ jobs:
     - name: Start mysql
       run: |
         docker-compose -f ./.github/infrastructure/docker-compose-mysql.yml -p mysql up -d
-      if: contains(matrix.component, 'mysql')
+      if: contains(matrix.component, 'mysql.mysql')
+
+    - name: Start mariadb
+      run: |
+        docker-compose -f ./.github/infrastructure/docker-compose-mariadb.yml -p mariadb up -d
+      if: contains(matrix.component, 'mysql.mariadb')
 
     - name: Start KinD
       uses: helm/kind-action@v1.0.0

--- a/tests/config/state/mysql/mariadb/statestore.yaml
+++ b/tests/config/state/mysql/mariadb/statestore.yaml
@@ -4,6 +4,7 @@ metadata:
   name: statestore
 spec:
   type: state.mysql
+  version: v1
   metadata:
   - name: connectionString
-    value: "dapr:example@tcp(localhost:3306)/?allowNativePasswords=true"
+    value: "dapr:example@tcp(localhost:3306)/"

--- a/tests/config/state/mysql/mysql/statestore.yaml
+++ b/tests/config/state/mysql/mysql/statestore.yaml
@@ -1,0 +1,10 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.mysql
+  version: v1
+  metadata:
+  - name: connectionString
+    value: "dapr:example@tcp(localhost:3306)/?allowNativePasswords=true"

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -22,7 +22,10 @@ components:
   - component: postgresql
     allOperations: false
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "query" ]
-  - component: mysql
+  - component: mysql.mysql
+    allOperations: false
+    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag",  "first-write" ]
+  - component: mysql.mariadb
     allOperations: false
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag",  "first-write" ]
   - component: azure.tablestorage.storage

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -443,7 +443,9 @@ func loadStateStore(tc TestComponent) state.Store {
 		store = s_sqlserver.NewSQLServerStateStore(testLogger)
 	case "postgresql":
 		store = s_postgresql.NewPostgreSQLStateStore(testLogger)
-	case "mysql":
+	case "mysql.mysql":
+		store = s_mysql.NewMySQLStateStore(testLogger)
+	case "mysql.mariadb":
 		store = s_mysql.NewMySQLStateStore(testLogger)
 	case "azure.tablestorage.storage":
 		store = s_azuretablestorage.NewAzureTablesStateStore(testLogger)


### PR DESCRIPTION
Makes the conformance tests for state.mysql run against MariaDB too.