### PR TITLE
[WIP] Update bulk publish response struct to match dapr/dapr

### DIFF
--- a/internal/component/kafka/producer.go
+++ b/internal/component/kafka/producer.go
@@ -145,7 +145,7 @@ func (k *Kafka) mapKafkaProducerErrors(err error, entries []pubsub.BulkMessageEn
 			resp.Statuses = append(resp.Statuses, pubsub.BulkPublishResponseEntry{
 				Status:  pubsub.PublishFailed,
 				EntryId: entryId,
-				Error:   pErr.Err,
+				Error:   pErr.Err.Error(),
 			})
 		} else {
 			// Ideally this condition should not be executed, but in the scenario that the Metadata field

--- a/pubsub/responses.go
+++ b/pubsub/responses.go
@@ -54,12 +54,13 @@ type AppBulkResponse struct {
 type BulkPublishResponseEntry struct {
 	EntryId string            `json:"entryId"` //nolint:stylecheck
 	Status  BulkPublishStatus `json:"status"`
-	Error   error             `json:"error"`
+	Error   string            `json:"error,omitempty"`
 }
 
 // BulkPublishResponse is the whole bulk publish response sent to App
 type BulkPublishResponse struct {
-	Statuses []BulkPublishResponseEntry `json:"statuses"`
+	Statuses  []BulkPublishResponseEntry `json:"statuses"`
+	ErrorCode string                     `json:"errorCode,omitempty"`
 }
 
 // BulkSubscribeResponseEntry Represents single subscribe response item, as part of BulkSubscribeResponse
@@ -85,7 +86,7 @@ func NewBulkPublishResponse(messages []BulkMessageEntry, status BulkPublishStatu
 		st.EntryId = msg.EntryId
 		st.Status = status
 		if err != nil {
-			st.Error = err
+			st.Error = err.Error()
 		}
 		response.Statuses[i] = st
 	}

--- a/pubsub/responses_test.go
+++ b/pubsub/responses_test.go
@@ -65,12 +65,12 @@ func TestNewBulkPublishResponse(t *testing.T) {
 				{
 					EntryId: "1",
 					Status:  PublishFailed,
-					Error:   assert.AnError,
+					Error:   assert.AnError.Error(),
 				},
 				{
 					EntryId: "2",
 					Status:  PublishFailed,
-					Error:   assert.AnError,
+					Error:   assert.AnError.Error(),
 				},
 			},
 		}


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

In the Bulk Publish response structs, two changes are being made
1. `BulkPublishResponse` contains an `errorCode` along with `statuses`
2. Each status contains a string error type instead of `Error`

## Issue reference

Refers https://github.com/dapr/dapr/issues/5368

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
