### PR TITLE
change GOLANG_PROTOBUF_REGISTRATION_CONFLICT from warn to ignore

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -245,7 +245,7 @@ jobs:
       working-directory: ${{ env.TEST_PATH }}
       run: |
         echo "Running certification tests for ${{ matrix.component }} ... "
-        export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
+        export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore
         set +e
         gotestsum --jsonfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.json \
           --junitfile ${{ env.TEST_OUTPUT_FILE_PREFIX }}_certification.xml --format standard-quiet -- \


### PR DESCRIPTION
Signed-off-by: zhangchao <zchao9100@gmail.com>

# Description

These protobuf registration conflict warning outputs in certification tests are useless, change GOLANG_PROTOBUF_REGISTRATION_CONFLICT to ignore can disable these logs.

```
WARNING: proto: file "dapr/proto/runtime/v1/dapr.proto" has a name conflict over dapr.proto.runtime.v1.ActiveActorsCount
	previously from: "github.com/dapr/dapr/pkg/proto/runtime/v1"
	currently from:  "github.com/dapr/go-sdk/dapr/proto/runtime/v1"
See https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict

```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
