### PR TITLE
Storage Queues Binding: Add b64encoding option for messages

### DIFF
--- a/tests/certification/bindings/azure/storagequeues/components/decode/azure_queue_storage.yaml
+++ b/tests/certification/bindings/azure/storagequeues/components/decode/azure_queue_storage.yaml
@@ -17,6 +17,8 @@ spec:
         key:  AzureBlobStorageAccessKey
   - name: decodeBase64
     value: true
+  - name: encodeBase64
+    value: true
   - name: queue
     value: "decodequeue"
 auth:

--- a/tests/certification/bindings/azure/storagequeues/storagequeue_test.go
+++ b/tests/certification/bindings/azure/storagequeues/storagequeue_test.go
@@ -16,7 +16,6 @@ package storagequeue_test
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -312,7 +311,7 @@ func TestAzureStorageQueueForDecode(t *testing.T) {
 		// Declare the expected data.
 		msgs := make([]string, numOfMessages)
 		for i := 0; i < numOfMessages; i++ {
-			msgs[i] = fmt.Sprintf("Message %03d", i)
+			msgs[i] = fmt.Sprintf("Message 新 %03d", i) // the chinese character is part of the test for UTF-8 characters
 		}
 
 		messages.ExpectStrings(msgs...)
@@ -323,7 +322,6 @@ func TestAzureStorageQueueForDecode(t *testing.T) {
 		for _, msg := range msgs {
 			ctx.Logf("Sending: %q", msg)
 			dataBytes := []byte(msg)
-			dataBytes = []byte(base64.StdEncoding.EncodeToString(dataBytes))
 			req := &daprClient.InvokeBindingRequest{Name: "decode-binding", Operation: "create", Data: dataBytes, Metadata: metadata}
 			err := client.InvokeOutputBinding(ctx, req)
 			require.NoError(ctx, err, "error publishing message")


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Adds base64 encoding option for Service Bus Queues binding
Fixes #2249 


* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
