### PR TITLE
Fix deletion of sqs queue regression

### DIFF
--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -855,13 +855,6 @@ func (s *snsSqs) Subscribe(subscribeCtx context.Context, req pubsub.SubscribeReq
 		// Remove the handler
 		delete(s.topicHandlers, sanitizedName)
 
-		// If we can perform management operations, remove the subscription entirely
-		if !s.metadata.disableEntityManagement {
-			// Use a background context because subscribeCtx is canceled already
-			// Error is logged already
-			_ = s.removeSnsSqsSubscription(s.ctx, subscriptionArn)
-		}
-
 		// If we don't have any topic left, close the poller
 		if len(s.topicHandlers) == 0 {
 			s.pollerCancel()


### PR DESCRIPTION
Multiple users of the AWS SQS component reported a regression caused by this commit: https://github.com/dapr/components-contrib/commit/704f4dd7307d96252d7cc92cf792fcfdebea3c6c.

Fixes https://github.com/dapr/components-contrib/issues/2266.