### PR TITLE
Adding KubeMQ Binding - Queue

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -57,6 +57,7 @@ jobs:
         - bindings.mqtt-vernemq
         - bindings.postgres
         - bindings.redis
+        - bindings.kubemq
         - bindings.rabbitmq
         - pubsub.aws.snssqs
         - pubsub.hazelcast

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ run:
   # skip-files:
   #  - ".*\\.my\\.go$"
   #  - lib/bad.go
-  
+
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
@@ -245,7 +245,6 @@ linters:
     - nestif
     - nlreturn
     - exhaustive
-    - exhaustruct
     - noctx
     - gci
     - golint
@@ -272,8 +271,6 @@ linters:
     - wastedassign
     - containedctx
     - gosimple
-    - nonamedreturns
-    - asasalint
     - rowserrcheck
     - sqlclosecheck
     - structcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -245,6 +245,7 @@ linters:
     - nestif
     - nlreturn
     - exhaustive
+    - exhaustruct
     - noctx
     - gci
     - golint
@@ -271,6 +272,8 @@ linters:
     - wastedassign
     - containedctx
     - gosimple
+    - nonamedreturns
+    - asasalint
     - rowserrcheck
     - sqlclosecheck
     - structcheck

--- a/bindings/kubemq/kubemq.go
+++ b/bindings/kubemq/kubemq.go
@@ -35,6 +35,7 @@ func NewKubeMQ(logger logger.Logger) Kubemq {
 		ctxCancel: nil,
 	}
 }
+
 func (k *kubeMQ) Init(metadata bindings.Metadata) error {
 	opts, err := createOptions(metadata)
 	if err != nil {

--- a/bindings/kubemq/kubemq.go
+++ b/bindings/kubemq/kubemq.go
@@ -91,9 +91,8 @@ func (k *kubeMQ) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bind
 		}
 	}
 	return &bindings.InvokeResponse{
-		Data:        nil,
-		Metadata:    nil,
-		ContentType: nil,
+		Data:     nil,
+		Metadata: nil,
 	}, nil
 }
 

--- a/bindings/kubemq/kubemq.go
+++ b/bindings/kubemq/kubemq.go
@@ -1,0 +1,143 @@
+package kubemq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	qs "github.com/kubemq-io/kubemq-go/queues_stream"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/kit/logger"
+)
+
+// interface used to allow unit testing.
+type Kubemq interface {
+	bindings.InputBinding
+	bindings.OutputBinding
+}
+
+type kubeMQ struct {
+	client    *qs.QueuesStreamClient
+	opts      *options
+	logger    logger.Logger
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func NewKubeMQ(logger logger.Logger) Kubemq {
+	return &kubeMQ{
+		client:    nil,
+		opts:      nil,
+		logger:    logger,
+		ctx:       nil,
+		ctxCancel: nil,
+	}
+}
+func (k *kubeMQ) Init(metadata bindings.Metadata) error {
+	opts, err := createOptions(metadata)
+	if err != nil {
+		return err
+	}
+	k.opts = opts
+	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
+	client, err := qs.NewQueuesStreamClient(k.ctx,
+		qs.WithAddress(opts.host, opts.port),
+		qs.WithCheckConnection(true),
+		qs.WithAuthToken(opts.authToken),
+		qs.WithAutoReconnect(true),
+		qs.WithReconnectInterval(time.Second))
+	if err != nil {
+		k.logger.Errorf("error init kubemq client error: %s", err.Error())
+		return err
+	}
+	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
+	k.client = client
+	return nil
+}
+
+func (k *kubeMQ) Read(ctx context.Context, handler bindings.Handler) error {
+	go func() {
+		for {
+			err := k.processQueueMessage(k.ctx, handler)
+			if err != nil {
+				k.logger.Error(err.Error())
+				time.Sleep(time.Second)
+			}
+			if k.ctx.Err() != nil {
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (k *kubeMQ) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	queueMessage := qs.NewQueueMessage().
+		SetChannel(k.opts.channel).
+		SetBody(req.Data).
+		SetPolicyDelaySeconds(parsePolicyDelaySeconds(req.Metadata)).
+		SetPolicyExpirationSeconds(parsePolicyExpirationSeconds(req.Metadata)).
+		SetPolicyMaxReceiveCount(parseSetPolicyMaxReceiveCount(req.Metadata)).
+		SetPolicyMaxReceiveQueue(parsePolicyMaxReceiveQueue(req.Metadata))
+	result, err := k.client.Send(k.ctx, queueMessage)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Results) > 0 {
+		if result.Results[0].IsError {
+			return nil, fmt.Errorf("error sending queue message: %s", result.Results[0].Error)
+		}
+	}
+	return &bindings.InvokeResponse{
+		Data:        nil,
+		Metadata:    nil,
+		ContentType: nil,
+	}, nil
+}
+
+func (k *kubeMQ) Operations() []bindings.OperationKind {
+	return []bindings.OperationKind{bindings.CreateOperation}
+}
+
+func (k *kubeMQ) processQueueMessage(ctx context.Context, handler bindings.Handler) error {
+	pr := qs.NewPollRequest().
+		SetChannel(k.opts.channel).
+		SetMaxItems(k.opts.pollMaxItems).
+		SetWaitTimeout(k.opts.pollTimeoutSeconds).
+		SetAutoAck(k.opts.autoAcknowledged)
+
+	pollResp, err := k.client.Poll(ctx, pr)
+	if err != nil {
+		if strings.Contains(err.Error(), "timout waiting response") {
+			return nil
+		}
+		return err
+	}
+	if !pollResp.HasMessages() {
+		return nil
+	}
+
+	for _, message := range pollResp.Messages {
+		_, err := handler(ctx, &bindings.ReadResponse{
+			Data: message.Body,
+		})
+		if err != nil {
+			k.logger.Errorf("error received from response handler: %s", err.Error())
+			err := message.NAck()
+			if err != nil {
+				k.logger.Errorf("error processing nack message error: %s", err.Error())
+			}
+			time.Sleep(time.Second)
+			continue
+		} else {
+			err := message.Ack()
+			if err != nil {
+				k.logger.Errorf("error processing ack queue message error: %s", err.Error())
+				continue
+			}
+		}
+	}
+	return nil
+}

--- a/bindings/kubemq/kubemq_integration_test.go
+++ b/bindings/kubemq/kubemq_integration_test.go
@@ -33,16 +33,17 @@ func getTestKubeMQHost() string {
 }
 
 func getDefaultMetadata(channel string) bindings.Metadata {
-	return bindings.Metadata{Base: metadata.Base{
-		Name: "kubemq",
-		Properties: map[string]string{
-			"address":            getTestKubeMQHost(),
-			"channel":            channel,
-			"pollMaxItems":       "1",
-			"autoAcknowledged":   "true",
-			"pollTimeoutSeconds": "2",
+	return bindings.Metadata{
+		Base: metadata.Base{
+			Name: "kubemq",
+			Properties: map[string]string{
+				"address":            getTestKubeMQHost(),
+				"channel":            channel,
+				"pollMaxItems":       "1",
+				"autoAcknowledged":   "true",
+				"pollTimeoutSeconds": "2",
+			},
 		},
-	},
 	}
 }
 
@@ -54,46 +55,49 @@ func Test_kubeMQ_Init(t *testing.T) {
 	}{
 		{
 			name: "init with valid options",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":            getTestKubeMQHost(),
-					"channel":            "test",
-					"pollMaxItems":       "1",
-					"autoAcknowledged":   "true",
-					"pollTimeoutSeconds": "2",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":            getTestKubeMQHost(),
+						"channel":            "test",
+						"pollMaxItems":       "1",
+						"autoAcknowledged":   "true",
+						"pollTimeoutSeconds": "2",
+					},
 				},
-			},
 			},
 			wantErr: false,
 		},
 		{
 			name: "init with invalid options",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":            "localhost-bad:50000",
-					"channel":            "test",
-					"pollMaxItems":       "1",
-					"autoAcknowledged":   "true",
-					"pollTimeoutSeconds": "2",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":            "localhost-bad:50000",
+						"channel":            "test",
+						"pollMaxItems":       "1",
+						"autoAcknowledged":   "true",
+						"pollTimeoutSeconds": "2",
+					},
 				},
-			},
 			},
 			wantErr: true,
 		},
 		{
 			name: "init with invalid parsing options",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":            "bad",
-					"channel":            "test",
-					"pollMaxItems":       "1",
-					"autoAcknowledged":   "true",
-					"pollTimeoutSeconds": "2",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":            "bad",
+						"channel":            "test",
+						"pollMaxItems":       "1",
+						"autoAcknowledged":   "true",
+						"pollTimeoutSeconds": "2",
+					},
 				},
-			},
 			},
 			wantErr: true,
 		},
@@ -136,6 +140,7 @@ func Test_kubeMQ_Invoke_Read_Single_Message(t *testing.T) {
 		require.Equal(t, invokeRequest.Data, data)
 	}
 }
+
 func Test_kubeMQ_Invoke_Read_Single_MessageWithHandlerError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()

--- a/bindings/kubemq/kubemq_integration_test.go
+++ b/bindings/kubemq/kubemq_integration_test.go
@@ -6,13 +6,15 @@ package kubemq
 import (
 	"context"
 	"fmt"
-	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/components-contrib/metadata"
-	"github.com/dapr/kit/logger"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
 )
 
 const (
@@ -35,7 +37,7 @@ func getDefaultMetadata(channel string) bindings.Metadata {
 		Name: "kubemq",
 		Properties: map[string]string{
 			"address":            getTestKubeMQHost(),
-			"channel":            string(channel),
+			"channel":            channel,
 			"pollMaxItems":       "1",
 			"autoAcknowledged":   "true",
 			"pollTimeoutSeconds": "2",

--- a/bindings/kubemq/kubemq_integration_test.go
+++ b/bindings/kubemq/kubemq_integration_test.go
@@ -1,0 +1,187 @@
+//go:build integration_test
+// +build integration_test
+
+package kubemq
+
+import (
+	"context"
+	"fmt"
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	// Environment variable containing the host name for KubeMQ integration tests
+	// To run using docker: docker run -d --hostname -kubemq --name test-kubemq -p 50000:50000 kubemq/kubemq-community:latest
+	// In that case the address string will be: "localhost:50000"
+	testKubeMQHostEnvKey = "DAPR_TEST_KUBEMQ_HOST"
+)
+
+func getTestKubeMQHost() string {
+	host := os.Getenv(testKubeMQHostEnvKey)
+	if host == "" {
+		host = "localhost:50000"
+	}
+	return host
+}
+
+func getDefaultMetadata(channel string) bindings.Metadata {
+	return bindings.Metadata{Base: metadata.Base{
+		Name: "kubemq",
+		Properties: map[string]string{
+			"address":            getTestKubeMQHost(),
+			"channel":            string(channel),
+			"pollMaxItems":       "1",
+			"autoAcknowledged":   "true",
+			"pollTimeoutSeconds": "2",
+		},
+	},
+	}
+}
+
+func Test_kubeMQ_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    bindings.Metadata
+		wantErr bool
+	}{
+		{
+			name: "init with valid options",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":            getTestKubeMQHost(),
+					"channel":            "test",
+					"pollMaxItems":       "1",
+					"autoAcknowledged":   "true",
+					"pollTimeoutSeconds": "2",
+				},
+			},
+			},
+			wantErr: false,
+		},
+		{
+			name: "init with invalid options",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":            "localhost-bad:50000",
+					"channel":            "test",
+					"pollMaxItems":       "1",
+					"autoAcknowledged":   "true",
+					"pollTimeoutSeconds": "2",
+				},
+			},
+			},
+			wantErr: true,
+		},
+		{
+			name: "init with invalid parsing options",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":            "bad",
+					"channel":            "test",
+					"pollMaxItems":       "1",
+					"autoAcknowledged":   "true",
+					"pollTimeoutSeconds": "2",
+				},
+			},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubemq := NewKubeMQ(logger.NewLogger("test"))
+			err := kubemq.Init(tt.meta)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_kubeMQ_Invoke_Read_Single_Message(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	kubemq := NewKubeMQ(logger.NewLogger("test"))
+	err := kubemq.Init(getDefaultMetadata("test.read.single"))
+	require.NoError(t, err)
+	dataReadCh := make(chan []byte)
+	invokeRequest := &bindings.InvokeRequest{
+		Data:     []byte("test"),
+		Metadata: map[string]string{},
+	}
+	_, err = kubemq.Invoke(ctx, invokeRequest)
+	require.NoError(t, err)
+	_ = kubemq.Read(ctx, func(ctx context.Context, req *bindings.ReadResponse) ([]byte, error) {
+		dataReadCh <- req.Data
+		return req.Data, nil
+	})
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout waiting for read response")
+	case data := <-dataReadCh:
+		require.Equal(t, invokeRequest.Data, data)
+	}
+}
+func Test_kubeMQ_Invoke_Read_Single_MessageWithHandlerError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	kubemq := NewKubeMQ(logger.NewLogger("test"))
+	md := getDefaultMetadata("test.read.single.error")
+	md.Properties["autoAcknowledged"] = "false"
+	err := kubemq.Init(md)
+	require.NoError(t, err)
+	invokeRequest := &bindings.InvokeRequest{
+		Data:     []byte("test"),
+		Metadata: map[string]string{},
+	}
+
+	_, err = kubemq.Invoke(ctx, invokeRequest)
+	require.NoError(t, err)
+	firstReadCtx, firstReadCancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer firstReadCancel()
+	_ = kubemq.Read(firstReadCtx, func(ctx context.Context, req *bindings.ReadResponse) ([]byte, error) {
+		return nil, fmt.Errorf("handler error")
+	})
+
+	<-firstReadCtx.Done()
+	dataReadCh := make(chan []byte)
+	secondReadCtx, secondReadCancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer secondReadCancel()
+	_ = kubemq.Read(secondReadCtx, func(ctx context.Context, req *bindings.ReadResponse) ([]byte, error) {
+		dataReadCh <- req.Data
+		return req.Data, nil
+	})
+	select {
+	case <-secondReadCtx.Done():
+		require.Fail(t, "timeout waiting for read response")
+	case data := <-dataReadCh:
+		require.Equal(t, invokeRequest.Data, data)
+	}
+}
+
+func Test_kubeMQ_Invoke_Error(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	kubemq := NewKubeMQ(logger.NewLogger("test"))
+	err := kubemq.Init(getDefaultMetadata("***test***"))
+	require.NoError(t, err)
+
+	invokeRequest := &bindings.InvokeRequest{
+		Data:     []byte("test"),
+		Metadata: map[string]string{},
+	}
+	_, err = kubemq.Invoke(ctx, invokeRequest)
+	require.Error(t, err)
+}

--- a/bindings/kubemq/kubemq_test.go
+++ b/bindings/kubemq/kubemq_test.go
@@ -18,17 +18,18 @@ func Test_createOptions(t *testing.T) {
 	}{
 		{
 			name: "create valid opts",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":            "localhost:50000",
-					"channel":            "test",
-					"authToken":          "authToken",
-					"pollMaxItems":       "10",
-					"autoAcknowledged":   "true",
-					"pollTimeoutSeconds": "10",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":            "localhost:50000",
+						"channel":            "test",
+						"authToken":          "authToken",
+						"pollMaxItems":       "10",
+						"autoAcknowledged":   "true",
+						"pollTimeoutSeconds": "10",
+					},
 				},
-			},
 			},
 			want: &options{
 				host:               "localhost",
@@ -43,39 +44,42 @@ func Test_createOptions(t *testing.T) {
 		},
 		{
 			name: "create invalid opts with bad host",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":  ":50000",
-					"clientId": "clientId",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":  ":50000",
+						"clientId": "clientId",
+					},
 				},
-			},
 			},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name: "create invalid opts with bad port",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":  "localhost:badport",
-					"clientId": "clientId",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":  "localhost:badport",
+						"clientId": "clientId",
+					},
 				},
-			},
 			},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name: "create invalid opts with empty address",
-			meta: bindings.Metadata{Base: metadata.Base{
-				Name: "kubemq",
-				Properties: map[string]string{
-					"address":  "",
-					"clientId": "clientId",
+			meta: bindings.Metadata{
+				Base: metadata.Base{
+					Name: "kubemq",
+					Properties: map[string]string{
+						"address":  "",
+						"clientId": "clientId",
+					},
 				},
-			},
 			},
 			want:    nil,
 			wantErr: true,
@@ -174,7 +178,6 @@ func Test_createOptions(t *testing.T) {
 			got, err := createOptions(tt.meta)
 			if tt.wantErr {
 				assert.Error(t, err)
-
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
@@ -251,7 +254,8 @@ func Test_parsePolicyExpirationSeconds(t *testing.T) {
 		args args
 		want int
 	}{
-		{name: "parse policy expiration seconds - nil",
+		{
+			name: "parse policy expiration seconds - nil",
 			args: args{
 				md: nil,
 			},

--- a/bindings/kubemq/kubemq_test.go
+++ b/bindings/kubemq/kubemq_test.go
@@ -1,0 +1,400 @@
+package kubemq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
+)
+
+func Test_createOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    bindings.Metadata
+		want    *options
+		wantErr bool
+	}{
+		{
+			name: "create valid opts",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":            "localhost:50000",
+					"channel":            "test",
+					"authToken":          "authToken",
+					"pollMaxItems":       "10",
+					"autoAcknowledged":   "true",
+					"pollTimeoutSeconds": "10",
+				},
+			},
+			},
+			want: &options{
+				host:               "localhost",
+				port:               50000,
+				authToken:          "authToken",
+				channel:            "test",
+				autoAcknowledged:   true,
+				pollMaxItems:       10,
+				pollTimeoutSeconds: 10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "create invalid opts with bad host",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":  ":50000",
+					"clientId": "clientId",
+				},
+			},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with bad port",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":  "localhost:badport",
+					"clientId": "clientId",
+				},
+			},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with empty address",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":  "",
+					"clientId": "clientId",
+				},
+			},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with bad address format",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address": "localhost50000",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with no channel",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address": "localhost:50000",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with bad autoAcknowledged",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":          "localhost:50000",
+					"channel":          "test",
+					"autoAcknowledged": "bad",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with invalid pollMaxItems",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":      "localhost:50000",
+					"channel":      "test",
+					"pollMaxItems": "0",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with bad pollMaxItems format",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":      "localhost:50000",
+					"channel":      "test",
+					"pollMaxItems": "bad",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with invalid pollTimeoutSeconds",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":            "localhost:50000",
+					"channel":            "test",
+					"pollTimeoutSeconds": "0",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "create invalid opts with bad format pollTimeoutSeconds",
+			meta: bindings.Metadata{Base: metadata.Base{
+				Name: "kubemq",
+				Properties: map[string]string{
+					"address":            "localhost:50000",
+					"channel":            "test",
+					"pollTimeoutSeconds": "bad",
+				},
+			}},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createOptions(tt.meta)
+			if tt.wantErr {
+				assert.Error(t, err)
+
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_parsePolicyDelaySeconds(t *testing.T) {
+	type args struct {
+		md map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "parse policy delay seconds - nil",
+			args: args{
+				md: nil,
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy delay seconds - empty",
+			args: args{
+				md: map[string]string{},
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy delay seconds",
+			args: args{
+				md: map[string]string{
+					"delaySeconds": "10",
+				},
+			},
+			want: 10,
+		},
+		{
+			name: "parse policy delay seconds with bad format",
+			args: args{
+				md: map[string]string{
+					"delaySeconds": "bad",
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy delay seconds with negative value",
+			args: args{
+				md: map[string]string{
+					"delaySeconds": "-10",
+				},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, parsePolicyDelaySeconds(tt.args.md), "parsePolicyDelaySeconds(%v)", tt.args.md)
+		})
+	}
+}
+
+func Test_parsePolicyExpirationSeconds(t *testing.T) {
+	type args struct {
+		md map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{name: "parse policy expiration seconds - nil",
+			args: args{
+				md: nil,
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy expiration seconds - empty",
+			args: args{
+				md: map[string]string{},
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy expiration seconds",
+			args: args{
+				md: map[string]string{
+					"expirationSeconds": "10",
+				},
+			},
+			want: 10,
+		},
+		{
+			name: "parse policy expiration seconds with bad format",
+			args: args{
+				md: map[string]string{
+					"expirationSeconds": "bad",
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy expiration seconds with negative value",
+			args: args{
+				md: map[string]string{
+					"expirationSeconds": "-10",
+				},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, parsePolicyExpirationSeconds(tt.args.md), "parsePolicyExpirationSeconds(%v)", tt.args.md)
+		})
+	}
+}
+
+func Test_parseSetPolicyMaxReceiveCount(t *testing.T) {
+	type args struct {
+		md map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "parse policy max receive count nil",
+			args: args{
+				md: nil,
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy max receive count empty",
+			args: args{
+				md: map[string]string{},
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy max receive count",
+			args: args{
+				md: map[string]string{
+					"maxReceiveCount": "10",
+				},
+			},
+			want: 10,
+		},
+
+		{
+			name: "parse policy max receive count with bad format",
+			args: args{
+				md: map[string]string{
+					"maxReceiveCount": "bad",
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "parse policy max receive count with negative value",
+			args: args{
+				md: map[string]string{
+					"maxReceiveCount": "-10",
+				},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, parseSetPolicyMaxReceiveCount(tt.args.md), "parseSetPolicyMaxReceiveCount(%v)", tt.args.md)
+		})
+	}
+}
+
+func Test_parsePolicyMaxReceiveQueue(t *testing.T) {
+	type args struct {
+		md map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "parse policy max receive queue nil",
+			args: args{
+				md: nil,
+			},
+			want: "",
+		},
+		{
+			name: "parse policy max receive queue empty",
+			args: args{
+				md: map[string]string{},
+			},
+			want: "",
+		},
+		{
+			name: "parse policy max receive queue",
+			args: args{
+				md: map[string]string{
+					"maxReceiveQueue": "some-queue",
+				},
+			},
+			want: "some-queue",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, parsePolicyMaxReceiveQueue(tt.args.md), "parsePolicyMaxReceiveQueue(%v)", tt.args.md)
+		})
+	}
+}

--- a/bindings/kubemq/options.go
+++ b/bindings/kubemq/options.go
@@ -1,0 +1,159 @@
+package kubemq
+
+import (
+	"fmt"
+	"github.com/dapr/components-contrib/bindings"
+	"strconv"
+	"strings"
+)
+
+type options struct {
+	host               string
+	port               int
+	channel            string
+	authToken          string
+	autoAcknowledged   bool
+	pollMaxItems       int
+	pollTimeoutSeconds int
+}
+
+func parseAddress(address string) (string, int, error) {
+	var host string
+	var port int
+	var err error
+	hostPort := strings.Split(address, ":")
+	if len(hostPort) != 2 {
+		return "", 0, fmt.Errorf("invalid kubemq address, address format is invalid")
+	}
+	host = hostPort[0]
+	if len(host) == 0 {
+		return "", 0, fmt.Errorf("invalid kubemq address, host is empty")
+	}
+	port, err = strconv.Atoi(hostPort[1])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid kubemq address, port is invalid")
+	}
+	return host, port, nil
+}
+
+// createOptions creates a new instance from the kubemq options
+func createOptions(md bindings.Metadata) (*options, error) {
+	result := &options{
+		host:               "",
+		port:               0,
+		channel:            "",
+		authToken:          "",
+		autoAcknowledged:   false,
+		pollMaxItems:       1,
+		pollTimeoutSeconds: 3600,
+	}
+	if val, found := md.Properties["address"]; found && val != "" {
+		var err error
+		result.host, result.port, err = parseAddress(val)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("invalid kubemq address, address is empty")
+	}
+	if val, ok := md.Properties["channel"]; ok && val != "" {
+		result.channel = val
+	} else {
+		return nil, fmt.Errorf("invalid kubemq channel, channel is empty")
+	}
+
+	if val, found := md.Properties["authToken"]; found && val != "" {
+		if found && val != "" {
+			result.authToken = val
+		}
+	}
+
+	if val, found := md.Properties["autoAcknowledged"]; found && val != "" {
+		autoAcknowledged, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, fmt.Errorf("invalid kubemq autoAcknowledged value, %s", err.Error())
+		}
+		result.autoAcknowledged = autoAcknowledged
+	}
+	if val, found := md.Properties["pollMaxItems"]; found && val != "" {
+		pollMaxItems, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("invalid kubemq pollMaxItems value, %s", err.Error())
+		}
+		if pollMaxItems < 1 {
+			return nil, fmt.Errorf("invalid kubemq pollMaxItems value, value must be greater than 0")
+		}
+		result.pollMaxItems = pollMaxItems
+	}
+	if val, found := md.Properties["pollTimeoutSeconds"]; found && val != "" {
+		timeoutSecond, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("invalid kubemq pollTimeoutSeconds value, %s", err.Error())
+		} else {
+			if timeoutSecond < 1 {
+				return nil, fmt.Errorf("invalid kubemq pollTimeoutSeconds value, value must be greater than 0")
+			}
+			result.pollTimeoutSeconds = timeoutSecond
+		}
+	}
+	return result, nil
+}
+
+func parsePolicyDelaySeconds(md map[string]string) int {
+	if md == nil {
+		return 0
+	}
+	if val, found := md["delaySeconds"]; found && val != "" {
+		delaySeconds, err := strconv.Atoi(val)
+		if err != nil {
+			return 0
+		}
+		if delaySeconds < 0 {
+			return 0
+		}
+		return delaySeconds
+	}
+	return 0
+}
+func parsePolicyExpirationSeconds(md map[string]string) int {
+	if md == nil {
+		return 0
+	}
+	if val, found := md["expirationSeconds"]; found && val != "" {
+		expirationSeconds, err := strconv.Atoi(val)
+		if err != nil {
+			return 0
+		}
+		if expirationSeconds < 0 {
+			return 0
+		}
+		return expirationSeconds
+	}
+	return 0
+}
+func parseSetPolicyMaxReceiveCount(md map[string]string) int {
+	if md == nil {
+		return 0
+	}
+	if val, found := md["maxReceiveCount"]; found && val != "" {
+		maxReceiveCount, err := strconv.Atoi(val)
+		if err != nil {
+			return 0
+		}
+		if maxReceiveCount < 0 {
+			return 0
+		}
+		return maxReceiveCount
+	}
+	return 0
+}
+
+func parsePolicyMaxReceiveQueue(md map[string]string) string {
+	if md == nil {
+		return ""
+	}
+	if val, found := md["maxReceiveQueue"]; found && val != "" {
+		return val
+	}
+	return ""
+}

--- a/bindings/kubemq/options.go
+++ b/bindings/kubemq/options.go
@@ -116,6 +116,7 @@ func parsePolicyDelaySeconds(md map[string]string) int {
 	}
 	return 0
 }
+
 func parsePolicyExpirationSeconds(md map[string]string) int {
 	if md == nil {
 		return 0
@@ -132,6 +133,7 @@ func parsePolicyExpirationSeconds(md map[string]string) int {
 	}
 	return 0
 }
+
 func parseSetPolicyMaxReceiveCount(md map[string]string) int {
 	if md == nil {
 		return 0

--- a/bindings/kubemq/options.go
+++ b/bindings/kubemq/options.go
@@ -2,9 +2,10 @@ package kubemq
 
 import (
 	"fmt"
-	"github.com/dapr/components-contrib/bindings"
 	"strconv"
 	"strings"
+
+	"github.com/dapr/components-contrib/bindings"
 )
 
 type options struct {

--- a/tests/config/bindings/kubemq/binding.yml
+++ b/tests/config/bindings/kubemq/binding.yml
@@ -1,0 +1,13 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: binding-topic
+  namespace: default
+spec:
+  type: bindings.kubemq
+  version: v1
+  metadata:
+    - name: address
+      value: localhost:50000
+    - name: channel
+      value: queue1

--- a/tests/config/bindings/tests.yml
+++ b/tests/config/bindings/tests.yml
@@ -38,7 +38,7 @@ components:
     operations: ["create", "operations"]
   - component: kafka
     profile: confluent
-    operations: ["create", "operations"]    
+    operations: ["create", "operations"]
   - component: http
     operations: ["create", "operations"]
     config:
@@ -61,6 +61,8 @@ components:
     operations: ["create", "operations", "read"]
     config:
       checkInOrderProcessing: false
+  - component: kubemq
+    operations: [ "create", "operations", "read" ]
   - component: postgres
     allOperations: false
     operations: [ "exec", "query", "close", "operations" ]

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -45,6 +45,7 @@ import (
 	b_http "github.com/dapr/components-contrib/bindings/http"
 	b_influx "github.com/dapr/components-contrib/bindings/influx"
 	b_kafka "github.com/dapr/components-contrib/bindings/kafka"
+	b_kubemq "github.com/dapr/components-contrib/bindings/kubemq"
 	b_mqtt "github.com/dapr/components-contrib/bindings/mqtt"
 	b_postgres "github.com/dapr/components-contrib/bindings/postgres"
 	b_rabbitmq "github.com/dapr/components-contrib/bindings/rabbitmq"
@@ -497,6 +498,8 @@ func loadOutputBindings(tc TestComponent) bindings.OutputBinding {
 		binding = b_mqtt.NewMQTT(testLogger)
 	case "rabbitmq":
 		binding = b_rabbitmq.NewRabbitMQ(testLogger)
+	case "kubemq":
+		binding = b_kubemq.NewKubeMQ(testLogger)
 	case "postgres":
 		binding = b_postgres.NewPostgres(testLogger)
 	default:
@@ -524,6 +527,8 @@ func loadInputBindings(tc TestComponent) bindings.InputBinding {
 		binding = b_mqtt.NewMQTT(testLogger)
 	case "rabbitmq":
 		binding = b_rabbitmq.NewRabbitMQ(testLogger)
+	case "kubemq":
+		binding = b_kubemq.NewKubeMQ(testLogger)
 	default:
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Lior Nabat <lior.nabat@gmail.clom>

# Description
This PR is to add KubeMQ Binding - Queue feature to DAPR.
This PR passed:
1. make lint
2. make test
3. go test -v -tags=conftests -count=1 ./tests/conformance -run="TestBindingsConformance/kubemq"

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ x] Code compiles correctly
* [ x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
