### PR TITLE
[WIP] Add bulk publish support to in-memory pubsub component

### DIFF
--- a/pubsub/in-memory/in-memory.go
+++ b/pubsub/in-memory/in-memory.go
@@ -53,6 +53,13 @@ func (a *bus) Publish(req *pubsub.PublishRequest) error {
 	return nil
 }
 
+func (a *bus) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
+	for _, m := range req.Entries {
+		a.bus.Publish(req.Topic, m.Event)
+	}
+	return pubsub.BulkPublishResponse{}, nil
+}
+
 func (a *bus) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {
 	// For this component we allow built-in retries because it is backed by memory
 	retryHandler := func(data []byte) {

--- a/pubsub/in-memory/in-memory_test.go
+++ b/pubsub/in-memory/in-memory_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -108,6 +109,7 @@ func TestBulkPublish(t *testing.T) {
 
 	ch := make(chan []byte)
 	bus.Subscribe(context.Background(), pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
+		time.Sleep(500 * time.Millisecond) // Ensure order of messages for the test
 		return publish(ch, msg)
 	})
 

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -75,7 +75,7 @@ components:
     config:
       checkInOrderProcessing: false
   - component: in-memory
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: ["publish", "subscribe", "multiplehandlers", "bulkpublish"]
   - component: aws.snssqs
     operations: ["publish", "subscribe", "multiplehandlers"]
     config:


### PR DESCRIPTION
# Description

**Note**, still evaluating if this PR is needed since the default implementation in runtime already does the same. Since EventBus does not have support for bulk-publish directly, this might be unnecessary.

This PR adds a bulk publish support to the in-memory pubsub component. It publishes multiple messages by invoking the EventBus package's [publish](https://pkg.go.dev/github.com/asaskevich/EventBus#EventBus.Publish) operation multiple times.

It also onboards the "bulkpublish" operation to the conformance test for in-memory pubsub.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2271 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: https://github.com/dapr/docs/issues/2954
