### PR TITLE
ASQ Binding: Make visibilityTimeout configurable

### DIFF
--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -203,7 +203,7 @@ func (a *AzureStorageQueues) Init(metadata bindings.Metadata) (err error) {
 }
 
 func parseMetadata(meta bindings.Metadata) (*storageQueuesMetadata, error) {
-	var m storageQueuesMetadata = storageQueuesMetadata{
+	var m storageQueuesMetadata = {
 		VisibilityTimeout: ptr.Of(time.Second * 30),
 	}
 	// AccountKey is parsed in azauth


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Adds ability to configure the Azure Storage Queue visibility timeout via `visibilityTimeout` metadata option. Default remains at 30 seconds.

Fixes #2259

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
