### PR TITLE
Adding CosmosDB and TableStorage Dapr User Agents

### DIFF
--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	"github.com/dapr/components-contrib/bindings"
@@ -60,6 +61,14 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 
 	c.partitionKey = m.PartitionKey
 
+	opts := azcosmos.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: "dapr-" + logger.DaprVersion,
+			},
+		},
+	}
+
 	// Create the client; first, try authenticating with a master key, if present
 	var client *azcosmos.Client
 	if m.MasterKey != "" {
@@ -67,7 +76,7 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 		if keyErr != nil {
 			return keyErr
 		}
-		client, err = azcosmos.NewClientWithKey(m.URL, cred, nil)
+		client, err = azcosmos.NewClientWithKey(m.URL, cred, &opts)
 		if err != nil {
 			return err
 		}
@@ -81,7 +90,7 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 		if errToken != nil {
 			return errToken
 		}
-		client, err = azcosmos.NewClient(m.URL, token, nil)
+		client, err = azcosmos.NewClient(m.URL, token, &opts)
 		if err != nil {
 			return err
 		}

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -143,6 +143,9 @@ func (c *StateStore) Init(meta state.Metadata) error {
 	opts := azcosmos.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			PerCallPolicies: []policy.Policy{queryPolicy},
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: "dapr-" + logger.DaprVersion,
+			},
 		},
 	}
 

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -45,6 +45,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -102,6 +103,14 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 		}
 	}
 
+	opts := aztables.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: "dapr-" + logger.DaprVersion,
+			},
+		},
+	}
+
 	if meta.AccountKey != "" {
 		// use shared key authentication
 		cred, innerErr := aztables.NewSharedKeyCredential(meta.AccountName, meta.AccountKey)
@@ -109,7 +118,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 			return innerErr
 		}
 
-		client, innerErr = aztables.NewServiceClientWithSharedKey(serviceURL, cred, nil)
+		client, innerErr = aztables.NewServiceClientWithSharedKey(serviceURL, cred, &opts)
 		if innerErr != nil {
 			return innerErr
 		}
@@ -130,7 +139,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 		if innerErr != nil {
 			return innerErr
 		}
-		client, innerErr = aztables.NewServiceClient(serviceURL, token, nil)
+		client, innerErr = aztables.NewServiceClient(serviceURL, token, &opts)
 		if err != nil {
 			return innerErr
 		}


### PR DESCRIPTION
# Description

User agents were not implemented when migrating to the Track 2 SDKs for CosmosDB. This sets the Dapr version user agent.