### PR TITLE
Postgres State Store: Add Support for First-Write concurrency

### DIFF
--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -44,6 +44,7 @@ type postgresDBAccess struct {
 	metadata         postgresMetadataStruct
 	db               *sql.DB
 	connectionString string
+	tableName        string
 }
 
 // newPostgresDBAccess creates a new instance of postgresAccess.
@@ -103,6 +104,7 @@ func (p *postgresDBAccess) Init(meta state.Metadata) error {
 	if err != nil {
 		return err
 	}
+	p.tableName = m.TableName
 
 	return nil
 }
@@ -146,12 +148,12 @@ func (p *postgresDBAccess) setValue(req *state.SetRequest) error {
 	if req.Options.Concurrency == state.FirstWrite && (req.ETag == nil || *req.ETag == "") {
 		result, err = p.db.Exec(fmt.Sprintf(
 			`INSERT INTO %s (key, value, isbinary) VALUES ($1, $2, $3);`,
-			defaultTableName), req.Key, value, isBinary)
+			p.tableName), req.Key, value, isBinary)
 	} else if req.ETag == nil {
 		result, err = p.db.Exec(fmt.Sprintf(
 			`INSERT INTO %s (key, value, isbinary) VALUES ($1, $2, $3)
 			ON CONFLICT (key) DO UPDATE SET value = $2, isbinary = $3, updatedate = NOW();`,
-			defaultTableName), req.Key, value, isBinary)
+			p.tableName), req.Key, value, isBinary)
 	} else {
 		// Convert req.ETag to uint32 for postgres XID compatibility
 		var etag64 uint64
@@ -165,7 +167,7 @@ func (p *postgresDBAccess) setValue(req *state.SetRequest) error {
 		result, err = p.db.Exec(fmt.Sprintf(
 			`UPDATE %s SET value = $1, isbinary = $2, updatedate = NOW()
 			 WHERE key = $3 AND xmin = $4;`,
-			defaultTableName), value, isBinary, req.Key, etag)
+			p.tableName), value, isBinary, req.Key, etag)
 	}
 
 	if err != nil {
@@ -222,7 +224,7 @@ func (p *postgresDBAccess) Get(req *state.GetRequest) (*state.GetResponse, error
 	var value string
 	var isBinary bool
 	var etag int
-	err := p.db.QueryRow(fmt.Sprintf("SELECT value, isbinary, xmin as etag FROM %s WHERE key = $1", defaultTableName), req.Key).Scan(&value, &isBinary, &etag)
+	err := p.db.QueryRow(fmt.Sprintf("SELECT value, isbinary, xmin as etag FROM %s WHERE key = $1", p.tableName), req.Key).Scan(&value, &isBinary, &etag)
 	if err != nil {
 		// If no rows exist, return an empty response, otherwise return the error.
 		if err == sql.ErrNoRows {
@@ -382,8 +384,9 @@ func (p *postgresDBAccess) ExecuteMulti(request *state.TransactionalStateRequest
 func (p *postgresDBAccess) Query(req *state.QueryRequest) (*state.QueryResponse, error) {
 	p.logger.Debug("Getting query value from PostgreSQL")
 	q := &Query{
-		query:  "",
-		params: []interface{}{},
+		query:     "",
+		params:    []interface{}{},
+		tableName: p.tableName,
 	}
 	qbuilder := query.NewQueryBuilder(q)
 	if err := qbuilder.BuildQuery(&req.Query); err != nil {

--- a/state/postgresql/postgresql_query.go
+++ b/state/postgresql/postgresql_query.go
@@ -27,10 +27,11 @@ import (
 )
 
 type Query struct {
-	query  string
-	params []interface{}
-	limit  int
-	skip   *int64
+	query     string
+	params    []interface{}
+	limit     int
+	skip      *int64
+	tableName string
 }
 
 func (q *Query) VisitEQ(f *query.EQ) (string, error) {
@@ -101,7 +102,7 @@ func (q *Query) VisitOR(f *query.OR) (string, error) {
 }
 
 func (q *Query) Finalize(filters string, qq *query.Query) error {
-	q.query = fmt.Sprintf("SELECT key, value, xmin as etag FROM %s", defaultTableName)
+	q.query = fmt.Sprintf("SELECT key, value, xmin as etag FROM %s", q.tableName)
 
 	if filters != "" {
 		q.query += fmt.Sprintf(" WHERE %s", filters)

--- a/state/postgresql/postgresql_query_test.go
+++ b/state/postgresql/postgresql_query_test.go
@@ -60,7 +60,9 @@ func TestPostgresqlQueryBuildQuery(t *testing.T) {
 		err = json.Unmarshal(data, &qq)
 		assert.NoError(t, err)
 
-		q := &Query{}
+		q := &Query{
+			tableName: defaultTableName,
+		}
 		qbuilder := query.NewQueryBuilder(q)
 		err = qbuilder.BuildQuery(&qq)
 		assert.NoError(t, err)

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -21,7 +21,7 @@ components:
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "first-write" ]
   - component: postgresql
     allOperations: false
-    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "query" ]
+    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag", "query", "first-write" ]
   - component: mysql.mysql
     allOperations: false
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag",  "first-write" ]


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Postgres State Store: Add Support for First-Write concurrency

Allows table name to be customized.

fixes #1163