### PR TITLE
Some misc refactorings in state stores

### DIFF
--- a/bindings/rabbitmq/rabbitmq_integration_test.go
+++ b/bindings/rabbitmq/rabbitmq_integration_test.go
@@ -130,12 +130,14 @@ func TestPublishingWithTTL(t *testing.T) {
 	const maxGetDuration = ttlInSeconds * time.Second
 
 	metadata := bindings.Metadata{
-		Name: "testQueue",
-		Properties: map[string]string{
-			"queueName":        queueName,
-			"host":             rabbitmqHost,
-			"deleteWhenUnused": strconv.FormatBool(exclusive),
-			"durable":          strconv.FormatBool(durable),
+		Base: contribMetadata.Base{
+			Name: "testQueue",
+			Properties: map[string]string{
+				"queueName":        queueName,
+				"host":             rabbitmqHost,
+				"deleteWhenUnused": strconv.FormatBool(exclusive),
+				"durable":          strconv.FormatBool(durable),
+			},
 		},
 	}
 
@@ -162,7 +164,7 @@ func TestPublishingWithTTL(t *testing.T) {
 		},
 	}
 
-	_, err = rabbitMQBinding1.Invoke(context.Backgound(), &writeRequest)
+	_, err = rabbitMQBinding1.Invoke(context.Background(), &writeRequest)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second + (ttlInSeconds * time.Second))
@@ -183,7 +185,7 @@ func TestPublishingWithTTL(t *testing.T) {
 			contribMetadata.TTLMetadataKey: strconv.Itoa(ttlInSeconds * 1000),
 		},
 	}
-	_, err = rabbitMQBinding2.Invoke(context.Backgound(), &writeRequest)
+	_, err = rabbitMQBinding2.Invoke(context.Background(), &writeRequest)
 	assert.Nil(t, err)
 
 	msg, ok, err := getMessageWithRetries(ch, queueName, maxGetDuration)
@@ -204,14 +206,16 @@ func TestExclusiveQueue(t *testing.T) {
 	const maxGetDuration = ttlInSeconds * time.Second
 
 	metadata := bindings.Metadata{
-		Name: "testQueue",
-		Properties: map[string]string{
-			"queueName":                    queueName,
-			"host":                         rabbitmqHost,
-			"deleteWhenUnused":             strconv.FormatBool(exclusive),
-			"durable":                      strconv.FormatBool(durable),
-			"exclusive":                    strconv.FormatBool(exclusive),
-			contribMetadata.TTLMetadataKey: strconv.FormatInt(ttlInSeconds, 10),
+		Base: contribMetadata.Base{
+			Name: "testQueue",
+			Properties: map[string]string{
+				"queueName":                    queueName,
+				"host":                         rabbitmqHost,
+				"deleteWhenUnused":             strconv.FormatBool(exclusive),
+				"durable":                      strconv.FormatBool(durable),
+				"exclusive":                    strconv.FormatBool(exclusive),
+				contribMetadata.TTLMetadataKey: strconv.FormatInt(ttlInSeconds, 10),
+			},
 		},
 	}
 
@@ -257,13 +261,15 @@ func TestPublishWithPriority(t *testing.T) {
 	const maxPriority = 10
 
 	metadata := bindings.Metadata{
-		Name: "testQueue",
-		Properties: map[string]string{
-			"queueName":        queueName,
-			"host":             rabbitmqHost,
-			"deleteWhenUnused": strconv.FormatBool(exclusive),
-			"durable":          strconv.FormatBool(durable),
-			"maxPriority":      strconv.FormatInt(maxPriority, 10),
+		Base: contribMetadata.Base{
+			Name: "testQueue",
+			Properties: map[string]string{
+				"queueName":        queueName,
+				"host":             rabbitmqHost,
+				"deleteWhenUnused": strconv.FormatBool(exclusive),
+				"durable":          strconv.FormatBool(durable),
+				"maxPriority":      strconv.FormatInt(maxPriority, 10),
+			},
 		},
 	}
 
@@ -283,7 +289,7 @@ func TestPublishWithPriority(t *testing.T) {
 	defer ch.Close()
 
 	const middlePriorityMsgContent = "middle"
-	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{
 		Metadata: map[string]string{
 			contribMetadata.PriorityMetadataKey: "5",
 		},
@@ -292,7 +298,7 @@ func TestPublishWithPriority(t *testing.T) {
 	assert.Nil(t, err)
 
 	const lowPriorityMsgContent = "low"
-	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{
 		Metadata: map[string]string{
 			contribMetadata.PriorityMetadataKey: "1",
 		},
@@ -301,7 +307,7 @@ func TestPublishWithPriority(t *testing.T) {
 	assert.Nil(t, err)
 
 	const highPriorityMsgContent = "high"
-	_, err = r.Invoke(context.Backgound(), &bindings.InvokeRequest{
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{
 		Metadata: map[string]string{
 			contribMetadata.PriorityMetadataKey: "10",
 		},

--- a/pubsub/azure/eventhubs/eventhubs_integration_test.go
+++ b/pubsub/azure/eventhubs/eventhubs_integration_test.go
@@ -52,11 +52,11 @@ func createIotHubPubsubMetadata() pubsub.Metadata {
 	metadata := pubsub.Metadata{
 		Base: metadata.Base{
 			Properties: map[string]string{
-				connectionString:     os.Getenv(iotHubConnectionStringEnvKey),
-				consumerID:           os.Getenv(iotHubConsumerGroupEnvKey),
-				storageAccountName:   os.Getenv(storageAccountNameEnvKey),
-				storageAccountKey:    os.Getenv(storageAccountKeyEnvKey),
-				storageContainerName: testStorageContainerName,
+				"connectionString":     os.Getenv(iotHubConnectionStringEnvKey),
+				"consumerID":           os.Getenv(iotHubConsumerGroupEnvKey),
+				"storageAccountName":   os.Getenv(storageAccountNameEnvKey),
+				"storageAccountKey":    os.Getenv(storageAccountKeyEnvKey),
+				"storageContainerName": testStorageContainerName,
 			},
 		},
 	}

--- a/state/cockroachdb/cockroachdb_access.go
+++ b/state/cockroachdb/cockroachdb_access.go
@@ -114,11 +114,6 @@ func (p *cockroachDBAccess) Init(metadata state.Metadata) error {
 
 // Set makes an insert or update to the database.
 func (p *cockroachDBAccess) Set(req *state.SetRequest) error {
-	return state.SetWithOptions(p.setValue, req)
-}
-
-// setValue is an internal implementation of set to enable passing the logic to state.SetWithRetries as a func.
-func (p *cockroachDBAccess) setValue(req *state.SetRequest) error {
 	p.logger.Debug("Setting state value in CockroachDB")
 
 	value, isBinary, err := validateAndReturnValue(req)
@@ -240,11 +235,6 @@ func (p *cockroachDBAccess) Get(req *state.GetRequest) (*state.GetResponse, erro
 
 // Delete removes an item from the state store.
 func (p *cockroachDBAccess) Delete(req *state.DeleteRequest) error {
-	return state.DeleteWithOptions(p.deleteValue, req)
-}
-
-// deleteValue is an internal implementation of delete to enable passing the logic to state.DeleteWithRetries as a func.
-func (p *cockroachDBAccess) deleteValue(req *state.DeleteRequest) error {
 	p.logger.Debug("Deleting state value from CockroachDB")
 	if req.Key == "" {
 		return fmt.Errorf("missing key in delete operation")

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -113,7 +113,8 @@ func (f *Firestore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	}, nil
 }
 
-func (f *Firestore) setValue(req *state.SetRequest) error {
+// Set saves state into Firestore.
+func (f *Firestore) Set(req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -142,12 +143,8 @@ func (f *Firestore) setValue(req *state.SetRequest) error {
 	return nil
 }
 
-// Set saves state into Firestore with retry.
-func (f *Firestore) Set(req *state.SetRequest) error {
-	return state.SetWithOptions(f.setValue, req)
-}
-
-func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
+// Delete performs a delete operation.
+func (f *Firestore) Delete(req *state.DeleteRequest) error {
 	ctx := context.Background()
 	key := datastore.NameKey(f.entityKind, req.Key, nil)
 
@@ -157,11 +154,6 @@ func (f *Firestore) deleteValue(req *state.DeleteRequest) error {
 	}
 
 	return nil
-}
-
-// Delete performs a delete operation.
-func (f *Firestore) Delete(req *state.DeleteRequest) error {
-	return state.DeleteWithOptions(f.deleteValue, req)
 }
 
 func getFirestoreMetadata(meta state.Metadata) (*firestoreMetadata, error) {

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -146,7 +146,7 @@ func (m *Memcached) parseTTL(req *state.SetRequest) (*int32, error) {
 	return nil, nil
 }
 
-func (m *Memcached) setValue(req *state.SetRequest) error {
+func (m *Memcached) Set(req *state.SetRequest) error {
 	var bt []byte
 	ttl, err := m.parseTTL(req)
 	if err != nil {
@@ -192,10 +192,6 @@ func (m *Memcached) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	return &state.GetResponse{
 		Data: item.Value,
 	}, nil
-}
-
-func (m *Memcached) Set(req *state.SetRequest) error {
-	return state.SetWithOptions(m.setValue, req)
 }
 
 func (m *Memcached) GetComponentMetadata() map[string]string {

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -30,7 +30,6 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/ptr"
 )
 
 // Optimistic Concurrency is implemented using a string column that stores a UUID.
@@ -337,8 +336,6 @@ func (m *MySQL) Delete(req *state.DeleteRequest) error {
 	return m.deleteValue(m.db, req)
 }
 
-// deleteValue is an internal implementation of delete to enable passing the
-// logic to state.DeleteWithRetries as a func.
 func (m *MySQL) deleteValue(querier querier, req *state.DeleteRequest) error {
 	m.logger.Debug("Deleting state value from MySql")
 
@@ -458,14 +455,14 @@ func (m *MySQL) Get(req *state.GetRequest) (*state.GetResponse, error) {
 
 		return &state.GetResponse{
 			Data:     data,
-			ETag:     ptr.Of(eTag),
+			ETag:     &eTag,
 			Metadata: req.Metadata,
 		}, nil
 	}
 
 	return &state.GetResponse{
 		Data:     value,
-		ETag:     ptr.Of(eTag),
+		ETag:     &eTag,
 		Metadata: req.Metadata,
 	}, nil
 }
@@ -476,8 +473,6 @@ func (m *MySQL) Set(req *state.SetRequest) error {
 	return m.setValue(m.db, req)
 }
 
-// setValue is an internal implementation of set to enable passing the logic
-// to state.SetWithRetries as a func.
 func (m *MySQL) setValue(querier querier, req *state.SetRequest) error {
 	m.logger.Debug("Setting state value in MySql")
 

--- a/state/postgresql/postgresql_query.go
+++ b/state/postgresql/postgresql_query.go
@@ -88,9 +88,9 @@ func (q *Query) visitFilters(op string, filters []query.Filter) (string, error) 
 		}
 	}
 
-	sep := fmt.Sprintf(" %s ", op)
+	sep := " " + op + " "
 
-	return fmt.Sprintf("(%s)", strings.Join(arr, sep)), nil
+	return "(" + strings.Join(arr, sep) + ")", nil
 }
 
 func (q *Query) VisitAND(f *query.AND) (string, error) {
@@ -102,10 +102,10 @@ func (q *Query) VisitOR(f *query.OR) (string, error) {
 }
 
 func (q *Query) Finalize(filters string, qq *query.Query) error {
-	q.query = fmt.Sprintf("SELECT key, value, xmin as etag FROM %s", q.tableName)
+	q.query = "SELECT key, value, xmin as etag FROM " + q.tableName
 
 	if filters != "" {
-		q.query += fmt.Sprintf(" WHERE %s", filters)
+		q.query += " WHERE " + filters
 	}
 
 	if len(qq.Sort) > 0 {
@@ -117,13 +117,13 @@ func (q *Query) Finalize(filters string, qq *query.Query) error {
 			}
 			q.query += translateFieldToFilter(sortItem.Key)
 			if sortItem.Order != "" {
-				q.query += fmt.Sprintf(" %s", sortItem.Order)
+				q.query += " " + sortItem.Order
 			}
 		}
 	}
 
 	if qq.Page.Limit > 0 {
-		q.query += fmt.Sprintf(" LIMIT %d", qq.Page.Limit)
+		q.query += " LIMIT " + strconv.Itoa(qq.Page.Limit)
 		q.limit = qq.Page.Limit
 	}
 
@@ -132,7 +132,7 @@ func (q *Query) Finalize(filters string, qq *query.Query) error {
 		if err != nil {
 			return err
 		}
-		q.query += fmt.Sprintf(" OFFSET %d", skip)
+		q.query += " OFFSET " + strconv.FormatInt(skip, 10)
 		q.skip = &skip
 	}
 
@@ -151,7 +151,7 @@ func (q *Query) execute(logger logger.Logger, db *sql.DB) ([]state.QueryItem, st
 		var (
 			key  string
 			data []byte
-			etag int
+			etag uint64 // Postgres uses uint32, but FormatUint requires uint64, so using uint64 directly to avoid re-allocations
 		)
 		if err = rows.Scan(&key, &data, &etag); err != nil {
 			return nil, "", err
@@ -159,7 +159,7 @@ func (q *Query) execute(logger logger.Logger, db *sql.DB) ([]state.QueryItem, st
 		result := state.QueryItem{
 			Key:  key,
 			Data: data,
-			ETag: ptr.Of(strconv.Itoa(etag)),
+			ETag: ptr.Of(strconv.FormatUint(etag, 10)),
 		}
 		ret = append(ret, result)
 	}
@@ -200,7 +200,7 @@ func translateFieldToFilter(key string) string {
 			filterField += ">"
 		}
 
-		filterField += fmt.Sprintf("'%s'", fieldPart)
+		filterField += "'" + fieldPart + "'"
 	}
 
 	return filterField
@@ -209,6 +209,6 @@ func translateFieldToFilter(key string) string {
 func (q *Query) whereFieldEqual(key string, value interface{}) string {
 	position := q.addParamValueAndReturnPosition(value)
 	filterField := translateFieldToFilter(key)
-	query := fmt.Sprintf("%s=$%v", filterField, position)
+	query := filterField + "=$" + strconv.Itoa(position)
 	return query
 }

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -196,7 +196,13 @@ func (r *StateStore) parseConnectedSlaves(res string) int {
 	return 0
 }
 
-func (r *StateStore) deleteValue(req *state.DeleteRequest) error {
+// Delete performs a delete operation.
+func (r *StateStore) Delete(req *state.DeleteRequest) error {
+	err := state.CheckRequestOptions(req.Options)
+	if err != nil {
+		return err
+	}
+
 	if req.ETag == nil {
 		etag := "0"
 		req.ETag = &etag
@@ -208,22 +214,12 @@ func (r *StateStore) deleteValue(req *state.DeleteRequest) error {
 	} else {
 		delQuery = delDefaultQuery
 	}
-	_, err := r.client.Do(r.ctx, "EVAL", delQuery, 1, req.Key, *req.ETag).Result()
+	_, err = r.client.Do(r.ctx, "EVAL", delQuery, 1, req.Key, *req.ETag).Result()
 	if err != nil {
 		return state.NewETagError(state.ETagMismatch, err)
 	}
 
 	return nil
-}
-
-// Delete performs a delete operation.
-func (r *StateStore) Delete(req *state.DeleteRequest) error {
-	err := state.CheckRequestOptions(req.Options)
-	if err != nil {
-		return err
-	}
-
-	return state.DeleteWithOptions(r.deleteValue, req)
 }
 
 func (r *StateStore) directGet(req *state.GetRequest) (*state.GetResponse, error) {
@@ -318,7 +314,8 @@ type jsonEntry struct {
 	Version *int        `json:"version,omitempty"`
 }
 
-func (r *StateStore) setValue(req *state.SetRequest) error {
+// Set saves state into redis.
+func (r *StateStore) Set(req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
@@ -382,11 +379,6 @@ func (r *StateStore) setValue(req *state.SetRequest) error {
 	}
 
 	return nil
-}
-
-// Set saves state into redis.
-func (r *StateStore) Set(req *state.SetRequest) error {
-	return state.SetWithOptions(r.setValue, req)
 }
 
 // Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail.

--- a/state/request_options.go
+++ b/state/request_options.go
@@ -66,13 +66,3 @@ func validateConsistencyOption(c string) error {
 
 	return nil
 }
-
-// SetWithOptions handles SetRequest with request options.
-func SetWithOptions(method func(req *SetRequest) error, req *SetRequest) error {
-	return method(req)
-}
-
-// DeleteWithOptions handles DeleteRequest with options.
-func DeleteWithOptions(method func(req *DeleteRequest) error, req *DeleteRequest) error {
-	return method(req)
-}

--- a/state/request_options_test.go
+++ b/state/request_options_test.go
@@ -19,31 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestSetRequestWithOptions is used to test request options.
-func TestSetRequestWithOptions(t *testing.T) {
-	t.Run("set with default options", func(t *testing.T) {
-		counter := 0
-		SetWithOptions(func(req *SetRequest) error {
-			counter++
-
-			return nil
-		}, &SetRequest{})
-		assert.Equal(t, 1, counter, "should execute only once")
-	})
-
-	t.Run("set with no explicit options", func(t *testing.T) {
-		counter := 0
-		SetWithOptions(func(req *SetRequest) error {
-			counter++
-
-			return nil
-		}, &SetRequest{
-			Options: SetStateOption{},
-		})
-		assert.Equal(t, 1, counter, "should execute only once")
-	})
-}
-
 // TestCheckRequestOptions is used to validate request options.
 func TestCheckRequestOptions(t *testing.T) {
 	t.Run("set state options", func(t *testing.T) {


### PR DESCRIPTION
- Removed `state.DeleteWithOptions` and `state.SetWithOptions` which were useless at this point (likely a leftover from when there were retries, but now they're just "passthrough" functions)
- Some improvements in etag handling in Postgres
- Other minor refactorings

Also fixed syntax errors in `bindings/rabbitmq/rabbitmq_integration_test.go`  and `pubsub/azure/eventhubs/eventhubs_integration_test.go`. Those files are unused but they kept popping up as errors in VS Code's "problems" tab