### PR TITLE
Dapr bot support labels on PRs, add support for "new component"

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -18,6 +18,8 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]
 
 jobs:
   daprbot:


### PR DESCRIPTION
# Description

Dapr bot in contrib should also get triggered on adding labels to PRs. This also adds support for handling "new component" and creating an issue in dapr/dapr.

## Issue reference

Closes #2209

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
