### PR TITLE
[Do-not-merge] Fix mqtt Pubsub re-publishing messages when application is unhealthy

### DIFF
--- a/pubsub/mqtt/metadata.go
+++ b/pubsub/mqtt/metadata.go
@@ -24,13 +24,12 @@ import (
 
 type metadata struct {
 	tlsCfg
-	url                      string
-	consumerID               string
-	producerID               string
-	qos                      byte
-	retain                   bool
-	cleanSession             bool
-	maxRetriableErrorsPerSec int
+	url          string
+	consumerID   string
+	producerID   string
+	qos          byte
+	retain       bool
+	cleanSession bool
 }
 
 type tlsCfg struct {
@@ -41,23 +40,21 @@ type tlsCfg struct {
 
 const (
 	// Keys
-	mqttURL                      = "url"
-	mqttQOS                      = "qos"
-	mqttRetain                   = "retain"
-	mqttConsumerID               = "consumerID"
-	mqttProducerID               = "producerID"
-	mqttCleanSession             = "cleanSession"
-	mqttCACert                   = "caCert"
-	mqttClientCert               = "clientCert"
-	mqttClientKey                = "clientKey"
-	mqttMaxRetriableErrorsPerSec = "maxRetriableErrorsPerSec"
+	mqttURL          = "url"
+	mqttQOS          = "qos"
+	mqttRetain       = "retain"
+	mqttConsumerID   = "consumerID"
+	mqttProducerID   = "producerID"
+	mqttCleanSession = "cleanSession"
+	mqttCACert       = "caCert"
+	mqttClientCert   = "clientCert"
+	mqttClientKey    = "clientKey"
 
 	// Defaults
-	defaultQOS                      = 1
-	defaultRetain                   = false
-	defaultWait                     = 30 * time.Second
-	defaultCleanSession             = false
-	defaultMaxRetriableErrorsPerSec = 10
+	defaultQOS          = 1
+	defaultRetain       = false
+	defaultWait         = 30 * time.Second
+	defaultCleanSession = false
 )
 
 func parseMQTTMetaData(md pubsub.Metadata, log logger.Logger) (*metadata, error) {
@@ -109,15 +106,6 @@ func parseMQTTMetaData(md pubsub.Metadata, log logger.Logger) (*metadata, error)
 		}
 	}
 
-	m.maxRetriableErrorsPerSec = defaultMaxRetriableErrorsPerSec
-	if val, ok := md.Properties[mqttMaxRetriableErrorsPerSec]; ok && val != "" {
-		var err error
-		m.maxRetriableErrorsPerSec, err = strconv.Atoi(val)
-		if err != nil {
-			return &m, fmt.Errorf("%s invalid maxRetriableErrorsPerSec %s, %s", errorMsgPrefix, val, err)
-		}
-	}
-
 	if val, ok := md.Properties[mqttCACert]; ok && val != "" {
 		if !isValidPEM(val) {
 			return &m, fmt.Errorf("%s invalid caCert", errorMsgPrefix)
@@ -141,6 +129,12 @@ func parseMQTTMetaData(md pubsub.Metadata, log logger.Logger) (*metadata, error)
 	// TODO: Remove in the future
 	if _, ok := md.Properties["backOffMaxRetries"]; ok {
 		log.Warnf("Metadata property 'backOffMaxRetries' for component pubsub.mqtt has been deprecated and will be ignored. See: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-mqtt/")
+	}
+
+	// Deprecated config option
+	// TODO: Remove in the future
+	if _, ok := md.Properties["maxRetriableErrorsPerSec"]; ok {
+		log.Warnf("Metadata property 'maxRetriableErrorsPerSec' for component pubsub.mqtt has been deprecated and will be ignored. See: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-mqtt/")
 	}
 
 	return &m, nil

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"go.uber.org/ratelimit"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
@@ -40,15 +39,14 @@ const (
 
 // mqttPubSub type allows sending and receiving data to/from MQTT broker.
 type mqttPubSub struct {
-	producer          mqtt.Client
-	consumer          mqtt.Client
-	metadata          *metadata
-	logger            logger.Logger
-	topics            map[string]mqttPubSubSubscription
-	retriableErrLimit ratelimit.Limiter
-	subscribingLock   sync.RWMutex
-	ctx               context.Context
-	cancel            context.CancelFunc
+	producer        mqtt.Client
+	consumer        mqtt.Client
+	metadata        *metadata
+	logger          logger.Logger
+	topics          map[string]mqttPubSubSubscription
+	subscribingLock sync.RWMutex
+	ctx             context.Context
+	cancel          context.CancelFunc
 }
 
 type mqttPubSubSubscription struct {
@@ -79,12 +77,6 @@ func (m *mqttPubSub) Init(metadata pubsub.Metadata) error {
 		return err
 	}
 	m.metadata = mqttMeta
-
-	if m.metadata.maxRetriableErrorsPerSec > 0 {
-		m.retriableErrLimit = ratelimit.New(m.metadata.maxRetriableErrorsPerSec)
-	} else {
-		m.retriableErrLimit = ratelimit.NewUnlimited()
-	}
 
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -247,34 +247,6 @@ func (m *mqttPubSub) startSubscription(ctx context.Context) error {
 // onMessage returns the callback to be invoked when there's a new message from a topic
 func (m *mqttPubSub) onMessage(ctx context.Context) func(client mqtt.Client, mqttMsg mqtt.Message) {
 	return func(client mqtt.Client, mqttMsg mqtt.Message) {
-		ack := false
-		defer func() {
-			// MQTT does not support NACK's, so in case of error we need to re-enqueue the message and then send a positive ACK for this message
-			// Note that if the connection drops before the message is explicitly ACK'd below, then it's automatically re-sent (assuming QoS is 1 or greater, which is the default). So we do not risk losing messages.
-			// Problem with this approach is that if the service crashes between the time the message is re-enqueued and when the ACK is sent, the message may be delivered twice
-			if !ack {
-				m.logger.Debugf("Re-publishing message %s#%d", mqttMsg.Topic(), mqttMsg.MessageID())
-				publishErr := m.Publish(&pubsub.PublishRequest{
-					Topic: mqttMsg.Topic(),
-					Data:  mqttMsg.Payload(),
-				})
-				if publishErr != nil {
-					m.logger.Errorf("Failed to re-publish message %s#%d. Error: %v", mqttMsg.Topic(), mqttMsg.MessageID(), publishErr)
-					// Return so Ack() isn't invoked
-					return
-				}
-			}
-			mqttMsg.Ack()
-
-			// If we re-published the message, consume a retriable error token
-			if !ack {
-				m.logger.Debugf("Taking a retriable error token")
-				before := time.Now()
-				_ = m.retriableErrLimit.Take()
-				m.logger.Debugf("Resumed after pausing for %v", time.Now().Sub(before))
-			}
-		}()
-
 		msg := pubsub.NewMessage{
 			Topic: mqttMsg.Topic(),
 			Data:  mqttMsg.Payload(),
@@ -294,7 +266,7 @@ func (m *mqttPubSub) onMessage(ctx context.Context) func(client mqtt.Client, mqt
 		}
 
 		m.logger.Debugf("Done processing MQTT message %s#%d; sending ACK", mqttMsg.Topic(), mqttMsg.MessageID())
-		ack = true
+		mqttMsg.Ack()
 	}
 }
 

--- a/tests/certification/pubsub/mqtt/components/consumer2/mqtt.yaml
+++ b/tests/certification/pubsub/mqtt/components/consumer2/mqtt.yaml
@@ -13,8 +13,6 @@ spec:
   - name: retain
     value: false
   - name: qos
-    value: 2
+    value: 1
   - name: cleanSession
     value: false
-  - name: backOffMaxRetries
-    value: 5

--- a/tests/certification/pubsub/mqtt/go.mod
+++ b/tests/certification/pubsub/mqtt/go.mod
@@ -18,7 +18,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a // indirect
 	github.com/PuerkitoBio/purell v1.2.0 // indirect
-	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
@@ -107,7 +106,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.11.1 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.1.0 // indirect

--- a/tests/certification/pubsub/mqtt/go.sum
+++ b/tests/certification/pubsub/mqtt/go.sum
@@ -49,8 +49,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
-github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -515,8 +513,6 @@ go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
-go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
-go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -42,7 +42,7 @@ const (
 	defaultMultiTopic1Name        = "multiTopic1"
 	defaultMultiTopic2Name        = "multiTopic2"
 	defaultMessageCount           = 10
-	defaultMaxReadDuration        = 180 * time.Second
+	defaultMaxReadDuration        = 240 * time.Second
 	defaultWaitDurationToPublish  = 5 * time.Second
 	defaultCheckInOrderProcessing = true
 	defaultMaxBulkCount           = 5

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -42,7 +42,7 @@ const (
 	defaultMultiTopic1Name        = "multiTopic1"
 	defaultMultiTopic2Name        = "multiTopic2"
 	defaultMessageCount           = 10
-	defaultMaxReadDuration        = 60 * time.Second
+	defaultMaxReadDuration        = 180 * time.Second
 	defaultWaitDurationToPublish  = 5 * time.Second
 	defaultCheckInOrderProcessing = true
 	defaultMaxBulkCount           = 5

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -42,7 +42,7 @@ const (
 	defaultMultiTopic1Name        = "multiTopic1"
 	defaultMultiTopic2Name        = "multiTopic2"
 	defaultMessageCount           = 10
-	defaultMaxReadDuration        = 240 * time.Second
+	defaultMaxReadDuration        = 600 * time.Second
 	defaultWaitDurationToPublish  = 5 * time.Second
 	defaultCheckInOrderProcessing = true
 	defaultMaxBulkCount           = 5


### PR DESCRIPTION
# Description

MQTT pub-sub currently re-publishes the messages once the handler returns error. This causes same message being re-delivered indefinitely even to other applications which are healthy and subscribed to same topic. This PR removes re-publishing logic as well as associated metadata. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2309 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
