### PR TITLE
Allow non-200 responses to be treated as non-errors

### DIFF
--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -56,7 +56,6 @@ type TestCase struct {
 }
 
 func (tc TestCase) ToInvokeRequest() bindings.InvokeRequest {
-
 	requestMetadata := tc.metadata
 
 	if requestMetadata == nil {
@@ -110,7 +109,6 @@ func NewHttpHandler() *HttpHandler {
 }
 
 func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.OutputBinding, error) {
-
 	m := bindings.Metadata{Base: metadata.Base{
 		Properties: map[string]string{
 			"url": s.URL,
@@ -289,7 +287,6 @@ func TestDefaultBehavior(t *testing.T) {
 }
 
 func TestNon2XXErrorsSuppressed(t *testing.T) {
-
 	handler := NewHttpHandler()
 	s := httptest.NewServer(handler)
 	defer s.Close()

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -45,153 +46,239 @@ func TestOperations(t *testing.T) {
 	}, opers)
 }
 
-func TestInit(t *testing.T) {
-	var path string
+type TestCase struct {
+	input      string
+	operation  string
+	metadata   map[string]string
+	path       string
+	err        string
+	statusCode int
+}
 
-	s := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			path = req.URL.Path
-			input := req.Method
-			if req.Body != nil {
-				defer req.Body.Close()
-				b, _ := io.ReadAll(req.Body)
-				if len(b) > 0 {
-					input = string(b)
-				}
-			}
-			inputFromHeader := req.Header.Get("X-Input")
-			if inputFromHeader != "" {
-				input = inputFromHeader
-			}
-			w.Header().Set("Content-Type", "text/plain")
-			if input == "internal server error" {
-				w.WriteHeader(http.StatusInternalServerError)
-			}
-			w.Write([]byte(strings.ToUpper(input)))
-		}),
-	)
-	defer s.Close()
+func (tc TestCase) ToInvokeRequest() bindings.InvokeRequest {
+
+	requestMetadata := tc.metadata
+
+	if requestMetadata == nil {
+		requestMetadata = map[string]string{}
+	}
+
+	requestMetadata["X-Status-Code"] = strconv.Itoa(tc.statusCode)
+
+	return bindings.InvokeRequest{
+		Data:      []byte(tc.input),
+		Metadata:  requestMetadata,
+		Operation: bindings.OperationKind(tc.operation),
+	}
+}
+
+type HttpHandler struct {
+	Path string
+}
+
+func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.Path = req.URL.Path
+
+	input := req.Method
+	if req.Body != nil {
+		defer req.Body.Close()
+		b, _ := io.ReadAll(req.Body)
+		if len(b) > 0 {
+			input = string(b)
+		}
+	}
+	inputFromHeader := req.Header.Get("X-Input")
+	if inputFromHeader != "" {
+		input = inputFromHeader
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+
+	statusCode := req.Header.Get("X-Status-Code")
+	if statusCode != "" {
+		code, _ := strconv.Atoi(statusCode)
+		w.WriteHeader(code)
+	}
+
+	w.Write([]byte(strings.ToUpper(input)))
+}
+
+func NewHttpHandler() *HttpHandler {
+	return &HttpHandler{
+		Path: "/",
+	}
+}
+
+func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.OutputBinding, error) {
 
 	m := bindings.Metadata{Base: metadata.Base{
 		Properties: map[string]string{
 			"url": s.URL,
 		},
 	}}
+
+	if extraProps != nil {
+		for k, v := range extraProps {
+			m.Properties[k] = v
+		}
+	}
+
 	hs := bindingHttp.NewHTTP(logger.NewLogger("test"))
 	err := hs.Init(m)
+	return hs, err
+}
+
+func TestInit(t *testing.T) {
+	handler := NewHttpHandler()
+	s := httptest.NewServer(handler)
+	defer s.Close()
+
+	_, err := InitBinding(s, nil)
+	require.NoError(t, err)
+}
+
+func TestDefaultBehavior(t *testing.T) {
+	handler := NewHttpHandler()
+	s := httptest.NewServer(handler)
+	defer s.Close()
+
+	hs, err := InitBinding(s, nil)
 	require.NoError(t, err)
 
-	tests := map[string]struct {
-		input     string
-		operation string
-		metadata  map[string]string
-		path      string
-		err       string
-	}{
+	tests := map[string]TestCase{
 		"get": {
-			input:     "GET",
-			operation: "get",
-			metadata:  nil,
-			path:      "/",
-			err:       "",
+			input:      "GET",
+			operation:  "get",
+			metadata:   nil,
+			path:       "/",
+			err:        "",
+			statusCode: 200,
 		},
 		"request headers": {
-			input:     "OVERRIDE",
-			operation: "get",
-			metadata:  map[string]string{"X-Input": "override"},
-			path:      "/",
-			err:       "",
+			input:      "OVERRIDE",
+			operation:  "get",
+			metadata:   map[string]string{"X-Input": "override"},
+			path:       "/",
+			err:        "",
+			statusCode: 200,
 		},
 		"post": {
-			input:     "expected",
-			operation: "post",
-			metadata:  map[string]string{"path": "/test"},
-			path:      "/test",
-			err:       "",
+			input:      "expected",
+			operation:  "post",
+			metadata:   map[string]string{"path": "/test"},
+			path:       "/test",
+			err:        "",
+			statusCode: 201,
 		},
 		"put": {
-			input:     "expected",
-			operation: "put",
-			metadata:  map[string]string{"path": "/test"},
-			path:      "/test",
-			err:       "",
+			input:      "expected",
+			operation:  "put",
+			statusCode: 204,
+			metadata:   map[string]string{"path": "/test"},
+			path:       "/test",
+			err:        "",
 		},
 		"patch": {
-			input:     "expected",
-			operation: "patch",
-			metadata:  map[string]string{"path": "/test"},
-			path:      "/test",
-			err:       "",
+			input:      "expected",
+			operation:  "patch",
+			metadata:   map[string]string{"path": "/test"},
+			path:       "/test",
+			err:        "",
+			statusCode: 206,
 		},
 		"delete": {
-			input:     "DELETE",
-			operation: "delete",
-			metadata:  nil,
-			path:      "/",
-			err:       "",
+			input:      "DELETE",
+			operation:  "delete",
+			metadata:   nil,
+			path:       "/",
+			err:        "",
+			statusCode: 200,
 		},
 		"options": {
-			input:     "OPTIONS",
-			operation: "options",
-			metadata:  nil,
-			path:      "/",
-			err:       "",
+			input:      "OPTIONS",
+			operation:  "options",
+			metadata:   nil,
+			path:       "/",
+			err:        "",
+			statusCode: 200,
 		},
 		"trace": {
-			input:     "TRACE",
-			operation: "trace",
-			metadata:  nil,
-			path:      "/",
-			err:       "",
+			input:      "TRACE",
+			operation:  "trace",
+			metadata:   nil,
+			path:       "/",
+			err:        "",
+			statusCode: 200,
 		},
 		"backward compatibility": {
-			input:     "expected",
-			operation: "create",
-			metadata:  map[string]string{"path": "/test"},
-			path:      "/test",
-			err:       "",
+			input:      "expected",
+			operation:  "create",
+			metadata:   map[string]string{"path": "/test"},
+			path:       "/test",
+			err:        "",
+			statusCode: 200,
 		},
 		"invalid path": {
-			input:     "expected",
-			operation: "POST",
-			metadata:  map[string]string{"path": "/../test"},
-			path:      "",
-			err:       "invalid path: /../test",
+			input:      "expected",
+			operation:  "POST",
+			metadata:   map[string]string{"path": "/../test"},
+			path:       "",
+			err:        "invalid path: /../test",
+			statusCode: 400,
 		},
 		"invalid operation": {
-			input:     "notvalid",
-			operation: "notvalid",
-			metadata:  map[string]string{"path": "/test"},
-			path:      "/test",
-			err:       "invalid operation: notvalid",
+			input:      "notvalid",
+			operation:  "notvalid",
+			metadata:   map[string]string{"path": "/test"},
+			path:       "/test",
+			err:        "invalid operation: notvalid",
+			statusCode: 400,
 		},
 		"internal server error": {
-			input:     "internal server error",
-			operation: "post",
-			metadata:  map[string]string{"path": "/"},
-			path:      "/",
-			err:       "received status code 500",
+			input:      "internal server error",
+			operation:  "post",
+			metadata:   map[string]string{"path": "/"},
+			path:       "/",
+			err:        "received status code 500",
+			statusCode: 500,
 		},
 		"internal server error suppressed": {
-			input:     "internal server error", // trigger 500
-			operation: "post",
-			metadata:  map[string]string{"path": "/", "errorIfNot2XX": "false"},
-			path:      "/",
-			err:       "",
+			input:      "internal server error", // trigger 500 downstream
+			operation:  "post",
+			metadata:   map[string]string{"path": "/", "errorIfNot2XX": "false"},
+			path:       "/",
+			err:        "",
+			statusCode: 500,
+		},
+		"redirect should not yield an error": {
+			input:      "show me the treasure!",
+			operation:  "post",
+			metadata:   map[string]string{"path": "/", "errorIfNot2XX": "false"},
+			path:       "/",
+			err:        "",
+			statusCode: 302,
+		},
+		"redirect results in an error if not suppressed": {
+			input:      "show me the treasure!",
+			operation:  "post",
+			metadata:   map[string]string{"path": "/"},
+			path:       "/",
+			err:        "received status code 302",
+			statusCode: 302,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := hs.Invoke(context.TODO(), &bindings.InvokeRequest{
-				Data:      []byte(tc.input),
-				Metadata:  tc.metadata,
-				Operation: bindings.OperationKind(tc.operation),
-			})
+			req := tc.ToInvokeRequest()
+			response, err := hs.Invoke(context.TODO(), &req)
 			if tc.err == "" {
 				require.NoError(t, err)
-				assert.Equal(t, tc.path, path)
-				assert.Equal(t, strings.ToUpper(tc.input), string(response.Data))
+				assert.Equal(t, tc.path, handler.Path)
+				if tc.statusCode != 204 {
+					// 204 will return no content, so we should skip checking
+					assert.Equal(t, strings.ToUpper(tc.input), string(response.Data))
+				}
 				assert.Equal(t, "text/plain", response.Metadata["Content-Type"])
 			} else {
 				require.Error(t, err)
@@ -199,55 +286,79 @@ func TestInit(t *testing.T) {
 			}
 		})
 	}
+}
 
-	// Test with errorIfNot2XX set to false
-	hs = bindingHttp.NewHTTP(logger.NewLogger("test"))
-	m.Properties["errorIfNot2XX"] = "false"
+func TestNon2XXErrorsSuppressed(t *testing.T) {
 
-	initErr := hs.Init(m)
-	require.NoError(t, initErr)
+	handler := NewHttpHandler()
+	s := httptest.NewServer(handler)
+	defer s.Close()
 
-	tests = map[string]struct {
-		input     string
-		operation string
-		metadata  map[string]string
-		path      string
-		err       string
-	}{
+	hs, err := InitBinding(s, map[string]string{"errorIfNot2XX": "false"})
+	require.NoError(t, err)
+
+	tests := map[string]TestCase{
 		"internal server error": {
-			input:     "internal server error",
-			operation: "post",
-			metadata:  map[string]string{"path": "/"},
-			path:      "/",
-			err:       "",
+			input:      "internal server error",
+			operation:  "post",
+			metadata:   map[string]string{"path": "/"},
+			path:       "/",
+			err:        "",
+			statusCode: 500,
 		},
 		"internal server error overridden": {
-			input:     "internal server error",
-			operation: "post",
-			metadata:  map[string]string{"path": "/", "errorIfNot2XX": "true"},
-			path:      "/",
-			err:       "received status code 500",
+			input:      "internal server error",
+			operation:  "post",
+			metadata:   map[string]string{"path": "/", "errorIfNot2XX": "true"},
+			path:       "/",
+			err:        "received status code 500",
+			statusCode: 500,
 		},
 		"internal server error suppressed by request and component": {
-			input:     "internal server error", // trigger 500
-			operation: "post",
-			metadata:  map[string]string{"path": "/", "errorIfNot2XX": "false"},
-			path:      "/",
-			err:       "",
+			input:      "internal server error", // trigger 500
+			operation:  "post",
+			metadata:   map[string]string{"path": "/", "errorIfNot2XX": "false"},
+			path:       "/",
+			err:        "",
+			statusCode: 500,
+		},
+		"trace": {
+			input:      "TRACE",
+			operation:  "trace",
+			metadata:   nil,
+			path:       "/",
+			err:        "",
+			statusCode: 200,
+		},
+		"backward compatibility": {
+			input:      "expected",
+			operation:  "create",
+			metadata:   map[string]string{"path": "/test"},
+			path:       "/test",
+			err:        "",
+			statusCode: 200,
+		},
+		"invalid path": {
+			input:      "expected",
+			operation:  "POST",
+			metadata:   map[string]string{"path": "/../test"},
+			path:       "",
+			err:        "invalid path: /../test",
+			statusCode: 400,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := hs.Invoke(context.TODO(), &bindings.InvokeRequest{
-				Data:      []byte(tc.input),
-				Metadata:  tc.metadata,
-				Operation: bindings.OperationKind(tc.operation),
-			})
+			req := tc.ToInvokeRequest()
+			response, err := hs.Invoke(context.TODO(), &req)
 			if tc.err == "" {
 				require.NoError(t, err)
-				assert.Equal(t, tc.path, path)
-				assert.Equal(t, strings.ToUpper(tc.input), string(response.Data))
+				assert.Equal(t, tc.path, handler.Path)
+				if tc.statusCode != 204 {
+					// 204 will return no content, so we should skip checking
+					assert.Equal(t, strings.ToUpper(tc.input), string(response.Data))
+				}
 				assert.Equal(t, "text/plain", response.Metadata["Content-Type"])
 			} else {
 				require.Error(t, err)

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -71,11 +71,11 @@ func (tc TestCase) ToInvokeRequest() bindings.InvokeRequest {
 	}
 }
 
-type HttpHandler struct {
+type HTTPHandler struct {
 	Path string
 }
 
-func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.Path = req.URL.Path
 
 	input := req.Method
@@ -102,8 +102,8 @@ func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte(strings.ToUpper(input)))
 }
 
-func NewHttpHandler() *HttpHandler {
-	return &HttpHandler{
+func NewHTTPHandler() *HTTPHandler {
+	return &HTTPHandler{
 		Path: "/",
 	}
 }
@@ -127,7 +127,7 @@ func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.Out
 }
 
 func TestInit(t *testing.T) {
-	handler := NewHttpHandler()
+	handler := NewHTTPHandler()
 	s := httptest.NewServer(handler)
 	defer s.Close()
 
@@ -136,7 +136,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestDefaultBehavior(t *testing.T) {
-	handler := NewHttpHandler()
+	handler := NewHTTPHandler()
 	s := httptest.NewServer(handler)
 	defer s.Close()
 
@@ -287,7 +287,7 @@ func TestDefaultBehavior(t *testing.T) {
 }
 
 func TestNon2XXErrorsSuppressed(t *testing.T) {
-	handler := NewHttpHandler()
+	handler := NewHTTPHandler()
 	s := httptest.NewServer(handler)
 	defer s.Close()
 


### PR DESCRIPTION
# Description

Adding support for an optional metadata field `treatNon200AsError` that will prevent the binding from returning an error object when the upstream service returns a non-2xx error; this component keeps the existing behavior by default (i.e a 500 or other status code will result in an error being returned), which will unfortunately swallow the HTTP server's response. 

## Issue reference

This is related to an issue opened in the Java SDK (https://github.com/dapr/java-sdk/issues/783) -- while this won't fix the open issue immediately it will allow for clients to decide if they want to receive the response object even if the response is not 2xx. 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation (will open a PR from https://github.com/dapr/docs/compare/v1.9...johnewart:http_binding_update?expand=1)