### PR TITLE
Hotfix: Cosmosdb StateTransactionRequest with etag crash

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -360,7 +360,7 @@ func (c *StateStore) Multi(request *state.TransactionalStateRequest) (err error)
 	numOperations := 0
 	// Loop through the list of operations. Create and add the operation to the batch
 	for _, o := range request.Operations {
-		var options *azcosmos.TransactionalBatchItemOptions
+		options := &azcosmos.TransactionalBatchItemOptions{}
 
 		if o.Operation == state.Upsert {
 			req := o.Request.(state.SetRequest)

--- a/tests/certification/state/azure/cosmosdb/cosmosdb_test.go
+++ b/tests/certification/state/azure/cosmosdb/cosmosdb_test.go
@@ -161,7 +161,7 @@ func TestAzureCosmosDBStorage(t *testing.T) {
 		Step("Run basic test with master key", basicTest("statestore-basic")).
 		Run()
 
-	flow.New(t, "Test etag operations").
+	flow.New(t, "Test transaction operations").
 		// Run the Dapr sidecar with azure CosmosDB storage.
 		Step(sidecar.Run(sidecarNamePrefix,
 			embedded.WithoutApp(),
@@ -169,7 +169,7 @@ func TestAzureCosmosDBStorage(t *testing.T) {
 			embedded.WithDaprHTTPPort(currentHTTPPort),
 			embedded.WithComponentsPath("./components/basictest"),
 			componentRuntimeOptions())).
-		Step("Run basic test with master key", transactionsTest("statestore-basic")).
+		Step("Run transaction test with etag present", transactionsTest("statestore-basic")).
 		Run()
 
 	flow.New(t, "Test basic operations with different partition keys").
@@ -183,16 +183,16 @@ func TestAzureCosmosDBStorage(t *testing.T) {
 		Step("Run basic test with multiple parition keys", partitionTest("statestore-basic")).
 		Run()
 
-	// flow.New(t, "Test AAD authentication").
-	// 	// Run the Dapr sidecar with azure CosmosDB storage.
-	// 	Step(sidecar.Run(sidecarNamePrefix,
-	// 		embedded.WithoutApp(),
-	// 		embedded.WithDaprGRPCPort(currentGrpcPort),
-	// 		embedded.WithDaprHTTPPort(currentHTTPPort),
-	// 		embedded.WithComponentsPath("./components/aadtest"),
-	// 		componentRuntimeOptions())).
-	// 	Step("Run basic test with Azure AD Authentication", basicTest("statestore-aad")).
-	// 	Run()
+	flow.New(t, "Test AAD authentication").
+		// Run the Dapr sidecar with azure CosmosDB storage.
+		Step(sidecar.Run(sidecarNamePrefix,
+			embedded.WithoutApp(),
+			embedded.WithDaprGRPCPort(currentGrpcPort),
+			embedded.WithDaprHTTPPort(currentHTTPPort),
+			embedded.WithComponentsPath("./components/aadtest"),
+			componentRuntimeOptions())).
+		Step("Run basic test with Azure AD Authentication", basicTest("statestore-aad")).
+		Run()
 }
 
 func componentRuntimeOptions() []runtime.Option {


### PR DESCRIPTION
Signed-off-by: Ryan Lettieri <ryanLettieri@microsoft.com>

# Description

Changed an asterisk to an ampersand to fix a nil pointer being dereferenced.

## Issue reference

When attempting to create a state transaction request in cosmosDB with an etag, a nil pointer was being dereferenced.

This PR will close: #[_[2319]_](https://github.com/dapr/components-contrib/issues/2319)

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
