### PR TITLE
re-connecting to broker in case of mqtt handler failure

### DIFF
--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -245,6 +245,15 @@ func (m *mqttPubSub) startSubscription(ctx context.Context) error {
 	return nil
 }
 
+func (m *mqttPubSub) reconnect() error {
+	m.subscribingLock.Lock()
+	defer m.subscribingLock.Unlock()
+
+	m.resetSubscription()
+
+	return m.startSubscription(m.ctx)
+}
+
 // onMessage returns the callback to be invoked when there's a new message from a topic
 func (m *mqttPubSub) onMessage(ctx context.Context) func(client mqtt.Client, mqttMsg mqtt.Message) {
 	return func(client mqtt.Client, mqttMsg mqtt.Message) {
@@ -253,22 +262,14 @@ func (m *mqttPubSub) onMessage(ctx context.Context) func(client mqtt.Client, mqt
 			// MQTT does not support NACK's, so in case of error we need to re-enqueue the message and then send a positive ACK for this message
 			// Note that if the connection drops before the message is explicitly ACK'd below, then it's automatically re-sent (assuming QoS is 1 or greater, which is the default). So we do not risk losing messages.
 			// Problem with this approach is that if the service crashes between the time the message is re-enqueued and when the ACK is sent, the message may be delivered twice
-			if !ack {
-				m.logger.Debugf("Re-publishing message %s#%d", mqttMsg.Topic(), mqttMsg.MessageID())
-				publishErr := m.Publish(&pubsub.PublishRequest{
-					Topic: mqttMsg.Topic(),
-					Data:  mqttMsg.Payload(),
-				})
-				if publishErr != nil {
-					m.logger.Errorf("Failed to re-publish message %s#%d. Error: %v", mqttMsg.Topic(), mqttMsg.MessageID(), publishErr)
-					// Return so Ack() isn't invoked
-					return
+			if ack {
+				mqttMsg.Ack()
+			} else {
+				if err := m.reconnect(); err != nil {
+					m.logger.Errorf("Failed re-connecting to broker. Error: %v", err)
 				}
-			}
-			mqttMsg.Ack()
 
-			// If we re-published the message, consume a retriable error token
-			if !ack {
+				// If we reconnected to broker, consume a retriable error token
 				m.logger.Debugf("Taking a retriable error token")
 				before := time.Now()
 				_ = m.retriableErrLimit.Take()


### PR DESCRIPTION
Signed-off-by: shivam <shivamkm07@gmail.com>

# Description

MQTT pub-sub currently re-publishes the messages once the handler returns error. This causes same message being re-delivered indefinitely even to other applications which are healthy and subscribed to same topic. This PR removes re-publishing logic and replaces with re-connecting logic where dapr sidecar disconnects and re-connects to broker to trigger broker re-sending unacknowledged messages.

Note that mqtt as per it's spec doesn't re-send unacknowledged messages unless there is re-connection. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2309 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
