### PR TITLE
[Hotfix release-1.9] MQTT PubSub: Resume subscriptions after a reconnection

### DIFF
--- a/pubsub/mqtt/metadata.go
+++ b/pubsub/mqtt/metadata.go
@@ -145,3 +145,29 @@ func parseMQTTMetaData(md pubsub.Metadata, log logger.Logger) (*metadata, error)
 
 	return &m, nil
 }
+
+// GetProducerClientID returns the client ID to use for the producer connection.
+func (m metadata) GetProducerClientID() string {
+	// First, let's use the value of producerID if set
+	producerClientID := m.producerID
+	if producerClientID == "" {
+		// If not set, fallback to consumerID + the "-producer" suffix.
+		// For backwards-compatibility; see: https://github.com/dapr/components-contrib/pull/2104
+		producerClientID = m.consumerID + "-producer"
+	}
+	return producerClientID
+}
+
+// GetConsumerClientID returns the client ID to use for the consumer connection.
+func (m metadata) GetConsumerClientID() string {
+	// Get the consumerID from the metadata
+	consumerClientID := m.consumerID
+
+	// The use of "producerID" here is not a typo and is due to legacy reasons (see https://github.com/dapr/components-contrib/pull/2104)
+	// If there's no producerID, it means that the consumerID was used for both consumer and producer, so we need to add the "-consumer" suffix.
+	if m.producerID == "" {
+		consumerClientID += "-consumer"
+	}
+
+	return consumerClientID
+}

--- a/pubsub/mqtt/mqtt.go
+++ b/pubsub/mqtt/mqtt.go
@@ -323,7 +323,7 @@ func (m *mqttPubSub) connect(ctx context.Context, clientID string, isConsumer bo
 	if isConsumer {
 		sendNotification := func() {
 			if readyCh != nil {
-				readyCh <- struct{}{}
+				close(readyCh)
 				readyCh = nil
 			}
 		}

--- a/tests/certification/pubsub/mqtt/mqtt_test.go
+++ b/tests/certification/pubsub/mqtt/mqtt_test.go
@@ -321,7 +321,7 @@ func TestMQTT(t *testing.T) {
 		//
 		// Send messages and test
 		Step("send and wait", test(topicName, consumerGroup1)).
-		Step("reset", flow.Reset(consumerGroup1)).
+		Step("reset 1", flow.Reset(consumerGroup1)).
 		//
 		//Run Second application App2
 		Step(app.Run(appID2, fmt.Sprintf(":%d", appPort+portOffset),
@@ -338,7 +338,7 @@ func TestMQTT(t *testing.T) {
 		//
 		// Send messages and test
 		Step("multiple send and wait", multipleTest(consumerGroup1, consumerGroup2)).
-		Step("reset", flow.Reset(consumerGroup1, consumerGroup2)).
+		Step("reset 2", flow.Reset(consumerGroup1, consumerGroup2)).
 		//
 		// Test multiple topics and wildcards
 		Step(
@@ -364,13 +364,13 @@ func TestMQTT(t *testing.T) {
 		Step("send and wait shared", test(sharedTopicPublish, consumerGroupMultiShared)).
 		//
 		// Infra test
-		StepAsync("steady flow of messages to publish", &task,
+		StepAsync("steady flow of messages to publish 1", &task,
 			sendMessagesInBackground(consumerGroup1, consumerGroup2)).
-		Step("wait", flow.Sleep(5*time.Second)).
+		Step("wait 1", flow.Sleep(5*time.Second)).
 		Step("stop sidecar 2", sidecar.Stop(sidecarName2)).
-		Step("wait", flow.Sleep(5*time.Second)).
+		Step("wait 2", flow.Sleep(5*time.Second)).
 		Step("stop sidecar 1", sidecar.Stop(sidecarName1)).
-		Step("wait", flow.Sleep(5*time.Second)).
+		Step("wait 3", flow.Sleep(5*time.Second)).
 		Step(sidecar.Run(sidecarName2,
 			embedded.WithComponentsPath("./components/consumer2"),
 			embedded.WithAppProtocol(runtime.HTTPProtocol, appPort+portOffset),
@@ -379,7 +379,7 @@ func TestMQTT(t *testing.T) {
 			embedded.WithProfilePort(runtime.DefaultProfilePort+portOffset),
 			componentRuntimeOptions(),
 		)).
-		Step("wait", flow.Sleep(5*time.Second)).
+		Step("wait 4", flow.Sleep(5*time.Second)).
 		Step(sidecar.Run(sidecarName1,
 			embedded.WithComponentsPath("./components/consumer1"),
 			embedded.WithAppProtocol(runtime.HTTPProtocol, appPort),
@@ -387,24 +387,24 @@ func TestMQTT(t *testing.T) {
 			embedded.WithDaprHTTPPort(runtime.DefaultDaprHTTPPort),
 			componentRuntimeOptions(),
 		)).
-		Step("wait", flow.Sleep(5*time.Second)).
-		Step("assert messages", assertMessages(consumerGroup1, consumerGroup2)).
-		Step("reset", flow.Reset(consumerGroup1, consumerGroup2)).
+		Step("wait 5", flow.Sleep(10*time.Second)).
+		Step("assert messages 1", assertMessages(consumerGroup1, consumerGroup2)).
+		Step("reset 3", flow.Reset(consumerGroup1, consumerGroup2)).
 		//
 		// Simulate a network interruption.
 		// This tests the components ability to handle reconnections
 		// when Dapr is disconnected abnormally.
-		StepAsync("steady flow of messages to publish", &task,
+		StepAsync("steady flow of messages to publish 2", &task,
 			sendMessagesInBackground(consumerGroup1, consumerGroup2)).
-		Step("wait", flow.Sleep(5*time.Second)).
+		Step("wait 6", flow.Sleep(15*time.Second)).
 		//
 		// Errors will occurring here.
 		Step("interrupt network",
-			network.InterruptNetwork(5*time.Second, nil, nil, "18084")).
+			network.InterruptNetwork(10*time.Second, nil, nil, "18084")).
 		//
 		// Component should recover at this point.
-		Step("wait", flow.Sleep(5*time.Second)).
-		Step("assert messages", assertMessages(consumerGroup1, consumerGroup2)).
+		Step("wait 7", flow.Sleep(15*time.Second)).
+		Step("assert messages 2", assertMessages(consumerGroup1, consumerGroup2)).
 		Run()
 }
 

--- a/tests/config/pubsub/mqtt/mosquitto/pubsub.yml
+++ b/tests/config/pubsub/mqtt/mosquitto/pubsub.yml
@@ -16,5 +16,3 @@ spec:
     value: 1
   - name: cleanSession
     value: false
-  - name: backOffMaxRetries
-    value: 5


### PR DESCRIPTION
Extracted from #2350 with the fix for the MQTT PubSub component only

The fix for the MQTT binding component will not be included in the hotfix