### PR TITLE
Add domain and apiPrefix for JetStream

### DIFF
--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -68,7 +68,7 @@ func (js *jetstreamPubSub) Init(metadata pubsub.Metadata) error {
 	}
 	js.l.Debugf("Connected to nats at %s", js.meta.natsURL)
 
-	js.jsc, err = js.nc.JetStream()
+	js.jsc, err = js.nc.JetStream(nats.Domain(js.meta.domain), nats.APIPrefix(js.meta.apiPrefix))
 	if err != nil {
 		return err
 	}

--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -68,7 +68,17 @@ func (js *jetstreamPubSub) Init(metadata pubsub.Metadata) error {
 	}
 	js.l.Debugf("Connected to nats at %s", js.meta.natsURL)
 
-	js.jsc, err = js.nc.JetStream(nats.Domain(js.meta.domain), nats.APIPrefix(js.meta.apiPrefix))
+	jsOpts := []nats.JSOpt{}
+
+	if js.meta.domain != "" {
+		jsOpts = append(jsOpts, nats.Domain(js.meta.domain))
+	}
+
+	if js.meta.apiPrefix != "" {
+		jsOpts = append(jsOpts, nats.APIPrefix(js.meta.apiPrefix))
+	}
+
+	js.jsc, err = js.nc.JetStream(jsOpts...)
 	if err != nil {
 		return err
 	}

--- a/pubsub/jetstream/metadata.go
+++ b/pubsub/jetstream/metadata.go
@@ -51,6 +51,8 @@ type metadata struct {
 	hearbeat       time.Duration
 	deliverPolicy  nats.DeliverPolicy
 	ackPolicy      nats.AckPolicy
+	domain         string
+	apiPrefix      string
 }
 
 func parseMetadata(psm pubsub.Metadata) (metadata, error) {
@@ -141,6 +143,13 @@ func parseMetadata(psm pubsub.Metadata) (metadata, error) {
 
 	if v, err := time.ParseDuration(psm.Properties["hearbeat"]); err == nil {
 		m.hearbeat = v
+	}
+
+	if domain := psm.Properties["domain"]; domain != "" {
+		m.domain = domain
+	}
+	if apiPrefix := psm.Properties["apiPrefix"]; apiPrefix != "" {
+		m.apiPrefix = apiPrefix
 	}
 
 	deliverPolicy := psm.Properties["deliverPolicy"]

--- a/pubsub/jetstream/metadata_test.go
+++ b/pubsub/jetstream/metadata_test.go
@@ -50,6 +50,7 @@ func TestParseMetadata(t *testing.T) {
 					"memoryStorage":  "true",
 					"rateLimit":      "20000",
 					"hearbeat":       "1s",
+					"domain":         "hub",
 				},
 			}},
 			want: metadata{
@@ -70,6 +71,7 @@ func TestParseMetadata(t *testing.T) {
 				hearbeat:       time.Second * 1,
 				deliverPolicy:  nats.DeliverAllPolicy,
 				ackPolicy:      nats.AckExplicitPolicy,
+				domain:         "hub",
 			},
 			expectErr: false,
 		},
@@ -95,6 +97,7 @@ func TestParseMetadata(t *testing.T) {
 					"deliverPolicy":  "sequence",
 					"startSequence":  "5",
 					"ackPolicy":      "all",
+					"apiPrefix":      "HUB",
 				},
 			}},
 			want: metadata{
@@ -116,6 +119,7 @@ func TestParseMetadata(t *testing.T) {
 				token:          "myToken",
 				deliverPolicy:  nats.DeliverByStartSequencePolicy,
 				ackPolicy:      nats.AckAllPolicy,
+				apiPrefix:      "HUB",
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

# Description

Adds ability to setup domain and api prefix for JetStream.
This would still require two instances of JetStream - one for publishing, targeted at original stream and one domain with a mirror.

## Issue reference

https://github.com/dapr/components-contrib/issues/2265

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
