### PR TITLE
Fix State Azure Blob cert test

### DIFF
--- a/tests/certification/state/azure/blobstorage/components/aadtest/blobaad.yaml
+++ b/tests/certification/state/azure/blobstorage/components/aadtest/blobaad.yaml
@@ -9,10 +9,6 @@ spec:
       secretKeyRef:
         name: AzureBlobStorageAccount
         key: AzureBlobStorageAccount
-    - name: accountKey
-      secretKeyRef:
-        name: AzureBlobStorageAccessKey
-        key: AzureBlobStorageAccessKey
     - name: azureTenantId
       secretKeyRef:
         name: AzureCertificationTenantId


### PR DESCRIPTION
State Azure Blob Cert test: AAD test was not actually using AAD

Signed-off-by: Bernd Verst <github@bernd.dev>

Fix certification test.