### PR TITLE
Fix bug in ASB pubsub

### DIFF
--- a/internal/component/azure/servicebus/subscription.go
+++ b/internal/component/azure/servicebus/subscription.go
@@ -363,8 +363,10 @@ func (s *Subscription) RenewLocksBlocking(ctx context.Context, receiver Receiver
 				// Snapshot the messages to try to renew locks for.
 				s.mu.RLock()
 				msgs := make([]*azservicebus.ReceivedMessage, 0, len(s.activeMessages))
+				var i int
 				for _, m := range s.activeMessages {
-					msgs = append(msgs, m)
+					msgs[i] = m
+					i++
 				}
 				s.mu.RUnlock()
 

--- a/internal/component/azure/servicebus/subscription.go
+++ b/internal/component/azure/servicebus/subscription.go
@@ -362,9 +362,9 @@ func (s *Subscription) RenewLocksBlocking(ctx context.Context, receiver Receiver
 			} else {
 				// Snapshot the messages to try to renew locks for.
 				s.mu.RLock()
-				msgs := make([]*azservicebus.ReceivedMessage, len(s.activeMessages))
-				for i, m := range s.activeMessages {
-					msgs[i] = m
+				msgs := make([]*azservicebus.ReceivedMessage, 0, len(s.activeMessages))
+				for _, m := range s.activeMessages {
+					msgs = append(msgs, m)
 				}
 				s.mu.RUnlock()
 


### PR DESCRIPTION
Signed-off-by: Joni Collinge <jonathancollinge@live.com>

# Description
[Reverts changes to active message snapshotting](https://github.com/dapr/components-contrib/pull/2346#discussion_r1052712437) as `activeMessages` is a map of message sequence number -> message and is being flattened to a slice. Reference: https://github.com/dapr/components-contrib/pull/2438#discussion_r1070259105. cc: @mukundansundar 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
