### PR TITLE
bindings.localstorage fixes

### DIFF
--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -210,8 +210,12 @@ func (ls *LocalStorage) get(filename string, req *bindings.InvokeRequest) (*bind
 
 	f, err := os.Open(absPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("file not found: %s", absPath)
+		}
 		return nil, fmt.Errorf("error opening path %s: %w", absPath, err)
 	}
+	defer f.Close()
 
 	b, err := io.ReadAll(f)
 	if err != nil {

--- a/bindings/localstorage/localstorage_test.go
+++ b/bindings/localstorage/localstorage_test.go
@@ -27,10 +27,10 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	m.Properties = map[string]string{"rootPath": "/files"}
+	m.Properties = map[string]string{"rootPath": filepath.Clean("/files")}
 	localStorage := NewLocalStorage(logger.NewLogger("test")).(*LocalStorage)
 	meta, err := localStorage.parseMetadata(m)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "/files", meta.RootPath)
 }
 

--- a/bindings/localstorage/localstorage_test.go
+++ b/bindings/localstorage/localstorage_test.go
@@ -14,9 +14,12 @@ limitations under the License.
 package localstorage
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
@@ -29,4 +32,76 @@ func TestParseMetadata(t *testing.T) {
 	meta, err := localStorage.parseMetadata(m)
 	assert.Nil(t, err)
 	assert.Equal(t, "/files", meta.RootPath)
+}
+
+func TestValidateRootPath(t *testing.T) {
+	// Set up some things in the FS
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "aaa/bbb"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "aaa/ccc"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "zzz/aaa"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "notgood"), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(tmpDir, "aaa/bbb"), filepath.Join(tmpDir, "zzz/link")))
+	require.NoError(t, os.Symlink(filepath.Join(tmpDir, "notgood"), filepath.Join(tmpDir, "aaa/notgood")))
+	f, err := os.Create(filepath.Join(tmpDir, "aaa/file"))
+	f.Close()
+	require.NoError(t, err)
+
+	// Set the list of disallowed paths to some locations that don't exist
+	// This is because the list contains folders that otherwise are resolved as symlinks in some OS's (like macOS)
+	oldDisallowedRootPaths := disallowedRootPaths
+	disallowedRootPaths = []string{
+		filepath.Clean("/notgood"),
+		filepath.Join(joinWithMustEvalSymlinks(tmpDir), "notgood"),
+	}
+	defer func() {
+		disallowedRootPaths = oldDisallowedRootPaths
+	}()
+
+	tests := []struct {
+		name     string
+		rootPath string
+		wantRes  string
+		// String that will be matched in the error
+		// If no error is expected, set this to an empty string
+		wantErr string
+	}{
+		{name: "empty", rootPath: "", wantErr: "must not be empty"},
+		{name: "relative path 1", rootPath: "path", wantErr: "must be an absolute path"},
+		{name: "relative path 2", rootPath: filepath.Clean("../path"), wantErr: "must be an absolute path"},
+		{name: "existing path 1", rootPath: filepath.Join(tmpDir, "aaa/bbb"), wantRes: joinWithMustEvalSymlinks(tmpDir, "aaa/bbb")},
+		{name: "existing path 2", rootPath: filepath.Join(tmpDir, "zzz/aaa"), wantRes: joinWithMustEvalSymlinks(tmpDir, "zzz/aaa")},
+		{name: "path does not exist 1", rootPath: filepath.Join(tmpDir, "zzz/foo"), wantRes: filepath.Join(joinWithMustEvalSymlinks(tmpDir, "zzz"), "foo")},
+		{name: "path does not exist 1", rootPath: filepath.Join(tmpDir, "zzz/aaa/deep/deep"), wantRes: filepath.Join(joinWithMustEvalSymlinks(tmpDir, "zzz/aaa"), "deep/deep")},
+		{name: "resolve symlinks", rootPath: filepath.Join(tmpDir, "zzz/link"), wantRes: joinWithMustEvalSymlinks(tmpDir, "aaa/bbb")},
+		{name: "resolve symlinks subfolder", rootPath: filepath.Join(tmpDir, "zzz/link/sub"), wantRes: filepath.Join(joinWithMustEvalSymlinks(tmpDir, "aaa/bbb"), "sub")},
+		{name: "file", rootPath: filepath.Join(tmpDir, "aaa/file"), wantErr: "not a directory"},
+		{name: "file in higher level", rootPath: filepath.Join(tmpDir, "aaa/file/2"), wantErr: "not a directory"},
+		{name: "disallowed path 1", rootPath: filepath.Clean("/notgood"), wantErr: "disallowed location"},
+		{name: "disallowed path 1 subfolder", rootPath: filepath.Clean("/notgood/foo"), wantErr: "disallowed location"},
+		{name: "disallowed path 2", rootPath: filepath.Join(tmpDir, "notgood"), wantErr: "disallowed location"},
+		{name: "disallowed path 2 subfolder", rootPath: filepath.Join(tmpDir, "notgood", "foo"), wantErr: "disallowed location"},
+		{name: "symlink to disallowed path", rootPath: filepath.Join(tmpDir, "aaa/notgood"), wantErr: "disallowed location"},
+		{name: "symlink to disallowed path subfolder", rootPath: filepath.Join(tmpDir, "aaa/notgood/foo"), wantErr: "disallowed location"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := validateRootPath(tt.rootPath)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantRes, res)
+		})
+	}
+}
+
+func joinWithMustEvalSymlinks(v ...string) string {
+	r, err := filepath.EvalSymlinks(filepath.Join(v...))
+	if err != nil {
+		panic(err)
+	}
+	return r
 }

--- a/bindings/localstorage/localstorage_test.go
+++ b/bindings/localstorage/localstorage_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	m := bindings.Metadata{}
-	var path string = "/files"
+	path := "/files"
 	if runtime.GOOS == "windows" {
 		path = "C:\\files"
 	}
@@ -62,8 +62,8 @@ func TestValidateRootPath(t *testing.T) {
 	oldDisallowedRootPaths := disallowedRootPaths
 	disallowedRootPaths = []string{
 		// Explicitly set both the Linux and Windows formats
-		filepath.Join("/notgood"),
-		filepath.Join("C:\\notgood"),
+		"/notgood",
+		"C:\\notgood",
 		filepath.Join(joinWithMustEvalSymlinks(tmpDir), "notgood"),
 	}
 	defer func() {

--- a/tests/certification/bindings/localstorage/components/localstorage.yaml
+++ b/tests/certification/bindings/localstorage/components/localstorage.yaml
@@ -8,4 +8,4 @@ spec:
   version: v1
   metadata:
   - name: rootPath
-    value: ./tmp
+    value: /tmp/dapr-cert-test/bindings.localstorage

--- a/tests/certification/bindings/localstorage/localstorage_test.go
+++ b/tests/certification/bindings/localstorage/localstorage_test.go
@@ -14,10 +14,13 @@ limitations under the License.
 package localstorage_test
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/bindings"
 	bindings_localstorage "github.com/dapr/components-contrib/bindings/localstorage"
@@ -28,20 +31,19 @@ import (
 	"github.com/dapr/dapr/pkg/runtime"
 	daprsdk "github.com/dapr/go-sdk/client"
 	"github.com/dapr/kit/logger"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
 	sidecarName = "localstorage-sidecar"
 	bindingName = "localstorage-binding"
-	dir         = "./tmp"
+	dir         = "/tmp/dapr-cert-test/bindings.localstorage"
 	fileName    = "test.txt"
 	fileData    = "test data"
 )
 
 func TestLocalStorage(t *testing.T) {
 	invokeCreateWithConfig := func(ctx flow.Context, config map[string]string) error {
-		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(runtime.DefaultDaprAPIGRPCPort))
+		client, clientErr := daprsdk.NewClientWithPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort))
 		if clientErr != nil {
 			panic(clientErr)
 		}
@@ -58,7 +60,7 @@ func TestLocalStorage(t *testing.T) {
 	}
 
 	invokeGetWithConfig := func(ctx flow.Context, config map[string]string) ([]byte, error) {
-		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(runtime.DefaultDaprAPIGRPCPort))
+		client, clientErr := daprsdk.NewClientWithPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort))
 		if clientErr != nil {
 			panic(clientErr)
 		}
@@ -78,7 +80,7 @@ func TestLocalStorage(t *testing.T) {
 	}
 
 	invokeDeleteWithConfig := func(ctx flow.Context, config map[string]string) error {
-		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(runtime.DefaultDaprAPIGRPCPort))
+		client, clientErr := daprsdk.NewClientWithPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort))
 		if clientErr != nil {
 			panic(clientErr)
 		}
@@ -94,7 +96,7 @@ func TestLocalStorage(t *testing.T) {
 	}
 
 	invokeListWithConfig := func(ctx flow.Context, config map[string]string) ([]byte, error) {
-		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(runtime.DefaultDaprAPIGRPCPort))
+		client, clientErr := daprsdk.NewClientWithPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort))
 		if clientErr != nil {
 			panic(clientErr)
 		}
@@ -132,7 +134,9 @@ func TestLocalStorage(t *testing.T) {
 		flow.Sleep(3 * time.Second)
 
 		_, err := invokeGetWithConfig(ctx, map[string]string{"fileName": "not-exists.txt"})
-		assert.Error(t, err)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "file not found:")
+		assert.ErrorContains(t, err, "not-exists.txt")
 
 		return clear()
 	}


### PR DESCRIPTION
1. Adds checks and enforcements on rootPath. Also includes ability to disallow certain root paths such as `/var/run/secrets` (also if there are symlinks to those paths)
2. Closes file descriptor that was left open after reading a file
3. If the file doesn't exist when reading it, returns a more specific error message

Fixes #2444
Fixes #2374