### PR TITLE
[HTTP Binding] fix error: filename too long

### DIFF
--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	MTLSEnable     = "MTLSEnable"
 	MTLSRootCA     = "MTLSRootCA"
 	MTLSClientCert = "MTLSClientCert"
 	MTLSClientKey  = "MTLSClientKey"
@@ -146,23 +145,19 @@ func (h *HTTPSource) readMTLSCertificates() (*tls.Config, error) {
 }
 
 // getPemBytes returns the PEM encoded bytes from the provided certName and certData.
-// If the certData is a file path, it reads the file and returns the bytes.
-// Else if the certData is a PEM encoded string, it returns the bytes.
-// Else it returns an error.
+// If the certData is a PEM encoded string, it returns the bytes.
+// If there is an error in decoding the PEM, assume it is a filepath and try to read its content.
+// Return the error occurred while reading the file.
 func (h *HTTPSource) getPemBytes(certName, certData string) ([]byte, error) {
-	// Read the file
-	pemBytes, err := os.ReadFile(certData)
-	// If there is an error assume it is already PEM encoded string not a file path.
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("failed to read %q file: %w", certName, err)
+	if !isValidPEM(certData) {
+		// Read the file
+		pemBytes, err := os.ReadFile(certData)
+		if err != nil {
+			return nil, fmt.Errorf("provided %q value is neither a valid file path or nor a valid pem encoded string: %w", certName, err)
 		}
-		if !isValidPEM(certData) {
-			return nil, fmt.Errorf("provided %q value is neither a valid file path or nor a valid pem encoded string", certName)
-		}
-		return []byte(certData), nil
+		return pemBytes, nil
 	}
-	return pemBytes, nil
+	return []byte(certData), nil
 }
 
 // isValidPEM validates the provided input has PEM formatted block.


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

This check here is little problematic - 
https://github.com/dapr/components-contrib/blob/7067334215da45305c687498fb538b35231c8080/bindings/http/http.go#L157

It might be possible that the the pem bytes that are passed are large in length, in that case the condition will evaluate to `true` and it will return from here. Where as we would want it to treat as pembytes in next line.
I was aable to reproduce it with self signed cert with open ssl.
The error logged will be something like - 

```text
failed to read "MTLSRootCA" file: open -----BEGIN CERTIFICATE-----
MIICHzCCAcWgAwIBAgIUVmulwhIO5Y2A8ACi3OcX94denFEwCgYIKoZIzj0EAwIw
......
IsCxyWZQ37yZpvS82Z/SnCIZuw==
-----END CERTIFICATE-----
: file name too long
```

We can invert the logic like this - 
1. treat it by default as pem bytes
2. if step 1 fails then try to read it assuming file path
3. return whatever error it encounters in step 3


 Related to PR https://github.com/dapr/components-contrib/pull/2399
