### PR TITLE
mdns: shut down on context cancelation and not on signal

### DIFF
--- a/nameresolution/mdns/mdns.go
+++ b/nameresolution/mdns/mdns.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/signal"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -172,7 +171,7 @@ func NewSubscriber() Subscriber {
 
 // NewResolver creates the instance of mDNS name resolver.
 func NewResolver(logger logger.Logger) nameresolution.Resolver {
-	refreshCtx, refreshCancel := context.WithCancel(context.Background())
+	runCtx, runCancel := context.WithCancel(context.Background())
 
 	r := &Resolver{
 		subs:             make(map[string]*SubscriberPool),
@@ -192,9 +191,9 @@ func NewResolver(logger logger.Logger) nameresolution.Resolver {
 		// stop serving queries for registered app ids.
 		registrations: make(map[string]chan struct{}),
 		// shutdown refreshers
-		refreshCtx:    refreshCtx,
-		refreshCancel: refreshCancel,
-		logger:        logger,
+		runCtx:    runCtx,
+		runCancel: runCancel,
+		logger:    logger,
 	}
 
 	return r
@@ -224,8 +223,9 @@ type Resolver struct {
 	registrationMu sync.RWMutex
 	registrations  map[string]chan struct{}
 	// shutdown refreshes.
-	refreshCtx     context.Context
-	refreshCancel  context.CancelFunc
+	runCtx         context.Context
+	runCancel      context.CancelFunc
+	serversRunning sync.WaitGroup
 	refreshRunning atomic.Bool
 	logger         logger.Logger
 }
@@ -247,19 +247,19 @@ func (m *Resolver) startRefreshers() {
 			// Refresh on demand
 			case appID := <-m.refreshChan:
 				go func() {
-					if err := m.refreshApp(m.refreshCtx, appID); err != nil {
+					if err := m.refreshApp(m.runCtx, appID); err != nil {
 						m.logger.Warnf(err.Error())
 					}
 				}()
 			// Refresh periodically
 			case <-time.After(refreshInterval):
 				go func() {
-					if err := m.refreshAllApps(m.refreshCtx); err != nil {
+					if err := m.refreshAllApps(m.runCtx); err != nil {
 						m.logger.Warnf(err.Error())
 					}
 				}()
 			// Stop on context canceled
-			case <-m.refreshCtx.Done():
+			case <-m.runCtx.Done():
 				m.logger.Debug("stopping cache refreshes")
 				return
 			}
@@ -338,27 +338,28 @@ func (m *Resolver) Close() error {
 	m.registrationMu.Lock()
 	defer m.registrationMu.Unlock()
 	for _, doneChan := range m.registrations {
-		doneChan <- struct{}{}
 		close(doneChan)
 	}
 	// clear the registrations map.
 	m.registrations = make(map[string]chan struct{})
 
-	// stop all refresh loops
-	if m.refreshCancel != nil {
-		m.refreshCancel()
+	// stop all background operations
+	if m.runCancel != nil {
+		m.runCancel()
 	}
+
+	// Wait for all running servers
+	m.serversRunning.Wait()
 
 	return nil
 }
 
 func (m *Resolver) registerMDNS(instanceID string, appID string, ips []string, port int) error {
-	started := make(chan bool, 1)
-	var err error
+	started := make(chan error)
 
 	// Register the app id with the resolver.
 	done := make(chan struct{}, 1)
-	key := fmt.Sprintf("%s:%d", appID, port) // WARN: we do not support unique ips.
+	key := appID + ":" + strconv.Itoa(port) // WARN: we do not support unique ips.
 
 	// NOTE: The registrations map is used to track all registered
 	// app ids. The Dapr runtime currently only registers 1 app ID
@@ -372,15 +373,20 @@ func (m *Resolver) registerMDNS(instanceID string, appID string, ips []string, p
 	m.registrations[key] = done
 	m.registrationMu.Unlock()
 
+	m.serversRunning.Add(1)
 	go func() {
-		var server *zeroconf.Server
+		var (
+			server *zeroconf.Server
+			err    error
+		)
+		defer m.serversRunning.Done()
 
 		host, _ := os.Hostname()
 		info := []string{appID}
 
 		// default instance id is unique to the process.
 		if instanceID == "" {
-			instanceID = fmt.Sprintf("%s-%d", host, syscall.Getpid())
+			instanceID = host + ":" + strconv.Itoa(syscall.Getpid())
 		}
 
 		if len(ips) > 0 {
@@ -390,31 +396,27 @@ func (m *Resolver) registerMDNS(instanceID string, appID string, ips []string, p
 		}
 
 		if err != nil {
-			started <- false
 			m.logger.Errorf("error from zeroconf register: %s", err)
-
+			started <- err
+			close(started)
 			return
 		}
-		started <- true
+		close(started)
 
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
-
-		// wait until either a SIGTERM or done is received.
+		// wait until either context is canceled (when the component is shut down) or done is received.
 		select {
-		case <-sig:
-			m.logger.Debugf("received SIGTERM signal, shutting down...")
+		case <-m.runCtx.Done():
+			m.logger.Debugf("context canceled, shutting down…")
 		case <-done:
-			m.logger.Debugf("received done signal , shutting down...")
+			m.logger.Debugf("received done signal, shutting down…")
 		}
 
 		m.logger.Info("stopping mDNS server for app id: ", appID)
 		server.Shutdown()
 	}()
 
-	<-started
-
-	return err
+	// Could return an error
+	return <-started
 }
 
 // ResolveID resolves name to address via mDNS.


### PR DESCRIPTION
Quick fix related to the work on shutdown improvements.

Currently the mDNS resolver is the only (left) component that listens to shutdown signals via the OS (like os.Interrupt), rather than shutting down on context cancellation. This fixes it so the component shuts down in a more streamlined way.