### PR TITLE
Firestore State Store: Adds `noindex` option to skip indexing of value.

### DIFF
--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -41,7 +41,7 @@ type Firestore struct {
 }
 
 type firestoreMetadata struct {
-	Type                string
+	Type                string `json:"type"`
 	ProjectID           string `json:"project_id" mapstructure:"project_id"`
 	PrivateKeyID        string `json:"private_key_id" mapstructure:"private_key_id"`
 	PrivateKey          string `json:"private_key" mapstructure:"private_key"`
@@ -52,7 +52,7 @@ type firestoreMetadata struct {
 	AuthProviderCertURL string `json:"auth_provider_x509_cert_url" mapstructure:"auth_provider_x509_cert_url"`
 	ClientCertURL       string `json:"client_x509_cert_url" mapstructure:"client_x509_cert_url"`
 	EntityKind          string `json:"entity_kind" mapstructure:"entity_kind"`
-	NoIndex             bool
+	NoIndex             bool   `json:"-"`
 }
 
 type StateEntity struct {

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -41,7 +41,7 @@ type Firestore struct {
 }
 
 type firestoreMetadata struct {
-	Type                string `json:"type" mapstructure:"type"`
+	Type                string
 	ProjectID           string `json:"project_id" mapstructure:"project_id"`
 	PrivateKeyID        string `json:"private_key_id" mapstructure:"private_key_id"`
 	PrivateKey          string `json:"private_key" mapstructure:"private_key"`
@@ -52,7 +52,7 @@ type firestoreMetadata struct {
 	AuthProviderCertURL string `json:"auth_provider_x509_cert_url" mapstructure:"auth_provider_x509_cert_url"`
 	ClientCertURL       string `json:"client_x509_cert_url" mapstructure:"client_x509_cert_url"`
 	EntityKind          string `json:"entity_kind" mapstructure:"entity_kind"`
-	NoIndex             bool   `json:"noindex" mapstructure:"noindex"`
+	NoIndex             bool
 }
 
 type StateEntity struct {

--- a/state/gcp/firestore/firestore_test.go
+++ b/state/gcp/firestore/firestore_test.go
@@ -35,6 +35,7 @@ func TestGetFirestoreMetadata(t *testing.T) {
 			"token_uri":                   "https://oauth2.googleapis.com/token",
 			"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
 			"client_x509_cert_url":        "https://www.googleapis.com/robot/v1/metadata/x509/x",
+			"noindex":                     "true",
 		}
 		m := state.Metadata{
 			Base: metadata.Base{Properties: properties},
@@ -46,6 +47,7 @@ func TestGetFirestoreMetadata(t *testing.T) {
 		assert.Equal(t, "123", metadata.PrivateKeyID)
 		assert.Equal(t, "mykey", metadata.PrivateKey)
 		assert.Equal(t, defaultEntityKind, metadata.EntityKind)
+		assert.Equal(t, true, metadata.NoIndex)
 	})
 
 	t.Run("With incorrect properties", func(t *testing.T) {


### PR DESCRIPTION
# Description

Adds `noindex` boolean metadata property to prevent the value from being indexed.

## Issue reference

Closes #2478

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
