### PR TITLE
[release-1.10] Fixed typo in ASB metadata property name

### DIFF
--- a/tests/certification/pubsub/aws/snssqs/components/entity_mgmt/pubsub.yaml
+++ b/tests/certification/pubsub/aws/snssqs/components/entity_mgmt/pubsub.yaml
@@ -46,7 +46,7 @@ spec:
       value: 10
     - name: publishMaxRetries
       value: 5
-    - name: publishInitialRetryInternalInMs
+    - name: publishInitialRetryIntervalInMs
       value: 500
 auth:
   secretstore: envvar-secret-store

--- a/tests/certification/pubsub/azure/servicebus/topics/components/entity_mgmt/service_bus.yaml
+++ b/tests/certification/pubsub/azure/servicebus/topics/components/entity_mgmt/service_bus.yaml
@@ -41,7 +41,7 @@ spec:
       value: 10
     - name: publishMaxRetries
       value: 5
-    - name: publishInitialRetryInternalInMs
+    - name: publishInitialRetryIntervalInMs
       value: 500
 auth:
   secretstore: envvar-secret-store


### PR DESCRIPTION
Typo in the metadata key `publishInitialRetryIntervalInMs`. This changes the metadata key, but maintains the old one for backwards-compatibility (with a warning log)