### PR TITLE
[release-1.10] SQlite: do not create an index on expiration_time by default

### DIFF
--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -370,12 +370,6 @@ func (a *sqliteDBAccess) ensureStateTable(parentCtx context.Context, stateTableN
 		return err
 	}
 
-	stmt = fmt.Sprintf(`CREATE INDEX idx_%s_expiration_time ON %s (expiration_time)`, stateTableName, stateTableName)
-	_, err = tx.Exec(stmt)
-	if err != nil {
-		return err
-	}
-
 	return tx.Commit()
 }
 


### PR DESCRIPTION
This makes SQLite behave more like Postgres, where the "expiration_time" column does not have an index by default.

For an explanation on why: https://v1-10.docs.dapr.io/reference/components-reference/supported-state-stores/setup-postgresql/#ttls-and-cleanups