### PR TITLE
[release-1.10] Fix "Azure Service Bus does not recover from failures when publishing"

### DIFF
--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -92,7 +92,7 @@ func (a *AzureServiceBusQueues) Invoke(invokeCtx context.Context, req *bindings.
 	if err != nil {
 		if impl.IsNetworkError(err) {
 			// Force reconnection on next call
-			a.client.CloseSender(a.metadata.QueueName)
+			a.client.CloseSender(a.metadata.QueueName, a.logger)
 		}
 		return nil, err
 	}
@@ -205,6 +205,6 @@ func (a *AzureServiceBusQueues) getHandlerFn(handler bindings.Handler) impl.Hand
 
 func (a *AzureServiceBusQueues) Close() (err error) {
 	a.logger.Debug("Closing component")
-	a.client.CloseSender(a.metadata.QueueName)
+	a.client.CloseAllSenders(a.logger)
 	return nil
 }

--- a/internal/component/azure/servicebus/errors.go
+++ b/internal/component/azure/servicebus/errors.go
@@ -36,8 +36,10 @@ func IsNetworkError(err error) bool {
 	}
 
 	// Context deadline exceeded errors often happen when the connection is just "hanging"
+	// As for checking the string value too... Seems that the go-amqp library (which is used by the Service Bus SDK) may return "context deadline exceeded" errors that don't pass the errors.Is(err, context.DeadlineExceeded) test.
+	// There are signs of the above in the Azure Service Bus SDK too: https://github.com/Azure/azure-sdk-for-go/blob/sdk/messaging/azservicebus/v1.1.4/sdk/messaging/azservicebus/internal/errors.go#L113
 	var connErr *amqp.ConnError
-	if errors.Is(err, context.DeadlineExceeded) || errors.As(err, &connErr) {
+	if errors.Is(err, context.DeadlineExceeded) || errors.As(err, &connErr) || err.Error() == context.DeadlineExceeded.Error() {
 		return true
 	}
 

--- a/pubsub/azure/servicebus/queues/servicebus.go
+++ b/pubsub/azure/servicebus/queues/servicebus.go
@@ -102,7 +102,7 @@ func (a *azureServiceBus) Publish(ctx context.Context, req *pubsub.PublishReques
 			if err != nil {
 				if impl.IsNetworkError(err) {
 					// Retry after reconnecting
-					a.client.CloseSender(req.Topic)
+					a.client.CloseSender(req.Topic, a.logger)
 					return err
 				}
 

--- a/pubsub/azure/servicebus/topics/servicebus.go
+++ b/pubsub/azure/servicebus/topics/servicebus.go
@@ -101,7 +101,7 @@ func (a *azureServiceBus) Publish(ctx context.Context, req *pubsub.PublishReques
 			if err != nil {
 				if impl.IsNetworkError(err) {
 					// Retry after reconnecting
-					a.client.CloseSender(req.Topic)
+					a.client.CloseSender(req.Topic, a.logger)
 					return err
 				}
 


### PR DESCRIPTION
# Description

This PR is an attempt at fixing #2483 , although I am not able to repro the issue so I can't validate this. The approach is two-fold:

1. We are already treating "context deadline exceeded" errors as errors that would require disconnecting and reconnecting. However, it seems that the check `errors.Is(err, context.DeadlineExceeded)` may not be detecting those errors, perhaps because an upstream library is wrapping the errors some way. Based on looking into how the Service Bus SDK works, I've seen a sign that something like that may be happening. So, I've changed the code to be more lax and also accept errors whose stringified message is "context deadline exceeded" (but which are not  context.DeadlineExceeded) as errors that would require reconnecting.
2. In parallel, I've added more logs that, should the error persist, would better help us understanding what is going on, and if the connection is indeed being re-created.

## Issue reference

(Hopefully) fixes #2483