### PR TITLE
Add `Close() error` function io input binding interface.

### DIFF
--- a/bindings/alicloud/dingtalk/webhook/webhook.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook.go
@@ -107,6 +107,13 @@ func (t *DingTalkWebhook) Read(ctx context.Context, handler bindings.Handler) er
 	return nil
 }
 
+func (t *DingTalkWebhook) Close() error {
+	webhooks.Lock()
+	defer webhooks.Unlock()
+	delete(webhooks.m, t.settings.ID)
+	return nil
+}
+
 // Operations returns list of operations supported by dingtalk webhook binding.
 func (t *DingTalkWebhook) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{bindings.CreateOperation, bindings.GetOperation}

--- a/bindings/alicloud/dingtalk/webhook/webhook.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook.go
@@ -80,7 +80,7 @@ func NewDingTalkWebhook(l logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init performs metadata parsing.
-func (t *DingTalkWebhook) Init(metadata bindings.Metadata) error {
+func (t *DingTalkWebhook) Init(ctx context.Context, metadata bindings.Metadata) error {
 	var err error
 	if err = t.settings.Decode(metadata.Properties); err != nil {
 		return fmt.Errorf("dingtalk configuration error: %w", err)

--- a/bindings/alicloud/dingtalk/webhook/webhook_test.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook_test.go
@@ -106,3 +106,18 @@ func TestBindingReadAndInvoke(t *testing.T) { //nolint:paralleltest
 		require.FailNow(t, "read timeout")
 	}
 }
+
+func TestBindingClose(t *testing.T) {
+	d := NewDingTalkWebhook(logger.NewLogger("test"))
+	m := bindings.Metadata{Base: metadata.Base{
+		Name: "test",
+		Properties: map[string]string{
+			"url":    "/test",
+			"secret": "",
+			"id":     "x",
+		},
+	}}
+	assert.NoError(t, d.Init(context.Background(), m))
+	assert.NoError(t, d.Close())
+	assert.NoError(t, d.Close(), "second close should not error")
+}

--- a/bindings/alicloud/dingtalk/webhook/webhook_test.go
+++ b/bindings/alicloud/dingtalk/webhook/webhook_test.go
@@ -57,7 +57,7 @@ func TestPublishMsg(t *testing.T) { //nolint:paralleltest
 	}}}
 
 	d := NewDingTalkWebhook(logger.NewLogger("test"))
-	err := d.Init(m)
+	err := d.Init(context.Background(), m)
 	require.NoError(t, err)
 
 	req := &bindings.InvokeRequest{Data: []byte(msg), Operation: bindings.CreateOperation, Metadata: map[string]string{}}
@@ -78,7 +78,7 @@ func TestBindingReadAndInvoke(t *testing.T) { //nolint:paralleltest
 	}}
 
 	d := NewDingTalkWebhook(logger.NewLogger("test"))
-	err := d.Init(m)
+	err := d.Init(context.Background(), m)
 	assert.NoError(t, err)
 
 	var count int32

--- a/bindings/alicloud/dubbo/dubbo_output.go
+++ b/bindings/alicloud/dubbo/dubbo_output.go
@@ -47,7 +47,7 @@ func NewDubboOutput(logger logger.Logger) bindings.OutputBinding {
 	return dubboBinding
 }
 
-func (out *DubboOutputBinding) Init(_ bindings.Metadata) error {
+func (out *DubboOutputBinding) Init(ctx context.Context, _ bindings.Metadata) error {
 	dubboImpl.SetSerializer(constant.Hessian2Serialization, HessianSerializer{})
 	return nil
 }

--- a/bindings/alicloud/dubbo/dubbo_output_test.go
+++ b/bindings/alicloud/dubbo/dubbo_output_test.go
@@ -54,12 +54,13 @@ func TestInvoke(t *testing.T) {
 	// 0. init dapr provided and dubbo server
 	stopCh := make(chan struct{})
 	defer close(stopCh)
+	// Create output and set serializer before go routine to prevent data race.
+	output := NewDubboOutput(logger.NewLogger("test"))
+	dubboImpl.SetSerializer(constant.Hessian2Serialization, HessianSerializer{})
 	go func() {
 		assert.Nil(t, runDubboServer(stopCh))
 	}()
 	time.Sleep(time.Second * 3)
-	dubboImpl.SetSerializer(constant.Hessian2Serialization, HessianSerializer{})
-	output := NewDubboOutput(logger.NewLogger("test"))
 
 	// 1. create req/rsp value
 	reqUser := &User{Name: testName}

--- a/bindings/alicloud/nacos/nacos.go
+++ b/bindings/alicloud/nacos/nacos.go
@@ -67,7 +67,7 @@ func NewNacos(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init implements InputBinding/OutputBinding's Init method.
-func (n *Nacos) Init(metadata bindings.Metadata) error {
+func (n *Nacos) Init(ctx context.Context, metadata bindings.Metadata) error {
 	n.settings = Settings{
 		Timeout: defaultTimeout,
 	}

--- a/bindings/alicloud/nacos/nacos_test.go
+++ b/bindings/alicloud/nacos/nacos_test.go
@@ -35,7 +35,7 @@ func TestInputBindingRead(t *testing.T) { //nolint:paralleltest
 	m.Properties, err = getNacosLocalCacheMetadata()
 	require.NoError(t, err)
 	n := NewNacos(logger.NewLogger("test")).(*Nacos)
-	err = n.Init(m)
+	err = n.Init(context.Background(), m)
 	require.NoError(t, err)
 	var count int32
 	ch := make(chan bool, 1)

--- a/bindings/alicloud/oss/oss.go
+++ b/bindings/alicloud/oss/oss.go
@@ -45,7 +45,7 @@ func NewAliCloudOSS(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (s *AliCloudOSS) Init(metadata bindings.Metadata) error {
+func (s *AliCloudOSS) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := s.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/alicloud/rocketmq/rocketmq.go
+++ b/bindings/alicloud/rocketmq/rocketmq.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -39,6 +40,7 @@ type AliCloudRocketMQ struct {
 	backOffConfig retry.Config
 	closeCh       chan struct{}
 	closed        atomic.Bool
+	wg            sync.WaitGroup
 }
 
 func NewAliCloudRocketMQ(l logger.Logger) *AliCloudRocketMQ {
@@ -118,7 +120,9 @@ func (a *AliCloudRocketMQ) Read(ctx context.Context, handler bindings.Handler) e
 	a.logger.Debugf("binding-rocketmq: consumer started")
 
 	// Listen for context cancelation to stop the subscription
+	a.wg.Add(1)
 	go func() {
+		defer a.wg.Done()
 		select {
 		case <-ctx.Done():
 		case <-a.closeCh:
@@ -135,6 +139,7 @@ func (a *AliCloudRocketMQ) Read(ctx context.Context, handler bindings.Handler) e
 
 // Close implements cancel all listeners, see https://github.com/dapr/components-contrib/issues/779
 func (a *AliCloudRocketMQ) Close() error {
+	defer a.wg.Wait()
 	if a.closed.CompareAndSwap(false, true) {
 		close(a.closeCh)
 	}

--- a/bindings/alicloud/rocketmq/rocketmq.go
+++ b/bindings/alicloud/rocketmq/rocketmq.go
@@ -35,26 +35,24 @@ type AliCloudRocketMQ struct {
 	settings Settings
 	producer mqw.Producer
 
-	ctx           context.Context
-	cancel        context.CancelFunc
 	backOffConfig retry.Config
+	closeCh       chan struct{}
 }
 
 func NewAliCloudRocketMQ(l logger.Logger) *AliCloudRocketMQ {
 	return &AliCloudRocketMQ{ //nolint:exhaustivestruct
 		logger:   l,
 		producer: nil,
+		closeCh:  make(chan struct{}),
 	}
 }
 
 // Init performs metadata parsing.
-func (a *AliCloudRocketMQ) Init(metadata bindings.Metadata) error {
+func (a *AliCloudRocketMQ) Init(ctx context.Context, metadata bindings.Metadata) error {
 	var err error
 	if err = a.settings.Decode(metadata.Properties); err != nil {
 		return err
 	}
-
-	a.ctx, a.cancel = context.WithCancel(context.Background())
 
 	// Default retry configuration is used if no
 	// backOff properties are set.
@@ -117,7 +115,7 @@ func (a *AliCloudRocketMQ) Read(ctx context.Context, handler bindings.Handler) e
 	go func() {
 		select {
 		case <-ctx.Done():
-		case <-a.ctx.Done():
+		case <-a.closeCh:
 		}
 
 		innerErr := consumer.Shutdown()
@@ -131,8 +129,7 @@ func (a *AliCloudRocketMQ) Read(ctx context.Context, handler bindings.Handler) e
 
 // Close implements cancel all listeners, see https://github.com/dapr/components-contrib/issues/779
 func (a *AliCloudRocketMQ) Close() error {
-	a.cancel()
-
+	close(a.closeCh)
 	return nil
 }
 
@@ -199,21 +196,21 @@ func (a *AliCloudRocketMQ) Operations() []bindings.OperationKind {
 	return []bindings.OperationKind{bindings.CreateOperation}
 }
 
-func (a *AliCloudRocketMQ) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (a *AliCloudRocketMQ) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	rst := &bindings.InvokeResponse{Data: nil, Metadata: nil}
 
 	if req.Operation != bindings.CreateOperation {
 		return rst, fmt.Errorf("binding-rocketmq error: unsupported operation %s", req.Operation)
 	}
 
-	return rst, a.sendMessage(req)
+	return rst, a.sendMessage(ctx, req)
 }
 
-func (a *AliCloudRocketMQ) sendMessage(req *bindings.InvokeRequest) error {
+func (a *AliCloudRocketMQ) sendMessage(ctx context.Context, req *bindings.InvokeRequest) error {
 	topic := req.Metadata[metadataRocketmqTopic]
 
 	if topic != "" {
-		_, err := a.send(topic, req.Metadata[metadataRocketmqTag], req.Metadata[metadataRocketmqKey], req.Data)
+		_, err := a.send(ctx, topic, req.Metadata[metadataRocketmqTag], req.Metadata[metadataRocketmqKey], req.Data)
 		if err != nil {
 			return err
 		}
@@ -229,7 +226,7 @@ func (a *AliCloudRocketMQ) sendMessage(req *bindings.InvokeRequest) error {
 		if err != nil {
 			return err
 		}
-		_, err = a.send(topic, mqExpression, req.Metadata[metadataRocketmqKey], req.Data)
+		_, err = a.send(ctx, topic, mqExpression, req.Metadata[metadataRocketmqKey], req.Data)
 		if err != nil {
 			return err
 		}
@@ -239,9 +236,9 @@ func (a *AliCloudRocketMQ) sendMessage(req *bindings.InvokeRequest) error {
 	return nil
 }
 
-func (a *AliCloudRocketMQ) send(topic, mqExpr, key string, data []byte) (bool, error) {
+func (a *AliCloudRocketMQ) send(ctx context.Context, topic, mqExpr, key string, data []byte) (bool, error) {
 	msg := primitive.NewMessage(topic, data).WithTag(mqExpr).WithKeys([]string{key})
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	rst, err := a.producer.SendSync(ctx, msg)
 	if err != nil {

--- a/bindings/alicloud/rocketmq/rocketmq_test.go
+++ b/bindings/alicloud/rocketmq/rocketmq_test.go
@@ -35,7 +35,7 @@ func TestInputBindingRead(t *testing.T) { //nolint:paralleltest
 	m := bindings.Metadata{} //nolint:exhaustivestruct
 	m.Properties = getTestMetadata()
 	r := NewAliCloudRocketMQ(logger.NewLogger("test"))
-	err := r.Init(m)
+	err := r.Init(context.Background(), m)
 	require.NoError(t, err)
 
 	var count int32
@@ -51,7 +51,7 @@ func TestInputBindingRead(t *testing.T) { //nolint:paralleltest
 	time.Sleep(5 * time.Second)
 	atomic.StoreInt32(&count, 0)
 	req := &bindings.InvokeRequest{Data: []byte("hello"), Operation: bindings.CreateOperation, Metadata: map[string]string{}}
-	_, err = r.Invoke(req)
+	_, err = r.Invoke(context.Background(), req)
 	require.NoError(t, err)
 
 	time.Sleep(10 * time.Second)

--- a/bindings/alicloud/sls/sls.go
+++ b/bindings/alicloud/sls/sls.go
@@ -31,7 +31,7 @@ type Callback struct {
 }
 
 // parse metadata field
-func (s *AliCloudSlsLogstorage) Init(metadata bindings.Metadata) error {
+func (s *AliCloudSlsLogstorage) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := s.parseMeta(metadata)
 	if err != nil {
 		return err

--- a/bindings/alicloud/tablestore/tablestore.go
+++ b/bindings/alicloud/tablestore/tablestore.go
@@ -58,7 +58,7 @@ func NewAliCloudTableStore(log logger.Logger) bindings.OutputBinding {
 	}
 }
 
-func (s *AliCloudTableStore) Init(metadata bindings.Metadata) error {
+func (s *AliCloudTableStore) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := s.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/alicloud/tablestore/tablestore_test.go
+++ b/bindings/alicloud/tablestore/tablestore_test.go
@@ -51,7 +51,7 @@ func TestDataEncodeAndDecode(t *testing.T) {
 	metadata := bindings.Metadata{Base: metadata.Base{
 		Properties: getTestProperties(),
 	}}
-	aliCloudTableStore.Init(metadata)
+	aliCloudTableStore.Init(context.Background(), metadata)
 
 	// test create
 	putData := map[string]interface{}{

--- a/bindings/apns/apns.go
+++ b/bindings/apns/apns.go
@@ -78,7 +78,7 @@ func NewAPNS(logger logger.Logger) bindings.OutputBinding {
 
 // Init will configure the APNS output binding using the metadata specified
 // in the binding's configuration.
-func (a *APNS) Init(metadata bindings.Metadata) error {
+func (a *APNS) Init(ctx context.Context, metadata bindings.Metadata) error {
 	if err := a.makeURLPrefix(metadata); err != nil {
 		return err
 	}

--- a/bindings/apns/apns_test.go
+++ b/bindings/apns/apns_test.go
@@ -51,7 +51,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, developmentPrefix, binding.urlPrefix)
 	})
@@ -66,7 +66,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, productionPrefix, binding.urlPrefix)
 	})
@@ -80,7 +80,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, productionPrefix, binding.urlPrefix)
 	})
@@ -95,7 +95,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Error(t, err, "invalid value for development parameter: True")
 	})
 
@@ -107,7 +107,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Error(t, err, "the key-id parameter is required")
 	})
 
@@ -120,7 +120,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, testKeyID, binding.authorizationBuilder.keyID)
 	})
@@ -133,7 +133,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Error(t, err, "the team-id parameter is required")
 	})
 
@@ -146,7 +146,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, testTeamID, binding.authorizationBuilder.teamID)
 	})
@@ -159,7 +159,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Error(t, err, "the private-key parameter is required")
 	})
 
@@ -172,7 +172,7 @@ func TestInit(t *testing.T) {
 			},
 		}}
 		binding := NewAPNS(testLogger).(*APNS)
-		err := binding.Init(metadata)
+		err := binding.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.NotNil(t, binding.authorizationBuilder.privateKey)
 	})
@@ -335,7 +335,7 @@ func makeTestBinding(t *testing.T, log logger.Logger) *APNS {
 			privateKeyKey:  testPrivateKey,
 		},
 	}}
-	err := testBinding.Init(bindingMetadata)
+	err := testBinding.Init(context.Background(), bindingMetadata)
 	assert.Nil(t, err)
 
 	return testBinding

--- a/bindings/aws/dynamodb/dynamodb.go
+++ b/bindings/aws/dynamodb/dynamodb.go
@@ -49,7 +49,7 @@ func NewDynamoDB(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs connection parsing for DynamoDB.
-func (d *DynamoDB) Init(metadata bindings.Metadata) error {
+func (d *DynamoDB) Init(ctx context.Context, metadata bindings.Metadata) error {
 	meta, err := d.getDynamoDBMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/aws/kinesis/kinesis.go
+++ b/bindings/aws/kinesis/kinesis.go
@@ -236,6 +236,9 @@ func (a *AWSKinesis) ensureConsumer(ctx context.Context, streamARN *string) (*st
 		consumer *kinesis.DescribeStreamConsumerOutput
 	)
 	{
+		// goling complains about redeclaring a ctx here, but we want a timeout on
+		// the describe call and not register consumer.
+		//nolint:govet
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		consumer, err = a.client.DescribeStreamConsumerWithContext(ctx, &kinesis.DescribeStreamConsumerInput{

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -99,7 +99,7 @@ func NewAWSS3(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (s *AWSS3) Init(metadata bindings.Metadata) error {
+func (s *AWSS3) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := s.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/aws/ses/ses.go
+++ b/bindings/aws/ses/ses.go
@@ -61,7 +61,7 @@ func NewAWSSES(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing.
-func (a *AWSSES) Init(metadata bindings.Metadata) error {
+func (a *AWSSES) Init(ctx context.Context, metadata bindings.Metadata) error {
 	// Parse input metadata
 	meta, err := a.parseMetadata(metadata)
 	if err != nil {

--- a/bindings/aws/sns/sns.go
+++ b/bindings/aws/sns/sns.go
@@ -53,7 +53,7 @@ func NewAWSSNS(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing.
-func (a *AWSSNS) Init(metadata bindings.Metadata) error {
+func (a *AWSSNS) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := a.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/aws/sqs/sqs.go
+++ b/bindings/aws/sqs/sqs.go
@@ -49,7 +49,7 @@ func NewAWSSQS(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (a *AWSSQS) Init(metadata bindings.Metadata) error {
+func (a *AWSSQS) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := a.parseSQSMetadata(metadata)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func (a *AWSSQS) Init(metadata bindings.Metadata) error {
 	}
 
 	queueName := m.QueueName
-	resultURL, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
+	resultURL, err := client.GetQueueUrlWithContext(ctx, &sqs.GetQueueUrlInput{
 		QueueName: aws.String(queueName),
 	})
 	if err != nil {

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -92,7 +92,7 @@ func NewAzureBlobStorage(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs metadata parsing.
-func (a *AzureBlobStorage) Init(metadata bindings.Metadata) error {
+func (a *AzureBlobStorage) Init(ctx context.Context, metadata bindings.Metadata) error {
 	var err error
 	a.containerClient, a.metadata, err = storageinternal.CreateContainerStorageClient(a.logger, metadata.Properties)
 	if err != nil {

--- a/bindings/azure/cosmosdb/cosmosdb.go
+++ b/bindings/azure/cosmosdb/cosmosdb.go
@@ -53,7 +53,7 @@ func NewCosmosDB(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs CosmosDB connection parsing and connecting.
-func (c *CosmosDB) Init(metadata bindings.Metadata) error {
+func (c *CosmosDB) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := c.parseMetadata(metadata)
 	if err != nil {
 		return err
@@ -103,9 +103,9 @@ func (c *CosmosDB) Init(metadata bindings.Metadata) error {
 	}
 
 	c.client = dbContainer
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutValue*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, timeoutValue*time.Second)
+	defer cancel()
 	_, err = c.client.Read(ctx, nil)
-	cancel()
 	return err
 }
 

--- a/bindings/azure/cosmosdbgremlinapi/cosmosdbgremlinapi.go
+++ b/bindings/azure/cosmosdbgremlinapi/cosmosdbgremlinapi.go
@@ -59,7 +59,7 @@ func NewCosmosDBGremlinAPI(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs CosmosDBGremlinAPI connection parsing and connecting.
-func (c *CosmosDBGremlinAPI) Init(metadata bindings.Metadata) error {
+func (c *CosmosDBGremlinAPI) Init(ctx context.Context, metadata bindings.Metadata) error {
 	c.logger.Debug("Initializing Cosmos Graph DB binding")
 
 	m, err := c.parseMetadata(metadata)

--- a/bindings/azure/eventgrid/eventgrid.go
+++ b/bindings/azure/eventgrid/eventgrid.go
@@ -73,7 +73,7 @@ func NewAzureEventGrid(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init performs metadata init.
-func (a *AzureEventGrid) Init(metadata bindings.Metadata) error {
+func (a *AzureEventGrid) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := a.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/azure/eventhubs/eventhubs.go
+++ b/bindings/azure/eventhubs/eventhubs.go
@@ -37,7 +37,7 @@ func NewAzureEventHubs(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init performs metadata init.
-func (a *AzureEventHubs) Init(metadata bindings.Metadata) error {
+func (a *AzureEventHubs) Init(ctx context.Context, metadata bindings.Metadata) error {
 	return a.AzureEventHubs.Init(metadata.Properties)
 }
 

--- a/bindings/azure/servicebusqueues/servicebusqueues.go
+++ b/bindings/azure/servicebusqueues/servicebusqueues.go
@@ -49,7 +49,7 @@ func NewAzureServiceBusQueues(logger logger.Logger) bindings.InputOutputBinding 
 }
 
 // Init parses connection properties and creates a new Service Bus Queue client.
-func (a *AzureServiceBusQueues) Init(metadata bindings.Metadata) (err error) {
+func (a *AzureServiceBusQueues) Init(ctx context.Context, metadata bindings.Metadata) (err error) {
 	a.metadata, err = impl.ParseMetadata(metadata.Properties, a.logger, (impl.MetadataModeBinding | impl.MetadataModeQueues))
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (a *AzureServiceBusQueues) Init(metadata bindings.Metadata) (err error) {
 	}
 
 	// Will do nothing if DisableEntityManagement is false
-	err = a.client.EnsureQueue(context.Background(), a.metadata.QueueName)
+	err = a.client.EnsureQueue(ctx, a.metadata.QueueName)
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/signalr/signalr.go
+++ b/bindings/azure/signalr/signalr.go
@@ -78,7 +78,7 @@ type SignalR struct {
 }
 
 // Init is responsible for initializing the SignalR output based on the metadata.
-func (s *SignalR) Init(metadata bindings.Metadata) (err error) {
+func (s *SignalR) Init(ctx context.Context, metadata bindings.Metadata) (err error) {
 	s.userAgent = "dapr-" + logger.DaprVersion
 
 	err = s.parseMetadata(metadata.Properties)

--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -40,7 +40,7 @@ type consumer struct {
 
 // QueueHelper enables injection for testnig.
 type QueueHelper interface {
-	Init(metadata bindings.Metadata) (*storageQueuesMetadata, error)
+	Init(ctx context.Context, metadata bindings.Metadata) (*storageQueuesMetadata, error)
 	Write(ctx context.Context, data []byte, ttl *time.Duration) error
 	Read(ctx context.Context, consumer *consumer) error
 }
@@ -55,7 +55,7 @@ type AzureQueueHelper struct {
 }
 
 // Init sets up this helper.
-func (d *AzureQueueHelper) Init(metadata bindings.Metadata) (*storageQueuesMetadata, error) {
+func (d *AzureQueueHelper) Init(ctx context.Context, metadata bindings.Metadata) (*storageQueuesMetadata, error) {
 	m, err := parseMetadata(metadata)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (d *AzureQueueHelper) Init(metadata bindings.Metadata) (*storageQueuesMetad
 		d.queueURL = azqueue.NewQueueURL(*URL, p)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	_, err = d.queueURL.Create(ctx, azqueue.Metadata{})
 	cancel()
 	if err != nil {
@@ -193,8 +193,8 @@ func NewAzureStorageQueues(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init parses connection properties and creates a new Storage Queue client.
-func (a *AzureStorageQueues) Init(metadata bindings.Metadata) (err error) {
-	a.metadata, err = a.helper.Init(metadata)
+func (a *AzureStorageQueues) Init(ctx context.Context, metadata bindings.Metadata) (err error) {
+	a.metadata, err = a.helper.Init(ctx, metadata)
 	if err != nil {
 		return err
 	}

--- a/bindings/azure/storagequeues/storagequeues_test.go
+++ b/bindings/azure/storagequeues/storagequeues_test.go
@@ -16,6 +16,7 @@ package storagequeues
 import (
 	"context"
 	"encoding/base64"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,6 +33,8 @@ type MockHelper struct {
 	mock.Mock
 	messages chan []byte
 	metadata *storageQueuesMetadata
+	closeCh  chan struct{}
+	wg       sync.WaitGroup
 }
 
 func (m *MockHelper) Init(ctx context.Context, metadata bindings.Metadata) (*storageQueuesMetadata, error) {
@@ -50,12 +53,23 @@ func (m *MockHelper) Write(ctx context.Context, data []byte, ttl *time.Duration)
 func (m *MockHelper) Read(ctx context.Context, consumer *consumer) error {
 	retvals := m.Called(ctx, consumer)
 
+	readCtx, cancel := context.WithCancel(ctx)
+	m.wg.Add(2)
 	go func() {
+		defer m.wg.Done()
+		defer cancel()
+		select {
+		case <-readCtx.Done():
+		case <-m.closeCh:
+		}
+	}()
+	go func() {
+		defer m.wg.Done()
 		for msg := range m.messages {
 			if m.metadata.DecodeBase64 {
 				msg, _ = base64.StdEncoding.DecodeString(string(msg))
 			}
-			go consumer.callback(ctx, &bindings.ReadResponse{
+			go consumer.callback(readCtx, &bindings.ReadResponse{
 				Data: msg,
 			})
 		}
@@ -64,13 +78,19 @@ func (m *MockHelper) Read(ctx context.Context, consumer *consumer) error {
 	return retvals.Error(0)
 }
 
+func (m *MockHelper) Close() error {
+	defer m.wg.Wait()
+	close(m.closeCh)
+	return nil
+}
+
 func TestWriteQueue(t *testing.T) {
 	mm := new(MockHelper)
 	mm.On("Write", mock.AnythingOfType("[]uint8"), mock.MatchedBy(func(in *time.Duration) bool {
 		return in == nil
 	})).Return(nil)
 
-	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test")}
+	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test"), closeCh: make(chan struct{})}
 
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
@@ -83,6 +103,7 @@ func TestWriteQueue(t *testing.T) {
 	_, err = a.Invoke(context.Background(), &r)
 
 	assert.Nil(t, err)
+	assert.NoError(t, a.Close())
 }
 
 func TestWriteWithTTLInQueue(t *testing.T) {
@@ -91,7 +112,7 @@ func TestWriteWithTTLInQueue(t *testing.T) {
 		return in != nil && *in == time.Second
 	})).Return(nil)
 
-	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test")}
+	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test"), closeCh: make(chan struct{})}
 
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"}
@@ -104,6 +125,7 @@ func TestWriteWithTTLInQueue(t *testing.T) {
 	_, err = a.Invoke(context.Background(), &r)
 
 	assert.Nil(t, err)
+	assert.NoError(t, a.Close())
 }
 
 func TestWriteWithTTLInWrite(t *testing.T) {
@@ -112,7 +134,7 @@ func TestWriteWithTTLInWrite(t *testing.T) {
 		return in != nil && *in == time.Second
 	})).Return(nil)
 
-	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test")}
+	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test"), closeCh: make(chan struct{})}
 
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"}
@@ -128,6 +150,7 @@ func TestWriteWithTTLInWrite(t *testing.T) {
 	_, err = a.Invoke(context.Background(), &r)
 
 	assert.Nil(t, err)
+	assert.NoError(t, a.Close())
 }
 
 // Uncomment this function to write a message to local storage queue
@@ -152,7 +175,7 @@ func TestReadQueue(t *testing.T) {
 	mm := new(MockHelper)
 	mm.On("Write", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("*time.Duration")).Return(nil)
 	mm.On("Read", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*storagequeues.consumer")).Return(nil)
-	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test")}
+	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test"), closeCh: make(chan struct{})}
 
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
@@ -186,6 +209,7 @@ func TestReadQueue(t *testing.T) {
 		t.Fatal("Timeout waiting for messages")
 	}
 	assert.Equal(t, 1, received)
+	assert.NoError(t, a.Close())
 }
 
 func TestReadQueueDecode(t *testing.T) {
@@ -193,7 +217,7 @@ func TestReadQueueDecode(t *testing.T) {
 	mm.On("Write", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("*time.Duration")).Return(nil)
 	mm.On("Read", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*storagequeues.consumer")).Return(nil)
 
-	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test")}
+	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test"), closeCh: make(chan struct{})}
 
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1", "decodeBase64": "true"}
@@ -227,6 +251,7 @@ func TestReadQueueDecode(t *testing.T) {
 		t.Fatal("Timeout waiting for messages")
 	}
 	assert.Equal(t, 1, received)
+	assert.NoError(t, a.Close())
 }
 
 // Uncomment this function to test reding from local queue
@@ -263,7 +288,7 @@ func TestReadQueueNoMessage(t *testing.T) {
 	mm.On("Write", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("*time.Duration")).Return(nil)
 	mm.On("Read", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*storagequeues.consumer")).Return(nil)
 
-	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test")}
+	a := AzureStorageQueues{helper: mm, logger: logger.NewLogger("test"), closeCh: make(chan struct{})}
 
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
@@ -285,6 +310,7 @@ func TestReadQueueNoMessage(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	cancel()
 	assert.Equal(t, 0, received)
+	assert.NoError(t, a.Close())
 }
 
 func TestParseMetadata(t *testing.T) {

--- a/bindings/azure/storagequeues/storagequeues_test.go
+++ b/bindings/azure/storagequeues/storagequeues_test.go
@@ -34,7 +34,7 @@ type MockHelper struct {
 	metadata *storageQueuesMetadata
 }
 
-func (m *MockHelper) Init(metadata bindings.Metadata) (*storageQueuesMetadata, error) {
+func (m *MockHelper) Init(ctx context.Context, metadata bindings.Metadata) (*storageQueuesMetadata, error) {
 	m.messages = make(chan []byte, 10)
 	var err error
 	m.metadata, err = parseMetadata(metadata)
@@ -75,7 +75,7 @@ func TestWriteQueue(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{Data: []byte("This is my message")}
@@ -96,7 +96,7 @@ func TestWriteWithTTLInQueue(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{Data: []byte("This is my message")}
@@ -117,7 +117,7 @@ func TestWriteWithTTLInWrite(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1", metadata.TTLMetadataKey: "1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{
@@ -138,7 +138,7 @@ func TestWriteWithTTLInWrite(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{Data: []byte("This is my message")}
@@ -157,7 +157,7 @@ func TestReadQueue(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{Data: []byte("This is my message")}
@@ -198,7 +198,7 @@ func TestReadQueueDecode(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1", "decodeBase64": "true"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{Data: []byte("VGhpcyBpcyBteSBtZXNzYWdl")}
@@ -237,7 +237,7 @@ func TestReadQueueDecode(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	r := bindings.InvokeRequest{Data: []byte("This is my message")}
@@ -268,7 +268,7 @@ func TestReadQueueNoMessage(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"storageAccessKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "queue": "queue1", "storageAccount": "devstoreaccount1"}
 
-	err := a.Init(m)
+	err := a.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/bindings/cloudflare/queues/cfqueues.go
+++ b/bindings/cloudflare/queues/cfqueues.go
@@ -48,7 +48,7 @@ func NewCFQueues(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init the component.
-func (q *CFQueues) Init(metadata bindings.Metadata) error {
+func (q *CFQueues) Init(ctx context.Context, metadata bindings.Metadata) error {
 	// Decode the metadata
 	err := mapstructure.Decode(metadata.Properties, &q.metadata)
 	if err != nil {

--- a/bindings/commercetools/commercetools.go
+++ b/bindings/commercetools/commercetools.go
@@ -51,7 +51,7 @@ func NewCommercetools(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing and connection establishment.
-func (ct *Binding) Init(metadata bindings.Metadata) error {
+func (ct *Binding) Init(ctx context.Context, metadata bindings.Metadata) error {
 	commercetoolsM, err := ct.getCommercetoolsMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/cron/cron.go
+++ b/bindings/cron/cron.go
@@ -56,7 +56,7 @@ func NewCronWithClock(logger logger.Logger, clk clock.Clock) bindings.InputBindi
 //
 //	"15 * * * * *" - Every 15 sec
 //	"0 30 * * * *" - Every 30 min
-func (b *Binding) Init(metadata bindings.Metadata) error {
+func (b *Binding) Init(ctx context.Context, metadata bindings.Metadata) error {
 	b.name = metadata.Name
 	s, f := metadata.Properties["schedule"]
 	if !f || s == "" {

--- a/bindings/cron/cron.go
+++ b/bindings/cron/cron.go
@@ -16,6 +16,8 @@ package cron
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -34,6 +36,9 @@ type Binding struct {
 	schedule string
 	parser   cron.Parser
 	clk      clock.Clock
+	closed   atomic.Bool
+	closeCh  chan struct{}
+	wg       sync.WaitGroup
 }
 
 // NewCron returns a new Cron event input binding.
@@ -48,6 +53,7 @@ func NewCronWithClock(logger logger.Logger, clk clock.Clock) bindings.InputBindi
 		parser: cron.NewParser(
 			cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 		),
+		closeCh: make(chan struct{}),
 	}
 }
 
@@ -73,6 +79,10 @@ func (b *Binding) Init(ctx context.Context, metadata bindings.Metadata) error {
 
 // Read triggers the Cron scheduler.
 func (b *Binding) Read(ctx context.Context, handler bindings.Handler) error {
+	if b.closed.Load() {
+		return errors.New("binding is closed")
+	}
+
 	c := cron.New(cron.WithParser(b.parser), cron.WithClock(b.clk))
 	id, err := c.AddFunc(b.schedule, func() {
 		b.logger.Debugf("name: %s, schedule fired: %v", b.name, time.Now())
@@ -89,12 +99,25 @@ func (b *Binding) Read(ctx context.Context, handler bindings.Handler) error {
 	c.Start()
 	b.logger.Debugf("name: %s, next run: %v", b.name, time.Until(c.Entry(id).Next))
 
+	b.wg.Add(1)
 	go func() {
-		// Wait for context to be canceled
-		<-ctx.Done()
+		defer b.wg.Done()
+		// Wait for context to be canceled or closed.
+		select {
+		case <-ctx.Done():
+		case <-b.closeCh:
+		}
 		b.logger.Debugf("name: %s, stopping schedule: %s", b.name, b.schedule)
 		c.Stop()
 	}()
 
+	return nil
+}
+
+func (b *Binding) Close() error {
+	defer b.wg.Wait()
+	if b.closed.CompareAndSwap(false, true) {
+		close(b.closeCh)
+	}
 	return nil
 }

--- a/bindings/cron/cron_test.go
+++ b/bindings/cron/cron_test.go
@@ -84,7 +84,7 @@ func TestCronInitSuccess(t *testing.T) {
 
 	for _, test := range initTests {
 		c := getNewCron()
-		err := c.Init(getTestMetadata(test.schedule))
+		err := c.Init(context.Background(), getTestMetadata(test.schedule))
 		if test.errorExpected {
 			assert.Errorf(t, err, "Got no error while initializing an invalid schedule: %s", test.schedule)
 		} else {
@@ -99,7 +99,7 @@ func TestCronRead(t *testing.T) {
 	clk := clock.NewMock()
 	c := getNewCronWithClock(clk)
 	schedule := "@every 1s"
-	assert.NoErrorf(t, c.Init(getTestMetadata(schedule)), "error initializing valid schedule")
+	assert.NoErrorf(t, c.Init(context.Background(), getTestMetadata(schedule)), "error initializing valid schedule")
 	expectedCount := 5
 	observedCount := 0
 	err := c.Read(context.Background(), func(ctx context.Context, res *bindings.ReadResponse) ([]byte, error) {
@@ -122,7 +122,7 @@ func TestCronReadWithContextCancellation(t *testing.T) {
 	clk := clock.NewMock()
 	c := getNewCronWithClock(clk)
 	schedule := "@every 1s"
-	assert.NoErrorf(t, c.Init(getTestMetadata(schedule)), "error initializing valid schedule")
+	assert.NoErrorf(t, c.Init(context.Background(), getTestMetadata(schedule)), "error initializing valid schedule")
 	expectedCount := 5
 	observedCount := 0
 	ctx, cancel := context.WithCancel(context.Background())

--- a/bindings/cron/cron_test.go
+++ b/bindings/cron/cron_test.go
@@ -16,6 +16,7 @@ package cron
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -100,22 +101,25 @@ func TestCronRead(t *testing.T) {
 	c := getNewCronWithClock(clk)
 	schedule := "@every 1s"
 	assert.NoErrorf(t, c.Init(context.Background(), getTestMetadata(schedule)), "error initializing valid schedule")
-	expectedCount := 5
-	observedCount := 0
+	expectedCount := int32(5)
+	var observedCount atomic.Int32
 	err := c.Read(context.Background(), func(ctx context.Context, res *bindings.ReadResponse) ([]byte, error) {
 		assert.NotNil(t, res)
-		observedCount++
+		observedCount.Add(1)
 		return nil, nil
 	})
 	// Check if cron triggers 5 times in 5 seconds
-	for i := 0; i < expectedCount; i++ {
+	for i := int32(0); i < expectedCount; i++ {
 		// Add time to mock clock in 1 second intervals using loop to allow cron go routine to run
 		clk.Add(time.Second)
 	}
 	// Wait for 1 second after adding the last second to mock clock to allow cron to finish triggering
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, expectedCount, observedCount, "Cron did not trigger expected number of times, expected %d, got %d", expectedCount, observedCount)
+	assert.Eventually(t, func() bool {
+		return observedCount.Load() == expectedCount
+	}, time.Second, time.Millisecond*10,
+		"Cron did not trigger expected number of times, expected %d, got %d", expectedCount, observedCount.Load())
 	assert.NoErrorf(t, err, "error on read")
+	assert.NoError(t, c.Close())
 }
 
 func TestCronReadWithContextCancellation(t *testing.T) {
@@ -123,14 +127,14 @@ func TestCronReadWithContextCancellation(t *testing.T) {
 	c := getNewCronWithClock(clk)
 	schedule := "@every 1s"
 	assert.NoErrorf(t, c.Init(context.Background(), getTestMetadata(schedule)), "error initializing valid schedule")
-	expectedCount := 5
-	observedCount := 0
+	expectedCount := int32(5)
+	var observedCount atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
 	err := c.Read(ctx, func(ctx context.Context, res *bindings.ReadResponse) ([]byte, error) {
 		assert.NotNil(t, res)
-		assert.LessOrEqualf(t, observedCount, expectedCount, "Invoke didn't stop the schedule")
-		observedCount++
-		if observedCount == expectedCount {
+		assert.LessOrEqualf(t, observedCount.Load(), expectedCount, "Invoke didn't stop the schedule")
+		observedCount.Add(1)
+		if observedCount.Load() == expectedCount {
 			// Cancel context after 5 triggers
 			cancel()
 		}
@@ -141,7 +145,10 @@ func TestCronReadWithContextCancellation(t *testing.T) {
 		// Add time to mock clock in 1 second intervals using loop to allow cron go routine to run
 		clk.Add(time.Second)
 	}
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, expectedCount, observedCount, "Cron did not trigger expected number of times, expected %d, got %d", expectedCount, observedCount)
+	assert.Eventually(t, func() bool {
+		return observedCount.Load() == expectedCount
+	}, time.Second, time.Millisecond*10,
+		"Cron did not trigger expected number of times, expected %d, got %d", expectedCount, observedCount.Load())
 	assert.NoErrorf(t, err, "error on read")
+	assert.NoError(t, c.Close())
 }

--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -83,14 +83,13 @@ func NewGCPStorage(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs connection parsing.
-func (g *GCPStorage) Init(metadata bindings.Metadata) error {
+func (g *GCPStorage) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, b, err := g.parseMetadata(metadata)
 	if err != nil {
 		return err
 	}
 
 	clientOptions := option.WithCredentialsJSON(b)
-	ctx := context.Background()
 	client, err := storage.NewClient(ctx, clientOptions)
 	if err != nil {
 		return err

--- a/bindings/gcp/pubsub/pubsub.go
+++ b/bindings/gcp/pubsub/pubsub.go
@@ -59,7 +59,7 @@ func NewGCPPubSub(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init parses metadata and creates a new Pub Sub client.
-func (g *GCPPubSub) Init(metadata bindings.Metadata) error {
+func (g *GCPPubSub) Init(ctx context.Context, metadata bindings.Metadata) error {
 	b, err := g.parseMetadata(metadata)
 	if err != nil {
 		return err
@@ -71,7 +71,6 @@ func (g *GCPPubSub) Init(metadata bindings.Metadata) error {
 		return err
 	}
 	clientOptions := option.WithCredentialsJSON(b)
-	ctx := context.Background()
 	pubsubClient, err := pubsub.NewClient(ctx, pubsubMeta.ProjectID, clientOptions)
 	if err != nil {
 		return fmt.Errorf("error creating pubsub client: %s", err)

--- a/bindings/graphql/graphql.go
+++ b/bindings/graphql/graphql.go
@@ -58,7 +58,7 @@ func NewGraphQL(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init initializes the GraphQL binding.
-func (gql *GraphQL) Init(metadata bindings.Metadata) error {
+func (gql *GraphQL) Init(ctx context.Context, metadata bindings.Metadata) error {
 	gql.logger.Debug("GraphQL Error: Initializing GraphQL binding")
 
 	p := metadata.Properties

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -74,7 +74,7 @@ func NewHTTP(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs metadata parsing.
-func (h *HTTPSource) Init(metadata bindings.Metadata) error {
+func (h *HTTPSource) Init(ctx context.Context, metadata bindings.Metadata) error {
 	var err error
 	if err = mapstructure.Decode(metadata.Properties, &h.metadata); err != nil {
 		return err

--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -132,7 +132,7 @@ func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.Out
 	}
 
 	hs := NewHTTP(logger.NewLogger("test"))
-	err := hs.Init(m)
+	err := hs.Init(context.Background(), m)
 	return hs, err
 }
 
@@ -269,7 +269,7 @@ func InitBindingForHTTPS(s *httptest.Server, extraProps map[string]string) (bind
 		m.Properties[k] = v
 	}
 	hs := NewHTTP(logger.NewLogger("test"))
-	err := hs.Init(m)
+	err := hs.Init(context.Background(), m)
 	return hs, err
 }
 

--- a/bindings/huawei/obs/obs.go
+++ b/bindings/huawei/obs/obs.go
@@ -75,7 +75,7 @@ func NewHuaweiOBS(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (o *HuaweiOBS) Init(metadata bindings.Metadata) error {
+func (o *HuaweiOBS) Init(ctx context.Context, metadata bindings.Metadata) error {
 	o.logger.Debugf("initializing Huawei OBS binding and parsing metadata")
 
 	m, err := o.parseMetadata(metadata)

--- a/bindings/huawei/obs/obs_test.go
+++ b/bindings/huawei/obs/obs_test.go
@@ -92,7 +92,7 @@ func TestInit(t *testing.T) {
 			"accessKey": "dummy-ak",
 			"secretKey": "dummy-sk",
 		}
-		err := obs.Init(m)
+		err := obs.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 	t.Run("Init with missing bucket name", func(t *testing.T) {
@@ -102,7 +102,7 @@ func TestInit(t *testing.T) {
 			"accessKey": "dummy-ak",
 			"secretKey": "dummy-sk",
 		}
-		err := obs.Init(m)
+		err := obs.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing obs bucket name"))
 	})
@@ -113,7 +113,7 @@ func TestInit(t *testing.T) {
 			"endpoint":  "dummy-endpoint",
 			"secretKey": "dummy-sk",
 		}
-		err := obs.Init(m)
+		err := obs.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing the huawei access key"))
 	})
@@ -124,7 +124,7 @@ func TestInit(t *testing.T) {
 			"endpoint":  "dummy-endpoint",
 			"accessKey": "dummy-ak",
 		}
-		err := obs.Init(m)
+		err := obs.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing the huawei secret key"))
 	})
@@ -135,7 +135,7 @@ func TestInit(t *testing.T) {
 			"accessKey": "dummy-ak",
 			"secretKey": "dummy-sk",
 		}
-		err := obs.Init(m)
+		err := obs.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing obs endpoint"))
 	})

--- a/bindings/influx/influx.go
+++ b/bindings/influx/influx.go
@@ -64,7 +64,7 @@ func NewInflux(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing and connection establishment.
-func (i *Influx) Init(metadata bindings.Metadata) error {
+func (i *Influx) Init(ctx context.Context, metadata bindings.Metadata) error {
 	influxMeta, err := i.getInfluxMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/influx/influx_test.go
+++ b/bindings/influx/influx_test.go
@@ -54,7 +54,7 @@ func TestInflux_Init(t *testing.T) {
 	assert.Nil(t, influx.client)
 
 	m := bindings.Metadata{Base: metadata.Base{Properties: map[string]string{"Url": "a", "Token": "a", "Org": "a", "Bucket": "a"}}}
-	err := influx.Init(m)
+	err := influx.Init(context.Background(), m)
 	assert.Nil(t, err)
 
 	assert.NotNil(t, influx.queryAPI)

--- a/bindings/input_binding.go
+++ b/bindings/input_binding.go
@@ -23,7 +23,7 @@ import (
 // InputBinding is the interface to define a binding that triggers on incoming events.
 type InputBinding interface {
 	// Init passes connection and properties metadata to the binding implementation.
-	Init(metadata Metadata) error
+	Init(ctx context.Context, metadata Metadata) error
 	// Read is a method that runs in background and triggers the callback function whenever an event arrives.
 	Read(ctx context.Context, handler Handler) error
 }
@@ -31,10 +31,10 @@ type InputBinding interface {
 // Handler is the handler used to invoke the app handler.
 type Handler func(context.Context, *ReadResponse) ([]byte, error)
 
-func PingInpBinding(inputBinding InputBinding) error {
+func PingInpBinding(ctx context.Context, inputBinding InputBinding) error {
 	// checks if this input binding has the ping option then executes
 	if inputBindingWithPing, ok := inputBinding.(health.Pinger); ok {
-		return inputBindingWithPing.Ping()
+		return inputBindingWithPing.Ping(ctx)
 	} else {
 		return fmt.Errorf("ping is not implemented by this input binding")
 	}

--- a/bindings/input_binding.go
+++ b/bindings/input_binding.go
@@ -16,6 +16,7 @@ package bindings
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/dapr/components-contrib/health"
 )
@@ -28,7 +29,7 @@ type InputBinding interface {
 	Read(ctx context.Context, handler Handler) error
 	// Close is a method that closes the connection to the binding. Must be
 	// called when the binding is no longer needed to free up resources.
-	Close() error
+	io.Closer
 }
 
 // Handler is the handler used to invoke the app handler.

--- a/bindings/input_binding.go
+++ b/bindings/input_binding.go
@@ -26,6 +26,9 @@ type InputBinding interface {
 	Init(ctx context.Context, metadata Metadata) error
 	// Read is a method that runs in background and triggers the callback function whenever an event arrives.
 	Read(ctx context.Context, handler Handler) error
+	// Close is a method that closes the connection to the binding. Must be
+	// called when the binding is no longer needed to free up resources.
+	Close() error
 }
 
 // Handler is the handler used to invoke the app handler.

--- a/bindings/kubernetes/kubernetes.go
+++ b/bindings/kubernetes/kubernetes.go
@@ -48,7 +48,7 @@ func NewKubernetes(logger logger.Logger) bindings.InputBinding {
 	return &kubernetesInput{logger: logger}
 }
 
-func (k *kubernetesInput) Init(metadata bindings.Metadata) error {
+func (k *kubernetesInput) Init(ctx context.Context, metadata bindings.Metadata) error {
 	client, err := kubeclient.GetKubeClient()
 	if err != nil {
 		return err

--- a/bindings/kubernetes/kubernetes.go
+++ b/bindings/kubernetes/kubernetes.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +37,9 @@ type kubernetesInput struct {
 	namespace    string
 	resyncPeriod time.Duration
 	logger       logger.Logger
+	closed       atomic.Bool
+	closeCh      chan struct{}
+	wg           sync.WaitGroup
 }
 
 type EventResponse struct {
@@ -45,7 +50,7 @@ type EventResponse struct {
 
 // NewKubernetes returns a new Kubernetes event input binding.
 func NewKubernetes(logger logger.Logger) bindings.InputBinding {
-	return &kubernetesInput{logger: logger}
+	return &kubernetesInput{logger: logger, closeCh: make(chan struct{})}
 }
 
 func (k *kubernetesInput) Init(ctx context.Context, metadata bindings.Metadata) error {
@@ -78,6 +83,9 @@ func (k *kubernetesInput) parseMetadata(metadata bindings.Metadata) error {
 }
 
 func (k *kubernetesInput) Read(ctx context.Context, handler bindings.Handler) error {
+	if k.closed.Load() {
+		return errors.New("binding is closed")
+	}
 	watchlist := cache.NewListWatchFromClient(
 		k.kubeClient.CoreV1().RESTClient(),
 		"events",
@@ -126,12 +134,28 @@ func (k *kubernetesInput) Read(ctx context.Context, handler bindings.Handler) er
 		},
 	)
 
+	k.wg.Add(3)
+	readCtx, cancel := context.WithCancel(ctx)
+
+	// catch when binding is closed.
+	go func() {
+		defer k.wg.Done()
+		defer cancel()
+		select {
+		case <-readCtx.Done():
+		case <-k.closeCh:
+		}
+	}()
+
 	// Start the controller in backgound
-	stopCh := make(chan struct{})
-	go controller.Run(stopCh)
+	go func() {
+		defer k.wg.Done()
+		controller.Run(readCtx.Done())
+	}()
 
 	// Watch for new messages and for context cancellation
 	go func() {
+		defer k.wg.Done()
 		var (
 			obj  EventResponse
 			data []byte
@@ -148,12 +172,19 @@ func (k *kubernetesInput) Read(ctx context.Context, handler bindings.Handler) er
 						Data: data,
 					})
 				}
-			case <-ctx.Done():
-				close(stopCh)
+			case <-readCtx.Done():
 				return
 			}
 		}
 	}()
 
+	return nil
+}
+
+func (k *kubernetesInput) Close() error {
+	defer k.wg.Wait()
+	if k.closed.CompareAndSwap(false, true) {
+		close(k.closeCh)
+	}
 	return nil
 }

--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -64,7 +64,7 @@ func NewLocalStorage(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs metadata parsing.
-func (ls *LocalStorage) Init(metadata bindings.Metadata) error {
+func (ls *LocalStorage) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m, err := ls.parseMetadata(metadata)
 	if err != nil {
 		return fmt.Errorf("failed to parse metadata: %w", err)

--- a/bindings/mqtt3/mqtt.go
+++ b/bindings/mqtt3/mqtt.go
@@ -335,7 +335,12 @@ func (m *MQTT) createSubscriberClientOptions(ctx context.Context, uri *url.URL, 
 
 	// On (re-)connection, add the topic subscription
 	opts.OnConnect = func(c mqtt.Client) {
-		token := c.Subscribe(m.metadata.topic, m.metadata.qos, m.handleMessage(ctx))
+		// Use a background context here so that the context is not tied to the
+		// first Invoke first created the producer.
+		// TODO: add context to mqtt library, and add a OnConnectWithContext option
+		// to change this func signature to
+		// func(c mqtt.Client, ctx context.Context)
+		token := c.Subscribe(m.metadata.topic, m.metadata.qos, m.handleMessage(context.Background()))
 
 		var err error
 		select {

--- a/bindings/mqtt3/mqtt_integration_test.go
+++ b/bindings/mqtt3/mqtt_integration_test.go
@@ -128,4 +128,5 @@ func TestInvokeWithTopic(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, dataCustomized, mqttMessage.Payload())
 	assert.Equal(t, topicCustomized, mqttMessage.Topic())
+	assert.NoError(t, r.Close())
 }

--- a/bindings/mqtt3/mqtt_integration_test.go
+++ b/bindings/mqtt3/mqtt_integration_test.go
@@ -49,6 +49,7 @@ func getConnectionString() string {
 
 func TestInvokeWithTopic(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	url := getConnectionString()
 	if url == "" {
@@ -79,10 +80,10 @@ func TestInvokeWithTopic(t *testing.T) {
 	logger := logger.NewLogger("test")
 
 	r := NewMQTT(logger).(*MQTT)
-	err := r.Init(metadata)
+	err := r.Init(ctx, metadata)
 	assert.Nil(t, err)
 
-	conn, err := r.connect(uuid.NewString(), false)
+	conn, err := r.connect(ctx, uuid.NewString(), false)
 	assert.Nil(t, err)
 	defer conn.Disconnect(1)
 

--- a/bindings/mqtt3/mqtt_test.go
+++ b/bindings/mqtt3/mqtt_test.go
@@ -205,7 +205,6 @@ func TestParseMetadata(t *testing.T) {
 		logger := logger.NewLogger("test")
 		m := NewMQTT(logger).(*MQTT)
 		m.backOff = backoff.NewConstantBackOff(5 * time.Second)
-		m.ctx, m.cancel = context.WithCancel(context.Background())
 		m.readHandler = func(ctx context.Context, r *bindings.ReadResponse) ([]byte, error) {
 			assert.Equal(t, payload, r.Data)
 			metadata := r.Metadata
@@ -215,7 +214,7 @@ func TestParseMetadata(t *testing.T) {
 			return r.Data, nil
 		}
 
-		m.handleMessage(nil, &mqttMockMessage{
+		m.handleMessage(context.Background())(nil, &mqttMockMessage{
 			topic:   topic,
 			payload: payload,
 		})

--- a/bindings/mysql/mysql.go
+++ b/bindings/mysql/mysql.go
@@ -115,7 +115,7 @@ func (m *Mysql) Init(ctx context.Context, metadata bindings.Metadata) error {
 		return err
 	}
 
-	err = db.Ping()
+	err = db.PingContext(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to ping the DB: %w", err)
 	}

--- a/bindings/mysql/mysql.go
+++ b/bindings/mysql/mysql.go
@@ -81,7 +81,7 @@ func NewMysql(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init initializes the MySQL binding.
-func (m *Mysql) Init(metadata bindings.Metadata) error {
+func (m *Mysql) Init(ctx context.Context, metadata bindings.Metadata) error {
 	m.logger.Debug("Initializing MySql binding")
 
 	p := metadata.Properties

--- a/bindings/mysql/mysql_integration_test.go
+++ b/bindings/mysql/mysql_integration_test.go
@@ -75,7 +75,7 @@ func TestMysqlIntegration(t *testing.T) {
 
 	b := NewMysql(logger.NewLogger("test")).(*Mysql)
 	m := bindings.Metadata{Base: metadata.Base{Properties: map[string]string{connectionURLKey: url}}}
-	if err := b.Init(m); err != nil {
+	if err := b.Init(context.Background(), m); err != nil {
 		t.Fatal(err)
 	}
 

--- a/bindings/output_binding.go
+++ b/bindings/output_binding.go
@@ -22,15 +22,15 @@ import (
 
 // OutputBinding is the interface for an output binding, allowing users to invoke remote systems with optional payloads.
 type OutputBinding interface {
-	Init(metadata Metadata) error
+	Init(ctx context.Context, metadata Metadata) error
 	Invoke(ctx context.Context, req *InvokeRequest) (*InvokeResponse, error)
 	Operations() []OperationKind
 }
 
-func PingOutBinding(outputBinding OutputBinding) error {
+func PingOutBinding(ctx context.Context, outputBinding OutputBinding) error {
 	// checks if this output binding has the ping option then executes
 	if outputBindingWithPing, ok := outputBinding.(health.Pinger); ok {
-		return outputBindingWithPing.Ping()
+		return outputBindingWithPing.Ping(ctx)
 	} else {
 		return fmt.Errorf("ping is not implemented by this output binding")
 	}

--- a/bindings/postgres/postgres.go
+++ b/bindings/postgres/postgres.go
@@ -48,7 +48,7 @@ func NewPostgres(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init initializes the PostgreSql binding.
-func (p *Postgres) Init(metadata bindings.Metadata) error {
+func (p *Postgres) Init(ctx context.Context, metadata bindings.Metadata) error {
 	url, ok := metadata.Properties[connectionURLKey]
 	if !ok || url == "" {
 		return errors.Errorf("required metadata not set: %s", connectionURLKey)
@@ -59,7 +59,7 @@ func (p *Postgres) Init(metadata bindings.Metadata) error {
 		return errors.Wrap(err, "error opening DB connection")
 	}
 
-	p.db, err = pgxpool.NewWithConfig(context.Background(), poolConfig)
+	p.db, err = pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to ping the DB")
 	}

--- a/bindings/postgres/postgres.go
+++ b/bindings/postgres/postgres.go
@@ -59,6 +59,8 @@ func (p *Postgres) Init(ctx context.Context, metadata bindings.Metadata) error {
 		return errors.Wrap(err, "error opening DB connection")
 	}
 
+	// This context doesn't control the lifetime of the connection pool, and is
+	// only scoped to postgres creating resources at init.
 	p.db, err = pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to ping the DB")

--- a/bindings/postgres/postgres_test.go
+++ b/bindings/postgres/postgres_test.go
@@ -64,7 +64,7 @@ func TestPostgresIntegration(t *testing.T) {
 	// live DB test
 	b := NewPostgres(logger.NewLogger("test")).(*Postgres)
 	m := bindings.Metadata{Base: metadata.Base{Properties: map[string]string{connectionURLKey: url}}}
-	if err := b.Init(m); err != nil {
+	if err := b.Init(context.Background(), m); err != nil {
 		t.Fatal(err)
 	}
 

--- a/bindings/postmark/postmark.go
+++ b/bindings/postmark/postmark.go
@@ -74,7 +74,7 @@ func (p *Postmark) parseMetadata(meta bindings.Metadata) (postmarkMetadata, erro
 }
 
 // Init does metadata parsing and not much else :).
-func (p *Postmark) Init(metadata bindings.Metadata) error {
+func (p *Postmark) Init(ctx context.Context, metadata bindings.Metadata) error {
 	// Parse input metadata
 	meta, err := p.parseMetadata(metadata)
 	if err != nil {

--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -70,7 +70,7 @@ func NewRabbitMQ(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (r *RabbitMQ) Init(metadata bindings.Metadata) error {
+func (r *RabbitMQ) Init(ctx context.Context, metadata bindings.Metadata) error {
 	err := r.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -50,6 +52,9 @@ type RabbitMQ struct {
 	metadata   rabbitMQMetadata
 	logger     logger.Logger
 	queue      amqp.Queue
+	closed     atomic.Bool
+	closeCh    chan struct{}
+	wg         sync.WaitGroup
 }
 
 // Metadata is the rabbitmq config.
@@ -66,7 +71,7 @@ type rabbitMQMetadata struct {
 
 // NewRabbitMQ returns a new rabbitmq instance.
 func NewRabbitMQ(logger logger.Logger) bindings.InputOutputBinding {
-	return &RabbitMQ{logger: logger}
+	return &RabbitMQ{logger: logger, closeCh: make(chan struct{})}
 }
 
 // Init does metadata parsing and connection creation.
@@ -226,6 +231,10 @@ func (r *RabbitMQ) declareQueue() (amqp.Queue, error) {
 }
 
 func (r *RabbitMQ) Read(ctx context.Context, handler bindings.Handler) error {
+	if r.closed.Load() {
+		return errors.New("binding already closed")
+	}
+
 	msgs, err := r.channel.Consume(
 		r.queue.Name,
 		"",
@@ -239,14 +248,27 @@ func (r *RabbitMQ) Read(ctx context.Context, handler bindings.Handler) error {
 		return err
 	}
 
+	readCtx, cancel := context.WithCancel(ctx)
+
+	r.wg.Add(2)
 	go func() {
+		defer r.wg.Done()
+		defer cancel()
+		select {
+		case <-r.closeCh:
+		case <-readCtx.Done():
+		}
+	}()
+
+	go func() {
+		defer r.wg.Done()
 		var err error
 		for {
 			select {
-			case <-ctx.Done():
+			case <-readCtx.Done():
 				return
 			case d := <-msgs:
-				_, err = handler(ctx, &bindings.ReadResponse{
+				_, err = handler(readCtx, &bindings.ReadResponse{
 					Data: d.Body,
 				})
 				if err != nil {
@@ -259,4 +281,12 @@ func (r *RabbitMQ) Read(ctx context.Context, handler bindings.Handler) error {
 	}()
 
 	return nil
+}
+
+func (r *RabbitMQ) Close() error {
+	defer r.wg.Wait()
+	if r.closed.CompareAndSwap(false, true) {
+		close(r.closeCh)
+	}
+	return r.channel.Close()
 }

--- a/bindings/rabbitmq/rabbitmq_integration_test.go
+++ b/bindings/rabbitmq/rabbitmq_integration_test.go
@@ -117,6 +117,7 @@ func TestQueuesWithTTL(t *testing.T) {
 	assert.True(t, ok)
 	msgBody := string(msg.Body)
 	assert.Equal(t, testMsgContent, msgBody)
+	assert.NoError(t, r.Close())
 }
 
 func TestPublishingWithTTL(t *testing.T) {
@@ -193,6 +194,9 @@ func TestPublishingWithTTL(t *testing.T) {
 	assert.True(t, ok)
 	msgBody := string(msg.Body)
 	assert.Equal(t, testMsgContent, msgBody)
+
+	assert.NoError(t, rabbitMQBinding1.Close())
+	assert.NoError(t, rabbitMQBinding1.Close())
 }
 
 func TestExclusiveQueue(t *testing.T) {

--- a/bindings/redis/redis_test.go
+++ b/bindings/redis/redis_test.go
@@ -40,7 +40,6 @@ func TestInvokeCreate(t *testing.T) {
 		client: c,
 		logger: logger.NewLogger("test"),
 	}
-	bind.ctx, bind.cancel = context.WithCancel(context.Background())
 
 	_, err := c.DoRead(context.Background(), "GET", testKey)
 	assert.Equal(t, redis.Nil, err)
@@ -66,7 +65,6 @@ func TestInvokeGet(t *testing.T) {
 		client: c,
 		logger: logger.NewLogger("test"),
 	}
-	bind.ctx, bind.cancel = context.WithCancel(context.Background())
 
 	err := c.DoWrite(context.Background(), "SET", testKey, testData)
 	assert.Equal(t, nil, err)
@@ -87,7 +85,6 @@ func TestInvokeDelete(t *testing.T) {
 		client: c,
 		logger: logger.NewLogger("test"),
 	}
-	bind.ctx, bind.cancel = context.WithCancel(context.Background())
 
 	err := c.DoWrite(context.Background(), "SET", testKey, testData)
 	assert.Equal(t, nil, err)

--- a/bindings/rethinkdb/statechange/statechange.go
+++ b/bindings/rethinkdb/statechange/statechange.go
@@ -50,7 +50,7 @@ func NewRethinkDBStateChangeBinding(logger logger.Logger) bindings.InputBinding 
 }
 
 // Init initializes the RethinkDB binding.
-func (b *Binding) Init(metadata bindings.Metadata) error {
+func (b *Binding) Init(ctx context.Context, metadata bindings.Metadata) error {
 	cfg, err := metadataToConfig(metadata.Properties, b.logger)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse metadata properties")

--- a/bindings/rethinkdb/statechange/statechange_test.go
+++ b/bindings/rethinkdb/statechange/statechange_test.go
@@ -71,7 +71,7 @@ func TestBinding(t *testing.T) {
 	assert.NotNil(t, m.Properties)
 
 	b := getNewRethinkActorBinding()
-	err := b.Init(m)
+	err := b.Init(context.Background(), m)
 	assert.NoErrorf(t, err, "error initializing")
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/bindings/smtp/smtp.go
+++ b/bindings/smtp/smtp.go
@@ -61,7 +61,7 @@ func NewSMTP(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init smtp component (parse metadata).
-func (s *Mailer) Init(metadata bindings.Metadata) error {
+func (s *Mailer) Init(ctx context.Context, metadata bindings.Metadata) error {
 	// parse metadata
 	meta, err := s.parseMetadata(metadata)
 	if err != nil {

--- a/bindings/twilio/sendgrid/sendgrid.go
+++ b/bindings/twilio/sendgrid/sendgrid.go
@@ -84,7 +84,7 @@ func (sg *SendGrid) parseMetadata(meta bindings.Metadata) (sendGridMetadata, err
 }
 
 // Init does metadata parsing and not much else :).
-func (sg *SendGrid) Init(metadata bindings.Metadata) error {
+func (sg *SendGrid) Init(ctx context.Context, metadata bindings.Metadata) error {
 	// Parse input metadata
 	meta, err := sg.parseMetadata(metadata)
 	if err != nil {

--- a/bindings/twilio/sms/sms.go
+++ b/bindings/twilio/sms/sms.go
@@ -60,7 +60,7 @@ func NewSMS(logger logger.Logger) bindings.OutputBinding {
 	}
 }
 
-func (t *SMS) Init(metadata bindings.Metadata) error {
+func (t *SMS) Init(ctx context.Context, metadata bindings.Metadata) error {
 	twilioM := twilioMetadata{
 		timeout: time.Minute * 5,
 	}

--- a/bindings/twilio/sms/sms_test.go
+++ b/bindings/twilio/sms/sms_test.go
@@ -53,7 +53,7 @@ func TestInit(t *testing.T) {
 	m := bindings.Metadata{}
 	m.Properties = map[string]string{"toNumber": "toNumber", "fromNumber": "fromNumber"}
 	tw := NewSMS(logger.NewLogger("test"))
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.NotNil(t, err)
 }
 
@@ -66,7 +66,7 @@ func TestParseDuration(t *testing.T) {
 		"authToken":  "authToken", "timeout": "badtimeout",
 	}
 	tw := NewSMS(logger.NewLogger("test"))
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.NotNil(t, err)
 }
 
@@ -85,7 +85,7 @@ func TestWriteShouldSucceed(t *testing.T) {
 	tw.httpClient = &http.Client{
 		Transport: httpTransport,
 	}
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.NoError(t, err)
 
 	t.Run("Should succeed with expected url and headers", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestWriteShouldFail(t *testing.T) {
 	tw.httpClient = &http.Client{
 		Transport: httpTransport,
 	}
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.NoError(t, err)
 
 	t.Run("Missing 'to' should fail", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestMessageBody(t *testing.T) {
 	tw.httpClient = &http.Client{
 		Transport: httpTransport,
 	}
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	require.NoError(t, err)
 
 	tester := func(reqData []byte, expectBody string) func(t *testing.T) {

--- a/bindings/twitter/twitter.go
+++ b/bindings/twitter/twitter.go
@@ -42,7 +42,7 @@ func NewTwitter(logger logger.Logger) bindings.InputOutputBinding {
 }
 
 // Init initializes the Twitter binding.
-func (t *Binding) Init(metadata bindings.Metadata) error {
+func (t *Binding) Init(ctx context.Context, metadata bindings.Metadata) error {
 	ck, f := metadata.Properties["consumerKey"]
 	if !f || ck == "" {
 		return fmt.Errorf("consumerKey not set")

--- a/bindings/twitter/twitter_test.go
+++ b/bindings/twitter/twitter_test.go
@@ -60,7 +60,7 @@ func getRuntimeMetadata() map[string]string {
 func TestInit(t *testing.T) {
 	m := getTestMetadata()
 	tw := NewTwitter(logger.NewLogger("test")).(*Binding)
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.Nilf(t, err, "error initializing valid metadata properties")
 }
 
@@ -69,7 +69,7 @@ func TestInit(t *testing.T) {
 func TestReadError(t *testing.T) {
 	tw := NewTwitter(logger.NewLogger("test")).(*Binding)
 	m := getTestMetadata()
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.Nilf(t, err, "error initializing valid metadata properties")
 
 	err = tw.Read(context.Background(), func(ctx context.Context, res *bindings.ReadResponse) ([]byte, error) {
@@ -93,7 +93,7 @@ func TestRead(t *testing.T) {
 	m.Properties["query"] = "microsoft"
 	tw := NewTwitter(logger.NewLogger("test")).(*Binding)
 	tw.logger.SetOutputLevel(logger.DebugLevel)
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.Nilf(t, err, "error initializing read")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -129,7 +129,7 @@ func TestInvoke(t *testing.T) {
 	m.Properties = getRuntimeMetadata()
 	tw := NewTwitter(logger.NewLogger("test")).(*Binding)
 	tw.logger.SetOutputLevel(logger.DebugLevel)
-	err := tw.Init(m)
+	err := tw.Init(context.Background(), m)
 	assert.Nilf(t, err, "error initializing Invoke")
 
 	req := &bindings.InvokeRequest{

--- a/bindings/twitter/twitter_test.go
+++ b/bindings/twitter/twitter_test.go
@@ -79,6 +79,8 @@ func TestReadError(t *testing.T) {
 		return nil, nil
 	})
 	assert.Error(t, err)
+
+	assert.NoError(t, tw.Close())
 }
 
 // TestRead executes the Read method which calls Twiter API
@@ -116,6 +118,8 @@ func TestRead(t *testing.T) {
 		cancel()
 		t.Fatal("Timeout waiting for messages")
 	}
+
+	assert.NoError(t, tw.Close())
 }
 
 // TestInvoke executes the Invoke method which calls Twiter API
@@ -141,4 +145,5 @@ func TestInvoke(t *testing.T) {
 	resp, err := tw.Invoke(context.Background(), req)
 	assert.Nilf(t, err, "error on invoke")
 	assert.NotNil(t, resp)
+	assert.NoError(t, tw.Close())
 }

--- a/bindings/zeebe/command/command.go
+++ b/bindings/zeebe/command/command.go
@@ -61,7 +61,7 @@ func NewZeebeCommand(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (z *ZeebeCommand) Init(metadata bindings.Metadata) error {
+func (z *ZeebeCommand) Init(ctx context.Context, metadata bindings.Metadata) error {
 	client, err := z.clientFactory.Get(metadata)
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (z *ZeebeCommand) Invoke(ctx context.Context, req *bindings.InvokeRequest) 
 	case UpdateJobRetriesOperation:
 		return z.updateJobRetries(ctx, req)
 	case ThrowErrorOperation:
-		return z.throwError(req)
+		return z.throwError(ctx, req)
 	case bindings.GetOperation:
 		fallthrough
 	case bindings.CreateOperation:

--- a/bindings/zeebe/command/command_test.go
+++ b/bindings/zeebe/command/command_test.go
@@ -58,7 +58,7 @@ func TestInit(t *testing.T) {
 		}
 
 		cmd := ZeebeCommand{clientFactory: mcf, logger: testLogger}
-		err := cmd.Init(metadata)
+		err := cmd.Init(context.Background(), metadata)
 		assert.Error(t, err, errParsing)
 	})
 
@@ -67,7 +67,7 @@ func TestInit(t *testing.T) {
 		mcf := mockClientFactory{}
 
 		cmd := ZeebeCommand{clientFactory: mcf, logger: testLogger}
-		err := cmd.Init(metadata)
+		err := cmd.Init(context.Background(), metadata)
 
 		assert.NoError(t, err)
 

--- a/bindings/zeebe/command/throw_error.go
+++ b/bindings/zeebe/command/throw_error.go
@@ -30,7 +30,7 @@ type throwErrorPayload struct {
 	ErrorMessage string `json:"errorMessage"`
 }
 
-func (z *ZeebeCommand) throwError(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (z *ZeebeCommand) throwError(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	var payload throwErrorPayload
 	err := json.Unmarshal(req.Data, &payload)
 	if err != nil {
@@ -53,7 +53,7 @@ func (z *ZeebeCommand) throwError(req *bindings.InvokeRequest) (*bindings.Invoke
 		cmd = cmd.ErrorMessage(payload.ErrorMessage)
 	}
 
-	_, err = cmd.Send(context.Background())
+	_, err = cmd.Send(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot throw error for job key %d: %w", payload.JobKey, err)
 	}

--- a/bindings/zeebe/jobworker/jobworker.go
+++ b/bindings/zeebe/jobworker/jobworker.go
@@ -68,7 +68,7 @@ func NewZeebeJobWorker(logger logger.Logger) bindings.InputBinding {
 }
 
 // Init does metadata parsing and connection creation.
-func (z *ZeebeJobWorker) Init(metadata bindings.Metadata) error {
+func (z *ZeebeJobWorker) Init(ctx context.Context, metadata bindings.Metadata) error {
 	meta, err := z.parseMetadata(metadata)
 	if err != nil {
 		return err

--- a/bindings/zeebe/jobworker/jobworker_test.go
+++ b/bindings/zeebe/jobworker/jobworker_test.go
@@ -54,10 +54,11 @@ func TestInit(t *testing.T) {
 		metadata := bindings.Metadata{}
 		var mcf mockClientFactory
 
-		jobWorker := ZeebeJobWorker{clientFactory: &mcf, logger: testLogger}
+		jobWorker := ZeebeJobWorker{clientFactory: &mcf, logger: testLogger, closeCh: make(chan struct{})}
 		err := jobWorker.Init(context.Background(), metadata)
 
 		assert.Error(t, err, ErrMissingJobType)
+		assert.NoError(t, jobWorker.Close())
 	})
 
 	t.Run("sets client from client factory", func(t *testing.T) {
@@ -67,7 +68,7 @@ func TestInit(t *testing.T) {
 		mcf := mockClientFactory{
 			metadata: metadata,
 		}
-		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger}
+		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger, closeCh: make(chan struct{})}
 		err := jobWorker.Init(context.Background(), metadata)
 
 		assert.NoError(t, err)
@@ -77,6 +78,7 @@ func TestInit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, mc, jobWorker.client)
 		assert.Equal(t, metadata, mcf.metadata)
+		assert.NoError(t, jobWorker.Close())
 	})
 
 	t.Run("returns error if client could not be instantiated properly", func(t *testing.T) {
@@ -86,9 +88,10 @@ func TestInit(t *testing.T) {
 			error: errParsing,
 		}
 
-		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger}
+		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger, closeCh: make(chan struct{})}
 		err := jobWorker.Init(context.Background(), metadata)
 		assert.Error(t, err, errParsing)
+		assert.NoError(t, jobWorker.Close())
 	})
 
 	t.Run("sets client from client factory", func(t *testing.T) {
@@ -99,7 +102,7 @@ func TestInit(t *testing.T) {
 			metadata: metadata,
 		}
 
-		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger}
+		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger, closeCh: make(chan struct{})}
 		err := jobWorker.Init(context.Background(), metadata)
 
 		assert.NoError(t, err)
@@ -109,5 +112,6 @@ func TestInit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, mc, jobWorker.client)
 		assert.Equal(t, metadata, mcf.metadata)
+		assert.NoError(t, jobWorker.Close())
 	})
 }

--- a/bindings/zeebe/jobworker/jobworker_test.go
+++ b/bindings/zeebe/jobworker/jobworker_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package jobworker
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestInit(t *testing.T) {
 		var mcf mockClientFactory
 
 		jobWorker := ZeebeJobWorker{clientFactory: &mcf, logger: testLogger}
-		err := jobWorker.Init(metadata)
+		err := jobWorker.Init(context.Background(), metadata)
 
 		assert.Error(t, err, ErrMissingJobType)
 	})
@@ -67,7 +68,7 @@ func TestInit(t *testing.T) {
 			metadata: metadata,
 		}
 		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger}
-		err := jobWorker.Init(metadata)
+		err := jobWorker.Init(context.Background(), metadata)
 
 		assert.NoError(t, err)
 
@@ -86,7 +87,7 @@ func TestInit(t *testing.T) {
 		}
 
 		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger}
-		err := jobWorker.Init(metadata)
+		err := jobWorker.Init(context.Background(), metadata)
 		assert.Error(t, err, errParsing)
 	})
 
@@ -99,7 +100,7 @@ func TestInit(t *testing.T) {
 		}
 
 		jobWorker := ZeebeJobWorker{clientFactory: mcf, logger: testLogger}
-		err := jobWorker.Init(metadata)
+		err := jobWorker.Init(context.Background(), metadata)
 
 		assert.NoError(t, err)
 

--- a/health/pinger.go
+++ b/health/pinger.go
@@ -1,5 +1,7 @@
 package health
 
+import "context"
+
 type Pinger interface {
-	Ping() error
+	Ping(ctx context.Context) error
 }

--- a/health/pinger.go
+++ b/health/pinger.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package health
 
 import "context"

--- a/internal/component/kafka/consumer.go
+++ b/internal/component/kafka/consumer.go
@@ -275,9 +275,6 @@ func (k *Kafka) Subscribe(ctx context.Context) error {
 
 	k.cg = cg
 
-	ctx, cancel := context.WithCancel(ctx)
-	k.cancel = cancel
-
 	ready := make(chan bool)
 	k.consumer = consumer{
 		k:       k,
@@ -331,7 +328,6 @@ func (k *Kafka) Subscribe(ctx context.Context) error {
 // Close down consumer group resources, refresh once.
 func (k *Kafka) closeSubscriptionResources() {
 	if k.cg != nil {
-		k.cancel()
 		err := k.cg.Close()
 		if err != nil {
 			k.logger.Errorf("Error closing consumer group: %v", err)

--- a/internal/component/kafka/kafka.go
+++ b/internal/component/kafka/kafka.go
@@ -36,7 +36,6 @@ type Kafka struct {
 	saslPassword    string
 	initialOffset   int64
 	cg              sarama.ConsumerGroup
-	cancel          context.CancelFunc
 	consumer        consumer
 	config          *sarama.Config
 	subscribeTopics TopicHandlerConfig
@@ -60,7 +59,7 @@ func NewKafka(logger logger.Logger) *Kafka {
 }
 
 // Init does metadata parsing and connection establishment.
-func (k *Kafka) Init(metadata map[string]string) error {
+func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 	upgradedMetadata, err := k.upgradeMetadata(metadata)
 	if err != nil {
 		return err

--- a/lock/redis/standalone_test.go
+++ b/lock/redis/standalone_test.go
@@ -42,7 +42,7 @@ func TestStandaloneRedisLock_InitError(t *testing.T) {
 		cfg.Properties["redisPassword"] = ""
 
 		// init
-		err := comp.InitLockStore(cfg)
+		err := comp.InitLockStore(context.Background(), cfg)
 		assert.Error(t, err)
 	})
 
@@ -58,7 +58,7 @@ func TestStandaloneRedisLock_InitError(t *testing.T) {
 		cfg.Properties["redisPassword"] = ""
 
 		// init
-		err := comp.InitLockStore(cfg)
+		err := comp.InitLockStore(context.Background(), cfg)
 		assert.Error(t, err)
 	})
 
@@ -75,7 +75,7 @@ func TestStandaloneRedisLock_InitError(t *testing.T) {
 		cfg.Properties["maxRetries"] = "1 "
 
 		// init
-		err := comp.InitLockStore(cfg)
+		err := comp.InitLockStore(context.Background(), cfg)
 		assert.Error(t, err)
 	})
 }
@@ -96,7 +96,7 @@ func TestStandaloneRedisLock_TryLock(t *testing.T) {
 	cfg.Properties["redisHost"] = s.Addr()
 	cfg.Properties["redisPassword"] = ""
 	// init
-	err = comp.InitLockStore(cfg)
+	err = comp.InitLockStore(context.Background(), cfg)
 	assert.NoError(t, err)
 	// 1. client1 trylock
 	ownerID1 := uuid.New().String()

--- a/lock/store.go
+++ b/lock/store.go
@@ -17,7 +17,7 @@ import "context"
 
 type Store interface {
 	// Init this component.
-	InitLockStore(metadata Metadata) error
+	InitLockStore(ctx context.Context, metadata Metadata) error
 
 	// TryLock tries to acquire a lock.
 	TryLock(ctx context.Context, req *TryLockRequest) (*TryLockResponse, error)

--- a/middleware/http/bearer/bearer_middleware.go
+++ b/middleware/http/bearer/bearer_middleware.go
@@ -45,13 +45,13 @@ const (
 )
 
 // GetHandler retruns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
 		return nil, err
 	}
 
-	provider, err := oidc.NewProvider(context.Background(), meta.IssuerURL)
+	provider, err := oidc.NewProvider(ctx, meta.IssuerURL)
 	if err != nil {
 		return nil, err
 	}

--- a/middleware/http/oauth2/oauth2_middleware.go
+++ b/middleware/http/oauth2/oauth2_middleware.go
@@ -14,6 +14,7 @@ limitations under the License.
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -59,7 +60,7 @@ const (
 )
 
 // GetHandler retruns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
 		return nil, err

--- a/middleware/http/oauth2clientcredentials/mocks/mock_TokenProviderInterface.go
+++ b/middleware/http/oauth2clientcredentials/mocks/mock_TokenProviderInterface.go
@@ -5,6 +5,7 @@
 package mock_oauth2clientcredentials
 
 import (
+	"context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,7 +37,7 @@ func (m *MockTokenProviderInterface) EXPECT() *MockTokenProviderInterfaceMockRec
 }
 
 // GetToken mocks base method
-func (m *MockTokenProviderInterface) GetToken(arg0 *clientcredentials.Config) (*oauth2.Token, error) {
+func (m *MockTokenProviderInterface) GetToken(ctx context.Context, arg0 *clientcredentials.Config) (*oauth2.Token, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetToken", arg0)
 	ret0, _ := ret[0].(*oauth2.Token)

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go
@@ -45,7 +45,7 @@ type oAuth2ClientCredentialsMiddlewareMetadata struct {
 
 // TokenProviderInterface provides a common interface to Mock the Token retrieval in unit tests.
 type TokenProviderInterface interface {
-	GetToken(conf *clientcredentials.Config) (*oauth2.Token, error)
+	GetToken(ctx context.Context, conf *clientcredentials.Config) (*oauth2.Token, error)
 }
 
 // NewOAuth2ClientCredentialsMiddleware returns a new oAuth2 middleware.
@@ -68,7 +68,7 @@ type Middleware struct {
 }
 
 // GetHandler retruns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(_ context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
 		m.log.Errorf("getNativeMetadata error: %s", err)
@@ -101,7 +101,7 @@ func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Ha
 			if !found {
 				m.log.Debugf("Cached token not found, try get one")
 
-				token, err := m.tokenProvider.GetToken(conf)
+				token, err := m.tokenProvider.GetToken(r.Context(), conf)
 				if err != nil {
 					m.log.Errorf("Error acquiring token: %s", err)
 					return
@@ -171,8 +171,8 @@ func (m *Middleware) SetTokenProvider(tokenProvider TokenProviderInterface) {
 }
 
 // GetToken returns a token from the current OAuth2 ClientCredentials Configuration.
-func (m *Middleware) GetToken(conf *clientcredentials.Config) (*oauth2.Token, error) {
-	tokenSource := conf.TokenSource(context.Background())
+func (m *Middleware) GetToken(ctx context.Context, conf *clientcredentials.Config) (*oauth2.Token, error) {
+	tokenSource := conf.TokenSource(ctx)
 
 	return tokenSource.Token()
 }

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
@@ -45,7 +45,7 @@ func TestOAuth2ClientCredentialsMetadata(t *testing.T) {
 	metadata.Properties = map[string]string{}
 
 	log := logger.NewLogger("oauth2clientcredentials.test")
-	_, err := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(metadata)
+	_, err := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
 	assert.EqualError(t, err, "metadata errors: Parameter 'headerName' needs to be set. Parameter 'clientID' needs to be set. Parameter 'clientSecret' needs to be set. Parameter 'scopes' needs to be set. Parameter 'tokenURL' needs to be set. ")
 
 	// Invalid authStyle (non int)
@@ -57,17 +57,17 @@ func TestOAuth2ClientCredentialsMetadata(t *testing.T) {
 		"headerName":   "someHeader",
 		"authStyle":    "asdf", // This is the value to test
 	}
-	_, err2 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(metadata)
+	_, err2 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
 	assert.EqualError(t, err2, "metadata errors: 1 error(s) decoding:\n\n* cannot parse 'AuthStyle' as int: strconv.ParseInt: parsing \"asdf\": invalid syntax")
 
 	// Invalid authStyle (int > 2)
 	metadata.Properties["authStyle"] = "3"
-	_, err3 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(metadata)
+	_, err3 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
 	assert.EqualError(t, err3, "metadata errors: Parameter 'authStyle' can only have the values 0,1,2. Received: '3'. ")
 
 	// Invalid authStyle (int < 0)
 	metadata.Properties["authStyle"] = "-1"
-	_, err4 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(metadata)
+	_, err4 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
 	assert.EqualError(t, err4, "metadata errors: Parameter 'authStyle' can only have the values 0,1,2. Received: '-1'. ")
 }
 
@@ -109,7 +109,7 @@ func TestOAuth2ClientCredentialsToken(t *testing.T) {
 	log := logger.NewLogger("oauth2clientcredentials.test")
 	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
 	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
-	handler, err := oauth2clientcredentialsMiddleware.GetHandler(metadata)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(nil, metadata)
 	require.NoError(t, err)
 
 	// First handler call should return abc Token
@@ -169,7 +169,7 @@ func TestOAuth2ClientCredentialsCache(t *testing.T) {
 	log := logger.NewLogger("oauth2clientcredentials.test")
 	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
 	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
-	handler, err := oauth2clientcredentialsMiddleware.GetHandler(metadata)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(nil, metadata)
 	require.NoError(t, err)
 
 	// First handler call should return abc Token

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package oauth2clientcredentials
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,7 +46,7 @@ func TestOAuth2ClientCredentialsMetadata(t *testing.T) {
 	metadata.Properties = map[string]string{}
 
 	log := logger.NewLogger("oauth2clientcredentials.test")
-	_, err := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
+	_, err := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(context.Background(), metadata)
 	assert.EqualError(t, err, "metadata errors: Parameter 'headerName' needs to be set. Parameter 'clientID' needs to be set. Parameter 'clientSecret' needs to be set. Parameter 'scopes' needs to be set. Parameter 'tokenURL' needs to be set. ")
 
 	// Invalid authStyle (non int)
@@ -57,17 +58,17 @@ func TestOAuth2ClientCredentialsMetadata(t *testing.T) {
 		"headerName":   "someHeader",
 		"authStyle":    "asdf", // This is the value to test
 	}
-	_, err2 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
+	_, err2 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(context.Background(), metadata)
 	assert.EqualError(t, err2, "metadata errors: 1 error(s) decoding:\n\n* cannot parse 'AuthStyle' as int: strconv.ParseInt: parsing \"asdf\": invalid syntax")
 
 	// Invalid authStyle (int > 2)
 	metadata.Properties["authStyle"] = "3"
-	_, err3 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
+	_, err3 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(context.Background(), metadata)
 	assert.EqualError(t, err3, "metadata errors: Parameter 'authStyle' can only have the values 0,1,2. Received: '3'. ")
 
 	// Invalid authStyle (int < 0)
 	metadata.Properties["authStyle"] = "-1"
-	_, err4 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(nil, metadata)
+	_, err4 := NewOAuth2ClientCredentialsMiddleware(log).GetHandler(context.Background(), metadata)
 	assert.EqualError(t, err4, "metadata errors: Parameter 'authStyle' can only have the values 0,1,2. Received: '-1'. ")
 }
 
@@ -109,7 +110,7 @@ func TestOAuth2ClientCredentialsToken(t *testing.T) {
 	log := logger.NewLogger("oauth2clientcredentials.test")
 	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
 	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
-	handler, err := oauth2clientcredentialsMiddleware.GetHandler(nil, metadata)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(context.Background(), metadata)
 	require.NoError(t, err)
 
 	// First handler call should return abc Token
@@ -169,7 +170,7 @@ func TestOAuth2ClientCredentialsCache(t *testing.T) {
 	log := logger.NewLogger("oauth2clientcredentials.test")
 	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
 	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
-	handler, err := oauth2clientcredentialsMiddleware.GetHandler(nil, metadata)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(context.Background(), metadata)
 	require.NoError(t, err)
 
 	// First handler call should return abc Token

--- a/middleware/http/opa/middleware.go
+++ b/middleware/http/opa/middleware.go
@@ -106,13 +106,13 @@ func (s *Status) Valid() bool {
 }
 
 // GetHandler returns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	query, err := rego.New(
 		rego.Query("result = data.http.allow"),
 		rego.Module("inline.rego", meta.Rego),

--- a/middleware/http/opa/middleware_test.go
+++ b/middleware/http/opa/middleware_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package opa
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -331,7 +332,7 @@ func TestOpaPolicy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			opaMiddleware := NewMiddleware(log)
 
-			handler, err := opaMiddleware.GetHandler(test.meta)
+			handler, err := opaMiddleware.GetHandler(context.Background(), test.meta)
 			if test.shouldHandlerError {
 				require.Error(t, err)
 				return

--- a/middleware/http/ratelimit/ratelimit_middleware.go
+++ b/middleware/http/ratelimit/ratelimit_middleware.go
@@ -14,6 +14,7 @@ limitations under the License.
 package ratelimit
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -46,7 +47,7 @@ func NewRateLimitMiddleware(_ logger.Logger) middleware.Middleware {
 type Middleware struct{}
 
 // GetHandler returns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
 		return nil, err

--- a/middleware/http/routeralias/routeralias_middleware.go
+++ b/middleware/http/routeralias/routeralias_middleware.go
@@ -40,7 +40,7 @@ func NewMiddleware(logger logger.Logger) middleware.Middleware {
 }
 
 // GetHandler retruns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (
 	func(next http.Handler) http.Handler, error,
 ) {
 	if err := m.getNativeMetadata(metadata); err != nil {

--- a/middleware/http/routeralias/routeralias_middleware_test.go
+++ b/middleware/http/routeralias/routeralias_middleware_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package routeralias
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +47,7 @@ func TestRequestHandlerWithIllegalRouterRule(t *testing.T) {
 	}
 	log := logger.NewLogger("routeralias.test")
 	ralias := NewMiddleware(log)
-	handler, err := ralias.GetHandler(meta)
+	handler, err := ralias.GetHandler(context.Background(), meta)
 	assert.Nil(t, err)
 
 	t.Run("hit: change router with common request", func(t *testing.T) {

--- a/middleware/http/routerchecker/routerchecker_middleware.go
+++ b/middleware/http/routerchecker/routerchecker_middleware.go
@@ -14,6 +14,7 @@ limitations under the License.
 package routerchecker
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -40,7 +41,7 @@ type Middleware struct {
 }
 
 // GetHandler retruns the HTTP handler provided by the middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
 		return nil, err

--- a/middleware/http/routerchecker/routerchecker_middleware_test.go
+++ b/middleware/http/routerchecker/routerchecker_middleware_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package routerchecker
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +38,7 @@ func TestRequestHandlerWithIllegalRouterRule(t *testing.T) {
 	}}}
 	log := logger.NewLogger("routerchecker.test")
 	rchecker := NewMiddleware(log)
-	handler, err := rchecker.GetHandler(meta)
+	handler, err := rchecker.GetHandler(context.Background(), meta)
 	assert.Nil(t, err)
 
 	r := httptest.NewRequest(http.MethodGet, "http://localhost:5001/v1.0/invoke/qcg.default/method/%20cat%20password", nil)
@@ -54,7 +55,7 @@ func TestRequestHandlerWithLegalRouterRule(t *testing.T) {
 
 	log := logger.NewLogger("routerchecker.test")
 	rchecker := NewMiddleware(log)
-	handler, err := rchecker.GetHandler(meta)
+	handler, err := rchecker.GetHandler(context.Background(), meta)
 	assert.Nil(t, err)
 
 	r := httptest.NewRequest(http.MethodGet, "http://localhost:5001/v1.0/invoke/qcg.default/method", nil)

--- a/middleware/http/sentinel/middleware.go
+++ b/middleware/http/sentinel/middleware.go
@@ -14,6 +14,7 @@ limitations under the License.
 package sentinel
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -51,7 +52,7 @@ type Middleware struct {
 }
 
 // GetHandler returns the HTTP handler provided by sentinel middleware.
-func (m *Middleware) GetHandler(metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
+func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	var (
 		meta *middlewareMetadata
 		err  error

--- a/middleware/http/sentinel/middleware_test.go
+++ b/middleware/http/sentinel/middleware_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package sentinel
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,7 +49,7 @@ func TestRequestHandlerWithFlowRules(t *testing.T) {
 
 	log := logger.NewLogger("sentinel.test")
 	sentinel := NewMiddleware(log)
-	handler, err := sentinel.GetHandler(meta)
+	handler, err := sentinel.GetHandler(context.Background(), meta)
 	assert.Nil(t, err)
 
 	r := httptest.NewRequest(http.MethodGet, "http://localhost:5001/v1.0/nodeapp/healthz", nil)

--- a/middleware/http/wasm/benchmark_test.go
+++ b/middleware/http/wasm/benchmark_test.go
@@ -1,6 +1,7 @@
 package wasm
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,7 +46,7 @@ func benchmarkMiddleware(b *testing.B, path string) {
 	l := logger.NewLogger(b.Name())
 	l.SetOutput(io.Discard)
 
-	handlerFn, err := NewMiddleware(l).GetHandler(dapr.Metadata{Base: md})
+	handlerFn, err := NewMiddleware(l).GetHandler(context.Background(), dapr.Metadata{Base: md})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/middleware/http/wasm/httpwasm_test.go
+++ b/middleware/http/wasm/httpwasm_test.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +32,7 @@ func Test_middleware_log(t *testing.T) {
 
 	m := &middleware{logger: l}
 	message := "alert"
-	m.Log(ctx, api.LogLevelInfo, message)
+	m.Log(context.Background(), api.LogLevelInfo, message)
 
 	require.Contains(t, buf.String(), `level=info msg=alert`)
 }
@@ -114,7 +115,7 @@ func Test_middleware_getHandler(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := m.getHandler(dapr.Metadata{Base: tc.metadata})
+			h, err := m.getHandler(context.Background(), dapr.Metadata{Base: tc.metadata})
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 				require.NotNil(t, h.mw)
@@ -135,7 +136,7 @@ func Test_Example(t *testing.T) {
 		//	tinygo build -o router.wasm -scheduler=none --no-debug -target=wasi router.go`
 		"path": "./example/router.wasm",
 	}}
-	handlerFn, err := NewMiddleware(l).GetHandler(dapr.Metadata{Base: meta})
+	handlerFn, err := NewMiddleware(l).GetHandler(context.Background(), dapr.Metadata{Base: meta})
 	require.NoError(t, err)
 
 	handler := handlerFn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))

--- a/middleware/http/wasm/internal/e2e_test.go
+++ b/middleware/http/wasm/internal/e2e_test.go
@@ -2,6 +2,7 @@ package internal_test
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -139,7 +140,7 @@ func Test_EndToEnd(t *testing.T) {
 			require.NoError(t, os.WriteFile(wasmPath, tc.guest, 0o600))
 
 			meta := metadata.Base{Properties: map[string]string{"path": wasmPath}}
-			handlerFn, err := wasm.NewMiddleware(l).GetHandler(middleware.Metadata{Base: meta})
+			handlerFn, err := wasm.NewMiddleware(l).GetHandler(context.Background(), middleware.Metadata{Base: meta})
 			require.NoError(t, err)
 			handler := handlerFn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 			tc.test(t, handler, &buf)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -14,10 +14,11 @@ limitations under the License.
 package middleware
 
 import (
+	"context"
 	"net/http"
 )
 
 // Middleware is the interface for a middleware.
 type Middleware interface {
-	GetHandler(metadata Metadata) (func(next http.Handler) http.Handler, error)
+	GetHandler(ctx context.Context, metadata Metadata) (func(next http.Handler) http.Handler, error)
 }

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -41,7 +41,7 @@ func NewAzureEventHubs(logger logger.Logger) pubsub.PubSub {
 }
 
 // Init the object.
-func (aeh *AzureEventHubs) Init(metadata pubsub.Metadata) error {
+func (aeh *AzureEventHubs) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	return aeh.AzureEventHubs.Init(metadata.Properties)
 }
 

--- a/pubsub/azure/servicebus/queues/servicebus.go
+++ b/pubsub/azure/servicebus/queues/servicebus.go
@@ -49,7 +49,7 @@ func NewAzureServiceBusQueues(logger logger.Logger) pubsub.PubSub {
 	}
 }
 
-func (a *azureServiceBus) Init(metadata pubsub.Metadata) (err error) {
+func (a *azureServiceBus) Init(ctx context.Context, metadata pubsub.Metadata) (err error) {
 	a.metadata, err = impl.ParseMetadata(metadata.Properties, a.logger, impl.MetadataModeQueues)
 	if err != nil {
 		return err

--- a/pubsub/azure/servicebus/topics/servicebus.go
+++ b/pubsub/azure/servicebus/topics/servicebus.go
@@ -49,7 +49,7 @@ func NewAzureServiceBusTopics(logger logger.Logger) pubsub.PubSub {
 	}
 }
 
-func (a *azureServiceBus) Init(metadata pubsub.Metadata) (err error) {
+func (a *azureServiceBus) Init(ctx context.Context, metadata pubsub.Metadata) (err error) {
 	a.metadata, err = impl.ParseMetadata(metadata.Properties, a.logger, impl.MetadataModeTopics)
 	if err != nil {
 		return err

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -175,13 +175,13 @@ func createMetadata(pubSubMetadata pubsub.Metadata) (*metadata, error) {
 }
 
 // Init parses metadata and creates a new Pub Sub client.
-func (g *GCPPubSub) Init(meta pubsub.Metadata) error {
+func (g *GCPPubSub) Init(ctx context.Context, meta pubsub.Metadata) error {
 	metadata, err := createMetadata(meta)
 	if err != nil {
 		return err
 	}
 
-	pubsubClient, err := g.getPubSubClient(context.Background(), metadata)
+	pubsubClient, err := g.getPubSubClient(ctx, metadata)
 	if err != nil {
 		return fmt.Errorf("%s error creating pubsub client: %w", errorMessagePrefix, err)
 	}

--- a/pubsub/hazelcast/hazelcast.go
+++ b/pubsub/hazelcast/hazelcast.go
@@ -65,7 +65,7 @@ func parseHazelcastMetadata(meta pubsub.Metadata) (metadata, error) {
 	return m, nil
 }
 
-func (p *Hazelcast) Init(metadata pubsub.Metadata) error {
+func (p *Hazelcast) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	p.logger.Warnf("DEPRECATION NOTICE: Component pubsub.hazelcast has been deprecated and will be removed in a future Dapr release.")
 
 	m, err := parseHazelcastMetadata(metadata)

--- a/pubsub/in-memory/in-memory.go
+++ b/pubsub/in-memory/in-memory.go
@@ -41,7 +41,7 @@ func (a *bus) Features() []pubsub.Feature {
 	return []pubsub.Feature{pubsub.FeatureSubscribeWildcards}
 }
 
-func (a *bus) Init(metadata pubsub.Metadata) error {
+func (a *bus) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	a.bus = eventbus.New(true)
 
 	return nil

--- a/pubsub/in-memory/in-memory_test.go
+++ b/pubsub/in-memory/in-memory_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestNewInMemoryBus(t *testing.T) {
 	bus := New(logger.NewLogger("test"))
-	bus.Init(pubsub.Metadata{})
+	bus.Init(context.Background(), pubsub.Metadata{})
 
 	ch := make(chan []byte)
 	bus.Subscribe(context.Background(), pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
@@ -39,7 +39,7 @@ func TestNewInMemoryBus(t *testing.T) {
 
 func TestMultipleSubscribers(t *testing.T) {
 	bus := New(logger.NewLogger("test"))
-	bus.Init(pubsub.Metadata{})
+	bus.Init(context.Background(), pubsub.Metadata{})
 
 	ch1 := make(chan []byte)
 	ch2 := make(chan []byte)
@@ -59,7 +59,7 @@ func TestMultipleSubscribers(t *testing.T) {
 
 func TestWildcards(t *testing.T) {
 	bus := New(logger.NewLogger("test"))
-	bus.Init(pubsub.Metadata{})
+	bus.Init(context.Background(), pubsub.Metadata{})
 
 	ch1 := make(chan []byte)
 	ch2 := make(chan []byte)
@@ -83,7 +83,7 @@ func TestWildcards(t *testing.T) {
 
 func TestRetry(t *testing.T) {
 	bus := New(logger.NewLogger("test"))
-	bus.Init(pubsub.Metadata{})
+	bus.Init(context.Background(), pubsub.Metadata{})
 
 	ch := make(chan []byte)
 	i := -1

--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -37,7 +37,7 @@ func NewJetStream(logger logger.Logger) pubsub.PubSub {
 	return &jetstreamPubSub{l: logger}
 }
 
-func (js *jetstreamPubSub) Init(metadata pubsub.Metadata) error {
+func (js *jetstreamPubSub) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	var err error
 	js.meta, err = parseMetadata(metadata)
 	if err != nil {

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -31,10 +31,10 @@ type PubSub struct {
 	subscribeCancel context.CancelFunc
 }
 
-func (p *PubSub) Init(metadata pubsub.Metadata) error {
+func (p *PubSub) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	p.subscribeCtx, p.subscribeCancel = context.WithCancel(context.Background())
 
-	return p.kafka.Init(metadata.Properties)
+	return p.kafka.Init(ctx, metadata.Properties)
 }
 
 func (p *PubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {

--- a/pubsub/kubemq/kubemq.go
+++ b/pubsub/kubemq/kubemq.go
@@ -14,8 +14,6 @@ import (
 type kubeMQ struct {
 	metadata         *metadata
 	logger           logger.Logger
-	ctx              context.Context
-	ctxCancel        context.CancelFunc
 	eventsClient     *kubeMQEvents
 	eventStoreClient *kubeMQEventStore
 }
@@ -26,14 +24,13 @@ func NewKubeMQ(logger logger.Logger) pubsub.PubSub {
 	}
 }
 
-func (k *kubeMQ) Init(metadata pubsub.Metadata) error {
+func (k *kubeMQ) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	meta, err := createMetadata(metadata)
 	if err != nil {
 		k.logger.Errorf("error init kubemq client error: %s", err.Error())
 		return err
 	}
 	k.metadata = meta
-	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
 	if meta.isStore {
 		k.eventStoreClient = newKubeMQEventsStore(k.logger)
 		_ = k.eventStoreClient.Init(meta)

--- a/pubsub/kubemq/kubemq_test.go
+++ b/pubsub/kubemq/kubemq_test.go
@@ -20,8 +20,6 @@ func getMockEventsClient() *kubeMQEvents {
 		publishFunc:          nil,
 		resultChan:           nil,
 		waitForResultTimeout: 0,
-		ctx:                  nil,
-		ctxCancel:            nil,
 		isInitialized:        true,
 	}
 }
@@ -34,8 +32,6 @@ func getMockEventsStoreClient() *kubeMQEventStore {
 		publishFunc:          nil,
 		resultChan:           nil,
 		waitForResultTimeout: 0,
-		ctx:                  nil,
-		ctxCancel:            nil,
 		isInitialized:        true,
 	}
 }
@@ -103,7 +99,7 @@ func Test_kubeMQ_Init(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k := NewKubeMQ(logger.NewLogger("test"))
-			err := k.Init(tt.meta)
+			err := k.Init(context.Background(), tt.meta)
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}
@@ -113,8 +109,6 @@ func Test_kubeMQ_Close(t *testing.T) {
 	type fields struct {
 		metadata         *metadata
 		logger           logger.Logger
-		ctx              context.Context
-		ctxCancel        context.CancelFunc
 		eventsClient     *kubeMQEvents
 		eventStoreClient *kubeMQEventStore
 	}
@@ -151,8 +145,6 @@ func Test_kubeMQ_Close(t *testing.T) {
 			k := &kubeMQ{
 				metadata:         tt.fields.metadata,
 				logger:           tt.fields.logger,
-				ctx:              tt.fields.ctx,
-				ctxCancel:        tt.fields.ctxCancel,
 				eventsClient:     tt.fields.eventsClient,
 				eventStoreClient: tt.fields.eventStoreClient,
 			}

--- a/pubsub/mqtt3/mqtt.go
+++ b/pubsub/mqtt3/mqtt.go
@@ -45,8 +45,7 @@ type mqttPubSub struct {
 	topics          map[string]mqttPubSubSubscription
 	subscribingLock sync.RWMutex
 	reconnectCh     chan struct{}
-	ctx             context.Context
-	cancel          context.CancelFunc
+	closeCh         chan struct{}
 }
 
 type mqttPubSubSubscription struct {
@@ -59,21 +58,20 @@ type mqttPubSubSubscription struct {
 func NewMQTTPubSub(logger logger.Logger) pubsub.PubSub {
 	return &mqttPubSub{
 		logger:      logger,
-		reconnectCh: make(chan struct{}, 1),
+		reconnectCh: make(chan struct{}),
+		closeCh:     make(chan struct{}),
 	}
 }
 
 // Init parses metadata and creates a new Pub Sub client.
-func (m *mqttPubSub) Init(metadata pubsub.Metadata) error {
+func (m *mqttPubSub) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	mqttMeta, err := parseMQTTMetaData(metadata, m.logger)
 	if err != nil {
 		return err
 	}
 	m.metadata = mqttMeta
 
-	m.ctx, m.cancel = context.WithCancel(context.Background())
-
-	err = m.connect()
+	err = m.connect(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to establish connection to broker: %w", err)
 	}
@@ -85,7 +83,7 @@ func (m *mqttPubSub) Init(metadata pubsub.Metadata) error {
 }
 
 // Publish the topic to mqtt pub sub.
-func (m *mqttPubSub) Publish(parentCtx context.Context, req *pubsub.PublishRequest) (err error) {
+func (m *mqttPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) (err error) {
 	if req.Topic == "" {
 		return errors.New("topic name is empty")
 	}
@@ -103,14 +101,13 @@ func (m *mqttPubSub) Publish(parentCtx context.Context, req *pubsub.PublishReque
 	}
 
 	token := m.conn.Publish(req.Topic, m.metadata.qos, retain, req.Data)
-	ctx, cancel := context.WithTimeout(parentCtx, defaultWait)
+	ctx, cancel := context.WithTimeout(ctx, defaultWait)
 	defer cancel()
 	select {
 	case <-token.Done():
 		err = token.Error()
-	case <-m.ctx.Done():
-		// Context canceled
-		err = m.ctx.Err()
+	case <-m.closeCh:
+		err = errors.New("mqtt client closed")
 	case <-ctx.Done():
 		// Context canceled
 		err = ctx.Err()
@@ -126,9 +123,10 @@ func (m *mqttPubSub) Publish(parentCtx context.Context, req *pubsub.PublishReque
 // Request metadata includes:
 // - "unsubscribeOnClose": if true, when the subscription is stopped (context canceled), then an Unsubscribe message is sent to the MQTT broker, which will stop delivering messages to this consumer ID until the subscription is explicitly re-started with a new Subscribe call. Otherwise, messages continue to be delivered but are not handled and are NACK'd automatically. "unsubscribeOnClose" should be used with dynamic subscriptions.
 func (m *mqttPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {
-	if ctxErr := m.ctx.Err(); ctxErr != nil {
-		// If the global context has been canceled, we do not allow more subscriptions
-		return ctxErr
+	select {
+	case <-m.closeCh:
+		return errors.New("mqtt client closed")
+	default:
 	}
 
 	topic := req.Topic
@@ -143,22 +141,23 @@ func (m *mqttPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 	// Add the topic then start the subscription
 	m.addTopic(topic, handler)
 
-	// Use the global context here to maintain the handler
-	token := m.conn.Subscribe(topic, m.metadata.qos, m.onMessage(m.ctx))
-	subscribeCtx, subscribeCancel := context.WithTimeout(m.ctx, defaultWait)
-	defer subscribeCancel()
-	var err error
-	select {
-	case <-token.Done():
-		// Subscription went through (sucecessfully or not)
-		err = token.Error()
-	case <-subscribeCtx.Done():
-		err = fmt.Errorf("error while waiting for subscription token: %w", subscribeCtx.Err())
-	}
-	if err != nil {
-		// Return an error
-		delete(m.topics, topic)
-		return fmt.Errorf("mqtt error from subscribe: %v", err)
+	token := m.conn.Subscribe(topic, m.metadata.qos, m.onMessage(ctx))
+	{
+		ctx, cancel := context.WithTimeout(ctx, defaultWait)
+		defer cancel()
+		var err error
+		select {
+		case <-token.Done():
+			// Subscription went through (sucecessfully or not)
+			err = token.Error()
+		case <-ctx.Done():
+			err = fmt.Errorf("error while waiting for subscription token: %w", ctx.Err())
+		}
+		if err != nil {
+			// Return an error
+			delete(m.topics, topic)
+			return fmt.Errorf("mqtt error from subscribe: %v", err)
+		}
 	}
 
 	m.logger.Infof("MQTT is subscribed to topic %s (qos: %d)", topic, m.metadata.qos)
@@ -167,11 +166,9 @@ func (m *mqttPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 	go func() {
 		select {
 		case <-ctx.Done():
-		case <-m.ctx.Done():
-		}
-
-		// If m.ctx has been canceled, nothing to do here as the entire connection will be closed
-		if m.ctx.Err() != nil {
+		case <-m.closeCh:
+			// If Close has been called, nothing to do here as the entire connection
+			// will be closed.
 			return
 		}
 
@@ -187,18 +184,16 @@ func (m *mqttPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 		}
 
 		unsubscribeToken := m.conn.Unsubscribe(topic)
-		unsubscribeCtx, unsubscribeCancel := context.WithTimeout(m.ctx, defaultWait)
-		defer unsubscribeCancel()
 		var unsubscribeErr error
 		select {
 		case <-unsubscribeToken.Done():
 			// Subscription went through (sucecessfully or not)
 			unsubscribeErr = token.Error()
-		case <-unsubscribeCtx.Done():
-			unsubscribeErr = fmt.Errorf("error while waiting for subscription token: %w", unsubscribeCtx.Err())
+		case <-time.After(defaultWait):
+			unsubscribeErr = fmt.Errorf("timeout while unsubscribing from topic %s", topic)
 		}
 		if unsubscribeErr != nil {
-			m.logger.Warnf("Failed to ubsubscribe from topic %s: %v", topic, err)
+			m.logger.Warnf("Failed to ubsubscribe from topic %s: %v", topic, unsubscribeErr)
 		}
 	}()
 
@@ -280,13 +275,13 @@ func (m *mqttPubSub) doConnect(ctx context.Context, clientID string) (mqtt.Clien
 }
 
 // Create a connection
-func (m *mqttPubSub) connect() error {
+func (m *mqttPubSub) connect(ctx context.Context) error {
 	m.subscribingLock.Lock()
 	defer m.subscribingLock.Unlock()
 
-	connCtx, connCancel := context.WithTimeout(m.ctx, defaultWait)
-	conn, err := m.doConnect(connCtx, m.metadata.consumerID)
-	connCancel()
+	ctx, cancel := context.WithTimeout(ctx, defaultWait)
+	defer cancel()
+	conn, err := m.doConnect(ctx, m.metadata.consumerID)
 	if err != nil {
 		return err
 	}
@@ -296,7 +291,7 @@ func (m *mqttPubSub) connect() error {
 }
 
 // Forcefully closes the connection and, after a delay, reconnects
-func (m *mqttPubSub) ResetConection() {
+func (m *mqttPubSub) ResetConection(ctx context.Context) {
 	const reconnectDelay = 30 * time.Second
 
 	// Do not reconnect if there's already one attempt in progress
@@ -312,16 +307,16 @@ func (m *mqttPubSub) ResetConection() {
 	m.logger.Info("Closing connection with broker… will reconnect in " + reconnectDelay.String())
 	m.conn.Disconnect(100)
 
-	for m.ctx.Err() == nil {
+	for ctx.Err() == nil {
 		time.Sleep(reconnectDelay)
 
 		// Check for context cancelation before reconnecting, since we slept
-		if m.ctx.Err() != nil {
+		if ctx.Err() != nil {
 			return
 		}
 
 		m.logger.Debug("Reconnecting…")
-		err := m.connect()
+		err := m.connect(ctx)
 		if err != nil {
 			m.logger.Errorf("Failed to reconnect, will retry in " + reconnectDelay.String())
 		} else {
@@ -372,15 +367,24 @@ func (m *mqttPubSub) createClientOptions(uri *url.URL, clientID string) *mqtt.Cl
 			subscribeTopics[k] = m.metadata.qos
 		}
 
-		// Note that this is a bit unusual for a pubsub component as we're using m.ctx on the handler, which is tied to the component rather than the individual subscription
-		// This is because we can't really use a different context for each handler in a single SubscribeMultiple call, and the alternative (multiple individual Subscribe calls) is not ideal
+		// Note that this is a bit unusual for a pubsub component as we're using
+		// closeCh on the handler, which is tied to the component rather than the
+		// individual subscription.
+		// This is because we can't really use a different context for each handler
+		// in a single SubscribeMultiple call, and the alternative (multiple
+		// individual Subscribe calls) is not ideal
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			defer cancel()
+			<-m.closeCh
+		}()
 		token := c.SubscribeMultiple(
 			subscribeTopics,
-			m.onMessage(m.ctx),
+			m.onMessage(ctx),
 		)
 
 		var err error
-		subscribeCtx, subscribeCancel := context.WithTimeout(m.ctx, defaultWait)
+		subscribeCtx, subscribeCancel := context.WithTimeout(ctx, defaultWait)
 		defer subscribeCancel()
 		select {
 		case <-token.Done():
@@ -432,8 +436,7 @@ func (m *mqttPubSub) Close() error {
 	// Clear all topics from the map as a first thing, before stopping all subscriptions (we have the lock anyways)
 	maps.Clear(m.topics)
 
-	// Cancel the context
-	m.cancel()
+	close(m.closeCh)
 
 	// Disconnect
 	m.conn.Disconnect(100)

--- a/pubsub/mqtt3/mqtt_test.go
+++ b/pubsub/mqtt3/mqtt_test.go
@@ -697,7 +697,6 @@ func Test_mqttPubSub_Publish(t *testing.T) {
 			m := &mqttPubSub{
 				conn:     newMockedMQTTClient(msgCh),
 				logger:   tt.fields.logger,
-				ctx:      tt.fields.ctx,
 				metadata: tt.fields.metadata,
 			}
 

--- a/pubsub/natsstreaming/natsstreaming.go
+++ b/pubsub/natsstreaming/natsstreaming.go
@@ -187,7 +187,7 @@ func parseNATSStreamingMetadata(meta pubsub.Metadata) (metadata, error) {
 	return m, nil
 }
 
-func (n *natsStreamingPubSub) Init(metadata pubsub.Metadata) error {
+func (n *natsStreamingPubSub) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	m, err := parseNATSStreamingMetadata(metadata)
 	if err != nil {
 		return err

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -22,7 +22,7 @@ import (
 
 // PubSub is the interface for message buses.
 type PubSub interface {
-	Init(metadata Metadata) error
+	Init(ctx context.Context, metadata Metadata) error
 	Features() []Feature
 	Publish(ctx context.Context, req *PublishRequest) error
 	Subscribe(ctx context.Context, req SubscribeRequest, handler Handler) error
@@ -64,10 +64,10 @@ type Handler func(ctx context.Context, msg *NewMessage) error
 // orderly fashion.
 type BulkHandler func(ctx context.Context, msg *BulkMessage) ([]BulkSubscribeResponseEntry, error)
 
-func Ping(pubsub PubSub) error {
+func Ping(ctx context.Context, pubsub PubSub) error {
 	// checks if this pubsub has the ping option then executes
 	if pubsubWithPing, ok := pubsub.(health.Pinger); ok {
-		return pubsubWithPing.Ping()
+		return pubsubWithPing.Ping(ctx)
 	} else {
 		return fmt.Errorf("ping is not implemented by this pubsub")
 	}

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -175,7 +175,7 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 	return &m, nil
 }
 
-func (p *Pulsar) Init(metadata pubsub.Metadata) error {
+func (p *Pulsar) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	m, err := parsePulsarMetadata(metadata)
 	if err != nil {
 		return err

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -58,10 +58,9 @@ type rabbitMQ struct {
 	connectionCount   int
 	metadata          *metadata
 	declaredExchanges map[string]bool
-	ctx               context.Context
-	cancel            context.CancelFunc
 
 	connectionDial func(protocol, uri string, tlsCfg *tls.Config) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error)
+	closeCh        chan struct{}
 
 	logger logger.Logger
 }
@@ -95,6 +94,7 @@ func NewRabbitMQ(logger logger.Logger) pubsub.PubSub {
 		declaredExchanges: make(map[string]bool),
 		logger:            logger,
 		connectionDial:    dial,
+		closeCh:           make(chan struct{}),
 	}
 }
 
@@ -124,13 +124,11 @@ func dial(protocol, uri string, tlsCfg *tls.Config) (rabbitMQConnectionBroker, r
 }
 
 // Init does metadata parsing and connection creation.
-func (r *rabbitMQ) Init(metadata pubsub.Metadata) error {
+func (r *rabbitMQ) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	meta, err := createMetadata(metadata, r.logger)
 	if err != nil {
 		return err
 	}
-
-	r.ctx, r.cancel = context.WithCancel(context.Background())
 
 	r.metadata = meta
 
@@ -563,17 +561,19 @@ func (r *rabbitMQ) reset() (err error) {
 }
 
 func (r *rabbitMQ) isStopped() bool {
-	return r.ctx.Err() != nil
+	select {
+	case <-r.closeCh:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *rabbitMQ) Close() error {
 	r.channelMutex.Lock()
 	defer r.channelMutex.Unlock()
-
-	r.cancel()
-	err := r.reset()
-
-	return err
+	close(r.closeCh)
+	return r.reset()
 }
 
 func (r *rabbitMQ) Features() []pubsub.Feature {

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -61,6 +62,8 @@ type rabbitMQ struct {
 
 	connectionDial func(protocol, uri string, tlsCfg *tls.Config) (rabbitMQConnectionBroker, rabbitMQChannelBroker, error)
 	closeCh        chan struct{}
+	closed         atomic.Bool
+	wg             sync.WaitGroup
 
 	logger logger.Logger
 }
@@ -245,6 +248,10 @@ func (r *rabbitMQ) publishSync(ctx context.Context, req *pubsub.PublishRequest) 
 }
 
 func (r *rabbitMQ) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
+	if r.closed.Load() {
+		return errors.New("error: rabbitMQ is closed")
+	}
+
 	r.logger.Debugf("%s publishing message to %s", logMessagePrefix, req.Topic)
 
 	attempt := 0
@@ -270,6 +277,10 @@ func (r *rabbitMQ) Publish(ctx context.Context, req *pubsub.PublishRequest) erro
 }
 
 func (r *rabbitMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {
+	if r.closed.Load() {
+		return errors.New("error: rabbitMQ is closed")
+	}
+
 	if r.metadata.consumerID == "" {
 		return errors.New("consumerID is required for subscriptions")
 	}
@@ -280,7 +291,18 @@ func (r *rabbitMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, h
 	// Do not set a timeout on the context, as we're just waiting for the first ack; we're using a semaphore instead
 	ackCh := make(chan struct{}, 1)
 	defer close(ackCh)
-	go r.subscribeForever(ctx, req, queueName, handler, ackCh)
+
+	subctx, cancel := context.WithCancel(ctx)
+	r.wg.Add(2)
+	go func() {
+		defer r.wg.Done()
+		r.subscribeForever(subctx, req, queueName, handler, ackCh)
+	}()
+	go func() {
+		defer r.wg.Done()
+		defer cancel()
+		<-r.closeCh
+	}()
 
 	// Wait for the ack for 1 minute or return an error
 	select {
@@ -465,13 +487,17 @@ func (r *rabbitMQ) listenMessages(ctx context.Context, channel rabbitMQChannelBr
 			switch r.metadata.concurrency {
 			case pubsub.Single:
 				err = r.handleMessage(ctx, d, topic, handler)
+				if err != nil && mustReconnect(channel, err) {
+					return err
+				}
 			case pubsub.Parallel:
+				r.wg.Add(1)
 				go func(d amqp.Delivery) {
-					err = r.handleMessage(ctx, d, topic, handler)
+					defer r.wg.Done()
+					if err := r.handleMessage(ctx, d, topic, handler); err != nil {
+						r.logger.Errorf("%s error handling message: %v", logMessagePrefix, err)
+					}
 				}(d)
-			}
-			if err != nil && mustReconnect(channel, err) {
-				return err
 			}
 		}
 	}
@@ -561,18 +587,20 @@ func (r *rabbitMQ) reset() (err error) {
 }
 
 func (r *rabbitMQ) isStopped() bool {
-	select {
-	case <-r.closeCh:
-		return true
-	default:
-		return false
-	}
+	return r.closed.Load()
 }
 
+// Close closes the rabbitMQ connection. Blocks until all go routines are done.
 func (r *rabbitMQ) Close() error {
+	defer r.wg.Wait()
+
 	r.channelMutex.Lock()
 	defer r.channelMutex.Unlock()
-	close(r.closeCh)
+
+	if r.closed.CompareAndSwap(false, true) {
+		close(r.closeCh)
+	}
+
 	return r.reset()
 }
 

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -43,6 +43,7 @@ func newRabbitMQTest(broker *rabbitMQInMemoryBroker) pubsub.PubSub {
 
 			return broker, broker, nil
 		},
+		closeCh: make(chan struct{}),
 	}
 }
 
@@ -54,7 +55,7 @@ func TestNoConsumer(t *testing.T) {
 			metadataHostnameKey: "anyhost",
 		},
 	}}
-	err := pubsubRabbitMQ.Init(metadata)
+	err := pubsubRabbitMQ.Init(context.Background(), metadata)
 	assert.NoError(t, err)
 	err = pubsubRabbitMQ.Subscribe(context.Background(), pubsub.SubscribeRequest{}, nil)
 	assert.Contains(t, err.Error(), "consumerID is required for subscriptions")
@@ -71,7 +72,7 @@ func TestConcurrencyMode(t *testing.T) {
 				pubsub.ConcurrencyKey: string(pubsub.Parallel),
 			},
 		}}
-		err := pubsubRabbitMQ.Init(metadata)
+		err := pubsubRabbitMQ.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, pubsub.Parallel, pubsubRabbitMQ.(*rabbitMQ).metadata.concurrency)
 	})
@@ -86,7 +87,7 @@ func TestConcurrencyMode(t *testing.T) {
 				pubsub.ConcurrencyKey: string(pubsub.Single),
 			},
 		}}
-		err := pubsubRabbitMQ.Init(metadata)
+		err := pubsubRabbitMQ.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, pubsub.Single, pubsubRabbitMQ.(*rabbitMQ).metadata.concurrency)
 	})
@@ -100,7 +101,7 @@ func TestConcurrencyMode(t *testing.T) {
 				metadataConsumerIDKey: "consumer",
 			},
 		}}
-		err := pubsubRabbitMQ.Init(metadata)
+		err := pubsubRabbitMQ.Init(context.Background(), metadata)
 		assert.Nil(t, err)
 		assert.Equal(t, pubsub.Parallel, pubsubRabbitMQ.(*rabbitMQ).metadata.concurrency)
 	})
@@ -115,7 +116,7 @@ func TestPublishAndSubscribe(t *testing.T) {
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
-	err := pubsubRabbitMQ.Init(metadata)
+	err := pubsubRabbitMQ.Init(context.Background(), metadata)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, broker.connectCount)
 	assert.Equal(t, 0, broker.closeCount)
@@ -158,7 +159,7 @@ func TestPublishReconnect(t *testing.T) {
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
-	err := pubsubRabbitMQ.Init(metadata)
+	err := pubsubRabbitMQ.Init(context.Background(), metadata)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, broker.connectCount)
 	assert.Equal(t, 0, broker.closeCount)
@@ -209,7 +210,7 @@ func TestPublishReconnectAfterClose(t *testing.T) {
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
-	err := pubsubRabbitMQ.Init(metadata)
+	err := pubsubRabbitMQ.Init(context.Background(), metadata)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, broker.connectCount)
 	assert.Equal(t, 0, broker.closeCount)
@@ -259,7 +260,7 @@ func TestSubscribeBindRoutingKeys(t *testing.T) {
 			metadataConsumerIDKey: "consumer",
 		},
 	}}
-	err := pubsubRabbitMQ.Init(metadata)
+	err := pubsubRabbitMQ.Init(context.Background(), metadata)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, broker.connectCount)
 	assert.Equal(t, 0, broker.closeCount)
@@ -286,7 +287,7 @@ func TestSubscribeReconnect(t *testing.T) {
 			pubsub.ConcurrencyKey:           string(pubsub.Single),
 		},
 	}}
-	err := pubsubRabbitMQ.Init(metadata)
+	err := pubsubRabbitMQ.Init(context.Background(), metadata)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, broker.connectCount)
 	assert.Equal(t, 0, broker.closeCount)

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -442,7 +442,7 @@ func (r *redisStreams) removeMessagesThatNoLongerExistFromPending(ctx context.Co
 
 func (r *redisStreams) Close() error {
 	defer r.wg.Wait()
-	if r.closed.CompareAndSwap(true, false) {
+	if r.closed.CompareAndSwap(false, true) {
 		close(r.closeCh)
 	}
 

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	rediscomponent "github.com/dapr/components-contrib/internal/component/redis"
@@ -46,6 +48,9 @@ type redisStreams struct {
 	client         rediscomponent.RedisClient
 	clientSettings *rediscomponent.Settings
 	logger         logger.Logger
+	wg             sync.WaitGroup
+	closed         atomic.Bool
+	closeCh        chan struct{}
 
 	queue chan redisMessageWrapper
 }
@@ -61,7 +66,7 @@ type redisMessageWrapper struct {
 
 // NewRedisStreams returns a new redis streams pub-sub implementation.
 func NewRedisStreams(logger logger.Logger) pubsub.PubSub {
-	return &redisStreams{logger: logger}
+	return &redisStreams{logger: logger, closeCh: make(chan struct{})}
 }
 
 func parseRedisMetadata(meta pubsub.Metadata) (metadata, error) {
@@ -143,13 +148,21 @@ func (r *redisStreams) Init(ctx context.Context, metadata pubsub.Metadata) error
 	r.queue = make(chan redisMessageWrapper, int(r.metadata.queueDepth))
 
 	for i := uint(0); i < r.metadata.concurrency; i++ {
-		go r.worker(ctx)
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			r.worker(ctx)
+		}()
 	}
 
 	return nil
 }
 
 func (r *redisStreams) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
+	if r.closed.Load() {
+		return errors.New("error: redis has been closed")
+	}
+
 	_, err := r.client.XAdd(ctx, req.Topic, r.metadata.maxLenApprox, map[string]interface{}{"data": req.Data})
 	if err != nil {
 		return fmt.Errorf("redis streams: error from publish: %s", err)
@@ -159,6 +172,10 @@ func (r *redisStreams) Publish(ctx context.Context, req *pubsub.PublishRequest) 
 }
 
 func (r *redisStreams) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {
+	if r.closed.Load() {
+		return errors.New("error: redis has been closed")
+	}
+
 	err := r.client.XGroupCreateMkStream(ctx, req.Topic, r.metadata.consumerID, "0")
 	// Ignore BUSYGROUP errors
 	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
@@ -166,8 +183,26 @@ func (r *redisStreams) Subscribe(ctx context.Context, req pubsub.SubscribeReques
 		return err
 	}
 
-	go r.pollNewMessagesLoop(ctx, req.Topic, handler)
-	go r.reclaimPendingMessagesLoop(ctx, req.Topic, handler)
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.wg.Add(3)
+	go func() {
+		// Add a context which catches the close signal to account for situations
+		// where Close is called, but the context is not cancelled.
+		defer r.wg.Done()
+		defer cancel()
+		select {
+		case <-loopCtx.Done():
+		case <-r.closeCh:
+		}
+	}()
+	go func() {
+		defer r.wg.Done()
+		r.pollNewMessagesLoop(ctx, req.Topic, handler)
+	}()
+	go func() {
+		defer r.wg.Done()
+		r.reclaimPendingMessagesLoop(ctx, req.Topic, handler)
+	}()
 
 	return nil
 }
@@ -247,7 +282,8 @@ func (r *redisStreams) processMessage(msg redisMessageWrapper) error {
 		return err
 	}
 
-	if err := r.client.XAck(ctx, msg.message.Topic, r.metadata.consumerID, msg.messageID); err != nil {
+	// Use the background context in case subscriptionCtx is already closed.
+	if err := r.client.XAck(context.Background(), msg.message.Topic, r.metadata.consumerID, msg.messageID); err != nil {
 		r.logger.Errorf("Error acknowledging Redis message %s: %v", msg.messageID, err)
 
 		return err
@@ -393,7 +429,8 @@ func (r *redisStreams) removeMessagesThatNoLongerExistFromPending(ctx context.Co
 
 		// Ack the message to remove it from the pending list.
 		if errors.Is(err, r.client.GetNilValueError()) {
-			if err = r.client.XAck(ctx, stream, r.metadata.consumerID, pendingID); err != nil {
+			// Use the background context in case subscriptionCtx is already closed.
+			if err = r.client.XAck(context.Background(), stream, r.metadata.consumerID, pendingID); err != nil {
 				r.logger.Errorf("error acknowledging Redis message %s after failed claim for %s: %v", pendingID, stream, err)
 			}
 		} else {
@@ -404,6 +441,11 @@ func (r *redisStreams) removeMessagesThatNoLongerExistFromPending(ctx context.Co
 }
 
 func (r *redisStreams) Close() error {
+	defer r.wg.Wait()
+	if r.closed.CompareAndSwap(true, false) {
+		close(r.closeCh)
+	}
+
 	if r.client == nil {
 		return nil
 	}

--- a/pubsub/redis/redis_test.go
+++ b/pubsub/redis/redis_test.go
@@ -96,9 +96,8 @@ func TestProcessStreams(t *testing.T) {
 
 	// act
 	testRedisStream := &redisStreams{logger: logger.NewLogger("test")}
-	testRedisStream.ctx, testRedisStream.cancel = context.WithCancel(context.Background())
 	testRedisStream.queue = make(chan redisMessageWrapper, 10)
-	go testRedisStream.worker()
+	go testRedisStream.worker(context.Background())
 	testRedisStream.enqueueMessages(context.Background(), fakeConsumerID, fakeHandler, generateRedisStreamTestData(2, 3, expectedData))
 
 	// Wait for the handler to finish processing

--- a/pubsub/rocketmq/rocketmq.go
+++ b/pubsub/rocketmq/rocketmq.go
@@ -85,7 +85,7 @@ func NewRocketMQ(l logger.Logger) pubsub.PubSub {
 	}
 }
 
-func (r *rocketMQ) Init(metadata pubsub.Metadata) error {
+func (r *rocketMQ) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	var err error
 	r.metadata, err = parseRocketMQMetaData(metadata)
 	if err != nil {

--- a/pubsub/rocketmq/rocketmq_test.go
+++ b/pubsub/rocketmq/rocketmq_test.go
@@ -47,7 +47,7 @@ func TestParseRocketMQMetadata(t *testing.T) {
 func TestRocketMQ_Init(t *testing.T) {
 	meta := getTestMetadata()
 	r := NewRocketMQ(logger.NewLogger("test"))
-	err := r.Init(pubsub.Metadata{Base: mdata.Base{Properties: meta}})
+	err := r.Init(context.Background(), pubsub.Metadata{Base: mdata.Base{Properties: meta}})
 	assert.Nil(t, err)
 }
 
@@ -217,6 +217,6 @@ func BuildRocketMQ() (logger.Logger, pubsub.PubSub, error) {
 	meta := getTestMetadata()
 	l := logger.NewLogger("test")
 	r := NewRocketMQ(l)
-	err := r.Init(pubsub.Metadata{Base: mdata.Base{Properties: meta}})
+	err := r.Init(context.Background(), pubsub.Metadata{Base: mdata.Base{Properties: meta}})
 	return l, r, err
 }

--- a/secretstores/alicloud/parameterstore/parameterstore.go
+++ b/secretstores/alicloud/parameterstore/parameterstore.go
@@ -61,7 +61,7 @@ type oosSecretStore struct {
 }
 
 // Init creates a Alicloud parameter store client.
-func (o *oosSecretStore) Init(metadata secretstores.Metadata) error {
+func (o *oosSecretStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
 	meta, err := o.getParameterStoreMetadata(metadata)
 	if err != nil {
 		return err

--- a/secretstores/alicloud/parameterstore/parameterstore_test.go
+++ b/secretstores/alicloud/parameterstore/parameterstore_test.go
@@ -81,7 +81,7 @@ func TestInit(t *testing.T) {
 			"accessKeyId":     "a",
 			"accessKeySecret": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 
@@ -90,7 +90,7 @@ func TestInit(t *testing.T) {
 			"accessKeyId":     "a",
 			"accessKeySecret": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.NotNil(t, err)
 	})
 }
@@ -208,7 +208,7 @@ func TestBulkGetSecret(t *testing.T) {
 func TestGetFeatures(t *testing.T) {
 	m := secretstores.Metadata{}
 	s := NewParameterStore(logger.NewLogger("test"))
-	s.Init(m)
+	s.Init(context.Background(), m)
 	t.Run("no features are advertised", func(t *testing.T) {
 		f := s.Features()
 		assert.Empty(t, f)

--- a/secretstores/aws/parameterstore/parameterstore.go
+++ b/secretstores/aws/parameterstore/parameterstore.go
@@ -55,7 +55,7 @@ type ssmSecretStore struct {
 }
 
 // Init creates a AWS secret manager client.
-func (s *ssmSecretStore) Init(metadata secretstores.Metadata) error {
+func (s *ssmSecretStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
 	meta, err := s.getSecretManagerMetadata(metadata)
 	if err != nil {
 		return err

--- a/secretstores/aws/parameterstore/parameterstore_test.go
+++ b/secretstores/aws/parameterstore/parameterstore_test.go
@@ -57,7 +57,7 @@ func TestInit(t *testing.T) {
 			"SecretKey":    "a",
 			"SessionToken": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 }

--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -53,7 +53,7 @@ type smSecretStore struct {
 }
 
 // Init creates a AWS secret manager client.
-func (s *smSecretStore) Init(metadata secretstores.Metadata) error {
+func (s *smSecretStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
 	meta, err := s.getSecretManagerMetadata(metadata)
 	if err != nil {
 		return err

--- a/secretstores/aws/secretmanager/secretmanager_test.go
+++ b/secretstores/aws/secretmanager/secretmanager_test.go
@@ -50,7 +50,7 @@ func TestInit(t *testing.T) {
 			"SecretKey":    "a",
 			"SessionToken": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 }

--- a/secretstores/azure/keyvault/keyvault.go
+++ b/secretstores/azure/keyvault/keyvault.go
@@ -61,7 +61,7 @@ func NewAzureKeyvaultSecretStore(logger logger.Logger) secretstores.SecretStore 
 }
 
 // Init creates a Azure Key Vault client.
-func (k *keyvaultSecretStore) Init(meta secretstores.Metadata) error {
+func (k *keyvaultSecretStore) Init(ctx context.Context, meta secretstores.Metadata) error {
 	m := KeyvaultMetadata{}
 	if err := metadata.DecodeMetadata(meta.Properties, &m); err != nil {
 		return err

--- a/secretstores/azure/keyvault/keyvault_test.go
+++ b/secretstores/azure/keyvault/keyvault_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package keyvault
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func TestInit(t *testing.T) {
 			"azureClientId":     "00000000-0000-0000-0000-000000000000",
 			"azureClientSecret": "passw0rd",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 		kv, ok := s.(*keyvaultSecretStore)
 		assert.True(t, ok)
@@ -49,7 +50,7 @@ func TestInit(t *testing.T) {
 			"azureClientSecret": "passw0rd",
 			"azureEnvironment":  "AZURECHINACLOUD",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 		kv, ok := s.(*keyvaultSecretStore)
 		assert.True(t, ok)
@@ -64,7 +65,7 @@ func TestInit(t *testing.T) {
 			"azureClientId":     "00000000-0000-0000-0000-000000000000",
 			"azureClientSecret": "passw0rd",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 		kv, ok := s.(*keyvaultSecretStore)
 		assert.True(t, ok)
@@ -79,7 +80,7 @@ func TestInit(t *testing.T) {
 			"azureClientId":     "00000000-0000-0000-0000-000000000000",
 			"azureClientSecret": "passw0rd",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 		kv, ok := s.(*keyvaultSecretStore)
 		assert.True(t, ok)

--- a/secretstores/gcp/secretmanager/secretmanager.go
+++ b/secretstores/gcp/secretmanager/secretmanager.go
@@ -68,13 +68,13 @@ func NewSecreteManager(logger logger.Logger) secretstores.SecretStore {
 }
 
 // Init creates a GCP secret manager client.
-func (s *Store) Init(metadataRaw secretstores.Metadata) error {
+func (s *Store) Init(ctx context.Context, metadataRaw secretstores.Metadata) error {
 	metadata, err := s.parseSecretManagerMetadata(metadataRaw)
 	if err != nil {
 		return err
 	}
 
-	client, err := s.getClient(metadata)
+	client, err := s.getClient(ctx, metadata)
 	if err != nil {
 		return fmt.Errorf("failed to setup secretmanager client: %s", err)
 	}
@@ -85,10 +85,9 @@ func (s *Store) Init(metadataRaw secretstores.Metadata) error {
 	return nil
 }
 
-func (s *Store) getClient(metadata *GcpSecretManagerMetadata) (*secretmanager.Client, error) {
+func (s *Store) getClient(ctx context.Context, metadata *GcpSecretManagerMetadata) (*secretmanager.Client, error) {
 	b, _ := json.Marshal(metadata)
 	clientOptions := option.WithCredentialsJSON(b)
-	ctx := context.Background()
 
 	client, err := secretmanager.NewClient(ctx, clientOptions)
 	if err != nil {

--- a/secretstores/gcp/secretmanager/secretmanager_test.go
+++ b/secretstores/gcp/secretmanager/secretmanager_test.go
@@ -53,6 +53,7 @@ func (s *MockStore) Close() error {
 }
 
 func TestInit(t *testing.T) {
+	ctx := context.Background()
 	m := secretstores.Metadata{}
 	sm := NewSecreteManager(logger.NewLogger("test"))
 	t.Run("Init with Wrong metadata", func(t *testing.T) {
@@ -69,7 +70,7 @@ func TestInit(t *testing.T) {
 			"client_x509_cert_url":        "a",
 		}
 
-		err := sm.Init(m)
+		err := sm.Init(ctx, m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("failed to setup secretmanager client: google: could not parse key: private key should be a PEM or plain PKCS1 or PKCS8; parse error: asn1: syntax error: truncated tag or length"))
 	})
@@ -78,7 +79,7 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"dummy": "a",
 		}
-		err := sm.Init(m)
+		err := sm.Init(ctx, m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing property `type` in metadata"))
 	})
@@ -87,13 +88,14 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"type": "service_account",
 		}
-		err := sm.Init(m)
+		err := sm.Init(ctx, m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing property `project_id` in metadata"))
 	})
 }
 
 func TestGetSecret(t *testing.T) {
+	ctx := context.Background()
 	sm := NewSecreteManager(logger.NewLogger("test"))
 
 	t.Run("Get Secret - without Init", func(t *testing.T) {
@@ -118,7 +120,7 @@ func TestGetSecret(t *testing.T) {
 				"client_x509_cert_url":        "a",
 			},
 		}}
-		sm.Init(m)
+		sm.Init(ctx, m)
 		v, err := sm.GetSecret(context.Background(), secretstores.GetSecretRequest{Name: "test"})
 		assert.NotNil(t, err)
 		assert.Equal(t, secretstores.GetSecretResponse{Data: nil}, v)
@@ -147,6 +149,7 @@ func TestGetSecret(t *testing.T) {
 }
 
 func TestBulkGetSecret(t *testing.T) {
+	ctx := context.Background()
 	sm := NewSecreteManager(logger.NewLogger("test"))
 
 	t.Run("Bulk Get Secret - without Init", func(t *testing.T) {
@@ -173,7 +176,7 @@ func TestBulkGetSecret(t *testing.T) {
 				},
 			},
 		}
-		sm.Init(m)
+		sm.Init(ctx, m)
 		v, err := sm.BulkGetSecret(context.Background(), secretstores.BulkGetSecretRequest{})
 		assert.NotNil(t, err)
 		assert.Equal(t, secretstores.BulkGetSecretResponse{Data: nil}, v)

--- a/secretstores/hashicorp/vault/vault.go
+++ b/secretstores/hashicorp/vault/vault.go
@@ -137,7 +137,7 @@ func NewHashiCorpVaultSecretStore(logger logger.Logger) secretstores.SecretStore
 }
 
 // Init creates a HashiCorp Vault client.
-func (v *vaultSecretStore) Init(meta secretstores.Metadata) error {
+func (v *vaultSecretStore) Init(ctx context.Context, meta secretstores.Metadata) error {
 	m := VaultMetadata{
 		VaultKVUsePrefix: true,
 	}

--- a/secretstores/hashicorp/vault/vault_test.go
+++ b/secretstores/hashicorp/vault/vault_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package vault
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"strconv"
@@ -119,7 +120,7 @@ func TestVaultEnginePath(t *testing.T) {
 	t.Run("without engine path config", func(t *testing.T) {
 		v := vaultSecretStore{}
 
-		err := v.Init(secretstores.Metadata{Base: metadata.Base{Properties: map[string]string{componentVaultToken: expectedTok, "skipVerify": "true"}}})
+		err := v.Init(context.Background(), secretstores.Metadata{Base: metadata.Base{Properties: map[string]string{componentVaultToken: expectedTok, "skipVerify": "true"}}})
 		assert.Nil(t, err)
 		assert.Equal(t, v.vaultEnginePath, defaultVaultEnginePath)
 	})
@@ -127,7 +128,7 @@ func TestVaultEnginePath(t *testing.T) {
 	t.Run("with engine path config", func(t *testing.T) {
 		v := vaultSecretStore{}
 
-		err := v.Init(secretstores.Metadata{Base: metadata.Base{Properties: map[string]string{componentVaultToken: expectedTok, "skipVerify": "true", vaultEnginePath: "kv"}}})
+		err := v.Init(context.Background(), secretstores.Metadata{Base: metadata.Base{Properties: map[string]string{componentVaultToken: expectedTok, "skipVerify": "true", vaultEnginePath: "kv"}}})
 		assert.Nil(t, err)
 		assert.Equal(t, v.vaultEnginePath, "kv")
 	})
@@ -151,7 +152,7 @@ func TestVaultTokenPrefix(t *testing.T) {
 			logger: nil,
 		}
 
-		if err := target.Init(m); err != nil {
+		if err := target.Init(context.Background(), m); err != nil {
 			t.Fatal(err)
 		}
 
@@ -174,7 +175,7 @@ func TestVaultTokenPrefix(t *testing.T) {
 			logger: nil,
 		}
 
-		if err := target.Init(m); err != nil {
+		if err := target.Init(context.Background(), m); err != nil {
 			t.Fatal(err)
 		}
 
@@ -215,7 +216,7 @@ func TestVaultTokenMountPathOrVaultTokenRequired(t *testing.T) {
 			logger: nil,
 		}
 
-		err := target.Init(m)
+		err := target.Init(context.Background(), m)
 
 		assert.Equal(t, "", target.vaultToken)
 		assert.Equal(t, "", target.vaultTokenMountPath)
@@ -237,7 +238,7 @@ func TestVaultTokenMountPathOrVaultTokenRequired(t *testing.T) {
 			logger: nil,
 		}
 
-		if err := target.Init(m); err != nil {
+		if err := target.Init(context.Background(), m); err != nil {
 			t.Fatal(err)
 		}
 
@@ -259,7 +260,7 @@ func TestVaultTokenMountPathOrVaultTokenRequired(t *testing.T) {
 			logger: nil,
 		}
 
-		if err := target.Init(m); err != nil {
+		if err := target.Init(context.Background(), m); err != nil {
 			t.Fatal(err)
 		}
 
@@ -282,7 +283,7 @@ func TestVaultTokenMountPathOrVaultTokenRequired(t *testing.T) {
 			logger: nil,
 		}
 
-		err := target.Init(m)
+		err := target.Init(context.Background(), m)
 
 		assert.Equal(t, expectedTok, target.vaultToken)
 		assert.Equal(t, expectedTokMountPath, target.vaultTokenMountPath)
@@ -309,7 +310,7 @@ func TestDefaultVaultAddress(t *testing.T) {
 			logger: nil,
 		}
 
-		if err := target.Init(m); err != nil {
+		if err := target.Init(context.Background(), m); err != nil {
 			t.Fatal(err)
 		}
 
@@ -334,7 +335,7 @@ func TestVaultValueType(t *testing.T) {
 			logger: nil,
 		}
 
-		err := target.Init(m)
+		err := target.Init(context.Background(), m)
 		assert.Nil(t, err)
 		assert.True(t, target.vaultValueType.isMapType())
 	})
@@ -355,7 +356,7 @@ func TestVaultValueType(t *testing.T) {
 			logger: nil,
 		}
 
-		err := target.Init(m)
+		err := target.Init(context.Background(), m)
 		assert.Nil(t, err)
 		assert.False(t, target.vaultValueType.isMapType())
 	})
@@ -375,7 +376,7 @@ func TestVaultValueType(t *testing.T) {
 			logger: nil,
 		}
 
-		err := target.Init(m)
+		err := target.Init(context.Background(), m)
 		assert.Nil(t, err)
 		assert.True(t, target.vaultValueType.isMapType())
 	})
@@ -396,7 +397,7 @@ func TestVaultValueType(t *testing.T) {
 			logger: nil,
 		}
 
-		err := target.Init(m)
+		err := target.Init(context.Background(), m)
 		assert.Error(t, err, "vault init error, invalid value type incorrect, accepted values are map or text")
 	})
 }
@@ -428,7 +429,7 @@ func TestGetFeatures(t *testing.T) {
 		// the call x509.SystemCertPool() because system root pool is not
 		// available on Windows so ignore the error for when the tests are run
 		// on the Windows platform during CI
-		_ = target.Init(m)
+		_ = target.Init(context.Background(), m)
 
 		return target
 	}

--- a/secretstores/huaweicloud/csms/csms.go
+++ b/secretstores/huaweicloud/csms/csms.go
@@ -57,7 +57,7 @@ func NewHuaweiCsmsSecretStore(logger logger.Logger) secretstores.SecretStore {
 }
 
 // Init creates a Huawei csms client.
-func (c *csmsSecretStore) Init(meta secretstores.Metadata) error {
+func (c *csmsSecretStore) Init(ctx context.Context, meta secretstores.Metadata) error {
 	m := CsmsSecretStoreMetadata{}
 	metadata.DecodeMetadata(meta.Properties, &m)
 	auth := basic.NewCredentialsBuilder().

--- a/secretstores/kubernetes/kubernetes.go
+++ b/secretstores/kubernetes/kubernetes.go
@@ -42,7 +42,7 @@ func NewKubernetesSecretStore(logger logger.Logger) secretstores.SecretStore {
 }
 
 // Init creates a Kubernetes client.
-func (k *kubernetesSecretStore) Init(metadata secretstores.Metadata) error {
+func (k *kubernetesSecretStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
 	client, err := kubeclient.GetKubeClient()
 	if err != nil {
 		return err

--- a/secretstores/local/env/envstore.go
+++ b/secretstores/local/env/envstore.go
@@ -38,7 +38,7 @@ func NewEnvSecretStore(logger logger.Logger) secretstores.SecretStore {
 }
 
 // Init creates a Local secret store.
-func (s *envSecretStore) Init(metadata secretstores.Metadata) error {
+func (s *envSecretStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
 	return nil
 }
 

--- a/secretstores/local/env/envstore_test.go
+++ b/secretstores/local/env/envstore_test.go
@@ -35,12 +35,12 @@ func TestInit(t *testing.T) {
 	assert.Equal(t, secret, os.Getenv(key))
 
 	t.Run("Test init", func(t *testing.T) {
-		err := s.Init(secretstores.Metadata{})
+		err := s.Init(context.Background(), secretstores.Metadata{})
 		assert.Nil(t, err)
 	})
 
 	t.Run("Test set and get", func(t *testing.T) {
-		err := s.Init(secretstores.Metadata{})
+		err := s.Init(context.Background(), secretstores.Metadata{})
 		assert.Nil(t, err)
 		resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{Name: key})
 		assert.Nil(t, err)
@@ -49,7 +49,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("Test bulk get", func(t *testing.T) {
-		err := s.Init(secretstores.Metadata{})
+		err := s.Init(context.Background(), secretstores.Metadata{})
 		assert.Nil(t, err)
 		resp, err := s.BulkGetSecret(context.Background(), secretstores.BulkGetSecretRequest{})
 		assert.Nil(t, err)

--- a/secretstores/local/file/filestore.go
+++ b/secretstores/local/file/filestore.go
@@ -56,7 +56,7 @@ func NewLocalSecretStore(logger logger.Logger) secretstores.SecretStore {
 }
 
 // Init creates a Local secret store.
-func (j *localSecretStore) Init(metadata secretstores.Metadata) error {
+func (j *localSecretStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
 	meta, err := j.getLocalSecretStoreMetadata(metadata)
 	if err != nil {
 		return err

--- a/secretstores/local/file/filestore_test.go
+++ b/secretstores/local/file/filestore_test.go
@@ -42,7 +42,7 @@ func TestInit(t *testing.T) {
 			"secretsFile":     "a",
 			"nestedSeparator": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 
@@ -50,7 +50,7 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"dummy": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing local secrets file in metadata"))
 	})
@@ -74,7 +74,7 @@ func TestSeparator(t *testing.T) {
 			"secretsFile":     "a",
 			"nestedSeparator": ".",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 
 		req := secretstores.GetSecretRequest{
@@ -90,7 +90,7 @@ func TestSeparator(t *testing.T) {
 		m.Properties = map[string]string{
 			"secretsFile": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 
 		req := secretstores.GetSecretRequest{
@@ -118,7 +118,7 @@ func TestGetSecret(t *testing.T) {
 			return secrets, nil
 		},
 	}
-	s.Init(m)
+	s.Init(context.Background(), m)
 
 	t.Run("successfully retrieve secrets", func(t *testing.T) {
 		req := secretstores.GetSecretRequest{
@@ -160,7 +160,7 @@ func TestBulkGetSecret(t *testing.T) {
 			return secrets, nil
 		},
 	}
-	s.Init(m)
+	s.Init(context.Background(), m)
 
 	t.Run("successfully retrieve secrets", func(t *testing.T) {
 		req := secretstores.BulkGetSecretRequest{}
@@ -197,7 +197,7 @@ func TestMultiValuedSecrets(t *testing.T) {
 			return secrets, err
 		},
 	}
-	err := s.Init(m)
+	err := s.Init(context.Background(), m)
 	require.NoError(t, err)
 
 	t.Run("MultiValued stores support MULTIPLE_KEY_VALUES_PER_SECRET", func(t *testing.T) {

--- a/secretstores/secret_store.go
+++ b/secretstores/secret_store.go
@@ -23,7 +23,7 @@ import (
 // SecretStore is the interface for a component that handles secrets management.
 type SecretStore interface {
 	// Init authenticates with the actual secret store and performs other init operation
-	Init(metadata Metadata) error
+	Init(ctx context.Context, metadata Metadata) error
 	// GetSecret retrieves a secret using a key and returns a map of decrypted string/string values.
 	GetSecret(ctx context.Context, req GetSecretRequest) (GetSecretResponse, error)
 	// BulkGetSecret retrieves all secrets in the store and returns a map of decrypted string/string values.
@@ -34,10 +34,10 @@ type SecretStore interface {
 	GetComponentMetadata() map[string]string
 }
 
-func Ping(secretStore SecretStore) error {
+func Ping(ctx context.Context, secretStore SecretStore) error {
 	// checks if this secretStore has the ping option then executes
 	if secretStoreWithPing, ok := secretStore.(health.Pinger); ok {
-		return secretStoreWithPing.Ping()
+		return secretStoreWithPing.Ping(ctx)
 	} else {
 		return fmt.Errorf("ping is not implemented by this secret store")
 	}

--- a/secretstores/tencentcloud/ssm/ssm.go
+++ b/secretstores/tencentcloud/ssm/ssm.go
@@ -69,7 +69,7 @@ func NewSSM(logger logger.Logger) secretstores.SecretStore {
 }
 
 // Init creates a TencentCloud ssm client.
-func (s *ssmSecretStore) Init(meta secretstores.Metadata) error {
+func (s *ssmSecretStore) Init(ctx context.Context, meta secretstores.Metadata) error {
 	m := SsmMetadata{}
 	err := metadata.DecodeMetadata(meta.Properties, &m)
 	if err != nil {

--- a/state/aerospike/aerospike.go
+++ b/state/aerospike/aerospike.go
@@ -91,7 +91,7 @@ func parseAndValidateMetadata(meta state.Metadata) (*aerospikeMetadata, error) {
 }
 
 // Init does metadata and connection parsing.
-func (aspike *Aerospike) Init(metadata state.Metadata) error {
+func (aspike *Aerospike) Init(ctx context.Context, metadata state.Metadata) error {
 	m, err := parseAndValidateMetadata(metadata)
 	if err != nil {
 		return err
@@ -112,7 +112,7 @@ func (aspike *Aerospike) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (aspike *Aerospike) Features() []state.Feature {
+func (aspike *Aerospike) Features(ctx context.Context) []state.Feature {
 	return aspike.features
 }
 

--- a/state/alicloud/tablestore/tablestore.go
+++ b/state/alicloud/tablestore/tablestore.go
@@ -54,7 +54,7 @@ func NewAliCloudTableStore(logger logger.Logger) state.Store {
 	}
 }
 
-func (s *AliCloudTableStore) Init(metadata state.Metadata) error {
+func (s *AliCloudTableStore) Init(ctx context.Context, metadata state.Metadata) error {
 	m, err := s.parse(metadata)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (s *AliCloudTableStore) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (s *AliCloudTableStore) Features() []state.Feature {
+func (s *AliCloudTableStore) Features(ctx context.Context) []state.Feature {
 	return s.features
 }
 

--- a/state/alicloud/tablestore/tablestore_test.go
+++ b/state/alicloud/tablestore/tablestore_test.go
@@ -52,7 +52,7 @@ func TestReadAndWrite(t *testing.T) {
 	defer ctl.Finish()
 
 	store := NewAliCloudTableStore(logger.NewLogger("test")).(*AliCloudTableStore)
-	store.Init(state.Metadata{})
+	store.Init(context.Background(), state.Metadata{})
 
 	store.client = &mockClient{
 		data: make(map[string][]byte),

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -66,7 +66,7 @@ func NewDynamoDBStateStore(_ logger.Logger) state.Store {
 }
 
 // Init does metadata and connection parsing.
-func (d *StateStore) Init(metadata state.Metadata) error {
+func (d *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := d.getDynamoDBMetadata(metadata)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func (d *StateStore) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (d *StateStore) Features() []state.Feature {
+func (d *StateStore) Features(ctx context.Context) []state.Feature {
 	return []state.Feature{state.FeatureETag}
 }
 

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -85,7 +85,7 @@ func TestInit(t *testing.T) {
 			"Table":            "a",
 			"TtlAttributeName": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 
@@ -93,7 +93,7 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"Dummy": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing dynamodb table name"))
 	})
@@ -103,7 +103,7 @@ func TestInit(t *testing.T) {
 			"Table":  "a",
 			"Region": "eu-west-1",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 	})
 
@@ -113,7 +113,7 @@ func TestInit(t *testing.T) {
 			"Table":        "a",
 			"partitionKey": pkey,
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 		assert.Equal(t, s.partitionKey, pkey)
 	})

--- a/state/azure/blobstorage/blobstorage.go
+++ b/state/azure/blobstorage/blobstorage.go
@@ -71,7 +71,7 @@ type StateStore struct {
 }
 
 // Init the connection to blob storage, optionally creates a blob container if it doesn't exist.
-func (r *StateStore) Init(metadata state.Metadata) error {
+func (r *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	var err error
 	r.containerClient, _, err = storageinternal.CreateContainerStorageClient(r.logger, metadata.Properties)
 	if err != nil {
@@ -81,7 +81,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (r *StateStore) Features() []state.Feature {
+func (r *StateStore) Features(ctx context.Context) []state.Feature {
 	return r.features
 }
 
@@ -100,8 +100,8 @@ func (r *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	return r.writeFile(ctx, req)
 }
 
-func (r *StateStore) Ping() error {
-	if _, err := r.containerClient.GetProperties(context.Background(), nil); err != nil {
+func (r *StateStore) Ping(ctx context.Context) error {
+	if _, err := r.containerClient.GetProperties(ctx, nil); err != nil {
 		return fmt.Errorf("blob storage: error connecting to Blob storage at %s: %s", r.containerClient.URL(), err)
 	}
 

--- a/state/azure/blobstorage/blobstorage_test.go
+++ b/state/azure/blobstorage/blobstorage_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package blobstorage
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestInit(t *testing.T) {
 			"accountKey":    "e+Dnvl8EOxYxV94nurVaRQ==",
 			"containerName": "dapr",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://acc.blob.core.windows.net/dapr", s.containerClient.URL())
 	})
@@ -41,7 +42,7 @@ func TestInit(t *testing.T) {
 		m.Properties = map[string]string{
 			"invalidValue": "a",
 		}
-		err := s.Init(m)
+		err := s.Init(context.Background(), m)
 		assert.NotNil(t, err)
 		assert.Equal(t, err, fmt.Errorf("missing or empty accountName field from metadata"))
 	})
@@ -52,8 +53,8 @@ func TestInit(t *testing.T) {
 			"accountKey":    "e+Dnvl8EOxYxV94nurVaRQ==",
 			"containerName": "dapr",
 		}
-		s.Init(m)
-		err := s.Ping()
+		s.Init(context.Background(), m)
+		err := s.Ping(context.Background())
 		assert.NotNil(t, err)
 	})
 }

--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -113,7 +113,7 @@ func (c *StateStore) GetComponentMetadata() map[string]string {
 }
 
 // Init does metadata and connection parsing.
-func (c *StateStore) Init(meta state.Metadata) error {
+func (c *StateStore) Init(ctx context.Context, meta state.Metadata) error {
 	c.logger.Debugf("CosmosDB init start")
 
 	m := metadata{
@@ -191,14 +191,14 @@ func (c *StateStore) Init(meta state.Metadata) error {
 	c.metadata = m
 	c.contentType = m.ContentType
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
 	_, err = c.client.Read(ctx, nil)
-	cancel()
 	return err
 }
 
 // Features returns the features available in this state store.
-func (c *StateStore) Features() []state.Feature {
+func (c *StateStore) Features(ctx context.Context) []state.Feature {
 	return []state.Feature{
 		state.FeatureETag,
 		state.FeatureTransactional,
@@ -464,8 +464,8 @@ func (c *StateStore) Query(ctx context.Context, req *state.QueryRequest) (*state
 	}, nil
 }
 
-func (c *StateStore) Ping() error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+func (c *StateStore) Ping(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	_, err := c.client.Read(ctx, nil)
 	cancel()
 	if err != nil {

--- a/state/azure/tablestorage/tablestorage.go
+++ b/state/azure/tablestorage/tablestorage.go
@@ -84,7 +84,7 @@ type tablesMetadata struct {
 }
 
 // Init Initialises connection to table storage, optionally creates a table if it doesn't exist.
-func (r *StateStore) Init(metadata state.Metadata) error {
+func (r *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := getTablesMetadata(metadata.Properties)
 	if err != nil {
 		return err
@@ -146,7 +146,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 	}
 
 	if !meta.SkipCreateTable {
-		createContext, cancel := context.WithTimeout(context.Background(), timeout)
+		createContext, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		_, innerErr := client.CreateTable(createContext, meta.TableName, nil)
 		if innerErr != nil {
@@ -166,7 +166,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (r *StateStore) Features() []state.Feature {
+func (r *StateStore) Features(ctx context.Context) []state.Feature {
 	return r.features
 }
 

--- a/state/cassandra/cassandra.go
+++ b/state/cassandra/cassandra.go
@@ -78,7 +78,7 @@ func NewCassandraStateStore(logger logger.Logger) state.Store {
 }
 
 // Init performs metadata and connection parsing.
-func (c *Cassandra) Init(metadata state.Metadata) error {
+func (c *Cassandra) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := getCassandraMetadata(metadata)
 	if err != nil {
 		return err
@@ -112,7 +112,7 @@ func (c *Cassandra) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (c *Cassandra) Features() []state.Feature {
+func (c *Cassandra) Features(ctx context.Context) []state.Feature {
 	return nil
 }
 

--- a/state/cloudflare/workerskv/workerskv.go
+++ b/state/cloudflare/workerskv/workerskv.go
@@ -56,7 +56,7 @@ func NewCFWorkersKV(logger logger.Logger) state.Store {
 }
 
 // Init the component.
-func (q *CFWorkersKV) Init(metadata state.Metadata) error {
+func (q *CFWorkersKV) Init(ctx context.Context, metadata state.Metadata) error {
 	// Decode the metadata
 	err := mapstructure.Decode(metadata.Properties, &q.metadata)
 	if err != nil {
@@ -89,7 +89,7 @@ func (q *CFWorkersKV) GetComponentMetadata() map[string]string {
 }
 
 // Features returns the features supported by this state store.
-func (q CFWorkersKV) Features() []state.Feature {
+func (q CFWorkersKV) Features(ctx context.Context) []state.Feature {
 	return []state.Feature{}
 }
 

--- a/state/cockroachdb/cockroachdb.go
+++ b/state/cockroachdb/cockroachdb.go
@@ -72,8 +72,8 @@ func (c *CockroachDB) Set(ctx context.Context, req *state.SetRequest) error {
 }
 
 // Ping checks if database is available.
-func (c *CockroachDB) Ping() error {
-	return c.dbaccess.Ping()
+func (c *CockroachDB) Ping(ctx context.Context) error {
+	return c.dbaccess.Ping(ctx)
 }
 
 // BulkDelete removes multiple entries from the store.

--- a/state/cockroachdb/cockroachdb.go
+++ b/state/cockroachdb/cockroachdb.go
@@ -47,12 +47,12 @@ func internalNew(logger logger.Logger, dba dbAccess) *CockroachDB {
 }
 
 // Init initializes the CockroachDB state store.
-func (c *CockroachDB) Init(metadata state.Metadata) error {
-	return c.dbaccess.Init(metadata)
+func (c *CockroachDB) Init(ctx context.Context, metadata state.Metadata) error {
+	return c.dbaccess.Init(ctx, metadata)
 }
 
 // Features returns the features available in this state store.
-func (c *CockroachDB) Features() []state.Feature {
+func (c *CockroachDB) Features(ctx context.Context) []state.Feature {
 	return c.features
 }
 

--- a/state/cockroachdb/cockroachdb_access.go
+++ b/state/cockroachdb/cockroachdb_access.go
@@ -107,7 +107,7 @@ func (p *cockroachDBAccess) Init(ctx context.Context, metadata state.Metadata) e
 
 	p.db = databaseConn
 
-	if err = databaseConn.Ping(); err != nil {
+	if err = databaseConn.PingContext(ctx); err != nil {
 		return err
 	}
 
@@ -116,7 +116,7 @@ func (p *cockroachDBAccess) Init(ctx context.Context, metadata state.Metadata) e
 	}
 
 	// Ensure that a connection to the database is actually established
-	err = p.Ping()
+	err = p.Ping(ctx)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,7 @@ func (p *cockroachDBAccess) Query(ctx context.Context, req *state.QueryRequest) 
 }
 
 // Ping implements database ping.
-func (p *cockroachDBAccess) Ping() error {
+func (p *cockroachDBAccess) Ping(ctx context.Context) error {
 	retryCount := defaultMaxConnectionAttempts
 	if p.metadata.MaxConnectionAttempts != nil && *p.metadata.MaxConnectionAttempts >= 0 {
 		retryCount = *p.metadata.MaxConnectionAttempts
@@ -411,7 +411,7 @@ func (p *cockroachDBAccess) Ping() error {
 	backoff := config.NewBackOff()
 
 	return retry.NotifyRecover(func() error {
-		err := p.db.Ping()
+		err := p.db.PingContext(ctx)
 		if errors.Is(err, driver.ErrBadConn) {
 			return fmt.Errorf("error when attempting to establish connection with cockroachDB: %v", err)
 		}

--- a/state/cockroachdb/cockroachdb_access.go
+++ b/state/cockroachdb/cockroachdb_access.go
@@ -81,7 +81,7 @@ func parseMetadata(meta state.Metadata) (*cockroachDBMetadata, error) {
 }
 
 // Init sets up CockroachDB connection and ensures that the state table exists.
-func (p *cockroachDBAccess) Init(metadata state.Metadata) error {
+func (p *cockroachDBAccess) Init(ctx context.Context, metadata state.Metadata) error {
 	p.logger.Debug("Initializing CockroachDB state store")
 
 	meta, err := parseMetadata(metadata)

--- a/state/cockroachdb/cockroachdb_integration_test.go
+++ b/state/cockroachdb/cockroachdb_integration_test.go
@@ -59,7 +59,7 @@ func TestCockroachDBIntegration(t *testing.T) {
 		defer pgs.Close()
 	})
 
-	if err := pgs.Init(metadata); err != nil {
+	if err := pgs.Init(context.Background(), metadata); err != nil {
 		t.Fatal(err)
 	}
 
@@ -615,7 +615,7 @@ func testInitConfiguration(t *testing.T) {
 				Base: metadata.Base{Properties: rowTest.props},
 			}
 
-			err := cockroackDB.Init(metadata)
+			err := cockroackDB.Init(context.Background(), metadata)
 			if rowTest.expectedErr == "" {
 				assert.Nil(t, err)
 			} else {

--- a/state/cockroachdb/cockroachdb_test.go
+++ b/state/cockroachdb/cockroachdb_test.go
@@ -37,7 +37,7 @@ type fakeDBaccess struct {
 	deleteExecuted bool
 }
 
-func (m *fakeDBaccess) Init(metadata state.Metadata) error {
+func (m *fakeDBaccess) Init(ctx context.Context, metadata state.Metadata) error {
 	m.initExecuted = true
 
 	return nil
@@ -121,7 +121,7 @@ func createCockroachDB(t *testing.T) *CockroachDB {
 		Base: metadata.Base{Properties: map[string]string{connectionStringKey: fakeConnectionString}},
 	}
 
-	err := pgs.Init(*metadata)
+	err := pgs.Init(context.Background(), *metadata)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, pgs.dbaccess)

--- a/state/cockroachdb/cockroachdb_test.go
+++ b/state/cockroachdb/cockroachdb_test.go
@@ -81,7 +81,7 @@ func (m *fakeDBaccess) Close() error {
 	return nil
 }
 
-func (m *fakeDBaccess) Ping() error {
+func (m *fakeDBaccess) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/state/cockroachdb/dbaccess.go
+++ b/state/cockroachdb/dbaccess.go
@@ -29,6 +29,6 @@ type dbAccess interface {
 	BulkDelete(ctx context.Context, req []state.DeleteRequest) error
 	ExecuteMulti(ctx context.Context, req *state.TransactionalStateRequest) error
 	Query(ctx context.Context, req *state.QueryRequest) (*state.QueryResponse, error)
-	Ping() error
+	Ping(context.Context) error
 	Close() error
 }

--- a/state/cockroachdb/dbaccess.go
+++ b/state/cockroachdb/dbaccess.go
@@ -21,7 +21,7 @@ import (
 
 // dbAccess is a private interface which enables unit testing of CockroachDB.
 type dbAccess interface {
-	Init(metadata state.Metadata) error
+	Init(ctx context.Context, metadata state.Metadata) error
 	Set(ctx context.Context, req *state.SetRequest) error
 	BulkSet(ctx context.Context, req []state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)

--- a/state/couchbase/couchbase.go
+++ b/state/couchbase/couchbase.go
@@ -119,7 +119,7 @@ func parseAndValidateMetadata(meta state.Metadata) (*couchbaseMetadata, error) {
 }
 
 // Init does metadata and connection parsing.
-func (cbs *Couchbase) Init(metadata state.Metadata) error {
+func (cbs *Couchbase) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := parseAndValidateMetadata(metadata)
 	if err != nil {
 		return err
@@ -156,7 +156,7 @@ func (cbs *Couchbase) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (cbs *Couchbase) Features() []state.Feature {
+func (cbs *Couchbase) Features(ctx context.Context) []state.Feature {
 	return cbs.features
 }
 

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -71,7 +71,7 @@ func NewFirestoreStateStore(logger logger.Logger) state.Store {
 }
 
 // Init does metadata and connection parsing.
-func (f *Firestore) Init(metadata state.Metadata) error {
+func (f *Firestore) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := getFirestoreMetadata(metadata)
 	if err != nil {
 		return err
@@ -82,7 +82,6 @@ func (f *Firestore) Init(metadata state.Metadata) error {
 	}
 
 	opt := option.WithCredentialsJSON(b)
-	ctx := context.Background()
 	client, err := datastore.NewClient(ctx, meta.ProjectID, opt)
 	if err != nil {
 		return err
@@ -96,7 +95,7 @@ func (f *Firestore) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (f *Firestore) Features() []state.Feature {
+func (f *Firestore) Features(ctx context.Context) []state.Feature {
 	return nil
 }
 

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -54,7 +54,7 @@ func NewConsulStateStore(logger logger.Logger) state.Store {
 
 // Init does metadata and config parsing and initializes the
 // Consul client.
-func (c *Consul) Init(metadata state.Metadata) error {
+func (c *Consul) Init(ctx context.Context, metadata state.Metadata) error {
 	consulConfig, err := metadataToConfig(metadata.Properties)
 	if err != nil {
 		return fmt.Errorf("couldn't convert metadata properties: %s", err)
@@ -84,7 +84,7 @@ func (c *Consul) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (c *Consul) Features() []state.Feature {
+func (c *Consul) Features(ctx context.Context) []state.Feature {
 	// Etag is just returned and not handled in set or delete operations.
 	return nil
 }

--- a/state/hazelcast/hazelcast.go
+++ b/state/hazelcast/hazelcast.go
@@ -69,7 +69,7 @@ func validateAndParseMetadata(meta state.Metadata) (*hazelcastMetadata, error) {
 }
 
 // Init does metadata and connection parsing.
-func (store *Hazelcast) Init(metadata state.Metadata) error {
+func (store *Hazelcast) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := validateAndParseMetadata(metadata)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func (store *Hazelcast) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (store *Hazelcast) Features() []state.Feature {
+func (store *Hazelcast) Features(ctx context.Context) []state.Feature {
 	return nil
 }
 

--- a/state/in-memory/in_memory.go
+++ b/state/in-memory/in_memory.go
@@ -71,7 +71,7 @@ func (store *inMemoryStore) Init(ctx context.Context, metadata state.Metadata) e
 
 func (store *inMemoryStore) Close() error {
 	defer store.wg.Wait()
-	if store.closed.CompareAndSwap(true, false) {
+	if store.closed.CompareAndSwap(false, true) {
 		close(store.closeCh)
 	}
 

--- a/state/in-memory/in_memory_test.go
+++ b/state/in-memory/in_memory_test.go
@@ -32,7 +32,7 @@ func TestReadAndWrite(t *testing.T) {
 	defer ctl.Finish()
 
 	store := NewInMemoryStateStore(logger.NewLogger("test"))
-	store.Init(state.Metadata{})
+	store.Init(context.Background(), state.Metadata{})
 
 	keyA := "theFirstKey"
 	valueA := "value of key"

--- a/state/jetstream/jetstream.go
+++ b/state/jetstream/jetstream.go
@@ -59,7 +59,7 @@ func NewJetstreamStateStore(logger logger.Logger) state.Store {
 }
 
 // Init does parse metadata and establishes connection to nats broker.
-func (js *StateStore) Init(metadata state.Metadata) error {
+func (js *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := js.getMetadata(metadata)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (js *StateStore) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (js *StateStore) Features() []state.Feature {
+func (js *StateStore) Features(ctx context.Context) []state.Feature {
 	return nil
 }
 

--- a/state/jetstream/jetstream_test.go
+++ b/state/jetstream/jetstream_test.go
@@ -97,7 +97,7 @@ func TestSetGetAndDelete(t *testing.T) {
 
 	store := NewJetstreamStateStore(nil)
 
-	err := store.Init(state.Metadata{
+	err := store.Init(context.Background(), state.Metadata{
 		Base: metadata.Base{Properties: map[string]string{
 			"natsURL": nats.DefaultURL,
 			"bucket":  "test",

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -78,6 +78,8 @@ func (m *Memcached) Init(ctx context.Context, metadata state.Metadata) error {
 
 	m.client = client
 
+	// TODO: pass context when PR is merged.
+	// https://github.com/bradfitz/gomemcache/pull/126
 	err = client.Ping()
 	if err != nil {
 		return err

--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -62,7 +62,7 @@ func NewMemCacheStateStore(logger logger.Logger) state.Store {
 	return s
 }
 
-func (m *Memcached) Init(metadata state.Metadata) error {
+func (m *Memcached) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := getMemcachedMetadata(metadata)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (m *Memcached) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (m *Memcached) Features() []state.Feature {
+func (m *Memcached) Features(ctx context.Context) []state.Feature {
 	return nil
 }
 

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -113,7 +113,7 @@ func NewMongoDB(logger logger.Logger) state.Store {
 }
 
 // Init establishes connection to the store based on the metadata.
-func (m *MongoDB) Init(metadata state.Metadata) error {
+func (m *MongoDB) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := getMongoDBMetaData(metadata)
 	if err != nil {
 		return err
@@ -121,12 +121,12 @@ func (m *MongoDB) Init(metadata state.Metadata) error {
 
 	m.operationTimeout = meta.OperationTimeout
 
-	client, err := getMongoDBClient(meta)
+	client, err := getMongoDBClient(ctx, meta)
 	if err != nil {
 		return fmt.Errorf("error in creating mongodb client: %s", err)
 	}
 
-	if err = client.Ping(context.Background(), nil); err != nil {
+	if err = client.Ping(ctx, nil); err != nil {
 		return fmt.Errorf("error in connecting to mongodb, host: %s error: %s", meta.Host, err)
 	}
 
@@ -154,7 +154,7 @@ func (m *MongoDB) Init(metadata state.Metadata) error {
 }
 
 // Features returns the features available in this state store.
-func (m *MongoDB) Features() []state.Feature {
+func (m *MongoDB) Features(ctx context.Context) []state.Feature {
 	return m.features
 }
 
@@ -168,8 +168,8 @@ func (m *MongoDB) Set(ctx context.Context, req *state.SetRequest) error {
 	return nil
 }
 
-func (m *MongoDB) Ping() error {
-	if err := m.client.Ping(context.Background(), nil); err != nil {
+func (m *MongoDB) Ping(ctx context.Context) error {
+	if err := m.client.Ping(ctx, nil); err != nil {
 		return fmt.Errorf("mongoDB store: error connecting to mongoDB at %s: %s", m.metadata.Host, err)
 	}
 
@@ -360,14 +360,14 @@ func getMongoURI(metadata *mongoDBMetadata) string {
 	return fmt.Sprintf(connectionURIFormat, metadata.Host, metadata.DatabaseName, metadata.Params)
 }
 
-func getMongoDBClient(metadata *mongoDBMetadata) (*mongo.Client, error) {
+func getMongoDBClient(ctx context.Context, metadata *mongoDBMetadata) (*mongo.Client, error) {
 	uri := getMongoURI(metadata)
 
 	// Set client options
 	clientOptions := options.Client().ApplyURI(uri)
 
 	// Connect to MongoDB
-	ctx, cancel := context.WithTimeout(context.Background(), metadata.OperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, metadata.OperationTimeout)
 	defer cancel()
 
 	daprUserAgent := "dapr-" + logger.DaprVersion

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -242,9 +242,9 @@ func (m *MySQL) ensureStateSchema(ctx context.Context) error {
 
 	if !exists {
 		m.logger.Infof("Creating MySql schema '%s'", m.schemaName)
-		ctx, cancel := context.WithTimeout(ctx, m.timeout)
+		cctx, cancel := context.WithTimeout(ctx, m.timeout)
 		defer cancel()
-		_, err = m.db.ExecContext(ctx,
+		_, err = m.db.ExecContext(cctx,
 			fmt.Sprintf("CREATE DATABASE %s;", m.schemaName),
 		)
 		if err != nil {
@@ -297,10 +297,10 @@ func (m *MySQL) ensureStateTable(ctx context.Context, stateTableName string) err
 			eTag VARCHAR(36) NOT NULL
 			);`, stateTableName)
 
+		//nolint:govet
 		ctx, cancel := context.WithTimeout(ctx, m.timeout)
 		defer cancel()
 		_, err = m.db.ExecContext(ctx, createTable)
-
 		if err != nil {
 			return err
 		}

--- a/state/mysql/mysql_integration_test.go
+++ b/state/mysql/mysql_integration_test.go
@@ -115,7 +115,7 @@ func TestMySQLIntegration(t *testing.T) {
 					Base: metadata.Base{Properties: tt.props},
 				}
 
-				err := p.Init(metadata)
+				err := p.Init(context.Background(), metadata)
 
 				if tt.expectedErr == "" {
 					assert.Nil(t, err)
@@ -138,7 +138,7 @@ func TestMySQLIntegration(t *testing.T) {
 		defer mys.Close()
 	})
 
-	error := mys.Init(metadata)
+	error := mys.Init(context.Background(), metadata)
 	if error != nil {
 		t.Fatal(error)
 	}
@@ -149,7 +149,7 @@ func TestMySQLIntegration(t *testing.T) {
 		tableName := "test_state"
 
 		// Drop the table if it already exists
-		exists, err := tableExists(mys.db, tableName, 10*time.Second)
+		exists, err := tableExists(context.Background(), mys.db, tableName, 10*time.Second)
 		assert.Nil(t, err)
 		if exists {
 			dropTable(t, mys.db, tableName)
@@ -157,11 +157,11 @@ func TestMySQLIntegration(t *testing.T) {
 
 		// Create the state table and test for its existence
 		// There should be no error
-		err = mys.ensureStateTable(tableName)
+		err = mys.ensureStateTable(context.Background(), tableName)
 		assert.Nil(t, err)
 
 		// Now create it and make sure there are no errors
-		exists, err = tableExists(mys.db, tableName, 10*time.Second)
+		exists, err = tableExists(context.Background(), mys.db, tableName, 10*time.Second)
 		assert.Nil(t, err)
 		assert.True(t, exists)
 

--- a/state/mysql/mysql_test.go
+++ b/state/mysql/mysql_test.go
@@ -49,7 +49,7 @@ func TestEnsureStateSchemaHandlesShortConnectionString(t *testing.T) {
 	m.mock1.ExpectQuery("SELECT EXISTS").WillReturnRows(rows)
 
 	// Act
-	m.mySQL.ensureStateSchema()
+	m.mySQL.ensureStateSchema(context.Background())
 
 	// Assert
 	assert.Equal(t, "theUser:thePassword@/theSchema", m.mySQL.connectionString)
@@ -64,7 +64,7 @@ func TestFinishInitHandlesSchemaExistsError(t *testing.T) {
 	m.mock1.ExpectQuery("SELECT EXISTS").WillReturnError(expectedErr)
 
 	// Act
-	actualErr := m.mySQL.finishInit(m.mySQL.db)
+	actualErr := m.mySQL.finishInit(context.Background(), m.mySQL.db)
 
 	// Assert
 	assert.NotNil(t, actualErr, "now error returned")
@@ -83,7 +83,7 @@ func TestFinishInitHandlesDatabaseCreateError(t *testing.T) {
 	m.mock1.ExpectExec("CREATE DATABASE").WillReturnError(expectedErr)
 
 	// Act
-	actualErr := m.mySQL.finishInit(m.mySQL.db)
+	actualErr := m.mySQL.finishInit(context.Background(), m.mySQL.db)
 
 	// Assert
 	assert.NotNil(t, actualErr, "now error returned")
@@ -107,7 +107,7 @@ func TestFinishInitHandlesPingError(t *testing.T) {
 	m.mock2.ExpectPing().WillReturnError(expectedErr)
 
 	// Act
-	actualErr := m.mySQL.finishInit(m.mySQL.db)
+	actualErr := m.mySQL.finishInit(context.Background(), m.mySQL.db)
 
 	// Assert
 	assert.NotNil(t, actualErr, "now error returned")
@@ -135,7 +135,7 @@ func TestFinishInitHandlesTableExistsError(t *testing.T) {
 	m.mock2.ExpectQuery("SELECT EXISTS").WillReturnError(fmt.Errorf("tableExistsError"))
 
 	// Act
-	err := m.mySQL.finishInit(m.mySQL.db)
+	err := m.mySQL.finishInit(context.Background(), m.mySQL.db)
 
 	// Assert
 	assert.NotNil(t, err, "no error returned")
@@ -541,7 +541,7 @@ func TestTableExists(t *testing.T) {
 	m.mock1.ExpectQuery("SELECT EXISTS").WillReturnRows(rows)
 
 	// Act
-	actual, err := tableExists(m.mySQL.db, "store", 10*time.Second)
+	actual, err := tableExists(context.Background(), m.mySQL.db, "store", 10*time.Second)
 
 	// Assert
 	assert.Nil(t, err, `error was returned`)
@@ -559,7 +559,7 @@ func TestEnsureStateTableHandlesCreateTableError(t *testing.T) {
 	m.mock1.ExpectExec("CREATE TABLE").WillReturnError(fmt.Errorf("CreateTableError"))
 
 	// Act
-	err := m.mySQL.ensureStateTable("state")
+	err := m.mySQL.ensureStateTable(context.Background(), "state")
 
 	// Assert
 	assert.NotNil(t, err, "no error returned")
@@ -580,7 +580,7 @@ func TestEnsureStateTableCreatesTable(t *testing.T) {
 	m.mock1.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Act
-	err := m.mySQL.ensureStateTable("state")
+	err := m.mySQL.ensureStateTable(context.Background(), "state")
 
 	// Assert
 	assert.Nil(t, err)
@@ -597,7 +597,7 @@ func TestInitReturnsErrorOnNoConnectionString(t *testing.T) {
 	}
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -614,7 +614,7 @@ func TestInitReturnsErrorOnFailOpen(t *testing.T) {
 	m.mock1.ExpectQuery("SELECT EXISTS").WillReturnError(sql.ErrConnDone)
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -637,7 +637,7 @@ func TestInitHandlesRegisterTLSConfigError(t *testing.T) {
 	}
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -653,7 +653,7 @@ func TestInitSetsTableName(t *testing.T) {
 	}
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -669,7 +669,7 @@ func TestInitInvalidTableName(t *testing.T) {
 	}
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.ErrorContains(t, err, "table name '🙃' is not valid")
@@ -684,7 +684,7 @@ func TestInitSetsSchemaName(t *testing.T) {
 	}
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.NotNil(t, err)
@@ -700,7 +700,7 @@ func TestInitInvalidSchemaName(t *testing.T) {
 	}
 
 	// Act
-	err := m.mySQL.Init(*metadata)
+	err := m.mySQL.Init(context.Background(), *metadata)
 
 	// Assert
 	assert.ErrorContains(t, err, "schema name '?' is not valid")

--- a/state/oci/objectstorage/objectstorage.go
+++ b/state/oci/objectstorage/objectstorage.go
@@ -85,9 +85,9 @@ type objectStoreClient interface {
 	getObject(ctx context.Context, objectname string) (content []byte, etag *string, metadata map[string]string, err error)
 	deleteObject(ctx context.Context, objectname string, etag *string) (err error)
 	putObject(ctx context.Context, objectname string, contentLen int64, content io.ReadCloser, metadata map[string]string, etag *string) error
-	initStorageBucket() error
-	initOCIObjectStorageClient() (*objectstorage.ObjectStorageClient, error)
-	pingBucket() error
+	initStorageBucket(ctx context.Context) error
+	initOCIObjectStorageClient(ctx context.Context) (*objectstorage.ObjectStorageClient, error)
+	pingBucket(ctx context.Context) error
 }
 
 type objectStorageClient struct {
@@ -101,7 +101,7 @@ type ociObjectStorageClient struct {
 
 /*********  Interface Implementations Init, Features, Get, Set, Delete and the instantiation function NewOCIObjectStorageStore. */
 
-func (r *StateStore) Init(metadata state.Metadata) error {
+func (r *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	r.logger.Debugf("Init OCI Object Storage State Store")
 	meta, err := getObjectStorageMetadata(metadata.Properties)
 	if err != nil {
@@ -114,13 +114,13 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 		logger: r.logger,
 	}
 
-	objectStorageClient, cerr := r.client.initOCIObjectStorageClient()
+	objectStorageClient, cerr := r.client.initOCIObjectStorageClient(ctx)
 	if cerr != nil {
 		return fmt.Errorf("failed to initialize client or create bucket : %w", cerr)
 	}
 	meta.OCIObjectStorageClient = objectStorageClient
 
-	cerr = r.client.initStorageBucket()
+	cerr = r.client.initStorageBucket(ctx)
 	if cerr != nil {
 		return fmt.Errorf("failed to create bucket : %w", cerr)
 	}
@@ -129,7 +129,7 @@ func (r *StateStore) Init(metadata state.Metadata) error {
 	return nil
 }
 
-func (r *StateStore) Features() []state.Feature {
+func (r *StateStore) Features(ctx context.Context) []state.Feature {
 	return r.features
 }
 
@@ -162,8 +162,8 @@ func (r *StateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	return r.writeDocument(ctx, req)
 }
 
-func (r *StateStore) Ping() error {
-	return r.pingBucket()
+func (r *StateStore) Ping(ctx context.Context) error {
+	return r.pingBucket(ctx)
 }
 
 func NewOCIObjectStorageStore(logger logger.Logger) state.Store {
@@ -312,8 +312,8 @@ func (r *StateStore) readDocument(ctx context.Context, req *state.GetRequest) ([
 	return content, etag, nil
 }
 
-func (r *StateStore) pingBucket() error {
-	err := r.client.pingBucket()
+func (r *StateStore) pingBucket(ctx context.Context) error {
+	err := r.client.pingBucket(ctx)
 	if err != nil {
 		r.logger.Debugf("ping bucket failed err %s", err)
 		return fmt.Errorf("failed to ping bucket on OCI Object storage : %w", err)
@@ -467,8 +467,7 @@ func (c *ociObjectStorageClient) putObject(ctx context.Context, objectname strin
 	return nil
 }
 
-func (c *ociObjectStorageClient) initStorageBucket() error {
-	ctx := context.Background()
+func (c *ociObjectStorageClient) initStorageBucket(ctx context.Context) error {
 	err := c.ensureBucketExists(ctx, *c.objectStorageMetadata.OCIObjectStorageClient, c.objectStorageMetadata.Namespace, c.objectStorageMetadata.BucketName, c.objectStorageMetadata.CompartmentOCID)
 	if err != nil {
 		return fmt.Errorf("failed to read or create bucket : %w", err)
@@ -476,7 +475,7 @@ func (c *ociObjectStorageClient) initStorageBucket() error {
 	return nil
 }
 
-func (c *ociObjectStorageClient) initOCIObjectStorageClient() (*objectstorage.ObjectStorageClient, error) {
+func (c *ociObjectStorageClient) initOCIObjectStorageClient(ctx context.Context) (*objectstorage.ObjectStorageClient, error) {
 	var configurationProvider common.ConfigurationProvider
 	if c.objectStorageMetadata.InstancePrincipalAuthentication {
 		c.logger.Debugf("instance principal authentication is used. ")
@@ -499,7 +498,6 @@ func (c *ociObjectStorageClient) initOCIObjectStorageClient() (*objectstorage.Ob
 	if cerr != nil {
 		return nil, fmt.Errorf("failed to create ObjectStorageClient : %w", cerr)
 	}
-	ctx := context.Background()
 	c.objectStorageMetadata.Namespace, cerr = getNamespace(ctx, objectStorageClient)
 	if cerr != nil {
 		return nil, fmt.Errorf("failed to get namespace : %w", cerr)
@@ -507,12 +505,12 @@ func (c *ociObjectStorageClient) initOCIObjectStorageClient() (*objectstorage.Ob
 	return &objectStorageClient, nil
 }
 
-func (c *ociObjectStorageClient) pingBucket() error {
+func (c *ociObjectStorageClient) pingBucket(ctx context.Context) error {
 	req := objectstorage.GetBucketRequest{
 		NamespaceName: &c.objectStorageMetadata.Namespace,
 		BucketName:    &c.objectStorageMetadata.BucketName,
 	}
-	_, err := c.objectStorageMetadata.OCIObjectStorageClient.GetBucket(context.Background(), req)
+	_, err := c.objectStorageMetadata.OCIObjectStorageClient.GetBucket(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve bucket details : %w", err)
 	}

--- a/state/oci/objectstorage/objectstorage_test.go
+++ b/state/oci/objectstorage/objectstorage_test.go
@@ -44,7 +44,7 @@ func TestInit(t *testing.T) {
 	t.Parallel()
 	t.Run("Init with beautifully complete yet incorrect metadata", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Error(t, err, "Incorrect configuration data should result in failure to create client")
 		assert.Contains(t, err.Error(), "failed to initialize client", "Incorrect configuration data should result in failure to create client")
@@ -52,56 +52,56 @@ func TestInit(t *testing.T) {
 	t.Run("Init with missing region", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[regionKey] = ""
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Errorf("missing or empty region field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 	t.Run("Init with missing tenancyOCID", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties["tenancyOCID"] = ""
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Errorf("missing or empty tenancyOCID field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 	t.Run("Init with missing userOCID", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[userKey] = ""
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Errorf("missing or empty userOCID field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 	t.Run("Init with missing compartmentOCID", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[compartmentKey] = ""
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Errorf("missing or empty compartmentOCID field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 	t.Run("Init with missing fingerprint", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[fingerPrintKey] = ""
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Errorf("missing or empty fingerPrint field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 	t.Run("Init with missing private key", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[privateKeyKey] = ""
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Errorf("missing or empty privateKey field from metadata"), err, "Lacking configuration property should be spotted")
 	})
 	t.Run("Init with incorrect value for instancePrincipalAuthentication", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[instancePrincipalAuthenticationKey] = "ZQWE"
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err, "if instancePrincipalAuthentication is defined, it should be true or false; if not: error should be raised ")
 	})
 	t.Run("Init with missing fingerprint with instancePrincipalAuthentication", func(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[fingerPrintKey] = ""
 		meta.Properties[instancePrincipalAuthenticationKey] = "true"
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		if err != nil {
 			assert.Contains(t, err.Error(), "failed to initialize client", "unit tests not run on OCI will not be able to correctly create an OCI client based on instance principal authentication")
 		}
@@ -110,7 +110,7 @@ func TestInit(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[configFileAuthenticationKey] = "true"
 		meta.Properties[configFilePathKey] = "file_does_not_exist"
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err, "if configFileAuthentication is true and configFilePath does not indicate an existing file, then an error should be produced")
 		if err != nil {
 			assert.Contains(t, err.Error(), "does not exist", "if configFileAuthentication is true and configFilePath does not indicate an existing file, then an error should be produced that indicates this")
@@ -120,7 +120,7 @@ func TestInit(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[configFileAuthenticationKey] = "true"
 		meta.Properties[configFilePathKey] = "~/some-file"
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err, "if configFileAuthentication is true and configFilePath contains a value that starts with ~/ , then an error should be produced")
 		if err != nil {
 			assert.Contains(t, err.Error(), "~", "if configFileAuthentication is true and configFilePath starts with ~/, then an error should be produced that indicates this")
@@ -130,7 +130,7 @@ func TestInit(t *testing.T) {
 		meta.Properties = getDummyOCIObjectStorageConfiguration()
 		meta.Properties[fingerPrintKey] = ""
 		meta.Properties[instancePrincipalAuthenticationKey] = "false"
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		assert.NotNil(t, err, "if instancePrincipalAuthentication and configFileAuthentication are both false, then fingerprint is required and an error should be raised when it is missing")
 	})
 	t.Run("Init with missing fingerprint with configFileAuthentication", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestInit(t *testing.T) {
 		meta.Properties[fingerPrintKey] = ""
 		meta.Properties[instancePrincipalAuthenticationKey] = "false"
 		meta.Properties[configFileAuthenticationKey] = "true"
-		err := statestore.Init(meta)
+		err := statestore.Init(context.Background(), meta)
 		if err != nil {
 			assert.Contains(t, err.Error(), "failed to initialize client", "if configFileAuthentication is true, then fingerprint is not required and error should be raised for failed to initialize client, not for missing fingerprint")
 		}
@@ -149,7 +149,7 @@ func TestFeatures(t *testing.T) {
 	t.Parallel()
 	s := NewOCIObjectStorageStore(logger.NewLogger("logger")).(*StateStore)
 	t.Run("Test contents of Features", func(t *testing.T) {
-		features := s.Features()
+		features := s.Features(context.Background())
 		assert.Contains(t, features, state.FeatureETag)
 	})
 }
@@ -220,11 +220,11 @@ func (c *mockedObjectStoreClient) putObject(ctx context.Context, objectname stri
 	return nil
 }
 
-func (c *mockedObjectStoreClient) initStorageBucket() error {
+func (c *mockedObjectStoreClient) initStorageBucket(ctx context.Context) error {
 	return nil
 }
 
-func (c *mockedObjectStoreClient) pingBucket() error {
+func (c *mockedObjectStoreClient) pingBucket(ctx context.Context) error {
 	c.pingBucketIsCalled = true
 	return nil
 }
@@ -264,7 +264,7 @@ func TestInitWithMockClient(t *testing.T) {
 	s.client = &mockedObjectStoreClient{}
 	meta := state.Metadata{}
 	t.Run("Test Init with incomplete configuration", func(t *testing.T) {
-		err := s.Init(meta)
+		err := s.Init(context.Background(), meta)
 		assert.NotNil(t, err, "Init should complain about lacking configuration settings")
 	})
 }
@@ -276,7 +276,7 @@ func TestPingWithMockClient(t *testing.T) {
 	s.client = mockClient
 
 	t.Run("Test Ping", func(t *testing.T) {
-		err := s.Ping()
+		err := s.Ping(context.Background())
 		assert.Nil(t, err)
 		assert.True(t, mockClient.pingBucketIsCalled, "function pingBucket should be invoked on the mockClient")
 	})

--- a/state/oracledatabase/dbaccess.go
+++ b/state/oracledatabase/dbaccess.go
@@ -21,7 +21,7 @@ import (
 
 // dbAccess is a private interface which enables unit testing of Oracle Database.
 type dbAccess interface {
-	Init(metadata state.Metadata) error
+	Init(ctx context.Context, metadata state.Metadata) error
 	Ping() error
 	Set(ctx context.Context, req *state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)

--- a/state/oracledatabase/dbaccess.go
+++ b/state/oracledatabase/dbaccess.go
@@ -22,7 +22,7 @@ import (
 // dbAccess is a private interface which enables unit testing of Oracle Database.
 type dbAccess interface {
 	Init(ctx context.Context, metadata state.Metadata) error
-	Ping() error
+	Ping(ctx context.Context) error
 	Set(ctx context.Context, req *state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
 	Delete(ctx context.Context, req *state.DeleteRequest) error

--- a/state/oracledatabase/oracledatabase.go
+++ b/state/oracledatabase/oracledatabase.go
@@ -52,8 +52,8 @@ func (o *OracleDatabase) Init(ctx context.Context, metadata state.Metadata) erro
 	return o.dbaccess.Init(ctx, metadata)
 }
 
-func (o *OracleDatabase) Ping() error {
-	return o.dbaccess.Ping()
+func (o *OracleDatabase) Ping(ctx context.Context) error {
+	return o.dbaccess.Ping(ctx)
 }
 
 // Features returns the features available in this state store.

--- a/state/oracledatabase/oracledatabase.go
+++ b/state/oracledatabase/oracledatabase.go
@@ -48,8 +48,8 @@ func newOracleDatabaseStateStore(logger logger.Logger, dba dbAccess) *OracleData
 }
 
 // Init initializes the SQL server state store.
-func (o *OracleDatabase) Init(metadata state.Metadata) error {
-	return o.dbaccess.Init(metadata)
+func (o *OracleDatabase) Init(ctx context.Context, metadata state.Metadata) error {
+	return o.dbaccess.Init(ctx, metadata)
 }
 
 func (o *OracleDatabase) Ping() error {
@@ -57,7 +57,7 @@ func (o *OracleDatabase) Ping() error {
 }
 
 // Features returns the features available in this state store.
-func (o *OracleDatabase) Features() []state.Feature {
+func (o *OracleDatabase) Features(ctx context.Context) []state.Feature {
 	return o.features
 }
 

--- a/state/oracledatabase/oracledatabase_integration_test.go
+++ b/state/oracledatabase/oracledatabase_integration_test.go
@@ -66,7 +66,7 @@ func TestOracleDatabaseIntegration(t *testing.T) {
 		defer ods.Close()
 	})
 
-	if initerror := ods.Init(metadata); initerror != nil {
+	if initerror := ods.Init(context.Background(), metadata); initerror != nil {
 		t.Fatal(initerror)
 	}
 
@@ -743,7 +743,7 @@ func testInitConfiguration(t *testing.T) {
 				Base: metadata.Base{Properties: tt.props},
 			}
 
-			err := p.Init(metadata)
+			err := p.Init(context.Background(), metadata)
 			if tt.expectedErr == "" {
 				assert.Nil(t, err)
 			} else {

--- a/state/oracledatabase/oracledatabase_test.go
+++ b/state/oracledatabase/oracledatabase_test.go
@@ -43,7 +43,7 @@ func (m *fakeDBaccess) Ping() error {
 	return nil
 }
 
-func (m *fakeDBaccess) Init(metadata state.Metadata) error {
+func (m *fakeDBaccess) Init(ctx context.Context, metadata state.Metadata) error {
 	m.initExecuted = true
 
 	return nil
@@ -212,7 +212,7 @@ func createOracleDatabase(t *testing.T) *OracleDatabase {
 		Base: metadata.Base{Properties: map[string]string{connectionStringKey: fakeConnectionString}},
 	}
 
-	err := odb.Init(*metadata)
+	err := odb.Init(context.Background(), *metadata)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, odb.dbaccess)

--- a/state/oracledatabase/oracledatabase_test.go
+++ b/state/oracledatabase/oracledatabase_test.go
@@ -38,7 +38,7 @@ type fakeDBaccess struct {
 	getExecuted  bool
 }
 
-func (m *fakeDBaccess) Ping() error {
+func (m *fakeDBaccess) Ping(ctx context.Context) error {
 	m.pingExecuted = true
 	return nil
 }
@@ -77,7 +77,7 @@ func (m *fakeDBaccess) Close() error {
 func TestInitRunsDBAccessInit(t *testing.T) {
 	t.Parallel()
 	ods, fake := createOracleDatabaseWithFake(t)
-	ods.Ping()
+	ods.Ping(context.Background())
 	assert.True(t, fake.initExecuted)
 }
 
@@ -194,7 +194,7 @@ func createOracleDatabaseWithFake(t *testing.T) (*OracleDatabase, *fakeDBaccess)
 func TestPingRunsDBAccessPing(t *testing.T) {
 	t.Parallel()
 	odb, fake := createOracleDatabaseWithFake(t)
-	odb.Ping()
+	odb.Ping(context.Background())
 	assert.True(t, fake.pingExecuted)
 }
 

--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -76,7 +76,7 @@ func parseMetadata(meta map[string]string) (oracleDatabaseMetadata, error) {
 }
 
 // Init sets up OracleDatabase connection and ensures that the state table exists.
-func (o *oracleDatabaseAccess) Init(metadata state.Metadata) error {
+func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata) error {
 	o.logger.Debug("Initializing OracleDatabase state store")
 	meta, err := parseMetadata(metadata.Properties)
 	o.metadata = meta

--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -63,8 +63,8 @@ func newOracleDatabaseAccess(logger logger.Logger) *oracleDatabaseAccess {
 	}
 }
 
-func (o *oracleDatabaseAccess) Ping() error {
-	return o.db.Ping()
+func (o *oracleDatabaseAccess) Ping(ctx context.Context) error {
+	return o.db.PingContext(ctx)
 }
 
 func parseMetadata(meta map[string]string) (oracleDatabaseMetadata, error) {
@@ -102,7 +102,7 @@ func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata
 
 	o.db = db
 
-	if pingErr := db.Ping(); pingErr != nil {
+	if pingErr := db.PingContext(ctx); pingErr != nil {
 		return pingErr
 	}
 	err = o.ensureStateTable(tableName)

--- a/state/postgresql/dbaccess.go
+++ b/state/postgresql/dbaccess.go
@@ -24,7 +24,7 @@ import (
 
 // dbAccess is a private interface which enables unit testing of PostgreSQL.
 type dbAccess interface {
-	Init(metadata state.Metadata) error
+	Init(ctx context.Context, metadata state.Metadata) error
 	Set(ctx context.Context, req *state.SetRequest) error
 	BulkSet(ctx context.Context, req []state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -66,7 +66,7 @@ func newPostgresDBAccess(logger logger.Logger) *PostgresDBAccess {
 }
 
 // Init sets up Postgres connection and ensures that the state table exists.
-func (p *PostgresDBAccess) Init(meta state.Metadata) error {
+func (p *PostgresDBAccess) Init(ctx context.Context, meta state.Metadata) error {
 	p.logger.Debug("Initializing Postgres state store")
 
 	p.ctx, p.cancel = context.WithCancel(context.Background())

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -52,8 +54,10 @@ type PostgresDBAccess struct {
 	logger   logger.Logger
 	metadata postgresMetadataStruct
 	db       pgxPoolConn
-	ctx      context.Context
-	cancel   context.CancelFunc
+
+	closeCh chan struct{}
+	closed  atomic.Bool
+	wg      sync.WaitGroup
 }
 
 // newPostgresDBAccess creates a new instance of postgresAccess.
@@ -61,15 +65,14 @@ func newPostgresDBAccess(logger logger.Logger) *PostgresDBAccess {
 	logger.Debug("Instantiating new Postgres state store")
 
 	return &PostgresDBAccess{
-		logger: logger,
+		logger:  logger,
+		closeCh: make(chan struct{}),
 	}
 }
 
 // Init sets up Postgres connection and ensures that the state table exists.
 func (p *PostgresDBAccess) Init(ctx context.Context, meta state.Metadata) error {
 	p.logger.Debug("Initializing Postgres state store")
-
-	p.ctx, p.cancel = context.WithCancel(context.Background())
 
 	err := p.metadata.InitWithMetadata(meta)
 	if err != nil {
@@ -87,7 +90,7 @@ func (p *PostgresDBAccess) Init(ctx context.Context, meta state.Metadata) error 
 		config.MaxConnIdleTime = p.metadata.ConnectionMaxIdleTime
 	}
 
-	connCtx, connCancel := context.WithTimeout(p.ctx, p.metadata.timeout)
+	connCtx, connCancel := context.WithTimeout(ctx, p.metadata.timeout)
 	p.db, err = pgxpool.NewWithConfig(connCtx, config)
 	connCancel()
 	if err != nil {
@@ -96,7 +99,7 @@ func (p *PostgresDBAccess) Init(ctx context.Context, meta state.Metadata) error 
 		return err
 	}
 
-	pingCtx, pingCancel := context.WithTimeout(p.ctx, p.metadata.timeout)
+	pingCtx, pingCancel := context.WithTimeout(ctx, p.metadata.timeout)
 	err = p.db.Ping(pingCtx)
 	pingCancel()
 	if err != nil {
@@ -111,12 +114,12 @@ func (p *PostgresDBAccess) Init(ctx context.Context, meta state.Metadata) error 
 		MetadataTableName: p.metadata.MetadataTableName,
 		StateTableName:    p.metadata.TableName,
 	}
-	err = migrate.Perform(p.ctx)
+	err = migrate.Perform(ctx)
 	if err != nil {
 		return err
 	}
 
-	p.ScheduleCleanupExpiredData(p.ctx)
+	p.ScheduleCleanupExpiredData(ctx)
 
 	return nil
 }
@@ -444,13 +447,15 @@ func (p *PostgresDBAccess) Query(parentCtx context.Context, req *state.QueryRequ
 }
 
 func (p *PostgresDBAccess) ScheduleCleanupExpiredData(ctx context.Context) {
-	if p.metadata.cleanupInterval == nil {
+	if p.metadata.cleanupInterval == nil || p.closed.Load() {
 		return
 	}
 
 	p.logger.Infof("Schedule expired data clean up every %d seconds", int(p.metadata.cleanupInterval.Seconds()))
 
+	p.wg.Add(1)
 	go func() {
+		defer p.wg.Done()
 		ticker := time.NewTicker(*p.metadata.cleanupInterval)
 		for {
 			select {
@@ -461,6 +466,9 @@ func (p *PostgresDBAccess) ScheduleCleanupExpiredData(ctx context.Context) {
 				}
 			case <-ctx.Done():
 				p.logger.Debug("Stopped background cleanup of expired data")
+				return
+			case <-p.closeCh:
+				p.logger.Debug("Stopping background because PostgresDBAccess is closing")
 				return
 			}
 		}
@@ -517,10 +525,11 @@ func (p *PostgresDBAccess) UpdateLastCleanup(ctx context.Context, db dbquerier, 
 
 // Close implements io.Close.
 func (p *PostgresDBAccess) Close() error {
-	if p.cancel != nil {
-		p.cancel()
-		p.cancel = nil
+	defer p.wg.Wait()
+	if p.closed.CompareAndSwap(true, false) {
+		close(p.closeCh)
 	}
+
 	if p.db != nil {
 		p.db.Close()
 		p.db = nil

--- a/state/postgresql/postgresdbaccess.go
+++ b/state/postgresql/postgresdbaccess.go
@@ -526,7 +526,7 @@ func (p *PostgresDBAccess) UpdateLastCleanup(ctx context.Context, db dbquerier, 
 // Close implements io.Close.
 func (p *PostgresDBAccess) Close() error {
 	defer p.wg.Wait()
-	if p.closed.CompareAndSwap(true, false) {
+	if p.closed.CompareAndSwap(false, true) {
 		close(p.closeCh)
 	}
 

--- a/state/postgresql/postgresql.go
+++ b/state/postgresql/postgresql.go
@@ -45,12 +45,12 @@ func newPostgreSQLStateStore(logger logger.Logger, dba dbAccess) *PostgreSQL {
 }
 
 // Init initializes the SQL server state store.
-func (p *PostgreSQL) Init(metadata state.Metadata) error {
-	return p.dbaccess.Init(metadata)
+func (p *PostgreSQL) Init(ctx context.Context, metadata state.Metadata) error {
+	return p.dbaccess.Init(ctx, metadata)
 }
 
 // Features returns the features available in this state store.
-func (p *PostgreSQL) Features() []state.Feature {
+func (p *PostgreSQL) Features(ctx context.Context) []state.Feature {
 	return []state.Feature{state.FeatureETag, state.FeatureTransactional, state.FeatureQueryAPI}
 }
 

--- a/state/postgresql/postgresql_integration_test.go
+++ b/state/postgresql/postgresql_integration_test.go
@@ -60,7 +60,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 		defer pgs.Close()
 	})
 
-	error := pgs.Init(metadata)
+	error := pgs.Init(context.Background(), metadata)
 	if error != nil {
 		t.Fatal(error)
 	}
@@ -472,7 +472,7 @@ func testInitConfiguration(t *testing.T) {
 				Base: metadata.Base{Properties: tt.props},
 			}
 
-			err := p.Init(metadata)
+			err := p.Init(context.Background(), metadata)
 			if tt.expectedErr == nil {
 				assert.NoError(t, err)
 			} else {

--- a/state/postgresql/postgresql_test.go
+++ b/state/postgresql/postgresql_test.go
@@ -38,7 +38,7 @@ type fakeDBaccess struct {
 	deleteExecuted bool
 }
 
-func (m *fakeDBaccess) Init(metadata state.Metadata) error {
+func (m *fakeDBaccess) Init(ctx context.Context, metadata state.Metadata) error {
 	m.initExecuted = true
 
 	return nil
@@ -110,7 +110,7 @@ func createPostgreSQL(t *testing.T) *PostgreSQL {
 		Base: metadata.Base{Properties: map[string]string{"connectionString": fakeConnectionString}},
 	}
 
-	err := pgs.Init(*metadata)
+	err := pgs.Init(context.Background(), *metadata)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, pgs.dbaccess)

--- a/state/redis/redis_test.go
+++ b/state/redis/redis_test.go
@@ -204,7 +204,6 @@ func TestTransactionalUpsert(t *testing.T) {
 		json:   jsoniter.ConfigFastest,
 		logger: logger.NewLogger("test"),
 	}
-	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	err := ss.Multi(context.Background(), &state.TransactionalStateRequest{
 		Operations: []state.TransactionalStateOperation{
@@ -270,7 +269,6 @@ func TestTransactionalDelete(t *testing.T) {
 		json:   jsoniter.ConfigFastest,
 		logger: logger.NewLogger("test"),
 	}
-	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	// Insert a record first.
 	ss.Set(context.Background(), &state.SetRequest{
@@ -307,12 +305,12 @@ func TestPing(t *testing.T) {
 		clientSettings: &rediscomponent.Settings{},
 	}
 
-	err := state.Ping(ss)
+	err := state.Ping(context.Background(), ss)
 	assert.NoError(t, err)
 
 	s.Close()
 
-	err = state.Ping(ss)
+	err = state.Ping(context.Background(), ss)
 	assert.Error(t, err)
 }
 
@@ -328,14 +326,13 @@ func TestRequestsWithGlobalTTL(t *testing.T) {
 		logger:   logger.NewLogger("test"),
 		metadata: rediscomponent.Metadata{TTLInSeconds: &globalTTLInSeconds},
 	}
-	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	t.Run("TTL: Only global specified", func(t *testing.T) {
 		ss.Set(context.Background(), &state.SetRequest{
 			Key:   "weapon100",
 			Value: "deathstar100",
 		})
-		ttl, _ := ss.client.TTLResult(ss.ctx, "weapon100")
+		ttl, _ := ss.client.TTLResult(context.Background(), "weapon100")
 
 		assert.Equal(t, time.Duration(globalTTLInSeconds)*time.Second, ttl)
 	})
@@ -349,7 +346,7 @@ func TestRequestsWithGlobalTTL(t *testing.T) {
 				"ttlInSeconds": strconv.Itoa(requestTTL),
 			},
 		})
-		ttl, _ := ss.client.TTLResult(ss.ctx, "weapon100")
+		ttl, _ := ss.client.TTLResult(context.Background(), "weapon100")
 
 		assert.Equal(t, time.Duration(requestTTL)*time.Second, ttl)
 	})
@@ -420,7 +417,6 @@ func TestSetRequestWithTTL(t *testing.T) {
 		json:   jsoniter.ConfigFastest,
 		logger: logger.NewLogger("test"),
 	}
-	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	t.Run("TTL specified", func(t *testing.T) {
 		ttlInSeconds := 100
@@ -432,7 +428,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 			},
 		})
 
-		ttl, _ := ss.client.TTLResult(ss.ctx, "weapon100")
+		ttl, _ := ss.client.TTLResult(context.Background(), "weapon100")
 
 		assert.Equal(t, time.Duration(ttlInSeconds)*time.Second, ttl)
 	})
@@ -443,7 +439,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 			Value: "deathstar200",
 		})
 
-		ttl, _ := ss.client.TTLResult(ss.ctx, "weapon200")
+		ttl, _ := ss.client.TTLResult(context.Background(), "weapon200")
 
 		assert.Equal(t, time.Duration(-1), ttl)
 	})
@@ -453,7 +449,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 			Key:   "weapon300",
 			Value: "deathstar300",
 		})
-		ttl, _ := ss.client.TTLResult(ss.ctx, "weapon300")
+		ttl, _ := ss.client.TTLResult(context.Background(), "weapon300")
 		assert.Equal(t, time.Duration(-1), ttl)
 
 		// make the key no longer persistent
@@ -465,7 +461,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 				"ttlInSeconds": strconv.Itoa(ttlInSeconds),
 			},
 		})
-		ttl, _ = ss.client.TTLResult(ss.ctx, "weapon300")
+		ttl, _ = ss.client.TTLResult(context.Background(), "weapon300")
 		assert.Equal(t, time.Duration(ttlInSeconds)*time.Second, ttl)
 
 		// make the key persistent again
@@ -476,7 +472,7 @@ func TestSetRequestWithTTL(t *testing.T) {
 				"ttlInSeconds": strconv.Itoa(-1),
 			},
 		})
-		ttl, _ = ss.client.TTLResult(ss.ctx, "weapon300")
+		ttl, _ = ss.client.TTLResult(context.Background(), "weapon300")
 		assert.Equal(t, time.Duration(-1), ttl)
 	})
 }
@@ -490,7 +486,6 @@ func TestTransactionalDeleteNoEtag(t *testing.T) {
 		json:   jsoniter.ConfigFastest,
 		logger: logger.NewLogger("test"),
 	}
-	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	// Insert a record first.
 	ss.Set(context.Background(), &state.SetRequest{

--- a/state/rethinkdb/rethinkdb_test.go
+++ b/state/rethinkdb/rethinkdb_test.go
@@ -70,13 +70,13 @@ func TestRethinkDBStateStore(t *testing.T) {
 	db := NewRethinkDBStateStore(logger.NewLogger("test")).(*RethinkDB)
 
 	t.Run("With init", func(t *testing.T) {
-		if err := db.Init(m); err != nil {
+		if err := db.Init(context.Background(), m); err != nil {
 			t.Fatalf("error initializing db: %v", err)
 		}
 		assert.Equal(t, stateTableNameDefault, db.config.Table)
 
 		m.Properties["table"] = "test"
-		if err := db.Init(m); err != nil {
+		if err := db.Init(context.Background(), m); err != nil {
 			t.Fatalf("error initializing db: %v", err)
 		}
 		assert.Equal(t, "test", db.config.Table)
@@ -157,7 +157,7 @@ func TestRethinkDBStateStoreRongRun(t *testing.T) {
 
 	m := state.Metadata{Base: metadata.Base{Properties: getTestMetadata()}}
 	db := NewRethinkDBStateStore(logger.NewLogger("test")).(*RethinkDB)
-	if err := db.Init(m); err != nil {
+	if err := db.Init(context.Background(), m); err != nil {
 		t.Fatalf("error initializing db: %v", err)
 	}
 
@@ -212,7 +212,7 @@ func TestRethinkDBStateStoreMulti(t *testing.T) {
 
 	m := state.Metadata{Base: metadata.Base{Properties: getTestMetadata()}}
 	db := NewRethinkDBStateStore(logger.NewLogger("test")).(*RethinkDB)
-	if err := db.Init(m); err != nil {
+	if err := db.Init(context.Background(), m); err != nil {
 		t.Fatalf("error initializing db: %v", err)
 	}
 

--- a/state/sqlite/sqlite.go
+++ b/state/sqlite/sqlite.go
@@ -45,8 +45,8 @@ func newSQLiteStateStore(logger logger.Logger, dba DBAccess) *SQLiteStore {
 }
 
 // Init initializes the Sql server state store.
-func (s *SQLiteStore) Init(metadata state.Metadata) error {
-	return s.dbaccess.Init(metadata)
+func (s *SQLiteStore) Init(ctx context.Context, metadata state.Metadata) error {
+	return s.dbaccess.Init(ctx, metadata)
 }
 
 func (s SQLiteStore) GetComponentMetadata() map[string]string {
@@ -57,7 +57,7 @@ func (s SQLiteStore) GetComponentMetadata() map[string]string {
 }
 
 // Features returns the features available in this state store.
-func (s *SQLiteStore) Features() []state.Feature {
+func (s *SQLiteStore) Features(ctx context.Context) []state.Feature {
 	return []state.Feature{
 		state.FeatureETag,
 		state.FeatureTransactional,

--- a/state/sqlite/sqlite.go
+++ b/state/sqlite/sqlite.go
@@ -64,8 +64,8 @@ func (s *SQLiteStore) Features(ctx context.Context) []state.Feature {
 	}
 }
 
-func (s *SQLiteStore) Ping() error {
-	return s.dbaccess.Ping(context.TODO())
+func (s *SQLiteStore) Ping(ctx context.Context) error {
+	return s.dbaccess.Ping(ctx)
 }
 
 // Delete removes an entity from the store.

--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -35,7 +35,7 @@ import (
 
 // DBAccess is a private interface which enables unit testing of SQLite.
 type DBAccess interface {
-	Init(metadata state.Metadata) error
+	Init(ctx context.Context, metadata state.Metadata) error
 	Ping(ctx context.Context) error
 	Set(ctx context.Context, req *state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
@@ -73,7 +73,7 @@ func newSqliteDBAccess(logger logger.Logger) *sqliteDBAccess {
 
 // Init sets up SQLite Database connection and ensures that the state table
 // exists.
-func (a *sqliteDBAccess) Init(md state.Metadata) error {
+func (a *sqliteDBAccess) Init(ctx context.Context, md state.Metadata) error {
 	err := a.metadata.InitWithMetadata(md)
 	if err != nil {
 		return err

--- a/state/sqlite/sqlite_integration_test.go
+++ b/state/sqlite/sqlite_integration_test.go
@@ -57,7 +57,7 @@ func TestSqliteIntegration(t *testing.T) {
 		defer s.Close()
 	})
 
-	if initerror := s.Init(metadata); initerror != nil {
+	if initerror := s.Init(context.Background(), metadata); initerror != nil {
 		t.Fatal(initerror)
 	}
 
@@ -683,7 +683,7 @@ func testInitConfiguration(t *testing.T) {
 				},
 			}
 
-			err := p.Init(metadata)
+			err := p.Init(context.Background(), metadata)
 			if tt.expectedErr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/state/sqlite/sqlite_test.go
+++ b/state/sqlite/sqlite_test.go
@@ -43,7 +43,7 @@ func (m *fakeDBaccess) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (m *fakeDBaccess) Init(metadata state.Metadata) error {
+func (m *fakeDBaccess) Init(ctx context.Context, metadata state.Metadata) error {
 	m.initExecuted = true
 
 	return nil
@@ -168,7 +168,7 @@ func createSqlite(t *testing.T) *SQLiteStore {
 		},
 	}
 
-	err := odb.Init(*metadata)
+	err := odb.Init(context.Background(), *metadata)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, odb.dbaccess)

--- a/state/sqlite/sqlite_test.go
+++ b/state/sqlite/sqlite_test.go
@@ -77,7 +77,7 @@ func (m *fakeDBaccess) Close() error {
 func TestInitRunsDBAccessInit(t *testing.T) {
 	t.Parallel()
 	ods, fake := createSqliteWithFake(t)
-	ods.Ping()
+	ods.Ping(context.Background())
 	assert.True(t, fake.initExecuted)
 }
 
@@ -146,7 +146,7 @@ func createSqliteWithFake(t *testing.T) (*SQLiteStore, *fakeDBaccess) {
 func TestPingRunsDBAccessPing(t *testing.T) {
 	t.Parallel()
 	odb, fake := createSqliteWithFake(t)
-	odb.Ping()
+	odb.Ping(context.Background())
 	assert.True(t, fake.pingExecuted)
 }
 

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -165,7 +165,7 @@ func isValidIndexedPropertyType(s string) bool {
 }
 
 // Init initializes the SQL server state store.
-func (s *SQLServer) Init(metadata state.Metadata) error {
+func (s *SQLServer) Init(ctx context.Context, metadata state.Metadata) error {
 	err := s.parseMetadata(metadata.Properties)
 	if err != nil {
 		return err
@@ -342,7 +342,7 @@ func (s *SQLServer) setTable(tableName string) error {
 }
 
 // Features returns the features available in this state store.
-func (s *SQLServer) Features() []state.Feature {
+func (s *SQLServer) Features(ctx context.Context) []state.Feature {
 	return s.features
 }
 

--- a/state/sqlserver/sqlserver_integration_test.go
+++ b/state/sqlserver/sqlserver_integration_test.go
@@ -124,7 +124,7 @@ func getTestStoreWithKeyType(t *testing.T, kt KeyType, indexedProperties string)
 	schema := getUniqueDBSchema()
 	metadata := createMetadata(schema, kt, indexedProperties)
 	store := NewSQLServerStateStore(logger.NewLogger("test")).(*SQLServer)
-	err := store.Init(metadata)
+	err := store.Init(context.Background(), metadata)
 	assert.Nil(t, err)
 
 	return store
@@ -800,7 +800,7 @@ func testMultipleInitializations(t *testing.T) {
 			store := getTestStoreWithKeyType(t, test.kt, test.indexedProperties)
 
 			store2 := NewSQLServerStateStore(logger.NewLogger("test")).(*SQLServer)
-			assert.Nil(t, store2.Init(createMetadata(store.schema, test.kt, test.indexedProperties)))
+			assert.Nil(t, store2.Init(context.Background(), createMetadata(store.schema, test.kt, test.indexedProperties)))
 		})
 	}
 }

--- a/state/sqlserver/sqlserver_test.go
+++ b/state/sqlserver/sqlserver_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package sqlserver
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -192,7 +193,7 @@ func TestValidConfiguration(t *testing.T) {
 				Base: metadata.Base{Properties: tt.props},
 			}
 
-			err := sqlStore.Init(metadata)
+			err := sqlStore.Init(context.Background(), metadata)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected.connectionString, sqlStore.connectionString)
 			assert.Equal(t, tt.expected.tableName, sqlStore.tableName)
@@ -329,7 +330,7 @@ func TestInvalidConfiguration(t *testing.T) {
 				Base: metadata.Base{Properties: tt.props},
 			}
 
-			err := sqlStore.Init(metadata)
+			err := sqlStore.Init(context.Background(), metadata)
 			assert.NotNil(t, err)
 
 			if tt.expectedErr != "" {
@@ -350,14 +351,14 @@ func TestExecuteMigrationFails(t *testing.T) {
 		Base: metadata.Base{Properties: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, databaseNameKey: "dapr_test_table"}},
 	}
 
-	err := sqlStore.Init(metadata)
+	err := sqlStore.Init(context.Background(), metadata)
 	assert.NotNil(t, err)
 }
 
 func TestSupportedFeatures(t *testing.T) {
 	sqlStore := NewSQLServerStateStore(logger.NewLogger("test")).(*SQLServer)
 
-	actual := sqlStore.Features()
+	actual := sqlStore.Features(context.Background())
 	assert.NotNil(t, actual)
 	assert.Equal(t, state.FeatureETag, actual[0])
 	assert.Equal(t, state.FeatureTransactional, actual[1])

--- a/state/store.go
+++ b/state/store.go
@@ -23,18 +23,18 @@ import (
 // Store is an interface to perform operations on store.
 type Store interface {
 	BulkStore
-	Init(metadata Metadata) error
-	Features() []Feature
+	Init(ctx context.Context, metadata Metadata) error
+	Features(ctx context.Context) []Feature
 	Delete(ctx context.Context, req *DeleteRequest) error
 	Get(ctx context.Context, req *GetRequest) (*GetResponse, error)
 	Set(ctx context.Context, req *SetRequest) error
 	GetComponentMetadata() map[string]string
 }
 
-func Ping(store Store) error {
+func Ping(ctx context.Context, store Store) error {
 	// checks if this store has the ping option then executes
 	if storeWithPing, ok := store.(health.Pinger); ok {
-		return storeWithPing.Ping()
+		return storeWithPing.Ping(ctx)
 	} else {
 		return fmt.Errorf("ping is not implemented by this state store")
 	}
@@ -61,8 +61,8 @@ func NewDefaultBulkStore(store Store) DefaultBulkStore {
 }
 
 // Features returns the features of the encapsulated store.
-func (b *DefaultBulkStore) Features() []Feature {
-	return b.s.Features()
+func (b *DefaultBulkStore) Features(ctx context.Context) []Feature {
+	return b.s.Features(ctx)
 }
 
 // BulkGet performs a bulks get operations.

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -107,7 +107,7 @@ type Store1 struct {
 	bulkCount int
 }
 
-func (s *Store1) Init(metadata Metadata) error {
+func (s *Store1) Init(ctx context.Context, metadata Metadata) error {
 	return nil
 }
 
@@ -142,11 +142,11 @@ type Store2 struct {
 	supportBulkGet bool
 }
 
-func (s *Store2) Init(metadata Metadata) error {
+func (s *Store2) Init(ctx context.Context, metadata Metadata) error {
 	return nil
 }
 
-func (s *Store2) Features() []Feature {
+func (s *Store2) Features(ctx context.Context) []Feature {
 	return nil
 }
 

--- a/state/transactional_store.go
+++ b/state/transactional_store.go
@@ -19,6 +19,6 @@ import (
 
 // TransactionalStore is an interface for initialization and support multiple transactional requests.
 type TransactionalStore interface {
-	Init(metadata Metadata) error
+	Init(ctx context.Context, metadata Metadata) error
 	Multi(ctx context.Context, request *TransactionalStateRequest) error
 }

--- a/state/zookeeper/zk.go
+++ b/state/zookeeper/zk.go
@@ -134,7 +134,7 @@ func NewZookeeperStateStore(logger logger.Logger) state.Store {
 	}
 }
 
-func (s *StateStore) Init(metadata state.Metadata) (err error) {
+func (s *StateStore) Init(ctx context.Context, metadata state.Metadata) (err error) {
 	var c *config
 
 	if c, err = newConfig(metadata.Properties); err != nil {
@@ -154,7 +154,7 @@ func (s *StateStore) Init(metadata state.Metadata) (err error) {
 }
 
 // Features returns the features available in this state store.
-func (s *StateStore) Features() []state.Feature {
+func (s *StateStore) Features(ctx context.Context) []state.Feature {
 	return s.features
 }
 

--- a/tests/certification/state/cockroachdb/cockroachdb_test.go
+++ b/tests/certification/state/cockroachdb/cockroachdb_test.go
@@ -70,7 +70,7 @@ func TestCockroach(t *testing.T) {
 		}
 		defer client.Close()
 
-		err = stateStore.Ping()
+		err = stateStore.Ping(context.Background())
 		assert.Equal(t, nil, err)
 
 		err = client.SaveState(ctx, stateStoreName, certificationTestPrefix+"key1", []byte("certificationdata"), nil)
@@ -106,7 +106,7 @@ func TestCockroach(t *testing.T) {
 		}
 		defer client.Close()
 
-		err = stateStore.Ping()
+		err = stateStore.Ping(context.Background())
 		assert.Equal(t, nil, err)
 
 		resp, err := stateStore.Get(context.Background(), &state.GetRequest{

--- a/tests/conformance/bindings/bindings.go
+++ b/tests/conformance/bindings/bindings.go
@@ -127,7 +127,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 		// Check for an output binding specific operation before init
 		if config.HasOperation("operations") {
 			testLogger.Info("Init output binding ...")
-			err := outputBinding.Init(bindings.Metadata{
+			err := outputBinding.Init(context.Background(), bindings.Metadata{
 				Base: metadata.Base{Properties: props},
 			})
 			assert.NoError(t, err, "expected no error setting up output binding")
@@ -135,7 +135,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 		// Check for an input binding specific operation before init
 		if config.HasOperation("read") {
 			testLogger.Info("Init input binding ...")
-			err := inputBinding.Init(bindings.Metadata{
+			err := inputBinding.Init(context.Background(), bindings.Metadata{
 				Base: metadata.Base{Properties: props},
 			})
 			assert.NoError(t, err, "expected no error setting up input binding")
@@ -145,7 +145,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 
 	t.Run("ping", func(t *testing.T) {
 		if config.HasOperation("read") {
-			errInp := bindings.PingInpBinding(inputBinding)
+			errInp := bindings.PingInpBinding(context.Background(), inputBinding)
 			// TODO: Ideally, all stable components should implenment ping function,
 			// so will only assert assert.NoError(t, err) finally, i.e. when current implementation
 			// implements ping in existing stable components
@@ -156,7 +156,7 @@ func ConformanceTests(t *testing.T, props map[string]string, inputBinding bindin
 			}
 		}
 		if config.HasOperation("operations") {
-			errOut := bindings.PingOutBinding(outputBinding)
+			errOut := bindings.PingOutBinding(context.Background(), outputBinding)
 			// TODO: Ideally, all stable components should implenment ping function,
 			// so will only assert assert.NoError(t, err) finally, i.e. when current implementation
 			// implements ping in existing stable components

--- a/tests/conformance/pubsub/pubsub.go
+++ b/tests/conformance/pubsub/pubsub.go
@@ -103,14 +103,14 @@ func ConformanceTests(t *testing.T, props map[string]string, ps pubsub.PubSub, c
 
 	// Init
 	t.Run("init", func(t *testing.T) {
-		err := ps.Init(pubsub.Metadata{
+		err := ps.Init(context.Background(), pubsub.Metadata{
 			Base: metadata.Base{Properties: props},
 		})
 		assert.NoError(t, err, "expected no error on setting up pubsub")
 	})
 
 	t.Run("ping", func(t *testing.T) {
-		err := pubsub.Ping(ps)
+		err := pubsub.Ping(context.Background(), ps)
 		// TODO: Ideally, all stable components should implenment ping function,
 		// so will only assert assert.Nil(t, err) finally, i.e. when current implementation
 		// implements ping in existing stable components

--- a/tests/conformance/secretstores/secretstores.go
+++ b/tests/conformance/secretstores/secretstores.go
@@ -51,14 +51,14 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 
 	// Init
 	t.Run("init", func(t *testing.T) {
-		err := store.Init(secretstores.Metadata{
+		err := store.Init(context.Background(), secretstores.Metadata{
 			Base: metadata.Base{Properties: props},
 		})
 		assert.NoError(t, err, "expected no error on initializing store")
 	})
 
 	t.Run("ping", func(t *testing.T) {
-		err := secretstores.Ping(store)
+		err := secretstores.Ping(context.Background(), store)
 		// TODO: Ideally, all stable components should implenment ping function,
 		// so will only assert assert.Nil(t, err) finally, i.e. when current implementation
 		// implements ping in existing stable components

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -223,7 +223,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 	}
 
 	t.Run("init", func(t *testing.T) {
-		err := statestore.Init(state.Metadata{
+		err := statestore.Init(context.Background(), state.Metadata{
 			Base: metadata.Base{Properties: props},
 		})
 		assert.Nil(t, err)
@@ -235,7 +235,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 	}
 
 	t.Run("ping", func(t *testing.T) {
-		err := state.Ping(statestore)
+		err := state.Ping(context.Background(), statestore)
 		// TODO: Ideally, all stable components should implenment ping function,
 		// so will only assert assert.Nil(t, err) finally, i.e. when current implementation
 		// implements ping in existing stable components
@@ -397,7 +397,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 	if config.HasOperation("transaction") {
 		t.Run("transaction", func(t *testing.T) {
 			// Check if transactional feature is listed
-			features := statestore.Features()
+			features := statestore.Features(context.Background())
 			assert.True(t, state.FeatureTransactional.IsPresent(features))
 
 			var transactionGroups []int
@@ -575,7 +575,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 		})
 	} else {
 		// Check if transactional feature is NOT listed
-		features := statestore.Features()
+		features := statestore.Features(context.Background())
 		assert.False(t, state.FeatureTransactional.IsPresent(features))
 	}
 
@@ -588,7 +588,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			fakeEtag := "not-an-etag"
 
 			// Check if eTag feature is listed
-			features := statestore.Features()
+			features := statestore.Features(context.Background())
 			require.True(t, state.FeatureETag.IsPresent(features))
 
 			// Delete any potential object, it's important to start from a clean slate.
@@ -653,7 +653,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 		})
 	} else {
 		// Check if eTag feature is NOT listed
-		features := statestore.Features()
+		features := statestore.Features(context.Background())
 		require.False(t, state.FeatureETag.IsPresent(features))
 	}
 

--- a/tests/e2e/bindings/zeebe/helper.go
+++ b/tests/e2e/bindings/zeebe/helper.go
@@ -69,7 +69,7 @@ func Command() (*command.ZeebeCommand, error) {
 	envVars := GetEnvVars()
 
 	cmd := command.NewZeebeCommand(testLogger).(*command.ZeebeCommand)
-	err := cmd.Init(bindings.Metadata{Base: metadata.Base{
+	err := cmd.Init(context.Background(), bindings.Metadata{Base: metadata.Base{
 		Name: "test",
 		Properties: map[string]string{
 			"gatewayAddr":            envVars.ZeebeBrokerHost + ":" + envVars.ZeebeBrokerGatewayPort,
@@ -103,7 +103,7 @@ func JobWorker(jobType string, additionalMetadata ...MetadataPair) (*jobworker.Z
 	}
 
 	cmd := jobworker.NewZeebeJobWorker(testLogger).(*jobworker.ZeebeJobWorker)
-	if err := cmd.Init(metadata); err != nil {
+	if err := cmd.Init(context.Background(), metadata); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Branched from https://github.com/dapr/components-contrib/pull/2474 which should be merged first.

Part of https://github.com/dapr/dapr/issues/2478

PR adds a `Close() error` function to the `InputBinding` interface. Close will release all resources associated with the input binding, and blocks until all go routines have returned.

`Close` is intended to always be called by the caller.