### PR TITLE
[release-1.10] bindings.localstorage: allow relative paths agian

### DIFF
--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -104,7 +104,8 @@ func validateRootPath(rootPath string) (string, error) {
 	// If the root path is relative, resolve it as absolute
 	rootPath = filepath.Clean(rootPath)
 	if !filepath.IsAbs(rootPath) {
-		cwd, err := os.Getwd()
+		var cwd string
+		cwd, err = os.Getwd()
 		if err != nil {
 			return "", fmt.Errorf("failed to obtain current working directory: %w", err)
 		}

--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -101,10 +101,14 @@ func validateRootPath(rootPath string) (string, error) {
 		return "", errors.New("property rootPath must not be empty")
 	}
 
-	// Require the path to be absolute since we can't depend on the Dapr binary to always be in a specific directory
+	// If the root path is relative, resolve it as absolute
 	rootPath = filepath.Clean(rootPath)
 	if !filepath.IsAbs(rootPath) {
-		return "", errors.New("property rootPath must be an absolute path")
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to obtain current working directory: %w", err)
+		}
+		rootPath = filepath.Join(cwd, rootPath)
 	}
 
 	// Resolve symlinks

--- a/bindings/localstorage/localstorage_test.go
+++ b/bindings/localstorage/localstorage_test.go
@@ -40,6 +40,10 @@ func TestParseMetadata(t *testing.T) {
 }
 
 func TestValidateRootPath(t *testing.T) {
+	// Get the current working directory
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
 	// Set up some things in the FS
 	tmpDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "aaa/bbb"), 0o755))
@@ -79,8 +83,8 @@ func TestValidateRootPath(t *testing.T) {
 		wantErr string
 	}{
 		{name: "empty", rootPath: "", wantErr: "must not be empty"},
-		{name: "relative path 1", rootPath: "path", wantErr: "must be an absolute path"},
-		{name: "relative path 2", rootPath: filepath.Clean("../path"), wantErr: "must be an absolute path"},
+		{name: "relative path 1", rootPath: "path", wantRes: filepath.Join(cwd, "path")},
+		{name: "relative path 2", rootPath: filepath.Clean("../path"), wantRes: filepath.Join(cwd, "..", "path")},
 		{name: "existing path 1", rootPath: filepath.Join(tmpDir, "aaa/bbb"), wantRes: joinWithMustEvalSymlinks(tmpDir, "aaa/bbb")},
 		{name: "existing path 2", rootPath: filepath.Join(tmpDir, "zzz/aaa"), wantRes: joinWithMustEvalSymlinks(tmpDir, "zzz/aaa")},
 		{name: "path does not exist 1", rootPath: filepath.Join(tmpDir, "zzz/foo"), wantRes: filepath.Join(joinWithMustEvalSymlinks(tmpDir, "zzz"), "foo")},


### PR DESCRIPTION
Fixes a regression introduced in #2449 which accidentally made it not possible to use relative paths.