### PR TITLE
Reduce default contrib test runs on PR. Moves them to `/ok-to-test` and scheduled runs.

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -195,6 +195,14 @@ async function cmdOkToTest(github, issue, isFromPulls) {
             client_payload: testPayload,
         });
 
+        // Fire repository_dispatch event to trigger unit tests for other architectures and OS
+        await github.rest.repos.createDispatchEvent({
+            owner: issue.owner,
+            repo: issue.repo,
+            event_type: "build-all",
+            client_payload: testPayload,
+        });
+
         console.log(`[cmdOkToTest] triggered certification and conformance tests for ${JSON.stringify(testPayload)}`);
     }
 }

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -18,10 +18,12 @@ on:
     types: [certification-test]
   workflow_dispatch:
   schedule:
-    - cron: '5 */12 * * *'
+    - cron: '25 */8 * * *'
+  push:
+    branches:
+      - release-*
   pull_request:
     branches:
-      - master
       - release-*
 
 jobs:

--- a/.github/workflows/components-contrib-all.yml
+++ b/.github/workflows/components-contrib-all.yml
@@ -1,0 +1,136 @@
+# ------------------------------------------------------------
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+name: "Build, Lint, Unit Test - complete matrix"
+
+on:
+  repository_dispatch:
+    types: [build-all]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches:
+      - release-*
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - release-*
+jobs:
+  build:
+    name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
+    runs-on: ${{ matrix.os }}
+    env:
+      GOVER: "1.19"
+      GOOS: ${{ matrix.target_os }}
+      GOARCH: ${{ matrix.target_arch }}
+      GOPROXY: https://proxy.golang.org
+      GOLANGCI_LINT_VER: "v1.50.1"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        target_arch: [arm, amd64]
+        include:
+          - os: ubuntu-latest
+            target_os: linux
+          - os: windows-latest
+            target_os: windows
+          - os: macOS-latest
+            target_os: darwin
+        exclude:
+          - os: windows-latest
+            target_arch: arm
+          - os: macOS-latest
+            target_arch: arm
+    steps:
+      - name: Set default payload repo and ref
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+      - name: Parse repository_dispatch payload
+        if: github.event_name == 'repository_dispatch'
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ ${{ github.event.client_payload.command }} = "ok-to-test" ]; then
+            echo "CHECKOUT_REF=${{ github.event.client_payload.pull_head_ref }}" >> $GITHUB_ENV
+            echo "PR_NUMBER=${{ github.event.client_payload.issue.number }}" >> $GITHUB_ENV
+          fi
+      - name: Set up Go ${{ env.GOVER }}
+        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Check out code into the Go module directory
+        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.CHECKOUT_REPO }}
+          ref: ${{ env.CHECKOUT_REF }}
+      - name: Cache Go modules (Linux)
+        if: matrix.target_os == 'linux'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-
+      - name: Cache Go modules (Windows)
+        if: matrix.target_os == 'windows'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+          key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-
+      - name: Cache Go modules (macOS)
+        if: matrix.target_os == 'darwin'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-
+      - name: Check components-schema
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+        run: make check-component-metadata-schema-diff
+      - name: Run golangci-lint
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+        uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          version: ${{ env.GOLANGCI_LINT_VER }}
+          skip-cache: true
+          args: --timeout 15m
+      - name: Run go mod tidy check diff
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+        run: make modtidy-all check-mod-diff
+#       - name: Run Go Vulnerability Check
+#         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+#         run: |
+#           go install golang.org/x/vuln/cmd/govulncheck@latest
+#           govulncheck ./...
+      - name: Run make test
+        env:
+          COVERAGE_OPTS: "-coverprofile=coverage.txt -covermode=atomic"
+          IPFS_TEST: "1"
+        if: matrix.target_arch != 'arm' && steps.skip_check.outputs.should_skip != 'true'
+        run: make test
+      - name: Codecov
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -11,47 +11,27 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-name: components-contrib
+name: "Build, Lint, Unit Test - Linux AMD64 Only"
 
 on:
   push:
     branches:
       - master
-      - release-*
       - feature/*
-    tags:
-      - v*
   pull_request:
     branches:
       - master
-      - release-*
       - feature/*
 jobs:
   build:
-    name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
-    runs-on: ${{ matrix.os }}
+    name: Build linux_amd64 binaries
+    runs-on: ubuntu-latest
     env:
       GOVER: "1.19"
-      GOOS: ${{ matrix.target_os }}
-      GOARCH: ${{ matrix.target_arch }}
+      GOOS: linux
+      GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       GOLANGCI_LINT_VER: "v1.50.1"
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        target_arch: [arm, amd64]
-        include:
-          - os: ubuntu-latest
-            target_os: linux
-          - os: windows-latest
-            target_os: windows
-          - os: macOS-latest
-            target_os: darwin
-        exclude:
-          - os: windows-latest
-            target_arch: arm
-          - os: macOS-latest
-            target_arch: arm
     steps:
       - name: Set up Go ${{ env.GOVER }}
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -68,9 +48,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
+          key: linux-amd64-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-
+            linux-amd64-go-${{ env.GOVER }}-
       - name: Cache Go modules (Windows)
         if: matrix.target_os == 'windows'
         uses: actions/cache@v3
@@ -78,9 +58,9 @@ jobs:
           path: |
             ~\AppData\Local\go-build
             ~\go\pkg\mod
-          key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
+          key: linux-amd64-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-
+            linux-amd64-go-${{ env.GOVER }}-
       - name: Cache Go modules (macOS)
         if: matrix.target_os == 'darwin'
         uses: actions/cache@v3
@@ -88,24 +68,24 @@ jobs:
           path: |
             ~/Library/Caches/go-build
             ~/go/pkg/mod
-          key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
+          key: linux-amd64-go-${{ env.GOVER }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-
+            linux-amd64-go-${{ env.GOVER }}-
       - name: Check components-schema
-        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+        if: steps.skip_check.outputs.should_skip != 'true'
         run: make check-component-metadata-schema-diff
       - name: Run golangci-lint
-        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+        if: steps.skip_check.outputs.should_skip != 'true'
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: ${{ env.GOLANGCI_LINT_VER }}
           skip-cache: true
           args: --timeout 15m
       - name: Run go mod tidy check diff
-        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+        if: steps.skip_check.outputs.should_skip != 'true'
         run: make modtidy-all check-mod-diff
 #       - name: Run Go Vulnerability Check
-#         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
+#         if: steps.skip_check.outputs.should_skip != 'true'
 #         run: |
 #           go install golang.org/x/vuln/cmd/govulncheck@latest
 #           govulncheck ./...
@@ -113,7 +93,7 @@ jobs:
         env:
           COVERAGE_OPTS: "-coverprofile=coverage.txt -covermode=atomic"
           IPFS_TEST: "1"
-        if: matrix.target_arch != 'arm' && steps.skip_check.outputs.should_skip != 'true'
+        if: steps.skip_check.outputs.should_skip != 'true'
         run: make test
       - name: Codecov
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,6 +19,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */8 * * *'
+  push:
+    branches:
+    - 'release-*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Signed-off-by: Bernd Verst <github@bernd.dev>

Changes below:

On every PR against Master
- Only run tests against Linux AMD64 (Use `/ok-to-test` for complete test matrix)
- Do not run certification tests. (Use `/ok-to-test` for all certification tests as necessary).

PR and Push against `Release-*`:
- Run complete build test matrix
- Run non-cloud certification tests
- Run non-cloud conformance tests

Using `/ok-to-test`:
- Runs complete build test matrix
- Runs complete conformance test matrix
- Runs complete certification test matrix

Scheduled runs:
- Conformance (full matrix) every 8 hours
- Certification (full matrix) every 8 hours
- Build / Lint / Unit test (full matrix) every 6 hours