### PR TITLE
remove `redisVersion` field

### DIFF
--- a/tests/config/bindings/redis/v7/bindings.yml
+++ b/tests/config/bindings/redis/v7/bindings.yml
@@ -10,8 +10,6 @@ spec:
   - name: redisHost
     value: localhost:6380
   - name: redisPassword
-    value: 
+    value:
   - name: enableTLS
     value: false
-  - name: redisVersion
-    value: "7"

--- a/tests/config/state/redis/v7/statestore.yaml
+++ b/tests/config/state/redis/v7/statestore.yaml
@@ -9,5 +9,3 @@ spec:
     value: localhost:6380
   - name: redisPassword
     value: ""
-  - name: redisVersion
-    value: "7"


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description

remove unneeded `redisVersion` field.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
