### PR TITLE
Removed warning on ConsumerID being deprecated by Kafka

### DIFF
--- a/internal/component/kafka/metadata.go
+++ b/internal/component/kafka/metadata.go
@@ -107,7 +107,6 @@ func (k *Kafka) getKafkaMetadata(metadata map[string]string) (*kafkaMetadata, er
 	if val, ok := metadata["consumerID"]; ok && val != "" {
 		meta.ConsumerGroup = val
 		k.logger.Debugf("Using %s as ConsumerGroup", meta.ConsumerGroup)
-		k.logger.Warn("ConsumerID is deprecated, if ConsumerID and ConsumerGroup are both set, ConsumerGroup is used")
 	}
 
 	if val, ok := metadata["consumerGroup"]; ok && val != "" {


### PR DESCRIPTION
# Description

Removed the warning on ConsumerID being deprecated by Kafka

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2520

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
