### PR TITLE
[release-1.10] Improve lock handling and renewal for ASB messages (fix #2532)

### DIFF
--- a/internal/component/azure/servicebus/errors.go
+++ b/internal/component/azure/servicebus/errors.go
@@ -30,7 +30,7 @@ func IsNetworkError(err error) bool {
 
 	var expError *azservicebus.Error
 	if errors.As(err, &expError) {
-		if expError.Code == "connlost" {
+		if expError.Code == azservicebus.CodeConnectionLost {
 			return true
 		}
 	}
@@ -54,5 +54,21 @@ func IsRetriableAMQPError(err error) bool {
 			return true
 		}
 	}
+	return false
+}
+
+// IsLockLostError returns true if the error is "locklost".
+func IsLockLostError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var expError *azservicebus.Error
+	if errors.As(err, &expError) {
+		if expError.Code == azservicebus.CodeLockLost {
+			return true
+		}
+	}
+
 	return false
 }

--- a/internal/component/azure/servicebus/subscription.go
+++ b/internal/component/azure/servicebus/subscription.go
@@ -38,7 +38,7 @@ const (
 	DefaultMaxConcurrentSessions    = 8
 
 	// Maximum number of concurrent operations such as lock renewals or message completion/abandonment
-	maxConcurrentOps = 10
+	maxConcurrentOps = 20
 )
 
 // HandlerResponseItem represents a response from the handler for each message.
@@ -321,7 +321,7 @@ func (s *Subscription) doRenewLocks(ctx context.Context, receiver *MessageReceiv
 		return
 	}
 
-	// Renew the locks for each message, with a limit of 10 in parallel
+	// Renew the locks for each message, with a limit of maxConcurrentOps in parallel
 	limitCh := make(chan struct{}, maxConcurrentOps)
 	errChan := make(chan error)
 	for _, msg := range msgs {
@@ -444,7 +444,7 @@ func (s *Subscription) handleAsync(ctx context.Context, msgs []*azservicebus.Rec
 
 		// Handle the errors on bulk messages and mark messages accordingly.
 		// Note, the order of the responses match the order of the messages.
-		// Perform the operations in a background goroutine with a limit of 10 concurrent
+		// Perform the operations in a background goroutine with a limit of maxConcurrentOps concurrent
 		limitCh := make(chan struct{}, maxConcurrentOps)
 		wg := sync.WaitGroup{}
 		for i := range resps {
@@ -482,7 +482,7 @@ func (s *Subscription) handleAsync(ctx context.Context, msgs []*azservicebus.Rec
 		s.CompleteMessage(finalizeCtx, receiver, msgs[0])
 		finalizeCancel()
 	} else {
-		// Perform the operations in a background goroutine with a limit of 10 concurrent
+		// Perform the operations in a background goroutine with a limit of maxConcurrentOps concurrent
 		limitCh := make(chan struct{}, maxConcurrentOps)
 		wg := sync.WaitGroup{}
 		for _, msg := range msgs {


### PR DESCRIPTION
Fixes #2532

Improves ASB lock renewal in a few ways to improve the user experience:

- Reduce the likelihood of users seeing warning messages in the logs saying that lock renewal failed if the message was already completed in the meanwhile. This is done by:
   - After taking the snapshot, check if the message is still active before attempting to renew the locks
   - Improved the error message in case of "locklost" errors, to make it more concise and explain more clearly than this is not a serious issue in _most_ cases. 
      - Before: "WARN[0100] Error renewing message locks for topic topic2: couldn't renew active message lock for message 22de340330524da39a28dd86bdf36fd1, (locklost): rpc: failed, status code 410 and description: The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue. For more information please see https://aka.ms/ServiceBusExceptions . Reference:556bb224-c652-4ac2-aba8-1d8b65f649e6, TrackingId:70cab73a-cadf-4d11-b93f-cd4d2c6d2829_B25, SystemTracker:aledevdapr:Topic:topic2|checkout, Timestamp:2023-02-14T17:31:10 "
      - After: "WARN[0100] Error renewing message locks for topic topic2: couldn't renew active message lock for message 22de340330524da39a28dd86bdf36fd1: lock has been lost (this often happens if the message has already been completed or abandoned)"
- Improved concurrency in how we renew locks:
   -  Before we were renewing all locks in parallel. In ASB, there can be thousands of active messages at the same time (actually, though: the default `maxActiveMessages` is 1,000). That meant 1,000 concurrent goroutines spawned at the same time. This has been changed to limit to 20 concurrent operations.
   - Also significantly reduced memory usage while renewing locks with many active messages, by avoiding keeping 2 extra buffers (a buffered channel and a slice) to collect all errors
- Completing or Abandoning messages now happens in parallel too (with again a limit of 20 concurrent ops), which should improve perf when using bulk pubsub and also help reduce the likelihood that locks are renewed for messages that have been ack'd already. 