### PR TITLE
HTTP binding: Make response timeout customizable

### DIFF
--- a/bindings/http/http_test.go
+++ b/bindings/http/http_test.go
@@ -639,7 +639,7 @@ func verifyTimeoutBehavior(t *testing.T, hs bindings.OutputBinding, handler *HTT
 			operation:  "get",
 			metadata:   map[string]string{"X-Delay-Seconds": "2"},
 			path:       "/",
-			err:        "context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+			err:        "context deadline exceeded",
 			statusCode: 200,
 		},
 		"meetsResposneTimeout": {


### PR DESCRIPTION
# Description

HTTP Binding
Makes the timeout waiting for a response customizable via metadata `responseTimeout`. The value is a duration of the form `1s`, `5m` etc.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
