### PR TITLE
[pubsub/rabbitmq]add queue type options - classic, qourum, stream

### DIFF
--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -208,6 +209,7 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*metadat
 	}
 
 	if val, found := pubSubMetadata.Properties[metadataQueueType]; found && val != "" {
+		val = strings.ToLower(val)
 		if queueTypeValid(val) {
 			result.queueType = val
 		} else {

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	fanoutExchangeKind              = "fanout"
+	classicQueueType                = "classic"
 	logMessagePrefix                = "rabbitmq pub/sub:"
 	errorMessagePrefix              = "rabbitmq pub/sub error:"
 	errorChannelNotInitialized      = "channel not initialized"
@@ -44,6 +45,7 @@ const (
 	publishRetryWaitSeconds = 2
 
 	argQueueMode          = "x-queue-mode"
+	argQueueType          = "x-queue-type"
 	argMaxLength          = "x-max-length"
 	argMaxLengthBytes     = "x-max-length-bytes"
 	argDeadLetterExchange = "x-dead-letter-exchange"
@@ -338,6 +340,7 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		dlqArgs := r.metadata.formatQueueDeclareArgs(nil)
 		// dead letter queue use lazy mode, keeping as many messages as possible on disk to reduce RAM usage
 		dlqArgs[argQueueMode] = queueModeLazy
+		dlqArgs[argQueueType] = r.metadata.queueType
 		q, err = channel.QueueDeclare(dlqName, true, r.metadata.deleteWhenUnused, false, false, dlqArgs)
 		if err != nil {
 			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueDeclare: %v", logMessagePrefix, req.Topic, dlqName, err)
@@ -354,6 +357,7 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		args = amqp.Table{argDeadLetterExchange: dlxName}
 	}
 	args = r.metadata.formatQueueDeclareArgs(args)
+	args[argQueueType] = r.metadata.queueType
 	q, err := channel.QueueDeclare(queueName, r.metadata.durable, r.metadata.deleteWhenUnused, false, false, args)
 	if err != nil {
 		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueDeclare: %v", logMessagePrefix, req.Topic, queueName, err)

--- a/tests/certification/pubsub/rabbitmq/components/alpha/rabbitmq-alpha.yml
+++ b/tests/certification/pubsub/rabbitmq/components/alpha/rabbitmq-alpha.yml
@@ -6,13 +6,15 @@ spec:
   type: pubsub.rabbitmq
   version: v1
   metadata:
-  - name: consumerID
-    value: alpha
-  - name: host
-    value: "amqp://test:test@localhost:5672"
-  - name: durable
-    value: true
-  - name: deletedWhenUnused
-    value: false
-  - name: requeueInFailure
-    value: true
+    - name: consumerID
+      value: alpha
+    - name: host
+      value: "amqp://test:test@localhost:5672"
+    - name: durable
+      value: true
+    - name: deletedWhenUnused
+      value: false
+    - name: requeueInFailure
+      value: true
+    - name: queueType
+      value: "classic"


### PR DESCRIPTION
# Description

Add the options for pub-sub Rabbitmq - "classic", "qourum", or "stream". Default to "classic" mode. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2544

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: https://github.com/dapr/docs/pull/3193
