### PR TITLE
deps: updates wazero to 1.0.0-pre.9, http-wasm-host-go to v3.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,9 +70,9 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a
-	github.com/http-wasm/http-wasm-host-go v0.3.1
+	github.com/http-wasm/http-wasm-host-go v0.3.3
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.23
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.26
 	github.com/influxdata/influxdb-client-go v1.4.0
 	github.com/jackc/pgx/v5 v5.3.0
 	github.com/json-iterator/go v1.1.12
@@ -101,7 +101,7 @@ require (
 	github.com/supplyon/gremcos v0.1.39
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.582
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.582
-	github.com/tetratelabs/wazero v1.0.0-pre.7
+	github.com/tetratelabs/wazero v1.0.0-pre.9
 	github.com/valyala/fasthttp v1.44.0
 	github.com/vmware/vmware-go-kcl v1.5.0
 	github.com/xdg-go/scram v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1188,12 +1188,12 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a h1:j6SSiw7fWemWfrJL801xiQ6xRT7ZImika50xvmPN+tg=
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a/go.mod h1:VhwtcZ7sg3xq7REqGzEy7ylSWGKz4jZd05eCJropNzI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/http-wasm/http-wasm-host-go v0.3.1 h1:4BzT7KneoXOB+RC5IqflOezrhrZTRT16Qoz8OxUmTW4=
-github.com/http-wasm/http-wasm-host-go v0.3.1/go.mod h1:fjRN9smjCFxvb8k7kvmYyFfHg3RRigRvzVA8H3C78FU=
+github.com/http-wasm/http-wasm-host-go v0.3.3 h1:RpemzyrFvvEYVSsbPT0kCxZmYW676QICo62A6PY64h8=
+github.com/http-wasm/http-wasm-host-go v0.3.3/go.mod h1:KCX850kbG590YkCZK7vMzG33B+iCml1dAhHAWI/WAtk=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible h1:bSww59mgbqFRGCRvlvfQutsptE3lRjNiU5C0YNT/bWw=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible/go.mod h1:l7VUhRbTKCzdOacdT4oWCwATKyvZqUOlOqr0Ous3k4s=
-github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.23 h1:23JnLqr4KR7+8HMrHm/cgLyZq7s5iUflnyZ5JuFm8fc=
-github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.23/go.mod h1:QpZ96CRqyqd5fEODVmnzDNp3IWi5W95BFmWz1nfkq+s=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.26 h1:/GtHSXWIO5gzKs/BC7jqncpvzPovQSSLCt11JWIFLdI=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.26/go.mod h1:KOw/faxHkY4mrJpY1e+chzi1Om7ioRkjovfHk9dM5aA=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -1737,8 +1737,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.582 h1:Td+y
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.582/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.582 h1:NELTUi0RsI/kuVu7ULGZe6+g+v+PBqiIymu5ThvWBFA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.582/go.mod h1:u9P13PFbN+1AGBUHWuOO9GEUqjsGvWpbVng/qT0qFLA=
-github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
-github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.9 h1:2uVdi2bvTi/JQxG2cp3LRm2aRadd3nURn5jcfbvqZcw=
+github.com/tetratelabs/wazero v1.0.0-pre.9/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tevid/gohamcrest v1.1.1/go.mod h1:3UvtWlqm8j5JbwYZh80D/PVBt0mJ1eJiYgZMibh0H/k=
 github.com/tidwall/gjson v1.2.1/go.mod h1:c/nTNbUr0E0OrXEhq1pwa8iEgc2DOt4ZZqAt1HtCkPA=
 github.com/tidwall/gjson v1.8.1/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
@@ -1926,7 +1926,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=


### PR DESCRIPTION
# Description

This PR updates [wazero](https://wazero.io/) to [1.0.0-pre.9][1]. Notably:

* This release includes our last breaking changes before 1.0.0 final:
  * Requires at least Go 1.18
* This release also integrates Go context to limit execution time. More details on the [Release Notes][1]
* We are now passing third-party integration test suites: wasi-testsuite, TinyGo's, Zig's.

It also updates [http-wasm](https://http-wasm.io) to [3.3.0][2], which syncs to wazero 1.0.0-pre.9

[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9
[2]: https://github.com/http-wasm/http-wasm-host-go/releases/tag/v3.3.0

## Issue reference

It is a trivial change, so I haven't created an issue, but will do if necessary

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

