### PR TITLE
Just pointing to the bindings tutorial

### DIFF
--- a/docs/developing-component.md
+++ b/docs/developing-component.md
@@ -76,8 +76,8 @@ make lint
    > Windows debuggable binary: `.\dist\windows_amd64\debug\daprd`
    > macOS (Intel) debuggable binary: `./dist/darwin_amd64/debug/daprd`
    > macOS (Apple Silicon) debuggable binary: `./dist/darwin_arm64/debug/daprd`
-1. Prepare your test app (e.g. kafka sample app: https://github.com/dapr/quickstarts/tree/master/tutorials/bindings/nodeapp/)
-1. Create a YAML for the component in './components' under app's directory (e.g. kafka example: https://github.com/dapr/quickstarts/blob/master/tutorials/bindings/components/kafka_bindings.yaml)
+1. Prepare your test app (e.g. see the binding tutorial sample apps: https://github.com/dapr/quickstarts/tree/master/tutorials/bindings/)
+1. Create a YAML for the component in './components' under app's directory (e.g. bindings tutorial: https://github.com/dapr/quickstarts/blob/master/tutorials/bindings/components)
 1. Run your test app using Dapr CLI.
 1. Make sure your component is loaded successfully in the daprd log.
 


### PR DESCRIPTION
# Description

As suggested by @berndverst just linking to the repo. I linked to the bindings quickstart, instead of a specific app (E.g. the node app like before)

## Issue reference

Follow up PR from https://github.com/dapr/components-contrib/pull/2560, based on feedback from @berndverst in #2559


