### PR TITLE
Support reconnection between sidecar and broker for RabbitMQ bindings

### DIFF
--- a/bindings/rabbitmq/rabbitmq_integration_test.go
+++ b/bindings/rabbitmq/rabbitmq_integration_test.go
@@ -29,9 +29,10 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/dapr/kit/logger"
+
 	"github.com/dapr/components-contrib/bindings"
 	contribMetadata "github.com/dapr/components-contrib/metadata"
-	"github.com/dapr/kit/logger"
 )
 
 const (
@@ -120,6 +121,59 @@ func TestQueuesWithTTL(t *testing.T) {
 	assert.NoError(t, r.Close())
 }
 
+func TestQueuesReconnect(t *testing.T) {
+	rabbitmqHost := getTestRabbitMQHost()
+	assert.NotEmpty(t, rabbitmqHost, fmt.Sprintf("RabbitMQ host configuration must be set in environment variable '%s' (example 'amqp://guest:guest@localhost:5672/')", testRabbitMQHostEnvKey))
+
+	queueName := uuid.New().String()
+	durable := true
+	exclusive := false
+
+	metadata := bindings.Metadata{
+		Base: contribMetadata.Base{
+			Name: "testQueue",
+			Properties: map[string]string{
+				"queueName":        queueName,
+				"host":             rabbitmqHost,
+				"deleteWhenUnused": strconv.FormatBool(exclusive),
+				"durable":          strconv.FormatBool(durable),
+			},
+		},
+	}
+
+	var messageReceivedCount int
+	var handler bindings.Handler = func(ctx context.Context, in *bindings.ReadResponse) ([]byte, error) {
+		messageReceivedCount++
+		return nil, nil
+	}
+
+	logger := logger.NewLogger("test")
+
+	r := NewRabbitMQ(logger).(*RabbitMQ)
+	err := r.Init(context.Background(), metadata)
+	assert.Nil(t, err)
+
+	err = r.Read(context.Background(), handler)
+	assert.Nil(t, err)
+
+	const tooLateMsgContent = "success_msg1"
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{Data: []byte(tooLateMsgContent)})
+	assert.Nil(t, err)
+
+	// perform a close connection with the rabbitmq server
+	r.channel.Close()
+	time.Sleep(3 * defaultReconnectWait)
+
+	const testMsgContent = "reconnect_msg"
+	_, err = r.Invoke(context.Background(), &bindings.InvokeRequest{Data: []byte(testMsgContent)})
+	assert.Nil(t, err)
+
+	time.Sleep(defaultReconnectWait)
+	// sending 2 messages, one before the reconnect and one after
+	assert.Equal(t, 2, messageReceivedCount)
+	assert.NoError(t, r.Close())
+}
+
 func TestPublishingWithTTL(t *testing.T) {
 	rabbitmqHost := getTestRabbitMQHost()
 	assert.NotEmpty(t, rabbitmqHost, fmt.Sprintf("RabbitMQ host configuration must be set in environment variable '%s' (example 'amqp://guest:guest@localhost:5672/')", testRabbitMQHostEnvKey))
@@ -196,7 +250,7 @@ func TestPublishingWithTTL(t *testing.T) {
 	assert.Equal(t, testMsgContent, msgBody)
 
 	assert.NoError(t, rabbitMQBinding1.Close())
-	assert.NoError(t, rabbitMQBinding1.Close())
+	assert.NoError(t, rabbitMQBinding2.Close())
 }
 
 func TestExclusiveQueue(t *testing.T) {


### PR DESCRIPTION
# Description

Support reconnect to RabbitMQ when RabbitMQ restarts or closes the channel with daprd. 
Also, continue consuming messages after reconnected. 


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2509

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
