### PR TITLE
Downgrade AWS action in cert/conf tests

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -191,9 +191,7 @@ jobs:
         echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" >> $GITHUB_ENV
 
     - name: Configure AWS Credentials
-      # TODO: Remove "v1-node16" when v2 is released
-      # See: https://github.com/aws-actions/configure-aws-credentials/issues/489
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v1
       if: matrix.require-aws-credentials == 'true'
       with:
         aws-access-key-id: "${{ secrets.AWS_ACCESS_KEY }}"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -184,9 +184,7 @@ jobs:
 
     - name: Configure AWS Credentials
       if: matrix.require-aws-credentials == 'true'
-      # TODO: Remove "v1-node16" when v2 is released
-      # See: https://github.com/aws-actions/configure-aws-credentials/issues/489
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}


### PR DESCRIPTION
The branch with Node.js 16 seems to not work well. We will live with a version that shows a warning in the meanwhile.