### PR TITLE
Merge queue support for required workflows

### DIFF
--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -14,15 +14,17 @@
 name: "Build, Lint, Unit Test - Linux AMD64 Only"
 
 on:
-  merge_group:
   push:
     branches:
-      - master
       - feature/*
+      - gh-readonly-queue/master/*
   pull_request:
     branches:
       - master
       - feature/*
+      - gh-readonly-queue/master/*
+  merge_group:
+
 jobs:
   build:
     name: Build linux_amd64 binaries

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,16 +17,18 @@ on:
   repository_dispatch:
     types: [conformance-test]
   workflow_dispatch:
-  merge_group:
   schedule:
     - cron: '0 */8 * * *'
   push:
     branches:
       - 'release-*'
+      - 'gh-readonly-queue/master/*'
   pull_request:
     branches:
       - 'master'
       - 'release-*'
+      - 'gh-readonly-queue/master/*'
+  merge_group:
 
 jobs:
   # Based on whether this is a PR or a scheduled run, we will run a different


### PR DESCRIPTION
# Description

Tiny workflow change for merge queue triggers.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue