### PR TITLE
Remove now-unused metadata properties

### DIFF
--- a/.github/infrastructure/conformance/temporal/worker/go.mod
+++ b/.github/infrastructure/conformance/temporal/worker/go.mod
@@ -28,8 +28,8 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 // indirect
-	google.golang.org/grpc v1.52.3 // indirect
+	google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc // indirect
+	google.golang.org/grpc v1.53.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/.github/infrastructure/conformance/temporal/worker/go.sum
+++ b/.github/infrastructure/conformance/temporal/worker/go.sum
@@ -1160,8 +1160,9 @@ google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029/go.mod h1:rZS5c/ZV
 google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
-google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 h1:O97sLx/Xmb/KIZHB/2/BzofxBs5QmmR0LcihPtllmbc=
 google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc h1:ijGwO+0vL2hJt5gaygqP2j6PfflOBrRot0IczKbmtio=
+google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -1200,8 +1201,8 @@ google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCD
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/grpc v1.52.1/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
-google.golang.org/grpc v1.52.3 h1:pf7sOysg4LdgBqduXveGKrcEwbStiK2rtfghdzlUYDQ=
-google.golang.org/grpc v1.52.3/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
+google.golang.org/grpc v1.53.0 h1:LAv2ds7cmFV/XTS3XG1NneeENYrXGmorPxsBbptIjNc=
+google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/nameresolution/metadata.go
+++ b/nameresolution/metadata.go
@@ -16,17 +16,6 @@ package nameresolution
 import "github.com/dapr/components-contrib/metadata"
 
 const (
-	// TODO: REMOVE THESE AFTER RUNTIME IS CHANGED
-
-	// MDNSInstanceName is the instance name which is broadcasted.
-	MDNSInstanceName string = "name"
-	// MDNSInstanceAddress is the address of the instance.
-	MDNSInstanceAddress string = "address"
-	// MDNSInstancePort is the port of instance.
-	MDNSInstancePort string = "port"
-	// MDNSInstanceID is an optional unique instance ID.
-	MDNSInstanceID string = "instance"
-
 	// HostAddress is the address of the instance.
 	HostAddress string = "HOST_ADDRESS"
 	// DaprHTTPPort is the dapr api http port.

--- a/tests/certification/bindings/azure/blobstorage/go.mod
+++ b/tests/certification/bindings/azure/blobstorage/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/bindings/azure/blobstorage/go.sum
+++ b/tests/certification/bindings/azure/blobstorage/go.sum
@@ -103,8 +103,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/azure/cosmosdb/go.mod
+++ b/tests/certification/bindings/azure/cosmosdb/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/a8m/documentdb v1.3.1-0.20220405205223-5b41ba0aaeb1
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/bindings/azure/cosmosdb/go.sum
+++ b/tests/certification/bindings/azure/cosmosdb/go.sum
@@ -107,8 +107,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/azure/eventhubs/go.mod
+++ b/tests/certification/bindings/azure/eventhubs/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/bindings/azure/eve
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/bindings/azure/eventhubs/go.sum
+++ b/tests/certification/bindings/azure/eventhubs/go.sum
@@ -107,8 +107,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/azure/servicebusqueues/go.mod
+++ b/tests/certification/bindings/azure/servicebusqueues/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/bindings/azure/ser
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/bindings/azure/servicebusqueues/go.sum
+++ b/tests/certification/bindings/azure/servicebusqueues/go.sum
@@ -107,8 +107,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/azure/storagequeues/go.mod
+++ b/tests/certification/bindings/azure/storagequeues/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/bindings/azure/sto
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/bindings/azure/storagequeues/go.sum
+++ b/tests/certification/bindings/azure/storagequeues/go.sum
@@ -103,8 +103,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/cron/go.mod
+++ b/tests/certification/bindings/cron/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/benbjohnson/clock v1.3.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220519061249-c2cb1dad5bb0
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/bindings/cron/go.sum
+++ b/tests/certification/bindings/cron/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/dubbo/go.mod
+++ b/tests/certification/bindings/dubbo/go.mod
@@ -5,9 +5,9 @@ go 1.20
 require (
 	dubbo.apache.org/dubbo-go/v3 v3.0.3-0.20230118042253-4f159a2b38f3
 	github.com/apache/dubbo-go-hessian2 v1.11.5
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/bindings/dubbo/go.sum
+++ b/tests/certification/bindings/dubbo/go.sum
@@ -172,8 +172,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creasty/defaults v1.5.2 h1:/VfB6uxpyp6h0fr7SPp7n8WJBoV8jfxQXPCnkVSjyls=
 github.com/creasty/defaults v1.5.2/go.mod h1:FPZ+Y0WNrbqOVw+c6av63eyHUAl6pMHZwqLPvXUZGfY=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/kafka/go.mod
+++ b/tests/certification/bindings/kafka/go.mod
@@ -5,9 +5,9 @@ go 1.20
 require (
 	github.com/Shopify/sarama v1.38.1
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220519061249-c2cb1dad5bb0
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/bindings/kafka/go.sum
+++ b/tests/certification/bindings/kafka/go.sum
@@ -96,8 +96,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/localstorage/go.mod
+++ b/tests/certification/bindings/localstorage/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/bindings/localstor
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-00010101000000-000000000000
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/bindings/localstorage/go.sum
+++ b/tests/certification/bindings/localstorage/go.sum
@@ -95,8 +95,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/nacos/go.mod
+++ b/tests/certification/bindings/nacos/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/bindings/nacos
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/nacos-group/nacos-sdk-go/v2 v2.1.3

--- a/tests/certification/bindings/nacos/go.sum
+++ b/tests/certification/bindings/nacos/go.sum
@@ -100,8 +100,8 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/postgres/go.mod
+++ b/tests/certification/bindings/postgres/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/postgresql
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/lib/pq v1.10.7

--- a/tests/certification/bindings/postgres/go.sum
+++ b/tests/certification/bindings/postgres/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/rabbitmq/go.mod
+++ b/tests/certification/bindings/rabbitmq/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/binding/rabbitmq
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/rabbitmq/amqp091-go v1.7.0

--- a/tests/certification/bindings/rabbitmq/go.sum
+++ b/tests/certification/bindings/rabbitmq/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/bindings/redis/go.mod
+++ b/tests/certification/bindings/redis/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/bindings/redis
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220908221803-2b5650c2faa4
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/go-redis/redis/v8 v8.11.5

--- a/tests/certification/bindings/redis/go.sum
+++ b/tests/certification/bindings/redis/go.sum
@@ -97,8 +97,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/go-cmp v0.5.9

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/aws/snssqs/go.mod
+++ b/tests/certification/pubsub/aws/snssqs/go.mod
@@ -8,9 +8,9 @@ replace github.com/dapr/components-contrib/tests/certification => ../../..
 
 require (
 	github.com/aws/aws-sdk-go v1.44.214
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-00010101000000-000000000000
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/aws/snssqs/go.sum
+++ b/tests/certification/pubsub/aws/snssqs/go.sum
@@ -95,8 +95,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/azure/eventhubs/go.mod
+++ b/tests/certification/pubsub/azure/eventhubs/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/pubsub/azure/event
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v1.4.0-rc2
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/azure/eventhubs/go.sum
+++ b/tests/certification/pubsub/azure/eventhubs/go.sum
@@ -107,8 +107,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/azure/servicebus/topics/go.mod
+++ b/tests/certification/pubsub/azure/servicebus/topics/go.mod
@@ -3,9 +3,9 @@ module servicebus_test
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/azure/servicebus/topics/go.sum
+++ b/tests/certification/pubsub/azure/servicebus/topics/go.sum
@@ -107,8 +107,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/kafka/go.mod
+++ b/tests/certification/pubsub/kafka/go.mod
@@ -5,9 +5,9 @@ go 1.20
 require (
 	github.com/Shopify/sarama v1.38.1
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220519061249-c2cb1dad5bb0
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/kafka/go.sum
+++ b/tests/certification/pubsub/kafka/go.sum
@@ -96,8 +96,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/mqtt3/go.mod
+++ b/tests/certification/pubsub/mqtt3/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v1.4.0-rc2
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/eclipse/paho.mqtt.golang v1.4.2

--- a/tests/certification/pubsub/mqtt3/go.sum
+++ b/tests/certification/pubsub/mqtt3/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/pulsar/go.mod
+++ b/tests/certification/pubsub/pulsar/go.mod
@@ -9,9 +9,9 @@ replace github.com/dapr/components-contrib => ../../../../
 require (
 	github.com/apache/pulsar-client-go v0.9.0
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-00010101000000-000000000000
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/pubsub/pulsar/go.sum
+++ b/tests/certification/pubsub/pulsar/go.sum
@@ -121,8 +121,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/pubsub/rabbitmq/go.mod
+++ b/tests/certification/pubsub/rabbitmq/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/rabbitmq/amqp091-go v1.7.0

--- a/tests/certification/pubsub/rabbitmq/go.sum
+++ b/tests/certification/pubsub/rabbitmq/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/secretstores/azure/keyvault/go.mod
+++ b/tests/certification/secretstores/azure/keyvault/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/secretstores/azure
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/secretstores/azure/keyvault/go.sum
+++ b/tests/certification/secretstores/azure/keyvault/go.sum
@@ -105,8 +105,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/secretstores/hashicorp/vault/go.mod
+++ b/tests/certification/secretstores/hashicorp/vault/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/secretstores/hashi
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/golang/protobuf v1.5.2

--- a/tests/certification/secretstores/hashicorp/vault/go.sum
+++ b/tests/certification/secretstores/hashicorp/vault/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/secretstores/local/env/go.mod
+++ b/tests/certification/secretstores/local/env/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/secretstores/local
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/secretstores/local/env/go.sum
+++ b/tests/certification/secretstores/local/env/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/secretstores/local/file/go.mod
+++ b/tests/certification/secretstores/local/file/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/secretstores/local
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/secretstores/local/file/go.sum
+++ b/tests/certification/secretstores/local/file/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/aws/dynamodb/go.mod
+++ b/tests/certification/state/aws/dynamodb/go.mod
@@ -7,9 +7,9 @@ replace github.com/dapr/components-contrib => ../../../../..
 replace github.com/dapr/components-contrib/tests/certification => ../../..
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-00010101000000-000000000000
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/aws/dynamodb/go.sum
+++ b/tests/certification/state/aws/dynamodb/go.sum
@@ -95,8 +95,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/azure/blobstorage/go.mod
+++ b/tests/certification/state/azure/blobstorage/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303235857-236104d7f560
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20230303235857-236104d7f560
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/azure/blobstorage/go.sum
+++ b/tests/certification/state/azure/blobstorage/go.sum
@@ -103,8 +103,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/azure/cosmosdb/go.mod
+++ b/tests/certification/state/azure/cosmosdb/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/azure/cosmos
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/azure/cosmosdb/go.sum
+++ b/tests/certification/state/azure/cosmosdb/go.sum
@@ -105,8 +105,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/azure/tablestorage/go.mod
+++ b/tests/certification/state/azure/tablestorage/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/azure/tables
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/azure/tablestorage/go.sum
+++ b/tests/certification/state/azure/tablestorage/go.sum
@@ -103,8 +103,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/cassandra/go.mod
+++ b/tests/certification/state/cassandra/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/cassandra
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211026011813-36b75e9ae272
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/cassandra/go.sum
+++ b/tests/certification/state/cassandra/go.sum
@@ -97,8 +97,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/cockroachdb/go.mod
+++ b/tests/certification/state/cockroachdb/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/cockroachdb
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20221111215803-c92827c3defc
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/google/uuid v1.3.0

--- a/tests/certification/state/cockroachdb/go.sum
+++ b/tests/certification/state/cockroachdb/go.sum
@@ -94,8 +94,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/memcached/go.mod
+++ b/tests/certification/state/memcached/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/memcached
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/memcached/go.sum
+++ b/tests/certification/state/memcached/go.sum
@@ -95,8 +95,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/mongodb/go.mod
+++ b/tests/certification/state/mongodb/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/mongodb
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/mongodb/go.sum
+++ b/tests/certification/state/mongodb/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/mysql/go.mod
+++ b/tests/certification/state/mysql/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/mysql
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/mysql/go.sum
+++ b/tests/certification/state/mysql/go.sum
@@ -94,8 +94,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/postgresql/go.mod
+++ b/tests/certification/state/postgresql/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/postgresql
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/jackc/pgx/v5 v5.3.1

--- a/tests/certification/state/postgresql/go.sum
+++ b/tests/certification/state/postgresql/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/redis/go.mod
+++ b/tests/certification/state/redis/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/redis
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/redis/go.sum
+++ b/tests/certification/state/redis/go.sum
@@ -97,8 +97,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/sqlite/go.mod
+++ b/tests/certification/state/sqlite/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/sqlite
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20220526162429-d03aeba3e0d6
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/sqlite/go.sum
+++ b/tests/certification/state/sqlite/go.sum
@@ -93,8 +93,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/certification/state/sqlserver/go.mod
+++ b/tests/certification/state/sqlserver/go.mod
@@ -3,9 +3,9 @@ module github.com/dapr/components-contrib/tests/certification/state/sqlserver
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.2
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/components-contrib/tests/certification v0.0.0-20211130185200-4918900c09e1
-	github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83
+	github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.4
 	github.com/stretchr/testify v1.8.2

--- a/tests/certification/state/sqlserver/go.sum
+++ b/tests/certification/state/sqlserver/go.sum
@@ -96,8 +96,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83 h1:1nbWHy1Jh4o/MJUAQjE6337OH37JdsTNe34ZWer1o7M=
-github.com/dapr/dapr v1.10.1-0.20230303202925-74458da97d83/go.mod h1:MAmt2o02+ozz97sIvTQ9kzu+b/L+UYB7wgvJv5apnq8=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7 h1:iuSE3EgJDvv2pddqcbcm/HvhYztZnx/IyPGL5q+Gl3k=
+github.com/dapr/dapr v1.10.1-0.20230306165150-8609d5aeedb7/go.mod h1:Fl+9Mxh4Dwk9k5U8VXLrQg3qXR+Y9XHp4aEoUWpPsng=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=

--- a/tests/e2e/pubsub/jetstream/go.mod
+++ b/tests/e2e/pubsub/jetstream/go.mod
@@ -3,7 +3,7 @@ module github.com/dapr/components-contrib/tests/e2e/pubsub/jetstream
 go 1.20
 
 require (
-	github.com/dapr/components-contrib v1.10.0-rc.1.0.20230217001905-83ebec68c13e
+	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/kit v0.0.4
 )
 


### PR DESCRIPTION
Completes the work from #2596 now that the runtime has been updated

Updates the pinned runtime in tests too