### PR TITLE
Restore Kafka CA Cert Auth without Password support, fix Jetstream pubsub issue

### DIFF
--- a/internal/component/kafka/auth.go
+++ b/internal/component/kafka/auth.go
@@ -50,7 +50,7 @@ func updateMTLSAuthInfo(config *sarama.Config, metadata *kafkaMetadata) error {
 }
 
 func updateTLSConfig(config *sarama.Config, metadata *kafkaMetadata) error {
-	if metadata.TLSDisable || metadata.AuthType == noAuthType {
+	if metadata.TLSDisable {
 		config.Net.TLS.Enable = false
 		return nil
 	}

--- a/internal/component/kafka/auth.go
+++ b/internal/component/kafka/auth.go
@@ -50,7 +50,7 @@ func updateMTLSAuthInfo(config *sarama.Config, metadata *kafkaMetadata) error {
 }
 
 func updateTLSConfig(config *sarama.Config, metadata *kafkaMetadata) error {
-	if metadata.TLSDisable {
+	if metadata.TLSDisable || metadata.AuthType == noAuthType {
 		config.Net.TLS.Enable = false
 		return nil
 	}

--- a/internal/component/kafka/auth_test.go
+++ b/internal/component/kafka/auth_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+func getAuthBaseMetadata() map[string]string {
+	return map[string]string{
+		"consumerGroup": "a", "clientID": "a", "brokers": "a",
+		"consumeRetryInterval": "200",
+	}
+}
+
+func createTestCert() ([]byte, []byte, error) {
+	// This helper function with modifications comes from https://github.com/madflojo/testcerts/blob/main/testcerts.go
+	// Copyright 2019 Benjamin Cane, MIT License
+
+	// Create a Certificate Authority Cert
+	ca := &x509.Certificate{
+		Subject: pkix.Name{
+			Organization: []string{"Dapr Development Only Organization"},
+		},
+		SerialNumber:          big.NewInt(123),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// Create a Private Key
+	keypair, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not generate rsa key - %s", err)
+	}
+
+	// Use CA Cert to sign a CSR and create a Public Certificate
+	csr := &keypair.PublicKey
+	cert, err := x509.CreateCertificate(rand.Reader, ca, ca, csr, keypair)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not generate certificate - %s", err)
+	}
+
+	// Convert keys into pem.Block
+	publiccert := &pem.Block{Type: "CERTIFICATE", Bytes: cert}
+	privatekey := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(keypair)}
+	return pem.EncodeToMemory(publiccert), pem.EncodeToMemory(privatekey), nil
+}
+
+func TestAuth(t *testing.T) {
+	k := getKafka()
+	publicCert, _, _ := createTestCert()
+
+	t.Run("certificate with auth type 'none'", func(t *testing.T) {
+		m := getAuthBaseMetadata()
+		m[caCert] = string(publicCert)
+		m[authType] = "none"
+
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.NotEmpty(t, meta)
+
+		require.False(t, meta.TLSDisable)
+
+		mockConfig := &sarama.Config{}
+		err = updateTLSConfig(mockConfig, meta)
+		require.NoError(t, err)
+
+		require.True(t, (*mockConfig).Net.TLS.Enable)
+		certs := mockConfig.Net.TLS.Config.RootCAs.Subjects()
+		require.Equal(t, 1, len(certs))
+	})
+}

--- a/internal/component/kafka/auth_test.go
+++ b/internal/component/kafka/auth_test.go
@@ -87,10 +87,15 @@ func TestAuth(t *testing.T) {
 		require.False(t, meta.TLSDisable)
 
 		mockConfig := &sarama.Config{}
+
+		tlsconfig := mockConfig.Net.TLS.Config
+		require.Nil(t, tlsconfig)
+
 		err = updateTLSConfig(mockConfig, meta)
 		require.NoError(t, err)
 
-		require.True(t, (*mockConfig).Net.TLS.Enable)
+		require.True(t, mockConfig.Net.TLS.Enable)
+		//nolint:staticcheck This is a test and we need the deprecated function
 		certs := mockConfig.Net.TLS.Config.RootCAs.Subjects()
 		require.Equal(t, 1, len(certs))
 	})

--- a/internal/component/kafka/auth_test.go
+++ b/internal/component/kafka/auth_test.go
@@ -95,7 +95,7 @@ func TestAuth(t *testing.T) {
 		require.NoError(t, err)
 
 		require.True(t, mockConfig.Net.TLS.Enable)
-		//nolint:staticcheck This is a test and we need the deprecated function
+		//nolint:staticcheck
 		certs := mockConfig.Net.TLS.Config.RootCAs.Subjects()
 		require.Equal(t, 1, len(certs))
 	})

--- a/internal/component/kafka/kafka.go
+++ b/internal/component/kafka/kafka.go
@@ -107,6 +107,8 @@ func (k *Kafka) Init(metadata map[string]string) error {
 		if err != nil {
 			return err
 		}
+	case certificateAuthType:
+		// already handled in updateTLSConfig
 	}
 
 	k.config = config

--- a/internal/component/kafka/metadata_test.go
+++ b/internal/component/kafka/metadata_test.go
@@ -318,4 +318,14 @@ func TestTls(t *testing.T) {
 
 		require.Equal(t, "kafka error: invalid ca certificate", err.Error())
 	})
+
+	t.Run("missing certificate for certificate auth", func(t *testing.T) {
+		m := getBaseMetadata()
+		m[authType] = certificateAuthType
+		meta, err := k.getKafkaMetadata(m)
+		require.Error(t, err)
+		require.Nil(t, meta)
+
+		require.Equal(t, "missing CA certificate property 'caCert' for authType 'certificate'", err.Error())
+	})
 }

--- a/pubsub/jetstream/metadata.go
+++ b/pubsub/jetstream/metadata.go
@@ -92,7 +92,7 @@ func parseMetadata(psm pubsub.Metadata) (metadata, error) {
 	}
 
 	m.durableName = psm.Properties["durableName"]
-	m.queueGroupName =  psm.Properties["queueGroupName"]
+	m.queueGroupName = psm.Properties["queueGroupName"]
 
 	if v, err := strconv.ParseUint(psm.Properties["startSequence"], 10, 64); err == nil {
 		m.startSequence = v

--- a/pubsub/jetstream/metadata.go
+++ b/pubsub/jetstream/metadata.go
@@ -92,11 +92,7 @@ func parseMetadata(psm pubsub.Metadata) (metadata, error) {
 	}
 
 	m.durableName = psm.Properties["durableName"]
-	if val, ok := psm.Properties["queueGroupName"]; ok && val != "" {
-		m.queueGroupName = val
-	} else {
-		m.queueGroupName = psm.Properties[pubsub.RuntimeConsumerIDKey]
-	}
+	m.queueGroupName =  psm.Properties["queueGroupName"]
 
 	if v, err := strconv.ParseUint(psm.Properties["startSequence"], 10, 64); err == nil {
 		m.startSequence = v


### PR DESCRIPTION
# Description

Restore Kafka CA Cert Auth without Password Support by introducing new auth type `certificate`

Fixes #2639 
Fixes #2645 

For Hotfix 1.10.3
