### PR TITLE
Remove `context.TODO()`s with passed context.

### DIFF
--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -92,9 +92,9 @@ func NewAzureBlobStorage(logger logger.Logger) bindings.OutputBinding {
 }
 
 // Init performs metadata parsing.
-func (a *AzureBlobStorage) Init(_ context.Context, metadata bindings.Metadata) error {
+func (a *AzureBlobStorage) Init(ctx context.Context, metadata bindings.Metadata) error {
 	var err error
-	a.containerClient, a.metadata, err = storageinternal.CreateContainerStorageClient(context.TODO(), a.logger, metadata.Properties)
+	a.containerClient, a.metadata, err = storageinternal.CreateContainerStorageClient(ctx, a.logger, metadata.Properties)
 	if err != nil {
 		return err
 	}

--- a/state/azure/blobstorage/blobstorage.go
+++ b/state/azure/blobstorage/blobstorage.go
@@ -68,9 +68,9 @@ type StateStore struct {
 }
 
 // Init the connection to blob storage, optionally creates a blob container if it doesn't exist.
-func (r *StateStore) Init(_ context.Context, metadata state.Metadata) error {
+func (r *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	var err error
-	r.containerClient, _, err = storageinternal.CreateContainerStorageClient(context.TODO(), r.logger, metadata.Properties)
+	r.containerClient, _, err = storageinternal.CreateContainerStorageClient(ctx, r.logger, metadata.Properties)
 	if err != nil {
 		return err
 	}

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -155,7 +155,7 @@ func (m *MongoDB) Init(ctx context.Context, metadata state.Metadata) error {
 	// values immediately when the TTL value is reached.
 	// MongoDB TTL Indexes: https://docs.mongodb.com/manual/core/index-ttl/
 	// TTL fields are deleted at most 60 seconds after the TTL value is reached.
-	_, err = m.collection.Indexes().CreateOne(context.TODO(), mongo.IndexModel{
+	_, err = m.collection.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    bson.M{ttl: 1},
 		Options: options.Index().SetExpireAfterSeconds(0),
 	})


### PR DESCRIPTION
Some `context.TODO()`s slipped through when merging https://github.com/dapr/components-contrib/pull/2474