### PR TITLE
Support Increment Operation, TTL in Redis Binding

### DIFF
--- a/tests/certification/bindings/redis/components/retryOptions/redis.yaml
+++ b/tests/certification/bindings/redis/components/retryOptions/redis.yaml
@@ -9,7 +9,7 @@ spec:
   ignoreErrors: true
   metadata:
     - name: redisHost
-      value: "localhost:6379"
+      value: "localhost:6399"
     - name: redisPassword
       value: ""
     - name: dialTimeout

--- a/tests/certification/bindings/redis/components/standard/redis.yaml
+++ b/tests/certification/bindings/redis/components/standard/redis.yaml
@@ -7,6 +7,6 @@ spec:
   version: v1
   metadata:
   - name: redisHost
-    value: "localhost:6379"
+    value: "localhost:6399"
   - name: redisPassword
     value: ""

--- a/tests/certification/bindings/redis/docker-compose.yml
+++ b/tests/certification/bindings/redis/docker-compose.yml
@@ -3,5 +3,5 @@ services:
   redis:
     image: 'redislabs/redisearch:latest'
     ports:
-      - '6379:6379'
+      - '6399:6379'
     command: redis-server


### PR DESCRIPTION
# Description

Adds "increment" operation for Redis Binding.

Also adds TTL support for "create" and "increment" operation via the standard "ttlInSeconds" request metadata.

Unit tests and certification test updates included. Also updates certification test to a different Redis port so not to clash with Redis already installed via Dapr CLI.

#2537 

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
