### PR TITLE
Add support for Workload identity

### DIFF
--- a/internal/authentication/azure/auth.go
+++ b/internal/authentication/azure/auth.go
@@ -133,6 +133,7 @@ func (s EnvironmentSettings) GetTokenCredential() (azcore.TokenCredential, error
 
 	// 3. Workload identity
 	// workload identity requires values for AZURE_AUTHORITY_HOST, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE, AZURE_TENANT_ID
+	// The workload identity mutating admissions webhook in Kubernetes injects these values into the pod.
 
 	const (
 		azureAuthorityHost      = "AZURE_AUTHORITY_HOST"
@@ -140,8 +141,6 @@ func (s EnvironmentSettings) GetTokenCredential() (azcore.TokenCredential, error
 		azureFederatedTokenFile = "AZURE_FEDERATED_TOKEN_FILE"
 		azureTenantID           = "AZURE_TENANT_ID"
 	)
-
-	// TODO, instead of reading env vars, we should read from the metadata
 
 	clientID, haveClientID := os.LookupEnv(azureClientID)
 	if haveClientID {


### PR DESCRIPTION
# Description

Azure Workload Identity Support

Fixes #1567

The implementation here comes directly from the Azure SDK for Go. I have manually verified in my AKS cluster that I am able to authenticate using Workload Identity from the Dapr sidecar!

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
