### PR TITLE
Fixed race condition in SQLite cert test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         // "BIND_LOCALHOST_DOCKER": "true",
 
         // Necessary for components-contrib's certification tests
-        "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "true"
+        "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "ignore"
     },
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {},

--- a/tests/certification/state/sqlite/sqlite_test.go
+++ b/tests/certification/state/sqlite/sqlite_test.go
@@ -613,9 +613,13 @@ func TestSQLite(t *testing.T) {
 
 				ctx := context.Background()
 
+				// We have as many counters as we have number of parallel workers. The final value will be one of them.
+				// This is because we have a race condition between the time we call `save := counter.Add(1)` and when we set the value, causing tests to be flaky since the value stored in the database may not be the one stored in counter.
+				// This is not a bug in the SQLite component, as it's working as intended; the race condition is on the tests themselves.
+				// The real solution to the race condition (and what one should do in a real-world app) would be to wrap the call to increment counter and the store operation in a mutex. However, that would make it so only one query is hitting the database at the same time, while here we're precisely testing how the component handles multiple writes at the same time.
 				wg := sync.WaitGroup{}
 				wg.Add(parallel)
-				counter := atomic.Int32{}
+				counters := [parallel]atomic.Int32{}
 				key := "same"
 				for i := 0; i < parallel; i++ {
 					go func(i int) {
@@ -626,7 +630,7 @@ func TestSQLite(t *testing.T) {
 						storeObj := storeObjs[i%len(storeObjs)]
 
 						for j := 0; j < runs; j++ {
-							save := counter.Add(1)
+							save := counters[i].Add(1)
 							// Save state
 							err = storeObj.Set(ctx, &state.SetRequest{
 								Key:   key,
@@ -644,7 +648,12 @@ func TestSQLite(t *testing.T) {
 					Key: key,
 				})
 				assert.NoError(t, err)
-				assert.Equal(t, strconv.Itoa(int(counter.Load())), string(res.Data))
+
+				expect := [parallel]string{}
+				for i := 0; i < parallel; i++ {
+					expect[i] = strconv.Itoa(int(counters[i].Load()))
+				}
+				assert.Contains(t, expect, string(res.Data))
 			}
 
 			// Init one store object
@@ -677,8 +686,8 @@ func TestSQLite(t *testing.T) {
 			embedded.WithoutApp(),
 			embedded.WithDaprGRPCPort(runtime.DefaultDaprAPIGRPCPort),
 			embedded.WithDaprHTTPPort(runtime.DefaultDaprHTTPPort),
-			embedded.WithProfilePort(runtime.DefaultProfilePort),
-			embedded.WithComponentsPath("resources/memory"),
+			embedded.WithProfilingEnabled(false),
+			embedded.WithResourcesPath("resources/memory"),
 			runtime.WithStates(stateRegistry),
 		)).
 
@@ -691,8 +700,8 @@ func TestSQLite(t *testing.T) {
 			embedded.WithoutApp(),
 			embedded.WithDaprGRPCPort(runtime.DefaultDaprAPIGRPCPort+portOffset),
 			embedded.WithDaprHTTPPort(runtime.DefaultDaprHTTPPort+portOffset),
-			embedded.WithProfilePort(runtime.DefaultProfilePort+portOffset),
-			embedded.WithComponentsPath("resources/readonly"),
+			embedded.WithProfilingEnabled(false),
+			embedded.WithResourcesPath("resources/readonly"),
 			runtime.WithStates(stateRegistry),
 		)).
 		Step("run read-only test", readonlyTest(runtime.DefaultDaprAPIGRPCPort+portOffset)).


### PR DESCRIPTION
Fixes #2628

The race condition was in the tests and not in the component itself.

PS: Also includes fixing a typo in devcontainer.json. Since otherwise I couldn't run the tests in a dev container / codespace