### PR TITLE
Create component metadata for pubsub.in-memory

### DIFF
--- a/pubsub/in-memory/metadata.yaml
+++ b/pubsub/in-memory/metadata.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../component-metadata-schema.json
+schemaVersion: v1
+type: pubsub
+name: in-memory
+version: v1
+status: stable
+title: "In-Memory"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-inmemory/
+metadata: []


### PR DESCRIPTION
# Description
Create component metadata for pubsub.in-memory.  
This component seems to require no specific metadata to work so I left metadata **empty**.
## Issue reference
Please reference the issue #2578.

