### PR TITLE
Revert "Creation of request and interface method for Workflow raise event"

### DIFF
--- a/tests/conformance/workflows/workflows.go
+++ b/tests/conformance/workflows/workflows.go
@@ -64,7 +64,7 @@ func ConformanceTests(t *testing.T, props map[string]string, workflowItem workfl
 				Input:        10, // Time that the activity within the workflow runs for
 				WorkflowName: "TestWorkflow",
 			}
-			req.InstanceID = "TestID"
+			req.WorkflowReference.InstanceID = "TestID"
 			req.Options = make(map[string]string)
 			req.Options["task_queue"] = "TestTaskQueue"
 			wf, err := workflowItem.Start(context.Background(), req)

--- a/workflows/requests.go
+++ b/workflows/requests.go
@@ -6,15 +6,8 @@ type WorkflowReference struct {
 
 // StartRequest is the object describing a Start Workflow request.
 type StartRequest struct {
-	Options      map[string]string `json:"workflow_options"`
-	InstanceID   string            `json:"workflow_reference"`
-	WorkflowName string            `json:"function_name"`
-	Input        interface{}       `json:"input"`
-}
-
-// RaiseEventRequest is the object describing a Raise Event request.
-type RaiseEventRequest struct {
-	InstanceID string `json:"workflow_reference"`
-	EventName  string `json:"event_name"`
-	Input      []byte `json:"input"`
+	Options           map[string]string `json:"workflow_options"`
+	WorkflowReference WorkflowReference `json:"workflow_reference"`
+	WorkflowName      string            `json:"function_name"`
+	Input             interface{}       `json:"input"`
 }

--- a/workflows/temporal/temporal.go
+++ b/workflows/temporal/temporal.go
@@ -86,7 +86,7 @@ func (c *TemporalWF) Start(ctx context.Context, req *workflows.StartRequest) (*w
 	}
 	taskQ := req.Options["task_queue"]
 
-	opt := client.StartWorkflowOptions{ID: req.InstanceID, TaskQueue: taskQ}
+	opt := client.StartWorkflowOptions{ID: req.WorkflowReference.InstanceID, TaskQueue: taskQ}
 	run, err := c.client.ExecuteWorkflow(ctx, opt, req.WorkflowName, req.Input)
 	if err != nil {
 		return &workflows.WorkflowReference{}, fmt.Errorf("error executing workflow: %w", err)
@@ -122,11 +122,6 @@ func (c *TemporalWF) Get(ctx context.Context, req *workflows.WorkflowReference) 
 	}
 
 	return &outputStruct, nil
-}
-
-func (c *TemporalWF) RaiseEvent(ctx context.Context, req *workflows.RaiseEventRequest) error {
-	// Unimplemented
-	return nil
 }
 
 func (c *TemporalWF) Close() {

--- a/workflows/workflow.go
+++ b/workflows/workflow.go
@@ -21,5 +21,4 @@ type Workflow interface {
 	Start(ctx context.Context, req *StartRequest) (*WorkflowReference, error)
 	Terminate(ctx context.Context, req *WorkflowReference) error
 	Get(ctx context.Context, req *WorkflowReference) (*StateResponse, error)
-	RaiseEvent(ctx context.Context, req *RaiseEventRequest) error
 }


### PR DESCRIPTION
Reverts dapr/components-contrib#2653

Because https://github.com/dapr/dapr/pull/6049 is no close to being ready to be merged, and with this PR merged in master our cert tests are broken (and so is our ability to merge any PR in dapr/components-contrib), we are going to revert this PR.

Once the runtime PR is ready, please re-open a PR to get the changes merged

This is @berndverst and I's decision