### PR TITLE
Add connectionString metadata to MongoDB State Store

### DIFF
--- a/state/mongodb/mongodb_test.go
+++ b/state/mongodb/mongodb_test.go
@@ -87,7 +87,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoURI(metadata)
+		uri := getMongoConnectionString(metadata)
 		expected := "mongodb://username:password@127.0.0.2/TestDB"
 
 		assert.Equal(t, expected, uri)
@@ -106,7 +106,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoURI(metadata)
+		uri := getMongoConnectionString(metadata)
 		expected := "mongodb://localhost:27017/TestDB"
 
 		assert.Equal(t, expected, uri)
@@ -128,7 +128,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoURI(metadata)
+		uri := getMongoConnectionString(metadata)
 		expected := "mongodb://username:password@127.0.0.2/TestDB?ssl=true"
 
 		assert.Equal(t, expected, uri)
@@ -148,7 +148,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoURI(metadata)
+		uri := getMongoConnectionString(metadata)
 		expected := "mongodb+srv://server.example.com/?ssl=true"
 
 		assert.Equal(t, expected, uri)
@@ -186,5 +186,25 @@ func TestGetMongoDBMetadata(t *testing.T) {
 
 		expected := "'host' or 'server' fields are mutually exclusive"
 		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("Connectionstring ignores all other connection details", func(t *testing.T) {
+		properties := map[string]string{
+			host:               "localhost:27017",
+			databaseName:       "TestDB",
+			collectionName:     "TestCollection",
+			"connectionString": "mongodb://localhost:99999/UnchanedDB",
+		}
+		m := state.Metadata{
+			Base: metadata.Base{Properties: properties},
+		}
+
+		metadata, err := getMongoDBMetaData(m)
+		assert.Nil(t, err)
+
+		uri := getMongoConnectionString(metadata)
+		expected := "mongodb://localhost:99999/UnchanedDB"
+
+		assert.Equal(t, expected, uri)
 	})
 }

--- a/tests/certification/state/mongodb/components/docker/singleNode/mongodbstatestore.yaml
+++ b/tests/certification/state/mongodb/components/docker/singleNode/mongodbstatestore.yaml
@@ -7,10 +7,8 @@ spec:
   version: v1
   initTimeout: 5m
   metadata:
-    - name: host
-      value: "localhost:27017"
-    - name: databaseName
-      value: "admin"
+    - name: connectionString
+      value: "mongodb://localhost:27017/admin"
     - name: writeConcern
       value: "majority"
     - name: readConcern

--- a/tests/certification/state/mongodb/mongodb_test.go
+++ b/tests/certification/state/mongodb/mongodb_test.go
@@ -2,10 +2,11 @@ package mongodb_test
 
 import (
 	"fmt"
-	"github.com/dapr/components-contrib/tests/certification/flow/network"
-	"github.com/dapr/go-sdk/client"
 	"testing"
 	"time"
+
+	"github.com/dapr/components-contrib/tests/certification/flow/network"
+	"github.com/dapr/go-sdk/client"
 
 	"github.com/dapr/components-contrib/state"
 	stateMongoDB "github.com/dapr/components-contrib/state/mongodb"
@@ -135,7 +136,7 @@ func TestMongoDB(t *testing.T) {
 		Step("Get Values Saved Earlier And Not Expired, after MongoDB restart", testGetAfterMongoDBRestart).
 		Run()
 
-	flow.New(t, "Connecting MongoDB And Verifying majority of the tests here for a single node with valid read, "+
+	flow.New(t, "Connecting MongoDB using connectionString And Verifying majority of the tests here for a single node with valid read, "+
 		"write concerns and operation timeout").
 		Step(dockercompose.Run("mongodb", dockerComposeSingleYAML)).
 		Step("Waiting for component to start...", flow.Sleep(10*time.Second)).


### PR DESCRIPTION
Adds connectionString metadata to MongoDB State Store.

IGNORE - this PR. Do not merge.