### PR TITLE
wasm: close module on invoke

### DIFF
--- a/bindings/wasm/output.go
+++ b/bindings/wasm/output.go
@@ -138,10 +138,11 @@ func (out *outputBinding) Invoke(ctx context.Context, req *bindings.InvokeReques
 	moduleConfig = moduleConfig.WithArgs(argsSlice...)
 
 	// Instantiating executes the guest's main function (exported as _start).
-	_, err := out.runtime.InstantiateModule(ctx, out.module, moduleConfig)
+	mod, err := out.runtime.InstantiateModule(ctx, out.module, moduleConfig)
 
 	// Return STDOUT if there was no error.
 	if err == nil {
+		_ = mod.Close(ctx)
 		return &bindings.InvokeResponse{Data: stdout.Bytes()}, nil
 	}
 

--- a/bindings/wasm/output_test.go
+++ b/bindings/wasm/output_test.go
@@ -213,11 +213,15 @@ func Test_Invoke(t *testing.T) {
 				reqCtx = ctx
 			}
 
-			resp, err := output.Invoke(reqCtx, tc.request)
 			if tc.expectedErr == "" {
-				require.NoError(t, err)
-				require.Equal(t, tc.expectedData, string(resp.Data))
+				// execute twice to prove idempotency
+				for i := 0; i < 2; i++ {
+					resp, err := output.Invoke(reqCtx, tc.request)
+					require.NoError(t, err)
+					require.Equal(t, tc.expectedData, string(resp.Data))
+				}
 			} else {
+				_, err = output.Invoke(reqCtx, tc.request)
 				require.EqualError(t, err, tc.expectedErr)
 			}
 		})


### PR DESCRIPTION
# Description

Before, we accidentally leaked a module resource until the output binding closed.

## Issue reference

https://github.com/dapr/components-contrib/pull/2685#discussion_r1145226223

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [n/a] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
