### PR TITLE
graphql binding variable support

### DIFF
--- a/bindings/graphql/graphql.go
+++ b/bindings/graphql/graphql.go
@@ -168,6 +168,12 @@ func (gql *GraphQL) runRequest(ctx context.Context, requestKey string, req *bind
 		}
 	}
 
+	for k, v := range req.Metadata {
+		if strings.HasPrefix(k, "variable:") {
+			request.Var(strings.TrimPrefix(k, "variable:"), v)
+		}
+	}
+
 	if err := gql.client.Run(ctx, request, response); err != nil {
 		return fmt.Errorf("GraphQL Error: %w", err)
 	}

--- a/bindings/graphql/graphql.go
+++ b/bindings/graphql/graphql.go
@@ -165,11 +165,7 @@ func (gql *GraphQL) runRequest(ctx context.Context, requestKey string, req *bind
 	for k, v := range req.Metadata {
 		if strings.HasPrefix(k, "header:") {
 			request.Header.Set(strings.TrimPrefix(k, "header:"), v)
-		}
-	}
-
-	for k, v := range req.Metadata {
-		if strings.HasPrefix(k, "variable:") {
+		} else if strings.HasPrefix(k, "variable:") {
 			request.Var(strings.TrimPrefix(k, "variable:"), v)
 		}
 	}

--- a/bindings/graphql/graphql_test.go
+++ b/bindings/graphql/graphql_test.go
@@ -57,7 +57,7 @@ func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.Out
 
 func TestInit(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(204)
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer s.Close()
 

--- a/bindings/graphql/graphql_test.go
+++ b/bindings/graphql/graphql_test.go
@@ -51,7 +51,7 @@ func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.Out
 	}
 
 	binding := NewGraphQL(logger.NewLogger("test"))
-	err := binding.Init(m)
+	err := binding.Init(context.Background(), m)
 	return binding, err
 }
 

--- a/bindings/graphql/graphql_test.go
+++ b/bindings/graphql/graphql_test.go
@@ -14,9 +14,18 @@ limitations under the License.
 package graphql
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
 )
 
 func TestOperations(t *testing.T) {
@@ -28,4 +37,77 @@ func TestOperations(t *testing.T) {
 		l := b.Operations()
 		assert.Equal(t, 2, len(l))
 	})
+}
+
+func InitBinding(s *httptest.Server, extraProps map[string]string) (bindings.OutputBinding, error) {
+	m := bindings.Metadata{Base: metadata.Base{
+		Properties: map[string]string{
+			"endpoint": s.URL,
+		},
+	}}
+
+	for k, v := range extraProps {
+		m.Properties[k] = v
+	}
+
+	binding := NewGraphQL(logger.NewLogger("test"))
+	err := binding.Init(m)
+	return binding, err
+}
+
+func TestInit(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer s.Close()
+
+	_, err := InitBinding(s, nil)
+	require.NoError(t, err)
+}
+
+type TestGraphQLRequest struct {
+	Query     string            `json:"query"`
+	Variables map[string]string `json:"variables"`
+}
+
+func TestGraphQlRequestHeadersAndVariables(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+
+		testHeader := r.Header.Get("X-Test-Header")
+		require.Equal(t, "test-header-value", testHeader)
+
+		var rBody *TestGraphQLRequest
+		json.NewDecoder(r.Body).Decode(&rBody)
+
+		require.Contains(t, rBody.Variables, "episode")
+		require.Equal(t, "JEDI", rBody.Variables["episode"])
+
+		m := make(map[string]interface{})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(m)
+	}))
+	defer s.Close()
+
+	gql, err := InitBinding(s, nil)
+	require.NoError(t, err)
+
+	req := &bindings.InvokeRequest{
+		Operation: "query",
+		Metadata: map[string]string{
+			"query": `query HeroNameAndFriends($episode: Episode) {
+				hero(episode: $episode) {
+				  name
+				  friends {
+					name
+				  }
+				}
+			  }`,
+			"header:X-Test-Header": "test-header-value",
+			"variable:episode":     "JEDI",
+		},
+	}
+	_, err = gql.Invoke(context.Background(), req)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
# Description
previous pr: #2522; rebased against master so couldn't re-open previous pr

attempt to idiomatically add support for graphql variables in the bindingrequest's metadata to help prevent injection attacks as outlined in https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html#injection-prevention

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2517

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#3165
