### PR TITLE
Many fixes to Oracle Database state store - now beta

### DIFF
--- a/.github/infrastructure/docker-compose-oracledatabase.yml
+++ b/.github/infrastructure/docker-compose-oracledatabase.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  oracledatabase:
+    # Uses "Express Edition"
+    image: gvenzl/oracle-xe:11-slim-faststart
+    ports:
+      - "1521:1521"
+    environment:
+      - ORACLE_PASSWORD=daprdev

--- a/.github/scripts/test-info.mjs
+++ b/.github/scripts/test-info.mjs
@@ -448,6 +448,10 @@ const components = {
         conformance: true,
         conformanceSetup: 'docker-compose.sh mysql',
     },
+    'state.oracledatabase': {
+        conformance: true,
+        conformanceSetup: 'docker-compose.sh oracledatabase',
+    },
     'state.postgresql': {
         conformance: true,
         certification: true,

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.7.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/sendgrid/sendgrid-go v3.12.0+incompatible
-	github.com/sijms/go-ora/v2 v2.5.33
+	github.com/sijms/go-ora/v2 v2.6.5
 	github.com/spf13/cast v1.5.0
 	github.com/stretchr/testify v1.8.2
 	github.com/supplyon/gremcos v0.1.40

--- a/go.sum
+++ b/go.sum
@@ -1771,8 +1771,8 @@ github.com/shirou/gopsutil/v3 v3.21.6/go.mod h1:JfVbDpIBLVzT8oKbvMg9P3wEIMDDpVn+
 github.com/shirou/gopsutil/v3 v3.22.2 h1:wCrArWFkHYIdDxx/FSfF5RB4dpJYW6t7rcp3+zL8uks=
 github.com/shirou/gopsutil/v3 v3.22.2/go.mod h1:WapW1AOOPlHyXr+yOyw3uYx36enocrtSoSBy0L5vUHY=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sijms/go-ora/v2 v2.5.33 h1:ICRRyLmmFK92TPcgzKvgq8K/lhR5A2A+UB3pUL68Agg=
-github.com/sijms/go-ora/v2 v2.5.33/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/sijms/go-ora/v2 v2.6.5 h1:+8V1m4Zmu3PmZJ6V9smUlXw/f6+4qZqOdrDwSB3+FoM=
+github.com/sijms/go-ora/v2 v2.6.5/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/state/oracledatabase/dbaccess.go
+++ b/state/oracledatabase/dbaccess.go
@@ -15,6 +15,7 @@ package oracledatabase
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/dapr/components-contrib/state"
 )
@@ -26,6 +27,13 @@ type dbAccess interface {
 	Set(ctx context.Context, req *state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
 	Delete(ctx context.Context, req *state.DeleteRequest) error
-	ExecuteMulti(ctx context.Context, sets []state.SetRequest, deletes []state.DeleteRequest) error
+	ExecuteMulti(parentCtx context.Context, reqs []state.TransactionalStateOperation) error
 	Close() error // io.Closer.
+}
+
+// Interface for both sql.DB and sql.Tx
+type querier interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }

--- a/state/oracledatabase/oracledatabase_test.go
+++ b/state/oracledatabase/oracledatabase_test.go
@@ -65,7 +65,7 @@ func (m *fakeDBaccess) Delete(ctx context.Context, req *state.DeleteRequest) err
 	return nil
 }
 
-func (m *fakeDBaccess) ExecuteMulti(ctx context.Context, sets []state.SetRequest, deletes []state.DeleteRequest) error {
+func (m *fakeDBaccess) ExecuteMulti(parentCtx context.Context, reqs []state.TransactionalStateOperation) error {
 	return nil
 }
 
@@ -91,22 +91,6 @@ func TestMultiWithNoRequestsReturnsNil(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestInvalidMultiAction(t *testing.T) {
-	t.Parallel()
-	var operations []state.TransactionalStateOperation
-
-	operations = append(operations, state.TransactionalStateOperation{
-		Operation: "Something invalid",
-		Request:   createSetRequest(),
-	})
-
-	ods := createOracleDatabase(t)
-	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
-		Operations: operations,
-	})
-	assert.NotNil(t, err)
-}
-
 func TestValidSetRequest(t *testing.T) {
 	t.Parallel()
 	var operations []state.TransactionalStateOperation
@@ -123,22 +107,6 @@ func TestValidSetRequest(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestInvalidMultiSetRequest(t *testing.T) {
-	t.Parallel()
-	var operations []state.TransactionalStateOperation
-
-	operations = append(operations, state.TransactionalStateOperation{
-		Operation: state.Upsert,
-		Request:   createDeleteRequest(), // Delete request is not valid for Upsert operation.
-	})
-
-	ods := createOracleDatabase(t)
-	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
-		Operations: operations,
-	})
-	assert.NotNil(t, err)
-}
-
 func TestValidMultiDeleteRequest(t *testing.T) {
 	t.Parallel()
 	var operations []state.TransactionalStateOperation
@@ -153,22 +121,6 @@ func TestValidMultiDeleteRequest(t *testing.T) {
 		Operations: operations,
 	})
 	assert.Nil(t, err)
-}
-
-func TestInvalidMultiDeleteRequest(t *testing.T) {
-	t.Parallel()
-	var operations []state.TransactionalStateOperation
-
-	operations = append(operations, state.TransactionalStateOperation{
-		Operation: state.Delete,
-		Request:   createSetRequest(), // Set request is not valid for Delete operation.
-	})
-
-	ods := createOracleDatabase(t)
-	err := ods.Multi(context.Background(), &state.TransactionalStateRequest{
-		Operations: operations,
-	})
-	assert.NotNil(t, err)
 }
 
 func createSetRequest() state.SetRequest {

--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -18,8 +18,10 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/google/uuid"
 
@@ -36,7 +38,6 @@ const (
 	connectionStringKey        = "connectionString"
 	oracleWalletLocationKey    = "oracleWalletLocation"
 	errMissingConnectionString = "missing connection string"
-	tableName                  = "state"
 )
 
 // oracleDatabaseAccess implements dbaccess.
@@ -45,7 +46,6 @@ type oracleDatabaseAccess struct {
 	metadata         oracleDatabaseMetadata
 	db               *sql.DB
 	connectionString string
-	tx               *sql.Tx
 }
 
 type oracleDatabaseMetadata struct {
@@ -56,8 +56,6 @@ type oracleDatabaseMetadata struct {
 
 // newOracleDatabaseAccess creates a new instance of oracleDatabaseAccess.
 func newOracleDatabaseAccess(logger logger.Logger) *oracleDatabaseAccess {
-	logger.Debug("Instantiating new Oracle Database state store")
-
 	return &oracleDatabaseAccess{
 		logger: logger,
 	}
@@ -77,7 +75,6 @@ func parseMetadata(meta map[string]string) (oracleDatabaseMetadata, error) {
 
 // Init sets up OracleDatabase connection and ensures that the state table exists.
 func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata) error {
-	o.logger.Debug("Initializing OracleDatabase state store")
 	meta, err := parseMetadata(metadata.Properties)
 	o.metadata = meta
 	if err != nil {
@@ -87,8 +84,7 @@ func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata
 		o.connectionString = meta.ConnectionString
 	} else {
 		o.logger.Error("Missing Oracle Database connection string")
-
-		return fmt.Errorf(errMissingConnectionString)
+		return errors.New(errMissingConnectionString)
 	}
 	if o.metadata.OracleWalletLocation != "" {
 		o.connectionString += "?TRACE FILE=trace.log&SSL=enable&SSL Verify=false&WALLET=" + url.QueryEscape(o.metadata.OracleWalletLocation)
@@ -102,10 +98,12 @@ func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata
 
 	o.db = db
 
-	if pingErr := db.PingContext(ctx); pingErr != nil {
-		return pingErr
+	err = db.PingContext(ctx)
+	if err != nil {
+		return err
 	}
-	err = o.ensureStateTable(tableName)
+
+	err = o.ensureStateTable(o.metadata.TableName)
 	if err != nil {
 		return err
 	}
@@ -115,30 +113,21 @@ func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata
 
 // Set makes an insert or update to the database.
 func (o *oracleDatabaseAccess) Set(ctx context.Context, req *state.SetRequest) error {
-	o.logger.Debug("Setting state value in OracleDatabase")
+	return o.doSet(ctx, o.db, req)
+}
+
+func (o *oracleDatabaseAccess) doSet(ctx context.Context, db querier, req *state.SetRequest) error {
 	err := state.CheckRequestOptions(req.Options)
 	if err != nil {
 		return err
 	}
 
 	if req.Key == "" {
-		return fmt.Errorf("missing key in set operation")
+		return errors.New("missing key in set operation")
 	}
 
 	if v, ok := req.Value.(string); ok && v == "" {
-		return fmt.Errorf("empty string is not allowed in set operation")
-	}
-	if req.Options.Concurrency == state.FirstWrite && (req.ETag == nil || len(*req.ETag) == 0) {
-		o.logger.Debugf("when FirstWrite is to be enforced, a value must be provided for the ETag")
-		return fmt.Errorf("when FirstWrite is to be enforced, a value must be provided for the ETag")
-	}
-	var ttlSeconds int
-	ttl, ttlerr := stateutils.ParseTTL(req.Metadata)
-	if ttlerr != nil {
-		return fmt.Errorf("error parsing TTL: %w", ttlerr)
-	}
-	if ttl != nil {
-		ttlSeconds = *ttl
+		return errors.New("empty string is not allowed in set operation")
 	}
 	requestValue := req.Value
 	byteArray, isBinary := req.Value.([]uint8)
@@ -148,48 +137,67 @@ func (o *oracleDatabaseAccess) Set(ctx context.Context, req *state.SetRequest) e
 		binaryYN = "Y"
 	}
 
-	// Convert to json string.
+	// Convert to json string
 	bt, _ := stateutils.Marshal(requestValue, json.Marshal)
 	value := string(bt)
 
-	var result sql.Result
-	var tx *sql.Tx
-	if o.tx == nil { // not joining a preexisting transaction.
-		tx, err = o.db.Begin()
-		if err != nil {
-			return fmt.Errorf("failed to start database transaction : %w", err)
-		}
-	} else { // join the transaction passed in.
-		tx = o.tx
+	// TTL
+	var ttlSeconds int
+	ttl, err := stateutils.ParseTTL(req.Metadata)
+	if err != nil {
+		return fmt.Errorf("error parsing TTL: %w", err)
 	}
-	etag := uuid.New().String()
-	// Only check for etag if FirstWrite specified - as per Discord message thread https://discord.com/channels/778680217417809931/901141713089863710/938520959562952735.
-	if req.Options.Concurrency != state.FirstWrite {
+	if ttl != nil {
+		ttlSeconds = *ttl
+	}
+	ttlStatement := "NULL"
+	if ttlSeconds > 0 {
+		// We're passing ttlStatements via string concatenation - no risk of SQL injection because we control the value and make sure it's a number
+		ttlStatement = "systimestamp + numtodsinterval(" + strconv.Itoa(ttlSeconds) + ", 'SECOND')"
+	}
+
+	// Generate new etag
+	etagObj, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("failed to generate UUID: %w", err)
+	}
+	etag := etagObj.String()
+
+	var result sql.Result
+	if req.ETag == nil || *req.ETag == "" {
 		// Sprintf is required for table name because sql.DB does not substitute parameters for table names.
 		// Other parameters use sql.DB parameter substitution.
-		// As per Discord Thread https://discord.com/channels/778680217417809931/901141713089863710/938520959562952735 expiration time is reset in case of an update.
-		mergeStatement := fmt.Sprintf(
-			`MERGE INTO %s t using (select :key key, :value value, :binary_yn binary_yn, :etag etag , :ttl_in_seconds ttl_in_seconds from dual) new_state_to_store
-			ON (t.key = new_state_to_store.key )
-			WHEN MATCHED THEN UPDATE SET value = new_state_to_store.value, binary_yn = new_state_to_store.binary_yn, update_time = systimestamp, etag = new_state_to_store.etag, t.expiration_time = case when new_state_to_store.ttl_in_seconds >0 then systimestamp + numtodsinterval(new_state_to_store.ttl_in_seconds, 'SECOND') end
-			WHEN NOT MATCHED THEN INSERT (t.key, t.value, t.binary_yn, t.etag, t.expiration_time) values (new_state_to_store.key, new_state_to_store.value, new_state_to_store.binary_yn, new_state_to_store.etag, case when new_state_to_store.ttl_in_seconds >0 then systimestamp + numtodsinterval(new_state_to_store.ttl_in_seconds, 'SECOND') end ) `,
-			tableName)
-		result, err = tx.ExecContext(ctx, mergeStatement, req.Key, value, binaryYN, etag, ttlSeconds)
+		var stmt string
+		if req.Options.Concurrency == state.FirstWrite {
+			stmt = `INSERT INTO ` + o.metadata.TableName + `
+				(key, value, binary_yn, etag, expiration_time)
+			VALUES 
+				(:key, :value, :binary_yn, :etag, ` + ttlStatement + `) `
+		} else {
+			// As per Discord Thread https://discord.com/channels/778680217417809931/901141713089863710/938520959562952735 expiration time is reset in case of an update.
+			stmt = `MERGE INTO ` + o.metadata.TableName + ` t
+				USING (SELECT :key key, :value value, :binary_yn binary_yn, :etag etag FROM dual) new_state_to_store
+				ON (t.key = new_state_to_store.key)
+				WHEN MATCHED THEN UPDATE SET value = new_state_to_store.value, binary_yn = new_state_to_store.binary_yn, update_time = systimestamp, etag = new_state_to_store.etag, t.expiration_time = ` + ttlStatement + `
+				WHEN NOT MATCHED THEN INSERT (t.key, t.value, t.binary_yn, t.etag, t.expiration_time) VALUES (new_state_to_store.key, new_state_to_store.value, new_state_to_store.binary_yn, new_state_to_store.etag, ` + ttlStatement + ` ) `
+		}
+		result, err = db.ExecContext(ctx, stmt, req.Key, value, binaryYN, etag)
 	} else {
-		// when first write policy is indicated, an existing record has to be updated - one that has the etag provided.
-		// TODO: Needs to update ttl_in_seconds
-		updateStatement := fmt.Sprintf(
-			`UPDATE %s SET value = :value, binary_yn = :binary_yn, etag = :new_etag
-			 WHERE key = :key AND etag = :etag`,
-			tableName)
-		result, err = tx.ExecContext(ctx, updateStatement, value, binaryYN, etag, req.Key, *req.ETag)
+		// When first write policy is indicated, an existing record has to be updated - one that has the etag provided.
+		updateStatement := `UPDATE ` + o.metadata.TableName + ` SET
+			  value = :value,
+			  binary_yn = :binary_yn,
+			  etag = :new_etag,
+			  update_time = systimestamp,
+			  expiration_time = ` + ttlStatement + `
+			 WHERE key = :key
+			   AND etag = :etag
+			   AND (expiration_time IS NULL OR expiration_time >= systimestamp)`
+		result, err = db.ExecContext(ctx, updateStatement, value, binaryYN, etag, req.Key, *req.ETag)
 	}
 	if err != nil {
 		if req.ETag != nil && *req.ETag != "" {
 			return state.NewETagError(state.ETagMismatch, err)
-		}
-		if o.tx == nil { // not in a preexisting transaction so rollback the local, failed tx.
-			tx.Rollback()
 		}
 		return err
 	}
@@ -197,25 +205,23 @@ func (o *oracleDatabaseAccess) Set(ctx context.Context, req *state.SetRequest) e
 	if err != nil {
 		return err
 	}
-	if o.tx == nil { // local transaction, take responsibility.
-		tx.Commit()
-	}
 	if rows != 1 {
-		return fmt.Errorf("no item was updated")
+		return errors.New("no item was updated")
 	}
 	return nil
 }
 
 // Get returns data from the database. If data does not exist for the key an empty state.GetResponse will be returned.
 func (o *oracleDatabaseAccess) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
-	o.logger.Debug("Getting state value from OracleDatabase")
 	if req.Key == "" {
-		return nil, fmt.Errorf("missing key in get operation")
+		return nil, errors.New("missing key in get operation")
 	}
-	var value string
-	var binaryYN string
-	var etag string
-	err := o.db.QueryRowContext(ctx, fmt.Sprintf("SELECT value, binary_yn, etag  FROM %s WHERE key = :key and (expiration_time is null or expiration_time > systimestamp)", tableName), req.Key).Scan(&value, &binaryYN, &etag)
+	var (
+		value    string
+		binaryYN string
+		etag     string
+	)
+	err := o.db.QueryRowContext(ctx, "SELECT value, binary_yn, etag FROM "+o.metadata.TableName+" WHERE key = :key AND (expiration_time IS NULL OR expiration_time > systimestamp)", req.Key).Scan(&value, &binaryYN, &etag)
 	if err != nil {
 		// If no rows exist, return an empty response, otherwise return the error.
 		if err == sql.ErrNoRows {
@@ -224,8 +230,10 @@ func (o *oracleDatabaseAccess) Get(ctx context.Context, req *state.GetRequest) (
 		return nil, err
 	}
 	if binaryYN == "Y" {
-		var s string
-		var data []byte
+		var (
+			s    string
+			data []byte
+		)
 		if err = json.Unmarshal([]byte(value), &s); err != nil {
 			return nil, err
 		}
@@ -247,80 +255,65 @@ func (o *oracleDatabaseAccess) Get(ctx context.Context, req *state.GetRequest) (
 
 // Delete removes an item from the state store.
 func (o *oracleDatabaseAccess) Delete(ctx context.Context, req *state.DeleteRequest) error {
-	o.logger.Debug("Deleting state value from OracleDatabase")
+	return o.doDelete(ctx, o.db, req)
+}
+
+func (o *oracleDatabaseAccess) doDelete(ctx context.Context, db querier, req *state.DeleteRequest) (err error) {
 	if req.Key == "" {
-		return fmt.Errorf("missing key in delete operation")
+		return errors.New("missing key in delete operation")
 	}
-	if req.Options.Concurrency == state.FirstWrite && (req.ETag == nil || len(*req.ETag) == 0) {
-		o.logger.Debugf("when FirstWrite is to be enforced, a value must be provided for the ETag")
-		return fmt.Errorf("when FirstWrite is to be enforced, a value must be provided for the ETag")
-	}
+
 	var result sql.Result
-	var err error
-	var tx *sql.Tx
-	if o.tx == nil { // not joining a preexisting transaction.
-		tx, err = o.db.Begin()
-		if err != nil {
-			return err
-		}
-	} else { // join the transaction passed in.
-		tx = o.tx
-	}
-	// QUESTION: only check for etag if FirstWrite specified - or always when etag is supplied??
-	if req.Options.Concurrency != state.FirstWrite {
-		result, err = tx.ExecContext(ctx, "DELETE FROM state WHERE key = :key", req.Key)
+	if req.ETag == nil || *req.ETag == "" {
+		result, err = db.ExecContext(ctx, "DELETE FROM "+o.metadata.TableName+" WHERE key = :key", req.Key)
 	} else {
-		result, err = tx.ExecContext(ctx, "DELETE FROM state WHERE key = :key and etag = :etag", req.Key, *req.ETag)
+		result, err = db.ExecContext(ctx, "DELETE FROM "+o.metadata.TableName+" WHERE key = :key AND etag = :etag", req.Key, *req.ETag)
 	}
 	if err != nil {
-		if o.tx == nil { // not joining a preexisting transaction.
-			tx.Rollback()
-		}
 		return err
-	}
-	if o.tx == nil { // not joining a preexisting transaction.
-		tx.Commit()
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
 		return err
 	}
-	if rows != 1 && req.ETag != nil && *req.ETag != "" && req.Options.Concurrency == state.FirstWrite {
+	if rows == 0 && req.ETag != nil && *req.ETag != "" {
 		return state.NewETagError(state.ETagMismatch, nil)
 	}
 	return nil
 }
 
-func (o *oracleDatabaseAccess) ExecuteMulti(ctx context.Context, sets []state.SetRequest, deletes []state.DeleteRequest) error {
-	o.logger.Debug("Executing multiple OracleDatabase operations,  within a single transaction")
-	tx, err := o.db.Begin()
+func (o *oracleDatabaseAccess) ExecuteMulti(parentCtx context.Context, reqs []state.TransactionalStateOperation) error {
+	tx, err := o.db.BeginTx(parentCtx, nil)
 	if err != nil {
 		return err
 	}
-	o.tx = tx
-	if len(deletes) > 0 {
-		for _, d := range deletes {
-			da := d // Fix for gosec  G601: Implicit memory aliasing in for looo.
-			err = o.Delete(ctx, &da)
-			if err != nil {
-				tx.Rollback()
-				return err
+	defer tx.Rollback()
+
+	for _, req := range reqs {
+		switch req.Operation {
+		case state.Upsert:
+			if setReq, ok := req.Request.(state.SetRequest); ok {
+				err = o.doSet(parentCtx, tx, &setReq)
+				if err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("expecting set request")
 			}
+		case state.Delete:
+			if delReq, ok := req.Request.(state.DeleteRequest); ok {
+				err = o.doDelete(parentCtx, tx, &delReq)
+				if err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("expecting delete request")
+			}
+		default:
+			// Do nothing
 		}
 	}
-	if len(sets) > 0 {
-		for _, s := range sets {
-			sa := s // Fix for gosec  G601: Implicit memory aliasing in for looo.
-			err = o.Set(ctx, &sa)
-			if err != nil {
-				tx.Rollback()
-				return err
-			}
-		}
-	}
-	err = tx.Commit()
-	o.tx = nil
-	return err
+	return tx.Commit()
 }
 
 // Close implements io.Closer.
@@ -332,20 +325,21 @@ func (o *oracleDatabaseAccess) Close() error {
 }
 
 func (o *oracleDatabaseAccess) ensureStateTable(stateTableName string) error {
+	// TODO: This is not atomic and can lead to race conditions if multiple sidecars are starting up at the same time
 	exists, err := tableExists(o.db, stateTableName)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		o.logger.Info("Creating OracleDatabase state table")
-		createTable := fmt.Sprintf(`CREATE TABLE %s (
-									key varchar2(100) NOT NULL PRIMARY KEY,
-									value clob NOT NULL,
-									binary_yn varchar2(1) NOT NULL,
-									etag varchar2(50)  NOT NULL,
-									creation_time TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL ,
-									expiration_time TIMESTAMP WITH TIME ZONE NULL,
-									update_time TIMESTAMP WITH TIME ZONE NULL)`, stateTableName)
+		o.logger.Info("Creating state table")
+		createTable := `CREATE TABLE ` + stateTableName + ` (
+						key varchar2(100) NOT NULL PRIMARY KEY,
+						value clob NOT NULL,
+						binary_yn varchar2(1) NOT NULL,
+						etag varchar2(50)  NOT NULL,
+						creation_time TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL ,
+						expiration_time TIMESTAMP WITH TIME ZONE NULL,
+						update_time TIMESTAMP WITH TIME ZONE NULL)`
 		_, err = o.db.Exec(createTable)
 		if err != nil {
 			return err
@@ -356,7 +350,7 @@ func (o *oracleDatabaseAccess) ensureStateTable(stateTableName string) error {
 
 func tableExists(db *sql.DB, tableName string) (bool, error) {
 	var tblCount int32
-	err := db.QueryRow("SELECT count(table_name) tbl_count FROM user_tables where table_name = upper(:tablename)", tableName).Scan(&tblCount)
+	err := db.QueryRow("SELECT count(table_name) tbl_count FROM user_tables WHERE table_name = upper(:tablename)", tableName).Scan(&tblCount)
 	exists := tblCount > 0
 	return exists, err
 }

--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -384,7 +384,6 @@ func (a *sqliteDBAccess) doSet(parentCtx context.Context, db querier, req *state
 		res, err = db.ExecContext(ctx, stmt, requestValue, newEtag, isBinary, req.Key, *req.ETag)
 		cancel()
 	}
-
 	if err != nil {
 		return err
 	}

--- a/tests/config/state/oracledatabase/statestore.yml
+++ b/tests/config/state/oracledatabase/statestore.yml
@@ -1,0 +1,10 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.oracledatabase
+  version: v1
+  metadata:
+  - name: connectionString
+    value: "oracle://system:daprdev@localhost:1521/xe"

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -38,6 +38,9 @@ components:
   - component: azure.tablestorage.cosmosdb
     allOperations: false
     operations: ["set", "get", "delete", "etag", "bulkset", "bulkdelete", "first-write"]
+  - component: oracledatabase
+    allOperations: false
+    operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "transaction", "etag",  "first-write", "ttl" ]
   - component: cassandra
     allOperations: false
     operations: [ "set", "get", "delete", "bulkset", "bulkdelete", "ttl" ]

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -90,6 +90,7 @@ import (
 	s_memcached "github.com/dapr/components-contrib/state/memcached"
 	s_mongodb "github.com/dapr/components-contrib/state/mongodb"
 	s_mysql "github.com/dapr/components-contrib/state/mysql"
+	s_oracledatabase "github.com/dapr/components-contrib/state/oracledatabase"
 	s_postgresql "github.com/dapr/components-contrib/state/postgresql"
 	s_redis "github.com/dapr/components-contrib/state/redis"
 	s_rethinkdb "github.com/dapr/components-contrib/state/rethinkdb"
@@ -565,6 +566,8 @@ func loadStateStore(tc TestComponent) state.Store {
 		store = s_mysql.NewMySQLStateStore(testLogger)
 	case "mysql.mariadb":
 		store = s_mysql.NewMySQLStateStore(testLogger)
+	case "oracledatabase":
+		store = s_oracledatabase.NewOracleDatabaseStateStore(testLogger)
 	case "azure.tablestorage.storage":
 		store = s_azuretablestorage.NewAzureTablesStateStore(testLogger)
 	case "azure.tablestorage.cosmosdb":

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -326,13 +326,13 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 						req.Metadata = map[string]string{metadata.ContentType: scenario.contentType}
 					}
 					err := statestore.Delete(context.Background(), req)
-					assert.Nil(t, err, "no error expected while deleting %s", scenario.key)
+					assert.NoError(t, err, "no error expected while deleting %s", scenario.key)
 
 					t.Logf("Checking value absence for %s", scenario.key)
 					res, err := statestore.Get(context.Background(), &state.GetRequest{
 						Key: scenario.key,
 					})
-					assert.Nil(t, err, "no error expected while checking for absence for %s", scenario.key)
+					assert.NoError(t, err, "no error expected while checking for absence for %s", scenario.key)
 					assert.Nil(t, res.Data, "no data expected while checking for absence for %s", scenario.key)
 				}
 			}
@@ -561,7 +561,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 				Operations: operations,
 				Metadata:   partitionMetadata,
 			})
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			// Assert
 			for k, v := range expected {
@@ -569,7 +569,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 					Key:      k,
 					Metadata: partitionMetadata,
 				})
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, v, res.Data)
 			}
 		})


### PR DESCRIPTION
> Spin-off from #2688 as while working on that, I noticed the issues were much bigger than originally thought

Contains a large number of fixes, some critical, to the component:

- State table name was hardcoded rather than read from the metadata
- Transactions had queries executed in the wrong order: first all sets, then all deletes
- Transactions were not concurrency-safe, since the transaction handler was stored as property in the object
- TTLs were not updated when a row was updated
- Lots more fixes

Conformance tests are now enabled and passing for the component