### PR TITLE
Small perf tweaks to K8s nameresolver

### DIFF
--- a/nameresolution/kubernetes/kubernetes.go
+++ b/nameresolution/kubernetes/kubernetes.go
@@ -14,7 +14,7 @@ limitations under the License.
 package kubernetes
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/dapr/components-contrib/nameresolution"
 	"github.com/dapr/kit/config"
@@ -61,5 +61,5 @@ func (k *resolver) Init(metadata nameresolution.Metadata) error {
 // ResolveID resolves name to address in Kubernetes.
 func (k *resolver) ResolveID(req nameresolution.ResolveRequest) (string, error) {
 	// Dapr requires this formatting for Kubernetes services
-	return fmt.Sprintf("%s-dapr.%s.svc.%s:%d", req.ID, req.Namespace, k.clusterDomain, req.Port), nil
+	return req.ID + "-dapr." + req.Namespace + ".svc." + k.clusterDomain + ":" + strconv.Itoa(req.Port), nil
 }

--- a/nameresolution/kubernetes/kubernetes_test.go
+++ b/nameresolution/kubernetes/kubernetes_test.go
@@ -26,11 +26,11 @@ func TestResolve(t *testing.T) {
 	resolver := NewResolver(logger.NewLogger("test"))
 	request := nameresolution.ResolveRequest{ID: "myid", Namespace: "abc", Port: 1234}
 
-	u := "myid-dapr.abc.svc.cluster.local:1234"
+	const expect = "myid-dapr.abc.svc.cluster.local:1234"
 	target, err := resolver.ResolveID(request)
 
-	assert.Nil(t, err)
-	assert.Equal(t, target, u)
+	assert.NoError(t, err)
+	assert.Equal(t, expect, target)
 }
 
 func TestResolveWithCustomClusterDomain(t *testing.T) {
@@ -42,9 +42,9 @@ func TestResolveWithCustomClusterDomain(t *testing.T) {
 	})
 	request := nameresolution.ResolveRequest{ID: "myid", Namespace: "abc", Port: 1234}
 
-	u := "myid-dapr.abc.svc.mydomain.com:1234"
+	const expect = "myid-dapr.abc.svc.mydomain.com:1234"
 	target, err := resolver.ResolveID(request)
 
-	assert.Nil(t, err)
-	assert.Equal(t, target, u)
+	assert.NoError(t, err)
+	assert.Equal(t, expect, target)
 }


### PR DESCRIPTION
Very small perf tweaks to K8s nameresolver.

```
Before:
BenchmarkResolve-4   3176529      377.0 ns/op   104 B/op   5 allocs/op

After:
BenchmarkResolve-4   10297288     115.0 ns/op   52 B/op   2 allocs/op
```

It's 70% faster. Although we're still talking about 262ns :) Also, causes 3 less allocations on the heap (less work on the GC).