### PR TITLE
deps: updates wazero to 1.0.0

### DIFF
--- a/bindings/wasm/output.go
+++ b/bindings/wasm/output.go
@@ -73,7 +73,7 @@ func NewWasmOutput(logger logger.Logger) bindings.OutputBinding {
 		runtimeConfig: wazero.NewRuntimeConfig().
 			WithCloseOnContextDone(true),
 
-		// The below violate sand-boxing, but allow code to behave as expecteout.
+		// The below violate sand-boxing, but allow code to behave as expected.
 		moduleConfig: wazero.NewModuleConfig().
 			WithRandSource(rand.Reader).
 			WithSysWalltime().

--- a/bindings/wasm/output_test.go
+++ b/bindings/wasm/output_test.go
@@ -178,7 +178,7 @@ func Test_Invoke(t *testing.T) {
 			request: &bindings.InvokeRequest{
 				Operation: ExecuteOperation,
 			},
-			expectedErr: `module "main-1" closed with context canceled`,
+			expectedErr: `module closed with context canceled`,
 		},
 		{
 			name: "example",

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a
-	github.com/http-wasm/http-wasm-host-go v0.3.4
+	github.com/http-wasm/http-wasm-host-go v0.4.1
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.28
 	github.com/influxdata/influxdb-client-go v1.4.0
@@ -102,7 +102,7 @@ require (
 	github.com/supplyon/gremcos v0.1.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.608
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.608
-	github.com/tetratelabs/wazero v1.0.0-rc.1
+	github.com/tetratelabs/wazero v1.0.0
 	github.com/valyala/fasthttp v1.44.0
 	github.com/vmware/vmware-go-kcl v1.5.0
 	github.com/xdg-go/scram v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1272,8 +1272,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a h1:j6SSiw7fWemWfrJL801xiQ6xRT7ZImika50xvmPN+tg=
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a/go.mod h1:VhwtcZ7sg3xq7REqGzEy7ylSWGKz4jZd05eCJropNzI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/http-wasm/http-wasm-host-go v0.3.4 h1:osszLJON59TaSJ5xf7Rp1ggo36pzFWRbLUutkXN0/W0=
-github.com/http-wasm/http-wasm-host-go v0.3.4/go.mod h1:PJEaw4IJ5vBnQfPvO7u83XRA/RmKFSd9IHyigl9SUO8=
+github.com/http-wasm/http-wasm-host-go v0.4.1 h1:kQS/icRt529GQ+OTIUAKAAguLZSJwbHZXtD6LIkWmkU=
+github.com/http-wasm/http-wasm-host-go v0.4.1/go.mod h1:oUhzCyp0mXpOawxgwGRebCcIC2oxAS5DB6+P7SXJAcA=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible h1:bSww59mgbqFRGCRvlvfQutsptE3lRjNiU5C0YNT/bWw=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible/go.mod h1:l7VUhRbTKCzdOacdT4oWCwATKyvZqUOlOqr0Ous3k4s=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.28 h1:2w2khA5uopaLcZactRuQFGtUgMbN92aWZdOuT4b9HxU=
@@ -1864,8 +1864,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.608 h1:yLiH
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.608/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.608 h1:Wi11Yw2E6W7ZE/B2whvLq5ILeZbrRukVCc1s6ptbOU8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.0.608/go.mod h1:oOEV4UP04zUSkZCjjfZ32DUpbWSdWbOyaO5gDfC1IH0=
-github.com/tetratelabs/wazero v1.0.0-rc.1 h1:ytecMV5Ue0BwezjKh/cM5yv1Mo49ep2R2snSsQUyToc=
-github.com/tetratelabs/wazero v1.0.0-rc.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.0.0 h1:sCE9+mjFex95Ki6hdqwvhyF25x5WslADjDKIFU5BXzI=
+github.com/tetratelabs/wazero v1.0.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tevid/gohamcrest v1.1.1/go.mod h1:3UvtWlqm8j5JbwYZh80D/PVBt0mJ1eJiYgZMibh0H/k=
 github.com/tidwall/gjson v1.2.1/go.mod h1:c/nTNbUr0E0OrXEhq1pwa8iEgc2DOt4ZZqAt1HtCkPA=
 github.com/tidwall/gjson v1.8.1/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatability promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

```bash
$ go test -run='^$' -bench '^Benchmark.*' ./bindings/wasm ./middleware/http/wasm -count=6 > old.txt
$ go test -run='^$' -bench '^Benchmark.*' ./bindings/wasm ./middleware/http/wasm -count=6 > new.txt
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/dapr/components-contrib/bindings/wasm
           │   old.txt   │              new.txt              │
           │   sec/op    │   sec/op     vs base              │
Example-12   12.83µ ± 3%   11.81µ ± 2%  -7.98% (p=0.002 n=6)

pkg: github.com/dapr/components-contrib/middleware/http/wasm
                          │   old.txt   │              new.txt              │
                          │   sec/op    │   sec/op     vs base              │
Native/rewrite/rewrite-12   578.5n ± 1%   573.2n ± 0%  -0.92% (p=0.004 n=6)
Tinygo/rewrite/rewrite-12   1.173µ ± 1%   1.164µ ± 1%  -0.77% (p=0.011 n=6)
Wat/rewrite/rewrite-12      1.016µ ± 2%   1.021µ ± 4%       ~ (p=0.660 n=6)
geomean                     883.4n        879.7n       -0.42%
```