### PR TITLE
Create component metadata for secretstores.kubernetes

### DIFF
--- a/secretstores/kubernetes/metadata.yaml
+++ b/secretstores/kubernetes/metadata.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../component-metadata-schema.json
+schemaVersion: v1
+type: secretstores
+name: kubernetes
+version: v1
+status: stable
+title: "Kubernetes"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-secret-stores/kubernetes-secret-store/
+metadata: []


### PR DESCRIPTION
# Description
Create component metadata for secretstores.kubernetes.
This component seems to require no specific metadata to work so I left metadata **empty**.

## Issue reference

Please reference the issue #2586 .


