### PR TITLE
Remove pgx/stdlib import

### DIFF
--- a/internal/component/postgresql/postgresql.go
+++ b/internal/component/postgresql/postgresql.go
@@ -17,9 +17,6 @@ import (
 	"context"
 	"reflect"
 
-	// Blank import for the underlying PostgreSQL driver.
-	_ "github.com/jackc/pgx/v5/stdlib"
-
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"

--- a/tests/certification/state/cockroachdb/cockroachdb_test.go
+++ b/tests/certification/state/cockroachdb/cockroachdb_test.go
@@ -22,13 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dapr/dapr/pkg/runtime"
-	dapr_testing "github.com/dapr/dapr/pkg/testing"
-	goclient "github.com/dapr/go-sdk/client"
-	"github.com/dapr/kit/logger"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	// Blank import for the underlying PostgreSQL driver.
+	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/dapr/components-contrib/internal/component/postgresql"
 	"github.com/dapr/components-contrib/metadata"
@@ -39,6 +38,10 @@ import (
 	"github.com/dapr/components-contrib/tests/certification/flow/dockercompose"
 	"github.com/dapr/components-contrib/tests/certification/flow/sidecar"
 	state_loader "github.com/dapr/dapr/pkg/components/state"
+	"github.com/dapr/dapr/pkg/runtime"
+	dapr_testing "github.com/dapr/dapr/pkg/testing"
+	goclient "github.com/dapr/go-sdk/client"
+	"github.com/dapr/kit/logger"
 )
 
 const (

--- a/tests/certification/state/cockroachdb/go.mod
+++ b/tests/certification/state/cockroachdb/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.5-0.20230321003608-efcc1af907a7
 	github.com/google/uuid v1.3.0
+	github.com/jackc/pgx/v5 v5.3.1
 	github.com/stretchr/testify v1.8.2
 )
 
@@ -63,7 +64,6 @@ require (
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.3.1 // indirect
 	github.com/jackc/puddle/v2 v2.2.0 // indirect
 	github.com/jhump/protoreflect v1.14.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
We don't need this (it was a leftover from when we were using pgx as a db/sql driver).

Removing this is actually gonna reduce our memory footprint.