### PR TITLE
MongoDB: Detect replica sets to improve error reporting and bulk operations

### DIFF
--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package mongodb is an implementation of StateStore interface to perform operations on store
 package mongodb
-
-// mongodb package is an implementation of StateStore interface to perform operations on store
 
 import (
 	"context"
@@ -75,13 +74,15 @@ const (
 // MongoDB is a state store implementation for MongoDB.
 type MongoDB struct {
 	state.DefaultBulkStore
+
 	client           *mongo.Client
 	collection       *mongo.Collection
 	operationTimeout time.Duration
 	metadata         mongoDBMetadata
 
-	features []state.Feature
-	logger   logger.Logger
+	features     []state.Feature
+	logger       logger.Logger
+	isReplicaSet bool
 }
 
 type mongoDBMetadata struct {
@@ -117,40 +118,39 @@ func NewMongoDB(logger logger.Logger) state.Store {
 }
 
 // Init establishes connection to the store based on the metadata.
-func (m *MongoDB) Init(ctx context.Context, metadata state.Metadata) error {
-	meta, err := getMongoDBMetaData(metadata)
+func (m *MongoDB) Init(ctx context.Context, metadata state.Metadata) (err error) {
+	m.metadata, err = getMongoDBMetaData(metadata)
 	if err != nil {
 		return err
 	}
 
-	m.operationTimeout = meta.OperationTimeout
+	m.operationTimeout = m.metadata.OperationTimeout
 
-	client, err := getMongoDBClient(ctx, meta)
+	client, err := m.getMongoDBClient(ctx)
 	if err != nil {
 		return fmt.Errorf("error in creating mongodb client: %s", err)
 	}
 
 	if err = client.Ping(ctx, nil); err != nil {
-		return fmt.Errorf("error in connecting to mongodb, host: %s error: %s", meta.Host, err)
+		return fmt.Errorf("error in connecting to mongodb, host: %s error: %s", m.metadata.Host, err)
 	}
 
 	m.client = client
 
 	// get the write concern
-	wc, err := getWriteConcernObject(meta.Writeconcern)
+	wc, err := getWriteConcernObject(m.metadata.Writeconcern)
 	if err != nil {
 		return fmt.Errorf("error in getting write concern object: %s", err)
 	}
 
 	// get the read concern
-	rc, err := getReadConcernObject(meta.Readconcern)
+	rc, err := getReadConcernObject(m.metadata.Readconcern)
 	if err != nil {
 		return fmt.Errorf("error in getting read concern object: %s", err)
 	}
 
-	m.metadata = *meta
 	opts := options.Collection().SetWriteConcern(wc).SetReadConcern(rc)
-	m.collection = m.client.Database(meta.DatabaseName).Collection(meta.CollectionName, opts)
+	m.collection = m.client.Database(m.metadata.DatabaseName).Collection(m.metadata.CollectionName, opts)
 
 	// Set expireAfterSeconds index on ttl field with a value of 0 to delete
 	// values immediately when the TTL value is reached.
@@ -162,6 +162,10 @@ func (m *MongoDB) Init(ctx context.Context, metadata state.Metadata) error {
 	})
 	if err != nil {
 		return fmt.Errorf("error in creating ttl index: %s", err)
+	}
+
+	if !m.isReplicaSet {
+		m.logger.Info("Connected to MongoDB without a replica set. Transactions are not available, and the component cannot be used as actor state store.")
 	}
 
 	return nil
@@ -184,7 +188,7 @@ func (m *MongoDB) Set(ctx context.Context, req *state.SetRequest) error {
 
 func (m *MongoDB) Ping(ctx context.Context) error {
 	if err := m.client.Ping(ctx, nil); err != nil {
-		return fmt.Errorf("mongoDB store: error connecting to mongoDB at %s: %s", m.metadata.Host, err)
+		return fmt.Errorf("error connecting to mongoDB at %s: %s", m.metadata.Host, err)
 	}
 
 	return nil
@@ -356,21 +360,65 @@ func (m *MongoDB) deleteInternal(ctx context.Context, req *state.DeleteRequest) 
 	return nil
 }
 
-// Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail.
-func (m *MongoDB) Multi(ctx context.Context, request *state.TransactionalStateRequest) error {
-	sess, err := m.client.StartSession()
-	txnOpts := options.Transaction().SetReadConcern(readconcern.Snapshot()).
-		SetWriteConcern(writeconcern.New(writeconcern.WMajority()))
-
-	defer sess.EndSession(ctx)
-
-	if err != nil {
-		return fmt.Errorf("error in starting the transaction: %s", err)
+// BulkSet performs a bulk save operation.
+// We need to implement a custom BulkSet/BulkDelete because with MongoDB transactions are not always available (only when connecting to a replica set), and when they're not, we need to fall back to performing operations in sequence.
+func (m *MongoDB) BulkSet(ctx context.Context, req []state.SetRequest) error {
+	// Use transactions if we can
+	if m.isReplicaSet {
+		return m.Multi(ctx, &state.TransactionalStateRequest{
+			Operations: state.ToTransactionalStateOperationSlice(state.Upsert, req),
+		})
 	}
 
+	// Fallback to executing all operations in sequence
+	for i := range req {
+		err := m.Set(ctx, &req[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BulkDelete performs a bulk delete operation.
+// We need to implement a custom BulkSet/BulkDelete because with MongoDB transactions are not always available (only when connecting to a replica set), and when they're not, we need to fall back to performing operations in sequence.
+func (m *MongoDB) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
+	// Use transactions if we can
+	if m.isReplicaSet {
+		return m.Multi(ctx, &state.TransactionalStateRequest{
+			Operations: state.ToTransactionalStateOperationSlice(state.Delete, req),
+		})
+	}
+
+	// Fallback to executing all operations in sequence
+	for i := range req {
+		err := m.Delete(ctx, &req[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail.
+func (m *MongoDB) Multi(ctx context.Context, request *state.TransactionalStateRequest) error {
+	if !m.isReplicaSet {
+		return errors.New("using transactions with MongoDB requires connecting to a replica set")
+	}
+
+	sess, err := m.client.StartSession()
+	if err != nil {
+		return fmt.Errorf("error starting the transaction: %w", err)
+	}
+	defer sess.EndSession(ctx)
+
+	txnOpts := options.Transaction().
+		SetReadConcern(readconcern.Snapshot()).
+		SetWriteConcern(writeconcern.New(writeconcern.WMajority()))
 	sess.WithTransaction(ctx, func(sessCtx mongo.SessionContext) (interface{}, error) {
 		err = m.doTransaction(sessCtx, request.Operations)
-
 		return nil, err
 	}, txnOpts)
 
@@ -390,8 +438,7 @@ func (m *MongoDB) doTransaction(sessCtx mongo.SessionContext, operations []state
 
 		if err != nil {
 			sessCtx.AbortTransaction(sessCtx)
-
-			return fmt.Errorf("error during transaction, aborting the transaction: %s", err)
+			return fmt.Errorf("error during transaction, aborting the transaction: %w", err)
 		}
 	}
 
@@ -416,7 +463,7 @@ func (m *MongoDB) Query(ctx context.Context, req *state.QueryRequest) (*state.Qu
 	}, nil
 }
 
-func getMongoConnectionString(metadata *mongoDBMetadata) string {
+func (metadata *mongoDBMetadata) getMongoConnectionString() string {
 	if metadata.ConnectionString != "" {
 		return metadata.ConnectionString
 	}
@@ -436,14 +483,15 @@ func getMongoConnectionString(metadata *mongoDBMetadata) string {
 	return fmt.Sprintf(connectionURIFormat, metadata.Host, metadata.DatabaseName, metadata.Params)
 }
 
-func getMongoDBClient(ctx context.Context, metadata *mongoDBMetadata) (*mongo.Client, error) {
-	uri := getMongoConnectionString(metadata)
+func (m *MongoDB) getMongoDBClient(ctx context.Context) (*mongo.Client, error) {
+	uri := m.metadata.getMongoConnectionString()
 
 	// Set client options
 	clientOptions := options.Client().ApplyURI(uri)
+	m.isReplicaSet = clientOptions.ReplicaSet != nil
 
 	// Connect to MongoDB
-	ctx, cancel := context.WithTimeout(ctx, metadata.OperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, m.metadata.OperationTimeout)
 	defer cancel()
 
 	daprUserAgent := "dapr-" + logger.DaprVersion
@@ -461,7 +509,7 @@ func getMongoDBClient(ctx context.Context, metadata *mongoDBMetadata) (*mongo.Cl
 	return client, nil
 }
 
-func getMongoDBMetaData(meta state.Metadata) (*mongoDBMetadata, error) {
+func getMongoDBMetaData(meta state.Metadata) (mongoDBMetadata, error) {
 	m := mongoDBMetadata{
 		DatabaseName:     defaultDatabaseName,
 		CollectionName:   defaultCollectionName,
@@ -470,16 +518,16 @@ func getMongoDBMetaData(meta state.Metadata) (*mongoDBMetadata, error) {
 
 	decodeErr := metadata.DecodeMetadata(meta.Properties, &m)
 	if decodeErr != nil {
-		return nil, decodeErr
+		return m, decodeErr
 	}
 
 	if m.ConnectionString == "" {
 		if len(m.Host) == 0 && len(m.Server) == 0 {
-			return nil, errors.New("must set 'host' or 'server' fields in metadata")
+			return m, errors.New("must set 'host' or 'server' fields in metadata")
 		}
 
 		if len(m.Host) != 0 && len(m.Server) != 0 {
-			return nil, errors.New("'host' or 'server' fields are mutually exclusive")
+			return m, errors.New("'host' or 'server' fields are mutually exclusive")
 		}
 	}
 
@@ -487,11 +535,11 @@ func getMongoDBMetaData(meta state.Metadata) (*mongoDBMetadata, error) {
 	if val, ok := meta.Properties[operationTimeout]; ok && val != "" {
 		m.OperationTimeout, err = time.ParseDuration(val)
 		if err != nil {
-			return nil, errors.New("incorrect operationTimeout field from metadata")
+			return m, errors.New("incorrect operationTimeout field from metadata")
 		}
 	}
 
-	return &m, nil
+	return m, nil
 }
 
 func getWriteConcernObject(cn string) (*writeconcern.WriteConcern, error) {

--- a/state/mongodb/mongodb_test.go
+++ b/state/mongodb/mongodb_test.go
@@ -87,7 +87,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoConnectionString(metadata)
+		uri := metadata.getMongoConnectionString()
 		expected := "mongodb://username:password@127.0.0.2/TestDB"
 
 		assert.Equal(t, expected, uri)
@@ -106,7 +106,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoConnectionString(metadata)
+		uri := metadata.getMongoConnectionString()
 		expected := "mongodb://localhost:27017/TestDB"
 
 		assert.Equal(t, expected, uri)
@@ -128,7 +128,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoConnectionString(metadata)
+		uri := metadata.getMongoConnectionString()
 		expected := "mongodb://username:password@127.0.0.2/TestDB?ssl=true"
 
 		assert.Equal(t, expected, uri)
@@ -148,7 +148,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoConnectionString(metadata)
+		uri := metadata.getMongoConnectionString()
 		expected := "mongodb+srv://server.example.com/?ssl=true"
 
 		assert.Equal(t, expected, uri)
@@ -202,7 +202,7 @@ func TestGetMongoDBMetadata(t *testing.T) {
 		metadata, err := getMongoDBMetaData(m)
 		assert.Nil(t, err)
 
-		uri := getMongoConnectionString(metadata)
+		uri := metadata.getMongoConnectionString()
 		expected := "mongodb://localhost:99999/UnchanedDB"
 
 		assert.Equal(t, expected, uri)

--- a/state/store.go
+++ b/state/store.go
@@ -100,3 +100,15 @@ func (b *DefaultBulkStore) BulkDelete(ctx context.Context, req []DeleteRequest) 
 type Querier interface {
 	Query(ctx context.Context, req *QueryRequest) (*QueryResponse, error)
 }
+
+// ToTransactionalStateOperationSlice converts []SetRequest and []DeleteRequest to []TransactionalStateOperation.
+func ToTransactionalStateOperationSlice[T SetRequest | DeleteRequest](operation OperationType, req []T) []TransactionalStateOperation {
+	ops := make([]TransactionalStateOperation, len(req))
+	for i, r := range req {
+		ops[i] = TransactionalStateOperation{
+			Operation: operation,
+			Request:   r,
+		}
+	}
+	return ops
+}


### PR DESCRIPTION
Changes the MongoDB state store to detect if it's connected to a replica set.

- When performing BulkSet or BulkDelete operations and connected to a replica set, uses a transaction to perform the operations more correctly (atomically) and faster
- When performing transactions, return an error if not connected to a replica set (the operation would fail, but this short-circuits the effort)