### PR TITLE
Fix vault prefix empty

### DIFF
--- a/secretstores/hashicorp/vault/vault.go
+++ b/secretstores/hashicorp/vault/vault.go
@@ -221,9 +221,9 @@ func (v *vaultSecretStore) getSecret(ctx context.Context, secret, version string
 	// Create get secret url
 	var vaultSecretPathAddr string
 	if v.vaultKVPrefix == "" {
-		vaultSecretPathAddr = fmt.Sprintf("%s/v1/%s/data/%s?version=%s", v.vaultAddress, v.vaultEnginePath, secret, version)
+		vaultSecretPathAddr = v.vaultAddress + "/v1/" + v.vaultEnginePath + "/data/" + secret + "?version=" + version
 	} else {
-		vaultSecretPathAddr = fmt.Sprintf("%s/v1/%s/data/%s/%s?version=%s", v.vaultAddress, v.vaultEnginePath, v.vaultKVPrefix, secret, version)
+		vaultSecretPathAddr = v.vaultAddress + "/v1/" + v.vaultEnginePath + "/data/" + v.vaultKVPrefix + "/" + secret + "?version=" + version
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, vaultSecretPathAddr, nil)

--- a/secretstores/hashicorp/vault/vault.go
+++ b/secretstores/hashicorp/vault/vault.go
@@ -219,7 +219,12 @@ func metadataToTLSConfig(meta *VaultMetadata) *tlsConfig {
 // GetSecret retrieves a secret using a key and returns a map of decrypted string/string values.
 func (v *vaultSecretStore) getSecret(ctx context.Context, secret, version string) (*vaultKVResponse, error) {
 	// Create get secret url
-	vaultSecretPathAddr := fmt.Sprintf("%s/v1/%s/data/%s/%s?version=%s", v.vaultAddress, v.vaultEnginePath, v.vaultKVPrefix, secret, version)
+	var vaultSecretPathAddr string
+	if v.vaultKVPrefix == "" {
+		vaultSecretPathAddr = fmt.Sprintf("%s/v1/%s/data/%s?version=%s", v.vaultAddress, v.vaultEnginePath, secret, version)
+	} else {
+		vaultSecretPathAddr = fmt.Sprintf("%s/v1/%s/data/%s/%s?version=%s", v.vaultAddress, v.vaultEnginePath, v.vaultKVPrefix, secret, version)
+	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, vaultSecretPathAddr, nil)
 	if err != nil {


### PR DESCRIPTION
# Description

Tiny fix when vault kv prefix is empty, found this when debugging #2711. When disables the `vaultKVUsePrefix`, formatting a URL like `http://localhost:8200/v1/secret/data//mysecret` will cause a redirect to `http://localhost:8200/v1/secret/data/mysecret`, which means sending 2 requests every time getting a secret.


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
