### PR TITLE
disable featureTransactional in alicloud tablestore statae backend

### DIFF
--- a/state/alicloud/tablestore/tablestore.go
+++ b/state/alicloud/tablestore/tablestore.go
@@ -49,7 +49,7 @@ type tablestoreMetadata struct {
 
 func NewAliCloudTableStore(logger logger.Logger) state.Store {
 	return &AliCloudTableStore{
-		features: []state.Feature{state.FeatureETag, state.FeatureTransactional},
+		features: []state.Feature{state.FeatureETag},
 		logger:   logger,
 	}
 }


### PR DESCRIPTION
# Description

Currently, the Alicloud table store state backend did not implement the interface related to `state.FeatureTransactional` feature, causing Dapr to fail to launch.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/6138

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
