### PR TITLE
Increase code_cov retention time

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -306,7 +306,7 @@ jobs:
       with:
         name: cert_code_cov
         path: ${{ env.TEST_PATH }}/tmp/cert_code_cov_files
-        retention-days: 1
+        retention-days: 7
 
     - name: Prepare test result info
       if: always()

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -349,6 +349,7 @@ jobs:
       with:
         name: conf_code_cov
         path: tmp/conf_code_cov
+        retention-days: 7
 
     # Upload logs for test analytics to consume
     - name: Upload test results


### PR DESCRIPTION
# Description

The coverage reports workflow runs weekly and uses the conformance and certification test coverage of last successful run. But currently the retention days of the reports published is set to 1, and so if all scheduled runs of cert or conf failed one day before running the coverage reports workflow(scheduled cert tests have been failing too much recently: https://github.com/dapr/components-contrib/actions/workflows/certification.yml?query=event%3Aschedule) , it fails. e.g. run: https://github.com/dapr/components-contrib/actions/runs/4585905816/jobs/8098332455

The PR increases the retention days to 7 so that it picks up any scheduled successful run in last 7 days.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
