### PR TITLE
Fixes MS SQL TTL not working

### DIFF
--- a/internal/component/sql/cleanup.go
+++ b/internal/component/sql/cleanup.go
@@ -237,7 +237,7 @@ func (g *gc) updateLastCleanup(ctx context.Context) (bool, error) {
 	} else {
 		// Use named parameters if we need to
 		if g.ulcqParamName != "" {
-			param = sql.Named("Interval", param)
+			param = sql.Named(g.ulcqParamName, param)
 		}
 		res, err := g.dbSQL.ExecContext(ctx, g.updateLastCleanupQuery, param)
 		if err != nil {

--- a/internal/component/sql/cleanup.go
+++ b/internal/component/sql/cleanup.go
@@ -41,6 +41,12 @@ type GCOptions struct {
 	// The caller will check the nuber of affected rows. If zero, it assumes that the GC has ran too recently, and will not proceed to delete expired records.
 	// The query receives one parameter that is the last cleanup interval, in milliseconds.
 	UpdateLastCleanupQuery string
+
+	// Name of the parameter passed to the UpdateLeastCleanupQuery query, to use named parameters (via `sql.Named`). The parameter is the time interval.
+	// If empty, assumes the parameter is positional and not named.
+	// This is ignored when using the pgx querier.
+	UpdateLastCleanupQueryParameterName string
+
 	// Query that performs the cleanup of all expired rows.
 	DeleteExpiredValuesQuery string
 
@@ -68,6 +74,7 @@ type DatabaseSQLConn interface {
 type gc struct {
 	log                      logger.Logger
 	updateLastCleanupQuery   string
+	ulcqParamName            string
 	deleteExpiredValuesQuery string
 	cleanupInterval          time.Duration
 	dbPgx                    PgxConn
@@ -93,6 +100,7 @@ func ScheduleGarbageCollector(opts GCOptions) (GarbageCollector, error) {
 	gc := &gc{
 		log:                      opts.Logger,
 		updateLastCleanupQuery:   opts.UpdateLastCleanupQuery,
+		ulcqParamName:            opts.UpdateLastCleanupQueryParameterName,
 		deleteExpiredValuesQuery: opts.DeleteExpiredValuesQuery,
 		cleanupInterval:          opts.CleanupInterval,
 		dbPgx:                    opts.DBPgx,
@@ -216,15 +224,22 @@ func (g *gc) CleanupExpired() error {
 // Returns true if the row was updated, which means that the cleanup can proceed.
 func (g *gc) updateLastCleanup(ctx context.Context) (bool, error) {
 	var n int64
+	// Query parameter: interval in ms
 	// Subtract 100ms for some buffer
+	var param any = (g.cleanupInterval.Milliseconds() - 100)
+
 	if g.dbPgx != nil {
-		res, err := g.dbPgx.Exec(ctx, g.updateLastCleanupQuery, g.cleanupInterval.Milliseconds()-100)
+		res, err := g.dbPgx.Exec(ctx, g.updateLastCleanupQuery, param)
 		if err != nil {
 			return false, fmt.Errorf("error updating last cleanup time: %w", err)
 		}
 		n = res.RowsAffected()
 	} else {
-		res, err := g.dbSQL.ExecContext(ctx, g.updateLastCleanupQuery, g.cleanupInterval.Milliseconds()-100)
+		// Use named parameters if we need to
+		if g.ulcqParamName != "" {
+			param = sql.Named("Interval", param)
+		}
+		res, err := g.dbSQL.ExecContext(ctx, g.updateLastCleanupQuery, param)
 		if err != nil {
 			return false, fmt.Errorf("error updating last cleanup time: %w", err)
 		}

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -209,9 +209,10 @@ BEGIN TRY
   INSERT INTO [%[1]s].[%[2]s] ([Key], [Value]) VALUES ('last-cleanup', CONVERT(nvarchar(MAX), GETDATE(), 21));
 END TRY
 BEGIN CATCH
-UPDATE [%[1]s].[%[2]s] SET [Value] = CONVERT(nvarchar(MAX), GETDATE(), 21) WHERE [Key] = 'last-cleanup' AND Datediff_big(MS, [Value], GETUTCDATE()) > @Interval
+  UPDATE [%[1]s].[%[2]s] SET [Value] = CONVERT(nvarchar(MAX), GETDATE(), 21) WHERE [Key] = 'last-cleanup' AND Datediff_big(MS, [Value], GETUTCDATE()) > @Interval
 END CATCH
 COMMIT TRANSACTION;`, s.schema, s.metaTableName),
+			UpdateLastCleanupQueryParameterName: "Interval",
 			DeleteExpiredValuesQuery: fmt.Sprintf(
 				`DELETE FROM [%s].[%s] WHERE [ExpireDate] IS NOT NULL AND [ExpireDate] < GETDATE()`,
 				s.schema, s.tableName,


### PR DESCRIPTION
MS SQL requires parameters in the query to be named, while MySQL wants them positional. This changes the internal/component/sql package to support both.

Fixes our cert tests not working in master at the moment: https://github.com/dapr/components-contrib/actions/runs/4610099241