### PR TITLE
Env secret store: add "prefix" metadata option (+ metadata.yaml)

### DIFF
--- a/secretstores/local/env/envstore_test.go
+++ b/secretstores/local/env/envstore_test.go
@@ -151,6 +151,8 @@ func TestEnvStoreWithPrefix(t *testing.T) {
 					"prefix": "DAPR_",
 				}},
 			})
+			require.NoError(t, err)
+
 			resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{
 				Name: "API_TOKEN",
 			})

--- a/secretstores/local/env/envstore_test.go
+++ b/secretstores/local/env/envstore_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Dapr Authors
+Copyright 2023 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package env
 
 import (
@@ -22,18 +23,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/kit/logger"
 )
 
 func TestEnvStore(t *testing.T) {
-	secret := "secret1"
-	key := "TEST_SECRET"
-
 	s := envSecretStore{logger: logger.NewLogger("test")}
 
-	t.Setenv(key, secret)
-	require.Equal(t, secret, os.Getenv(key))
+	t.Setenv("TEST_SECRET", "secret1")
+	require.Equal(t, "secret1", os.Getenv("TEST_SECRET"))
 
 	t.Run("Init", func(t *testing.T) {
 		err := s.Init(context.Background(), secretstores.Metadata{})
@@ -41,30 +40,31 @@ func TestEnvStore(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		err := s.Init(context.Background(), secretstores.Metadata{})
-		require.NoError(t, err)
-		resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{Name: key})
+		resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{Name: "TEST_SECRET"})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, secret, resp.Data[key])
+		assert.Equal(t, "secret1", resp.Data["TEST_SECRET"])
+	})
+
+	t.Run("Get case sensitive", func(t *testing.T) {
+		resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{Name: "test_secret"})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Data["test_secret"])
 	})
 
 	t.Run("Bulk get", func(t *testing.T) {
-		err := s.Init(context.Background(), secretstores.Metadata{})
-		require.NoError(t, err)
 		resp, err := s.BulkGetSecret(context.Background(), secretstores.BulkGetSecretRequest{})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, secret, resp.Data[key][key])
+		assert.Equal(t, "secret1", resp.Data["TEST_SECRET"]["TEST_SECRET"])
 	})
 
 	t.Run("Disallowed keys", func(t *testing.T) {
 		t.Setenv("APP_API_TOKEN", "ciao")
 		t.Setenv("DAPR_API_TOKEN", "mondo")
+		t.Setenv("dapr_notallowed", "notallowed")
 		t.Setenv("FOO", "bar")
-
-		err := s.Init(context.Background(), secretstores.Metadata{})
-		require.NoError(t, err)
 
 		t.Run("Get", func(t *testing.T) {
 			resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{
@@ -73,6 +73,20 @@ func TestEnvStore(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp.Data)
 			assert.Empty(t, resp.Data["APP_API_TOKEN"])
+
+			resp, err = s.GetSecret(context.Background(), secretstores.GetSecretRequest{
+				Name: "dapr_notallowed",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp.Data)
+			assert.Empty(t, resp.Data["dapr_notallowed"])
+
+			resp, err = s.GetSecret(context.Background(), secretstores.GetSecretRequest{
+				Name: "DAPR_NOTALLOWED",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp.Data)
+			assert.Empty(t, resp.Data["DAPR_NOTALLOWED"])
 		})
 
 		t.Run("Bulk get", func(t *testing.T) {
@@ -81,7 +95,75 @@ func TestEnvStore(t *testing.T) {
 			require.NotNil(t, resp.Data)
 			assert.Empty(t, resp.Data["APP_API_TOKEN"])
 			assert.Empty(t, resp.Data["DAPR_API_TOKEN"])
+			assert.Empty(t, resp.Data["DAPR_NOTALLOWED"])
 			assert.Equal(t, "bar", resp.Data["FOO"]["FOO"])
+		})
+	})
+}
+
+func TestEnvStoreWithPrefix(t *testing.T) {
+	s := envSecretStore{logger: logger.NewLogger("test")}
+
+	t.Setenv("TEST_SECRET", "test1")
+	t.Setenv("test_secret2", "test2")
+	t.Setenv("FOO_SECRET", "foo1")
+	require.Equal(t, "test1", os.Getenv("TEST_SECRET"))
+	require.Equal(t, "test2", os.Getenv("test_secret2"))
+	require.Equal(t, "foo1", os.Getenv("FOO_SECRET"))
+
+	t.Run("Get", func(t *testing.T) {
+		err := s.Init(context.Background(), secretstores.Metadata{
+			Base: metadata.Base{Properties: map[string]string{
+				// Prefix should be case-sensitive
+				"prefix": "TEST_",
+			}},
+		})
+		require.NoError(t, err)
+
+		resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{Name: "SECRET"})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Len(t, resp.Data, 1)
+		assert.Equal(t, "test1", resp.Data["SECRET"])
+	})
+
+	t.Run("Bulk get", func(t *testing.T) {
+		err := s.Init(context.Background(), secretstores.Metadata{
+			Base: metadata.Base{Properties: map[string]string{
+				"prefix": "TEST_",
+			}},
+		})
+		require.NoError(t, err)
+
+		resp, err := s.BulkGetSecret(context.Background(), secretstores.BulkGetSecretRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Len(t, resp.Data, 1)
+		assert.Equal(t, "test1", resp.Data["SECRET"]["SECRET"])
+	})
+
+	t.Run("Disallowed keys", func(t *testing.T) {
+		t.Setenv("DAPR_API_TOKEN", "hi")
+
+		t.Run("Get", func(t *testing.T) {
+			err := s.Init(context.Background(), secretstores.Metadata{
+				Base: metadata.Base{Properties: map[string]string{
+					"prefix": "DAPR_",
+				}},
+			})
+			resp, err := s.GetSecret(context.Background(), secretstores.GetSecretRequest{
+				Name: "API_TOKEN",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp.Data)
+			assert.Empty(t, resp.Data["API_TOKEN"])
+		})
+
+		t.Run("Bulk get", func(t *testing.T) {
+			resp, err := s.BulkGetSecret(context.Background(), secretstores.BulkGetSecretRequest{})
+			require.NoError(t, err)
+			require.NotNil(t, resp.Data)
+			assert.Empty(t, resp.Data["API_TOKEN"])
 		})
 	})
 }

--- a/secretstores/local/env/metadata.yaml
+++ b/secretstores/local/env/metadata.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../../component-metadata-schema.json
+schemaVersion: v1
+type: secretstores
+name: local.env
+version: v1
+status: stable
+title: "Local environment variables"
+urls:
+  - title: Reference
+    url: "https://docs.dapr.io/reference/components-reference/supported-secret-stores/envvar-secret-store/"
+metadata:
+  - name: prefix
+    description: |
+      If set, limits operations to environmental variables with the given prefix. The prefix is case-sensitive and is removed from the returned secrets' names.
+    example: '"MYAPP_"'
+    type: string


### PR DESCRIPTION
Adds a new option to the Local Env secret store to limit operations to keys with a given prefix.

For example, if the component is initialized with the metadata `prefix="MYAPP_"`, then:

- `Get` with key `FOO` will look for `MYAPP_FOO`. The result will be still returned as `FOO` (i.e. the prefix name is removed from the returned values)
- `GetBulk` will only return env vars with the prefix `MYAPP_` (which is stripped from the returned value)

Also included:

1. Added `metadata.yaml` for the component
2. The denylist now denies every secret that starts with `DAPR_` (after resolving the prefix), for future-proofing the component.

Tests have been included in the unit tests for the component

Docs issue: dapr/docs#3329