### PR TITLE
fixup: even numbers must be strings in metadata

### DIFF
--- a/state/azure/blobstorage/metadata.yaml
+++ b/state/azure/blobstorage/metadata.yaml
@@ -80,8 +80,8 @@ metadata:
     # getBlobRetryCount is a deprecated alias for this field
     type: number
     required: false
-    default: 3
-    example: 3
+    default: "3"
+    example: "3"
     description: |
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.


### PR DESCRIPTION
# Description

FYI @tmacam - this fixes up your metadata contribution.

cc @ItalyPaleAle

The command `make bundle-component-metadata` did not work because the number value was a number and not a string of a number.