### PR TITLE
fix postgres error handling for upsert with etag

### DIFF
--- a/internal/component/postgresql/postgresdbaccess.go
+++ b/internal/component/postgresql/postgresdbaccess.go
@@ -216,13 +216,12 @@ func (p *PostgresDBAccess) doSet(parentCtx context.Context, db dbquerier, req *s
 
 	result, err := db.Exec(parentCtx, query, params...)
 	if err != nil {
-		if req.ETag != nil && *req.ETag != "" {
-			return state.NewETagError(state.ETagMismatch, err)
-		}
 		return err
 	}
-
 	if result.RowsAffected() != 1 {
+		if req.ETag != nil && *req.ETag != "" {
+			return state.NewETagError(state.ETagMismatch, nil)
+		}
 		return errors.New("no item was updated")
 	}
 

--- a/tests/certification/state/cockroachdb/cockroachdb_test.go
+++ b/tests/certification/state/cockroachdb/cockroachdb_test.go
@@ -138,7 +138,7 @@ func TestCockroach(t *testing.T) {
 		return nil
 	}
 
-	//ETag test
+	// ETag test
 	eTagTest := func(ctx flow.Context) error {
 		etag1 := "1"
 		etag100 := "100"
@@ -156,14 +156,14 @@ func TestCockroach(t *testing.T) {
 			Value: "v3",
 			ETag:  &etag100,
 		})
-		assert.Equal(t, fmt.Errorf("no item was updated"), err)
+		assert.Equal(t, state.NewETagError(state.ETagMismatch, nil), err)
 
 		resp, err := stateStore.Get(context.Background(), &state.GetRequest{
 			Key: keyOneString,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, etag1, *resp.ETag)           //1 is returned since the default when the new data is written is a value of 1
-		assert.Equal(t, "\"v1\"", string(resp.Data)) //v1 is returned since it was the only item successfully inserted with the key of keyOneString
+		assert.Equal(t, etag1, *resp.ETag)           // 1 is returned since the default when the new data is written is a value of 1
+		assert.Equal(t, "\"v1\"", string(resp.Data)) // v1 is returned since it was the only item successfully inserted with the key of keyOneString
 
 		// This will update the value stored in key K with "Overwrite Success" since the previously created etag has a value of 1
 		// It will also increment the etag stored by a value of 1
@@ -178,7 +178,7 @@ func TestCockroach(t *testing.T) {
 			Key: keyOneString,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, "2", *resp.ETag) //2 is returned since the previous etag value of "1" was incremented by 1 when the update occurred
+		assert.Equal(t, "2", *resp.ETag) // 2 is returned since the previous etag value of "1" was incremented by 1 when the update occurred
 		assert.Equal(t, "\"Overwrite Success\"", string(resp.Data))
 
 		return nil


### PR DESCRIPTION
# Description

Fixes #2773

During upsert with etag, if no DB error is returned and rows affected is 0 an ETAG Mismatch error should be thrown.

This fixes that.