### PR TITLE
Adds new property "deprecated" to Metadata schema.

### DIFF
--- a/.build-tools/pkg/metadataschema/schema.go
+++ b/.build-tools/pkg/metadataschema/schema.go
@@ -99,6 +99,8 @@ type Metadata struct {
 	Binding *MetadataBinding `json:"binding,omitempty"`
 	// URL with additional information, such as docs.
 	URL *URL `json:"url,omitempty"`
+	// If set, specifies that the property is deprecated and should not be used in new configurations.
+	Deprecated bool `json:"deprecated,omitempty"`
 }
 
 // MetadataBinding is the type for the "binding" property in the "metadata" object.

--- a/component-metadata-schema.json
+++ b/component-metadata-schema.json
@@ -143,6 +143,10 @@
         "url": {
           "$ref": "#/$defs/URL",
           "description": "URL with additional information, such as docs."
+        },
+        "deprecated": {
+          "type": "boolean",
+          "description": "If set, specifies that the property is deprecated and should not be used in new configurations."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# Description

We noticed the need for a better way of flagging deprecated properties
in metadata.yaml files other than adding "Deprecated" to their
`description`s. This is also helps when working with properties
that have aliases by marking undesired aliases as `deprecated`,
thus helping convergence to the preferred property names.

## Issue reference

Related to PR #2784

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
