### PR TITLE
Metadata YAML for state.mysql and metadata parsing improvement.

### DIFF
--- a/state/mysql/metadata.yaml
+++ b/state/mysql/metadata.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=../../component-metadata-schema.json
+schemaVersion: v1
+type: state
+name: mysql
+version: v1
+status: stable
+title: "MySQL"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-state-stores/setup-mysql/
+capabilities:
+  # If actorStateStore is present, the metadata key actorStateStore can be used
+  - actorStateStore
+  - crud
+  - transactional
+  - etag
+authenticationProfiles:
+  - title: "Connection string"
+    description: |
+      Authenticate using a connetion string.
+    metadata:
+      - name: connectionString
+        required: true
+        description: |
+          The connection string to connect to MySQL. Do not add the schema to the connection string.
+        example: '""<user>:<password>@tcp(<server>:3306)/?allowNativePasswords=true&tls=custom""'
+metadata:
+  - name: cleanupInterval
+    description: "Interval at which entries with TTL are cleaned up."
+    type: duration
+    default: "1h"
+    example: "20m"
+    # We do not expose TTL as a feature, but we have cleanupInterval :)
+  - name: metadataTableName
+    description: "Name of the table Dapr uses to store a few metadata properties"
+    type: string
+    default: "dapr_metadata"
+  - name: pemPath
+    description: |
+      Full path to the PEM file to use for enforced SSL Connection.
+    type: string
+    example: '"/path/to/file.pem" '
+    # Docs mention "pemContents" but there is no mention of this metadata in the code
+    # in this whole repository
+  - name: schemaName
+    description: "The schema name to use. Will be created if schema does not exist."
+    type: string
+    default: "dapr_state_store"
+    example: '"custom_schema"'
+  - name: tableName
+    description: "The table name to use. Will be created if table does not exist."
+    type: string
+    default: "state"
+    example: '"table_name"'
+  - name: timeoutInSeconds
+    description: "Timeout for all database operations (in seconds)."
+    type: number
+    default: "20"
+    example: "30"

--- a/state/mysql/metadata.yaml
+++ b/state/mysql/metadata.yaml
@@ -23,7 +23,7 @@ authenticationProfiles:
         required: true
         description: |
           The connection string to connect to MySQL. Do not add the schema to the connection string.
-        example: '""<user>:<password>@tcp(<server>:3306)/?allowNativePasswords=true&tls=custom""'
+        example: '"<user>:<password>@tcp(<server>:3306)/?allowNativePasswords=true&tls=custom"'
 metadata:
   - name: cleanupInterval
     description: "Interval at which entries with TTL are cleaned up."

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -38,9 +38,6 @@ import (
 // Optimistic Concurrency is implemented using a string column that stores a UUID.
 
 const (
-	// The key name in the metadata for the timeout of operations, in seconds.
-	keyTimeoutInSeconds = "timeoutInSeconds"
-
 	// To connect to MySQL running in Azure over SSL you have to download a
 	// SSL certificate. If this is provided the driver will connect using
 	// SSL. If you have disable SSL you can leave this empty.
@@ -97,7 +94,7 @@ type mySQLMetadata struct {
 	TableName         string
 	SchemaName        string
 	ConnectionString  string
-	Timeout           int
+	TimeoutInSeconds  int
 	PemPath           string
 	MetadataTableName string
 	CleanupInterval   *time.Duration
@@ -213,14 +210,9 @@ func (m *MySQL) parseMetadata(md map[string]string) error {
 		}
 	}
 
-	val, ok := md[keyTimeoutInSeconds]
-	if ok && val != "" {
-		n, err := strconv.Atoi(val)
-		if err == nil && n > 0 {
-			m.timeout = time.Duration(n) * time.Second
-		}
-	}
-	if m.timeout <= 0 {
+	if meta.TimeoutInSeconds > 0 {
+		m.timeout = time.Duration(meta.TimeoutInSeconds) * time.Second
+	} else {
 		m.timeout = time.Duration(defaultTimeoutInSeconds) * time.Second
 	}
 


### PR DESCRIPTION
# Description

Metadata YAML for state.mysql and metadata parsing improvement.


* Improves metadata parsing by avoiding indirection on parsing of
  `timeoutInSeconds` and adding it directly in the metadata struct.
  Before we had a `Time` field that wasn't used and was causing
  validation problems with `make check-component-metadata`


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
