### PR TITLE
Point certification tests to latest dapr/dapr

### DIFF
--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cloudwego/kitex v0.5.0
 	github.com/cloudwego/kitex-examples v0.1.1
-	github.com/dapr/components-contrib v1.10.6-0.20230419230437-7099066436ee
-	github.com/dapr/dapr v1.10.5-rc.1.0.20230404115414-eed80024b415
+	github.com/dapr/components-contrib v1.10.6-0.20230426221256-e099a548fbb5
+	github.com/dapr/dapr v1.10.5-rc.1.0.20230430203526-7a0fdf9f016b
 	github.com/dapr/go-sdk v1.7.0
 	github.com/dapr/kit v0.0.5-0.20230418193628-15a7040dec41
 	github.com/eclipse/paho.mqtt.golang v1.4.2
@@ -312,5 +312,3 @@ require (
 )
 
 replace github.com/dapr/components-contrib => ../../
-
-replace github.com/dapr/dapr => github.com/cgillum/dapr v0.8.1-0.20230424162247-11bd4e3b1457

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -249,8 +249,6 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cgillum/dapr v0.8.1-0.20230424162247-11bd4e3b1457 h1:pywebUtl08YDm3Hhqrsplf7/GxierKhpeTDVXBnmhLM=
-github.com/cgillum/dapr v0.8.1-0.20230424162247-11bd4e3b1457/go.mod h1:YHVKBaXLMqSEfXgP9XJUKbxtS/u8P/Y0ASA4HihJ72w=
 github.com/chebyrash/promise v0.0.0-20220530143319-1123826567d6 h1:AtcTeZIfucJjiqhIeMoOAR292ti2QOyo2aqN3SoWopo=
 github.com/chebyrash/promise v0.0.0-20220530143319-1123826567d6/go.mod h1:4DRxP3p0R7/5msq1uKcI1THYmfWgFXxQqr0DutaIAEk=
 github.com/chenzhuoyu/iasm v0.0.0-20220818063314-28c361dae733/go.mod h1:wOQ0nsbeOLa2awv8bUYFW/EHXbjQMlZ10fAlXDB2sz8=
@@ -342,6 +340,8 @@ github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
+github.com/dapr/dapr v1.10.5-rc.1.0.20230430203526-7a0fdf9f016b h1:+6TVW2t2GveAxqVNSOezU2fUJVec5MCS5J/MXycfwFs=
+github.com/dapr/dapr v1.10.5-rc.1.0.20230430203526-7a0fdf9f016b/go.mod h1:o/M7becq2NE4unx2v3Hv6vq2DrLmUQx5Knkn+6QTkY4=
 github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
 github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
 github.com/dapr/kit v0.0.5-0.20230418193628-15a7040dec41 h1:G55KmJAn2UsJm2+T0Vyz8gPcbphDe1PvjrES18JxfHQ=


### PR DESCRIPTION
# Description

Updating the certification tests to point to the latest commits in dapr/dapr, now that the set of features for v1.11 is stabilized.

## Issue reference

N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] ~Created/updated tests~ N/A
* [x] ~Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~ N/A
