### PR TITLE
Update Go SDK version in certification tests

### DIFF
--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -31,7 +31,7 @@ authenticationProfiles:
         example:  "KeFg23!"
         default: ""
 metadata:
- - name: redisHost
+  - name: redisHost
     required: true
     description: Connection-string for the Redis host
     example: "redis-master.default.svc.cluster.local:6379"

--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -9,129 +9,166 @@ urls:
   - title: Reference
     url: https://docs.dapr.io/reference/components-reference/supported-configuration-stores/redis-configuration-store/
 capabilities: []
+authenticationProfiles:
+  - title: "Username and password"
+    description: "Authenticate using username and password."
+    metadata:
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username for Redis host. Defaults to empty. Make sure your Redis server
+          version is 6 or above, and have created ACL rule correctly.
+        example:  "my-username"
+        default: ""
+      - name: redisPassword
+        type: string
+        required: false
+        sensitive: true
+        description: |
+          Password for Redis host. Use secretKeyRef for
+          secret reference
+        example:  "KeFg23!"
+        default: ""
 metadata:
-  - name: redisHost
+ - name: redisHost
     required: true
-    description: Connection string for the Redis host
+    description: Connection-string for the Redis host
     example: "redis-master.default.svc.cluster.local:6379"
     type: string
-  - name: redisPassword
-    required: false
-    description: Password for the Redis host
-    example:  "KeFg23!"
-    type: string
-  - name: redisUsername
-    required: false
-    description: Username for Redis host. Defaults to empty. Make sure your redis server version is 6 or above, and have created acl rule correctly.
-    example: "default"
-    type: string
-  - name: redisType
-    required: false
-    description: |
-      The type of redis. There are two valid values, one is "node" for single node mode, the other is "cluster" for redis cluster mode. Defaults to "node".
-    example: "cluster"
-    type: string
   - name: enableTLS
+    type: bool
     required: false
     description: | 
-      If enabled, connects to Redis using TLS with public certificates.
-    example: "false"
+      If the Redis instance supports TLS with public certificates, can be
+      configured to be enabled or disabled.
+    example: "true"
     default: "false"
-    type: bool
   - name: redisMaxRetries
+    type: number
     required: false
     description: |
-      Maximum number of retries before giving up. Defaults to "3".
+      Maximum number of retries before giving up.
     default: "3"
     example: "5"
-    type: number
   - name: redisMinRetryInterval
+    type: duration
     required: false
     description: |
-      Minimum backoff for redis commands between each retry. Default is "8ms"; "-1" disables backoff.
-    example: "8ms"
-    type: duration
-  - name: redisMaxRetryInterval
-    required: false
-    description: |
-      Maximum backoff for redis commands between each retry. Default is "2s";"-1" disables backoff.
-    example: "5s"
-    type: duration
-  - name: dialTimeout
-    required: false
-    description: |
-      Dial timeout for establishing new connections. Defaults to "5s".
-    example: "5s"
-    type: duration
-  - name: readTimeout
-    required: false
-    description: |
-      Timeout for socket reads. If reached, redis commands will fail with a timeout instead of blocking. Defaults to "3s", "-1" for no timeout.
-    example: "3s"
-    type: duration
-  - name: writeTimeout
-    required: false
-    description: Timeout for socket writes. If reached, redis commands will fail with a timeout instead of blocking. Defaults is readTimeout.
-    example: "3s"
-    type: duration
-  - name: poolSize
-    required: false
-    description: Maximum number of socket connections. Default is 10 connections per every CPU as reported by runtime.NumCPU.
-    example: "20"
-    type: number
-  - name: poolTimeout
-    required: false
-    description: Amount of time client waits for a connection if all connections are busy before returning an error. Default is readTimeout + 1 second.
-    example: "5s"
-    type: duration
-  - name: maxConnAge
-    required: false
-    description: Connection age at which the client retires (closes) the connection. Default is to not close aged connections.
-    example: "30m"
-    type: duration
-  - name: minIdleConns
-    required: false
-    description: |
-      Minimum number of idle connections to keep open in order to avoid the performance degradation associated with creating new connections. Defaults to "0".
-    example: "2"
-    type: number
-  - name: idleCheckFrequency
-    required: false
-    description: |
-      Frequency of idle checks made by idle connections reaper. Default is "1m". "-1" disables idle connections reaper.
+      Minimum backoff for Redis commands between each retry.
+      "-1" disables backoff.
+    default: "8ms"
     example: "-1"
+  - name: redisMaxRetryInterval
     type: duration
-  - name: idleTimeout
     required: false
     description: |
-      Amount of time after which the client closes idle connections. Should be less than server's timeout. Default is "5m". "-1" disables idle timeout check.
-    example: "10m"
-    type: duration
+      Maximum backoff for Redis commands between each retry.
+      "-1" disables backoff.
+    example: "-1"
+    default: "2s"
   - name: failover
+    type: bool
     required: false
     description: |
       Enables failover configuration. It requires "sentinelMasterName" to
       be set, and "redisHost" to be the sentinel host address.
     default: "false"
     example: "true"
-    type: bool
     url:
       title: "Redis Sentinel documentation"
       url: "https://redis.io/docs/manual/sentinel/"
   - name: sentinelMasterName
+    type: string
     required: false
     description: |
       The Redis sentinel master name. Required when "failover" is enabled.
     example:  "127.0.0.1:6379"
-    type: string
     url:
       title: "Redis Sentinel documentation"
       url: "https://redis.io/docs/manual/sentinel/"
   - name: redisDB
+    type: number
     required: false
     description: |
-      Database selected after connecting to redis. If "redisType" is "cluster"
+      Database selected after connecting to Redis. If "redisType" is "cluster"
       this option is ignored.
     default: "0"
     example: "0"
+  - name: redisType
+    type: string
+    required: false
+    allowedValues:
+      - "node"
+      - "cluster"
+    default: "node"
+    description: |
+      Redis service type. Set to "node" for single-node mode, or "cluster" for Redis Cluster.
+    example: "cluster"
+  - name: dialTimeout
+    required: false
+    description: Dial timeout for establishing new connections.
+    default: "5s"
+    example: "10s"
+    type: duration
+  - name: readTimeout
+    required: false
+    type: duration
+    description: |
+      Timeout for socket reads. If reached, Redis commands will fail with a
+      timeout instead of blocking. Use "-1" for no timeout.
+    default: "3s"
+    example: "10s"
+  - name: writeTimeout
+    type: duration
+    required: false
+    description: |
+      Timeout for socket writes. If reached, Redis commands will fail with
+      a timeout instead of blocking. Defaults to "readTimeout".
+    example: "3s"
+  - name: poolSize
+    required: false
     type: number
+    description: |
+      Maximum number of socket connections. Default is 10 connections per
+      every CPU as reported by runtime.NumCPU.
+    example: "20"
+  - name: poolTimeout
+    required: false
+    type: duration
+    description: |
+      Amount of time client waits for a connection if all connections are busy
+      before returning an error. Default is readTimeout + 1 second.
+    example: "5s"
+  - name: maxConnAge
+    type: duration
+    required: false
+    description: |
+      Connection age at which the client retires (closes) the connection.
+      Default is to not close aged connections.
+    example: "30m"
+  - name: minIdleConns
+    required: false
+    type: number
+    description: |
+      Minimum number of idle connections to keep open in order to avoid
+      the performance degradation associated with creating new connections.
+    default: "0"
+    example: "2"
+  - name: idleCheckFrequency
+    type: duration
+    required: false
+    description: |
+      Frequency of idle checks made by idle connections reaper.
+      "-1" disables idle connections reaper.
+    default: "1m"
+    example: "-1"
+  - name: idleTimeout
+    type: duration
+    required: false
+    description: |
+      Amount of time after which the client closes idle connections. Should be
+      less than server's timeout.
+      "-1" disables idle timeout check.
+    default: "5m"
+    example: "10m"

--- a/configuration/redis/redis.go
+++ b/configuration/redis/redis.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
@@ -34,25 +33,11 @@ import (
 )
 
 const (
-	connectedSlavesReplicas      = "connected_slaves:"
-	infoReplicationDelimiter     = "\r\n"
-	host                         = "redisHost"
-	password                     = "redisPassword"
-	enableTLS                    = "enableTLS"
-	redisMaxRetries              = "redisMaxRetries"
-	redisMaxRetryInterval        = "redisMaxRetryInterval"
-	redisMinRetryInterval        = "redisMinRetryInterval"
-	failover                     = "failover"
-	sentinelMasterName           = "sentinelMasterName"
-	redisDB                      = "redisDB"
-	defaultBase                  = 10
-	defaultBitSize               = 0
-	defaultDB                    = 0
-	defaultRedisMaxRetries       = 3
-	defaultRedisMaxRetryInterval = time.Second * 2
-	defaultRedisMinRetryInterval = time.Millisecond * 8
-	defaultEnableTLS             = false
-	redisWrongTypeIdentifyStr    = "WRONGTYPE"
+	connectedSlavesReplicas   = "connected_slaves:"
+	infoReplicationDelimiter  = "\r\n"
+	defaultBase               = 10
+	defaultBitSize            = 0
+	redisWrongTypeIdentifyStr = "WRONGTYPE"
 )
 
 // ConfigurationStore is a Redis configuration store.

--- a/configuration/redis/redis_test.go
+++ b/configuration/redis/redis_test.go
@@ -15,7 +15,6 @@ package redis
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -242,15 +241,15 @@ func Test_parseRedisMetadata(t *testing.T) {
 		meta configuration.Metadata
 	}
 	testProperties := make(map[string]string)
-	testProperties[host] = "testHost"
-	testProperties[password] = "testPassword"
-	testProperties[enableTLS] = "true"
-	testProperties[redisMaxRetries] = "10"
-	testProperties[redisMaxRetryInterval] = "100ms"
-	testProperties[redisMinRetryInterval] = "10ms"
-	testProperties[failover] = "true"
-	testProperties[sentinelMasterName] = "tesSentinelMasterName"
-	testProperties[redisDB] = "1"
+	testProperties["redisHost"] = "testHost"
+	testProperties["redisPassword"] = "testPassword"
+	testProperties["enableTLS"] = "true"
+	testProperties["redisMaxRetries"] = "10"
+	testProperties["redisMaxRetryInterval"] = "100ms"
+	testProperties["redisMinRetryInterval"] = "10ms"
+	testProperties["failover"] = "true"
+	testProperties["sentinelMasterName"] = "tesSentinelMasterName"
+	testProperties["redisDB"] = "1"
 	testSettings := redisComponent.Settings{
 		Host:                  "testHost",
 		Password:              "testPassword",
@@ -264,17 +263,17 @@ func Test_parseRedisMetadata(t *testing.T) {
 	}
 
 	testDefaultProperties := make(map[string]string)
-	testDefaultProperties[host] = "testHost"
+	testDefaultProperties["redisHost"] = "testHost"
 	defaultSettings := redisComponent.Settings{
 		Host:                  "testHost",
 		Password:              "",
 		EnableTLS:             false,
-		RedisMaxRetries:       defaultRedisMaxRetries,
-		RedisMaxRetryInterval: redisComponent.Duration(defaultRedisMaxRetryInterval),
-		RedisMinRetryInterval: redisComponent.Duration(defaultRedisMinRetryInterval),
+		RedisMaxRetries:       3,
+		RedisMaxRetryInterval: redisComponent.Duration(time.Second * 2),
+		RedisMinRetryInterval: redisComponent.Duration(time.Millisecond * 8),
 		Failover:              false,
 		SentinelMasterName:    "",
-		DB:                    defaultDB,
+		DB:                    0,
 	}
 
 	tests := []struct {
@@ -327,7 +326,7 @@ func setupMiniredis() (*miniredis.Miniredis, redisComponent.RedisClient) {
 	}
 	props := map[string]string{
 		"redisHost": s.Addr(),
-		"redisDB":   fmt.Sprint(defaultDB),
+		"redisDB":   "0",
 	}
 	redisClient, _, _ := redisComponent.ParseClientFromProperties(props, contribMetadata.ConfigurationStoreType)
 

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cloudwego/kitex-examples v0.1.1
 	github.com/dapr/components-contrib v1.10.6-0.20230426221256-e099a548fbb5
 	github.com/dapr/dapr v1.10.5-rc.1.0.20230430203526-7a0fdf9f016b
-	github.com/dapr/go-sdk v1.7.0
+	github.com/dapr/go-sdk v1.6.1-0.20230427230219-d485c1775c37
 	github.com/dapr/kit v0.0.5-0.20230418193628-15a7040dec41
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/go-chi/chi/v5 v5.0.8
@@ -145,7 +145,6 @@ require (
 	github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grandcat/zeroconf v1.0.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -342,8 +342,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/dapr v1.10.5-rc.1.0.20230430203526-7a0fdf9f016b h1:+6TVW2t2GveAxqVNSOezU2fUJVec5MCS5J/MXycfwFs=
 github.com/dapr/dapr v1.10.5-rc.1.0.20230430203526-7a0fdf9f016b/go.mod h1:o/M7becq2NE4unx2v3Hv6vq2DrLmUQx5Knkn+6QTkY4=
-github.com/dapr/go-sdk v1.7.0 h1:SJC8layk2eKuJ8N+S84DtYpP4fgVugu8sUAliGu6/nM=
-github.com/dapr/go-sdk v1.7.0/go.mod h1:kWMKJ39k2smLVnB6v5Y6dMbwfj1Z3XBxa4Q2dCFzf2U=
+github.com/dapr/go-sdk v1.6.1-0.20230427230219-d485c1775c37 h1:gAiBprMLnsdaz4mhr28RlmK1PTnz+UXDNy0Giujty5c=
+github.com/dapr/go-sdk v1.6.1-0.20230427230219-d485c1775c37/go.mod h1:+ec5FDv7wGcy+Hlg7vY6msKQClm6es2Q5yCGbDHoURQ=
 github.com/dapr/kit v0.0.5-0.20230418193628-15a7040dec41 h1:G55KmJAn2UsJm2+T0Vyz8gPcbphDe1PvjrES18JxfHQ=
 github.com/dapr/kit v0.0.5-0.20230418193628-15a7040dec41/go.mod h1:VTWiX6nk5RWZ/kqEJD/EGjJU8hdwHZ73r75K510OHBY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -654,8 +654,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=


### PR DESCRIPTION
# Description

Go-SDK Configuration subscribe method has been modified (https://github.com/dapr/go-sdk/pull/389), and so the configuration certification tests using go-sdk need to be updated. Also there were some unresolved comments in PR https://github.com/dapr/components-contrib/pull/2807. This PR also includes those changes.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
