### PR TITLE
Makes Redis7 (v9 client) match the Redis6 (v8 client) behavior

### DIFF
--- a/bindings/redis/metadata.yaml
+++ b/bindings/redis/metadata.yaml
@@ -79,11 +79,6 @@ metadata:
       "-1" disables backoff.
     example: "-1"
     default: "512ms"
-  - name: maxLenApprox
-    required: false
-    type: number
-    description: |
-      The approximate maximum length of a stream.
   - name: failover
     type: bool
     required: false

--- a/internal/component/redis/settings.go
+++ b/internal/component/redis/settings.go
@@ -95,7 +95,7 @@ type Settings struct {
 	Concurrency uint `mapstructure:"concurrency" only:"pubsub"`
 
 	// the max len of stream
-	MaxLenApprox int64 `mapstructure:"maxLenApprox" only:"bindings"`
+	MaxLenApprox int64 `mapstructure:"maxLenApprox" only:"pubsub"`
 }
 
 func (s *Settings) Decode(in interface{}) error {

--- a/internal/component/redis/v9client.go
+++ b/internal/component/redis/v9client.go
@@ -176,6 +176,7 @@ func (c v9Client) XAdd(ctx context.Context, stream string, maxLenApprox int64, v
 		Stream: stream,
 		Values: values,
 		MaxLen: maxLenApprox,
+		Approx: true,
 	}).Result()
 }
 


### PR DESCRIPTION
# Description

Ensures Redis 7 v9 Client uses the approximate max length of a stream, instead of the exact length. This matches the Redis 6 (v8 Client) behavior.

This was an oversight due to significant SDK changes between v8 and v9 SDKs (which we both support).