### PR TITLE
[jetstream] Fix setting omitted QueueGroupName on ConsumerConfig

### DIFF
--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -153,6 +153,9 @@ func (js *jetstreamPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRe
 	if v := js.meta.DurableName; v != "" {
 		consumerConfig.Durable = v
 	}
+	if v := js.meta.QueueGroupName; v != "" {
+		consumerConfig.DeliverGroup = v
+	}
 
 	if v := js.meta.internalStartTime; !v.IsZero() {
 		consumerConfig.OptStartTime = &v


### PR DESCRIPTION
# Description

The `QueueGroupName` was omitted from being set on the `ConsumerConfig` resulting in an error from server (NATS) due to misconfiguration.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2827 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
