### PR TITLE
Add dynamic template support to Twilio Sendgrid binding

### DIFF
--- a/bindings/twilio/sendgrid/sendgrid.go
+++ b/bindings/twilio/sendgrid/sendgrid.go
@@ -270,7 +270,7 @@ func (sg *SendGrid) GetComponentMetadata() map[string]string {
 func UnmarshalDynamicTemplateData(jsonString string, result *map[string]interface{}) error {
 	err := json.Unmarshal([]byte(jsonString), &result)
 	if err != nil {
-		return fmt.Errorf("error from SendGrid binding, dynamic template data is not valid JSON: %+v", err)
+		return fmt.Errorf("error from SendGrid binding, dynamic template data is not valid JSON: %w", err)
 	}
 	return nil
 }

--- a/bindings/twilio/sendgrid/sendgrid_test.go
+++ b/bindings/twilio/sendgrid/sendgrid_test.go
@@ -44,11 +44,23 @@ func TestParseMetadataWithOptionalNames(t *testing.T) {
 
 	t.Run("Has correct metadata", func(t *testing.T) {
 		// Sample nested JSON with Dynamic Template Data
-		dynamicTemplateData, _ := json.Marshal(map[string]interface{}{"name": map[string]interface{}{"first": "MyFirst", "last": "MyLast"}})
+		dynamicTemplateData, _ := json.Marshal(map[string]any{
+			"name": map[string]any{
+				"first": "MyFirst",
+				"last":  "MyLast",
+			},
+		})
 
 		m := bindings.Metadata{}
-		m.Properties = map[string]string{"apiKey": "123", "emailFrom": "test1@example.net", "emailFromName": "test 1", "emailTo": "test2@example.net", "emailToName": "test 2", "subject": "hello",
-			"dynamicTemplateData": string(dynamicTemplateData), "dynamicTemplateId": "456"}
+		m.Properties = map[string]string{
+			"apiKey":        "123",
+			"emailFrom":     "test1@example.net",
+			"emailFromName": "test 1",
+			"emailTo":       "test2@example.net",
+			"emailToName":   "test 2", "subject": "hello",
+			"dynamicTemplateData": string(dynamicTemplateData),
+			"dynamicTemplateId":   "456",
+		}
 		r := SendGrid{logger: logger}
 		sgMeta, err := r.parseMetadata(m)
 		assert.Nil(t, err)
@@ -58,14 +70,22 @@ func TestParseMetadataWithOptionalNames(t *testing.T) {
 		assert.Equal(t, "test2@example.net", sgMeta.EmailTo)
 		assert.Equal(t, "test 2", sgMeta.EmailToName)
 		assert.Equal(t, "hello", sgMeta.Subject)
-		assert.Equal(t, "{\"name\":{\"first\":\"MyFirst\",\"last\":\"MyLast\"}}", sgMeta.DynamicTemplateData)
+		assert.Equal(t, `{"name":{"first":"MyFirst","last":"MyLast"}}`, sgMeta.DynamicTemplateData)
 		assert.Equal(t, "456", sgMeta.DynamicTemplateID)
 	})
 
 	t.Run("Has incorrect template data metadata", func(t *testing.T) {
 		m := bindings.Metadata{}
-		m.Properties = map[string]string{"apiKey": "123", "emailFrom": "test1@example.net", "emailFromName": "test 1", "emailTo": "test2@example.net", "emailToName": "test 2", "subject": "hello",
-			"dynamicTemplateData": "{\"wrong\"}", "dynamicTemplateId": "456"}
+		m.Properties = map[string]string{
+			"apiKey":              "123",
+			"emailFrom":           "test1@example.net",
+			"emailFromName":       "test 1",
+			"emailTo":             "test2@example.net",
+			"emailToName":         "test 2",
+			"subject":             "hello",
+			"dynamicTemplateData": `{"wrong"}`,
+			"dynamicTemplateId":   "456",
+		}
 		r := SendGrid{logger: logger}
 		_, err := r.parseMetadata(m)
 		assert.Error(t, err)

--- a/bindings/twilio/sendgrid/sendgrid_test.go
+++ b/bindings/twilio/sendgrid/sendgrid_test.go
@@ -61,11 +61,20 @@ func TestParseMetadataWithOptionalNames(t *testing.T) {
 		assert.Equal(t, "{\"name\":{\"first\":\"MyFirst\",\"last\":\"MyLast\"}}", sgMeta.DynamicTemplateData)
 		assert.Equal(t, "456", sgMeta.DynamicTemplateID)
 	})
+
+	t.Run("Has incorrect template data metadata", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{"apiKey": "123", "emailFrom": "test1@example.net", "emailFromName": "test 1", "emailTo": "test2@example.net", "emailToName": "test 2", "subject": "hello",
+			"dynamicTemplateData": "{\"wrong\"}", "dynamicTemplateId": "456"}
+		r := SendGrid{logger: logger}
+		_, err := r.parseMetadata(m)
+		assert.Error(t, err)
+	})
 }
 
 // Test UnmarshalDynamicTemplateData function
 func TestUnmarshalDynamicTemplateData(t *testing.T) {
-	t.Run("Has correct metadata", func(t *testing.T) {
+	t.Run("Test Template Data", func(t *testing.T) {
 		// Sample nested JSON with Dynamic Template Data
 		dynamicTemplateData, _ := json.Marshal(map[string]interface{}{"name": map[string]interface{}{"first": "MyFirst", "last": "MyLast"}})
 

--- a/bindings/twilio/sendgrid/sendgrid_test.go
+++ b/bindings/twilio/sendgrid/sendgrid_test.go
@@ -73,11 +73,11 @@ func TestUnmarshalDynamicTemplateData(t *testing.T) {
 
 		// Test valid JSON
 		err := UnmarshalDynamicTemplateData(string(dynamicTemplateData), &data)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{"first": "MyFirst", "last": "MyLast"}, data["name"])
 
 		// Test invalid JSON
 		err = UnmarshalDynamicTemplateData("{\"wrong\"}", &data)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
# Description

Adding support for dynamic templates. This includes allowing to provide a template id and template JSON data.
Supports these additional optional metadata (in configuration or request):
* dynamicTemplateId: the template id. Eg. "d-123456"
* dynamicTemplateData: the JSON passed to Sendgrid to populate the template. Eg. '{"customerName":"John Smith"}'

## Issue reference

Please reference the issue this PR will close: #2412

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo. Issue: dapr/docs#3421 PR: https://github.com/dapr/docs/pull/3422
