### PR TITLE
Conformance tests: always enable required operations

### DIFF
--- a/tests/config/bindings/tests.yml
+++ b/tests/config/bindings/tests.yml
@@ -1,4 +1,4 @@
-# Supported operations: create, operations and read
+# Supported operations: create, operations, read
 # Config map:
 ## output: A map of strings that will be part of the request for the output binding
 ## readBindingTimeout : timeout to wait to receive test event
@@ -74,7 +74,6 @@ components:
   - component: kubemq
     operations: [ "create", "operations", "read" ]
   - component: postgres
-    allOperations: false
     operations: [ "exec", "query", "close", "operations" ]
   - component: aws.s3.docker
     operations: ["create", "operations", "get", "list"]

--- a/tests/config/configuration/tests.yml
+++ b/tests/config/configuration/tests.yml
@@ -1,9 +1,9 @@
-# Supported operation: get, subscribe, unsubscribe
+# Supported additional operation: (none)
 componentType: configuration
 components:
   - component: redis.v6
-    allOperations: true
+    operations: []
   - component: redis.v7
-    allOperations: true
+    operations: []
   - component: postgres
-    allOperations: true
+    operations: []

--- a/tests/config/crypto/tests.yml
+++ b/tests/config/crypto/tests.yml
@@ -4,7 +4,7 @@
 componentType: crypto
 components:
   - component: localstorage
-    allOperations: true
+    operations: ["public", "symmetric"]
     config:
       keys:
         - algorithms: ["EdDSA"]
@@ -29,7 +29,7 @@ components:
           type: symmetric
           name: symmetric-256.b64
   - component: jwks
-    allOperations: true
+    operations: ["public", "symmetric"]
     config:
       keys:
         - algorithms: ["EdDSA"]
@@ -55,7 +55,6 @@ components:
           name: symmetric-256
   - component: azure.keyvault
     # Althoguh Azure Key Vault supports symmetric keys, those are only available in "Managed HSMs", which are too impractical for our tests
-    allOperations: false
     operations: []
     config:
       keys:

--- a/tests/config/pubsub/tests.yml
+++ b/tests/config/pubsub/tests.yml
@@ -1,18 +1,18 @@
-# Supported operation: publish, subscribe, multiplehandlers, bulkpublish, bulksubscribe
-# bulkpublish should only be run for components that implement pubsub.BulkPublisher interface
-# bulksubscribe should only be run for components that implement pubsub.BulkSubscriber interface
+# Supported additional operation: 
+# - bulkpublish (should only be run for components that implement pubsub.BulkPublisher interface)
+# - bulksubscribe (should only be run for components that implement pubsub.BulkSubscriber interface)
 # Config map:
-## pubsubName : name of the pubsub
-## testTopicName: name of the test topic to use
-## publishMetadata: A map of strings that will be part of the publish metadata in the Publish call
-## subscribeMetadata: A map of strings that will be part of the subscribe metadata in the Subscribe call
-## maxReadDuration: duration to wait for read to complete
-## messageCount: no. of messages to publish
-## checkInOrderProcessing: false disables in-order message processing checking
+# - pubsubName : name of the pubsub
+# - testTopicName: name of the test topic to use
+# - publishMetadata: A map of strings that will be part of the publish metadata in the Publish call
+# - subscribeMetadata: A map of strings that will be part of the subscribe metadata in the Subscribe call
+# - maxReadDuration: duration to wait for read to complete
+# - messageCount: no. of messages to publish
+# - checkInOrderProcessing: false disables in-order message processing checking
 componentType: pubsub
 components:
   - component: azure.eventhubs
-    operations: ['publish', 'subscribe', 'multiplehandlers', 'bulkpublish']
+    operations: ['bulkpublish']
     config:
       pubsubName: azure-eventhubs
       testTopicName: eventhubs-pubsub-topic
@@ -24,7 +24,7 @@ components:
       publishMetadata:
         partitionKey: abcd
   - component: azure.servicebus.topics
-    allOperations: true
+    operations: ['bulkpublish', 'bulksubscribe']
     config:
       pubsubName: azure-servicebus
       testTopicName: dapr-conf-test
@@ -33,7 +33,7 @@ components:
       testMultiTopic2Name: dapr-conf-test-multi2
       checkInOrderProcessing: false
   - component: azure.servicebus.queues
-    allOperations: true
+    operations: ['bulkpublish', 'bulksubscribe']
     config:
       pubsubName: azure-servicebus
       testTopicName: dapr-conf-queue
@@ -42,43 +42,43 @@ components:
       testMultiTopic2Name: dapr-conf-queue-multi2
       checkInOrderProcessing: false
   - component: redis.v6
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
     config:
       checkInOrderProcessing: false
   - component: redis.v7
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
     config:
       checkInOrderProcessing: false
   - component: natsstreaming
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
   - component: jetstream
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
   - component: kafka
-    allOperations: true
+    operations: ['bulkpublish', 'bulksubscribe']
   - component: kafka
     profile: wurstmeister
-    allOperations: true
+    operations: ['bulkpublish', 'bulksubscribe']
   - component: kafka
     profile: confluent
-    allOperations: true
+    operations: ['bulkpublish', 'bulksubscribe']
   - component: pulsar
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
   - component: solace.amqp
-    operations: ['publish', 'subscribe']
+    operations: []
   - component: mqtt3
     profile: emqx
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
   - component: mqtt3
     profile: vernemq
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
   - component: rabbitmq
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
     config:
       checkInOrderProcessing: false
   - component: in-memory
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
   - component: aws.snssqs.terraform
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
     config:
       pubsubName: aws-snssqs
       testTopicName: ${{PUBSUB_AWS_SNSSQS_TOPIC}}
@@ -86,14 +86,14 @@ components:
       testMultiTopic2Name: ${{PUBSUB_AWS_SNSSQS_TOPIC_MULTI_2}}
       checkInOrderProcessing: false
   - component: aws.snssqs.docker
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
     config:
       pubsubName: aws-snssqs
       checkInOrderProcessing: false
   - component: kubemq
-    operations: ['publish', 'subscribe', 'multiplehandlers']
+    operations: []
   - component: gcp.pubsub.terraform
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
     config:
       pubsubName: gcp-pubsub
       testTopicName: ${{PUBSUB_GCP_TOPIC}}
@@ -102,7 +102,7 @@ components:
       testMultiTopic2Name: ${{PUBSUB_GCP_TOPIC_MULTI_2}}
       checkInOrderProcessing: false
   - component: gcp.pubsub.docker
-    operations: ["publish", "subscribe", "multiplehandlers"]
+    operations: []
     config:
       pubsubName: gcp-pubsub
       checkInOrderProcessing: false

--- a/tests/config/secretstores/tests.yml
+++ b/tests/config/secretstores/tests.yml
@@ -1,16 +1,16 @@
-# Supported operations: get, bulkget
+# Supported additional operations: (none)
 componentType: secretstores
 components:
   - component: local.env
-    allOperations: true
+    operations: []
   - component: local.file
-    allOperations: true
+    operations: []
   - component: azure.keyvault.certificate
-    allOperations: true
+    operations: []
   - component: azure.keyvault.serviceprincipal
-    allOperations: true
+    operations: []
   - component: kubernetes
-    allOperations: true
+    operations: []
   - component: hashicorp.vault
-    allOperations: true
+    operations: []
 

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -4,103 +4,78 @@
 componentType: state
 components:
   - component: redis.v6
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "query", "ttl" ]
     config:
       # This component requires etags to be numeric
       badEtag: "9999999"
   - component: redis.v7
-    allOperations: false
     # "query" is not included because redisjson hasn't been updated to Redis v7 yet
     operations: [ "transaction", "etag", "first-write", "ttl" ]
     config:
       # This component requires etags to be numeric
       badEtag: "9999999"
   - component: mongodb
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "query", "ttl" ]
   - component: memcached
-    allOperations: false
     operations: [ "ttl" ]
   - component: azure.cosmosdb
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "query", "ttl" ]
   - component: azure.blobstorage
-    allOperations: false
     operations: [ "etag", "first-write" ]
   - component: azure.sql
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "ttl" ]
     config:
       # This component requires etags to be hex-encoded numbers
       badEtag: "FFFF"
   - component: sqlserver
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "ttl" ]
     config:
       # This component requires etags to be hex-encoded numbers
       badEtag: "FFFF"
   - component: postgresql
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "query", "ttl" ]
     config:
       # This component requires etags to be numeric
       badEtag: "1"
   - component: sqlite
-    allOperations: false
     operations: [ "transaction", "etag",  "first-write", "ttl" ]
   - component: mysql.mysql
-    allOperations: false
     operations: [ "transaction", "etag",  "first-write", "ttl" ]
   - component: mysql.mariadb
-    allOperations: false
     operations: [ "transaction", "etag",  "first-write", "ttl" ]
   - component: azure.tablestorage.storage
-    allOperations: false
     operations: [ "etag", "first-write"]
     config:
       # This component requires etags to be in this format
       badEtag: "W/\"datetime'2023-05-09T12%3A28%3A54.1442151Z'\""
   - component: azure.tablestorage.cosmosdb
-    allOperations: false
     operations: [ "etag", "first-write"]
     config:
       # This component requires etags to be in this format
       badEtag: "W/\"datetime'2023-05-09T12%3A28%3A54.1442151Z'\""
   - component: oracledatabase
-    allOperations: false
     operations: [ "transaction", "etag",  "first-write", "ttl" ]
   - component: cassandra
-    allOperations: false
     operations: [ "ttl" ]
   - component: cloudflare.workerskv
-    allOperations: false
     # Although this component supports TTLs, the minimum TTL is 60s, which makes it not suitable for our conformance tests
     operations: []
   - component: cockroachdb
-    allOperations: false
     operations: [ "transaction", "etag", "first-write", "query", "ttl" ]
     config:
       # This component requires etags to be numeric
       badEtag: "9999999"
   - component: rethinkdb
-    allOperations: false
     operations: []
   - component: in-memory
-    allOperations: false
     operations: [ "transaction", "etag",  "first-write", "ttl" ]
   - component: aws.dynamodb.docker
-    allOperations: false
     operations: [ "transaction", "etag", "first-write" ]
   - component: aws.dynamodb.terraform
-    allOperations: false
     operations: [ "transaction", "etag", "first-write" ]
   - component: etcd
-    allOperations: false
     operations: [ "transaction", "etag",  "first-write", "ttl" ]
   - component: gcp.firestore.docker
-    allOperations: false
     operations: []
   - component: gcp.firestore.cloud
-    allOperations: false
     operations: []

--- a/tests/config/workflows/tests.yml
+++ b/tests/config/workflows/tests.yml
@@ -1,6 +1,5 @@
-# Supported operations: start, get, terminate
+# Supported additional operations: (none)
 componentType: workflows
 components:
   - component: temporal
-    allOperations: false
-    operations: [ "start", "get", "terminate"]
+    operations: []

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -5,12 +5,14 @@
 1. `tests/` directory contains the configuration and the test definition for conformance tests.
 2. All the conformance tests are within the `tests/conformance` directory.
 3. All the configurations are in the `tests/config` directory.
-4. Each of the component specific `component` definition are in their specific `component type` folder in the `tests/config` folder. E.g. `redis` statestore component definition within `state` directory. The component types are `bindings`, `state`, `secretstores`, `pubsub`. Cloud specific components will be within their own `cloud` directory within the `component type` folder, e.g. `pubsub/azure/servicebus`.
+4. Each of the component specific `component` definition are in their specific `component type` folder in the `tests/config` folder. For example, the `redis` statestore component definition within `state` directory.
+  - The component types are: `bindings`, `configuration`, `crypto`, `pubsub`, `state`, `secretstores`, `workflows`.
+  - Cloud specific components will be within their own `cloud` directory within the `component type` folder, e.g. `pubsub/azure/servicebus`.
 5. Similar to the component definitions, each component type has its own set of the conformance tests definitions.
-6. Each `component type` contains a `tests.yml` definition that defines the component to be tested along with component specific test configuration. Nested folder names have their `/` in path replaced by `.` in the component name in `tests.yml`, e.g. `azure/servicebus` should be `azure.servicebus`
+6. Each `component type` contains a `tests.yml` definition that defines the component to be tested along with component specific test configuration. Nested folder names have their `/` in path replaced by `.` in the component name in `tests.yml`, e.g. `azure/servicebus/topics` should be `azure.servicebus.topics`
 7. All the tests configurations are defined in `common.go` file.
 8. Each `component type` has its own `_test` file to trigger the conformance tests. E.g. `bindings_test.go`.
-9. Each test added will also need to be added to the `conformance.yml` workflow file.
+9. Each test added will also need to be added to the `component type/tests.yml` workflow file.
 
 ## Conformance test workflow
 
@@ -48,10 +50,12 @@
     ```yaml
     componentType: binding
     components:
-    ## All other components
-    - component: <COMPONENT>
-        allOperations: <true/false>
-        operations: <List of operations if needed>
+      # For each component
+      - component: <COMPONENT>
+        # If the component supports additional (optional) operations
+        operations: [ '<operation1>', '<operation2'> ]
+        # If the component does NOT support additional operations
+        operations: []
     ```
 
 5. Any UUID generation for keys can be specified using `$((uuid))`. E.g. see [/tests/config/bindings/tests.yml](../config/bindings/tests.yml)

--- a/tests/conformance/bindings/bindings.go
+++ b/tests/conformance/bindings/bindings.go
@@ -59,13 +59,12 @@ type TestConfig struct {
 	ReadBindingWait    time.Duration     `mapstructure:"readBindingWait"`
 }
 
-func NewTestConfig(name string, allOperations bool, operations []string, configMap map[string]interface{}) (TestConfig, error) {
+func NewTestConfig(name string, operations []string, configMap map[string]interface{}) (TestConfig, error) {
 	waitForSetup = false
 	testConfig := TestConfig{
 		CommonConfig: utils.CommonConfig{
 			ComponentType: "bindings",
 			ComponentName: name,
-			AllOperations: allOperations,
 			Operations:    utils.NewStringSet(operations...),
 		},
 		InputMetadata:      make(map[string]string),

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -139,11 +139,10 @@ type TestConfiguration struct {
 }
 
 type TestComponent struct {
-	Component     string                 `yaml:"component,omitempty"`
-	Profile       string                 `yaml:"profile,omitempty"`
-	AllOperations bool                   `yaml:"allOperations,omitempty"`
-	Operations    []string               `yaml:"operations,omitempty"`
-	Config        map[string]interface{} `yaml:"config,omitempty"`
+	Component  string                 `yaml:"component,omitempty"`
+	Profile    string                 `yaml:"profile,omitempty"`
+	Operations []string               `yaml:"operations,omitempty"`
+	Config     map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // NewTestConfiguration reads the tests.yml and loads the TestConfiguration.
@@ -368,7 +367,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				store := loadStateStore(comp)
 				require.NotNilf(t, store, "error running conformance test for component %s", comp.Component)
-				storeConfig, err := conf_state.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				storeConfig, err := conf_state.NewTestConfig(comp.Component, comp.Operations, comp.Config)
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				conf_state.ConformanceTests(t, props, store, storeConfig)
 			case "secretstores":
@@ -377,7 +376,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				store := loadSecretStore(comp)
 				require.NotNilf(t, store, "error running conformance test for component %s", comp.Component)
-				storeConfig := conf_secret.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations)
+				storeConfig := conf_secret.NewTestConfig(comp.Component, comp.Operations)
 				conf_secret.ConformanceTests(t, props, store, storeConfig)
 			case "pubsub":
 				filepath := fmt.Sprintf("../config/pubsub/%s", componentConfigPath)
@@ -385,7 +384,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				pubsub := loadPubSub(comp)
 				require.NotNil(t, pubsub, "error running conformance test for component %s", comp.Component)
-				pubsubConfig, err := conf_pubsub.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				pubsubConfig, err := conf_pubsub.NewTestConfig(comp.Component, comp.Operations, comp.Config)
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				conf_pubsub.ConformanceTests(t, props, pubsub, pubsubConfig)
 			case "bindings":
@@ -395,7 +394,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				inputBinding := loadInputBindings(comp)
 				outputBinding := loadOutputBindings(comp)
 				require.True(t, inputBinding != nil || outputBinding != nil)
-				bindingsConfig, err := conf_bindings.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				bindingsConfig, err := conf_bindings.NewTestConfig(comp.Component, comp.Operations, comp.Config)
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				conf_bindings.ConformanceTests(t, props, inputBinding, outputBinding, bindingsConfig)
 			case "workflows":
@@ -403,7 +402,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				props, err := tc.loadComponentsAndProperties(t, filepath)
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				wf := loadWorkflow(comp)
-				wfConfig := conf_workflows.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				wfConfig := conf_workflows.NewTestConfig(comp.Component, comp.Operations, comp.Config)
 				conf_workflows.ConformanceTests(t, props, wf, wfConfig)
 			case "crypto":
 				filepath := fmt.Sprintf("../config/crypto/%s", componentConfigPath)
@@ -411,7 +410,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				component := loadCryptoProvider(comp)
 				require.NotNil(t, component, "error running conformance test for component %s", comp.Component)
-				cryptoConfig, err := conf_crypto.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				cryptoConfig, err := conf_crypto.NewTestConfig(comp.Component, comp.Operations, comp.Config)
 				require.NoErrorf(t, err, "error running conformance test for component %s", comp.Component)
 				conf_crypto.ConformanceTests(t, props, component, cryptoConfig)
 			case "configuration":
@@ -421,7 +420,7 @@ func (tc *TestConfiguration) Run(t *testing.T) {
 				store, updater := loadConfigurationStore(comp)
 				require.NotNil(t, store, "error running conformance test for component %s", comp.Component)
 				require.NotNil(t, updater, "error running conformance test for component %s", comp.Component)
-				configurationConfig := conf_configuration.NewTestConfig(comp.Component, comp.AllOperations, comp.Operations, comp.Config)
+				configurationConfig := conf_configuration.NewTestConfig(comp.Component, comp.Operations, comp.Config)
 				conf_configuration.ConformanceTests(t, props, store, updater, configurationConfig, comp.Component)
 			default:
 				t.Fatalf("unknown component type %s", tc.ComponentType)

--- a/tests/conformance/common_test.go
+++ b/tests/conformance/common_test.go
@@ -29,8 +29,7 @@ func TestDecodeYaml(t *testing.T) {
 		yam := `componentType: state
 components:
   - component: redis
-    allOperations: false
-    operations: ["init", "set"]
+    operations: ["foo", "bar"]
     config:
       maxInitDurationInMs: 20
       maxSetDurationInMs: 20
@@ -41,9 +40,8 @@ components:
 		assert.NoError(t, err)
 		assert.NotNil(t, config)
 		assert.Equal(t, 1, len(config.Components))
-		assert.False(t, config.Components[0].AllOperations)
 		assert.Equal(t, "state", config.ComponentType)
-		assert.Equal(t, 2, len(config.Components[0].Operations))
+		assert.Equal(t, []string{"foo", "bar"}, config.Components[0].Operations)
 		assert.Equal(t, 5, len(config.Components[0].Config))
 	})
 

--- a/tests/conformance/configuration/configuration.go
+++ b/tests/conformance/configuration/configuration.go
@@ -46,12 +46,11 @@ type TestConfig struct {
 	utils.CommonConfig
 }
 
-func NewTestConfig(componentName string, allOperations bool, operations []string, configMap map[string]interface{}) TestConfig {
+func NewTestConfig(componentName string, operations []string, configMap map[string]interface{}) TestConfig {
 	tc := TestConfig{
 		utils.CommonConfig{
 			ComponentType: "configuration",
 			ComponentName: componentName,
-			AllOperations: allOperations,
 			Operations:    utils.NewStringSet(operations...),
 		},
 	}
@@ -177,7 +176,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store configuration
 		require.NoError(t, err, "expected no error on adding keys")
 	})
 
-	if config.HasOperation("get") {
+	t.Run("get", func(t *testing.T) {
 		t.Run("get with non-empty key list", func(t *testing.T) {
 			keys := getKeys(initValues1)
 
@@ -218,9 +217,9 @@ func ConformanceTests(t *testing.T, props map[string]string, store configuration
 			require.NoError(t, err)
 			assert.Equal(t, expectedResponse, resp.Items)
 		})
-	}
+	})
 
-	if config.HasOperation("subscribe") {
+	t.Run("subscribe", func(t *testing.T) {
 		subscribeMetadata := make(map[string]string)
 		if component == postgresComponent {
 			subscribeMetadata[pgNotifyChannelKey] = pgNotifyChannel
@@ -318,9 +317,9 @@ func ConformanceTests(t *testing.T, props map[string]string, store configuration
 			verifyMessagesReceived(t, processedC2, awaitingMessages2)
 			verifyMessagesReceived(t, processedC3, awaitingMessages3)
 		})
-	}
+	})
 
-	if config.HasOperation("unsubscribe") {
+	t.Run("unsubscribe", func(t *testing.T) {
 		t.Run("unsubscribe subscriber 1", func(t *testing.T) {
 			ID1 := subscribeIDs[0]
 			err := store.Unsubscribe(context.Background(),
@@ -382,7 +381,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store configuration
 
 			verifyNoMessagesReceived(t, processedC3)
 		})
-	}
+	})
 }
 
 func verifyNoMessagesReceived(t *testing.T, processedChan chan *configuration.UpdateEvent) {

--- a/tests/conformance/crypto/crypto.go
+++ b/tests/conformance/crypto/crypto.go
@@ -71,12 +71,11 @@ type TestConfig struct {
 	Keys []testConfigKey `mapstructure:"keys"`
 }
 
-func NewTestConfig(name string, allOperations bool, operations []string, configMap map[string]interface{}) (TestConfig, error) {
+func NewTestConfig(name string, operations []string, configMap map[string]interface{}) (TestConfig, error) {
 	testConfig := TestConfig{
 		CommonConfig: utils.CommonConfig{
 			ComponentType: "crypto",
 			ComponentName: name,
-			AllOperations: allOperations,
 			Operations:    utils.NewStringSet(operations...),
 		},
 	}

--- a/tests/conformance/secretstores/secretstores.go
+++ b/tests/conformance/secretstores/secretstores.go
@@ -29,12 +29,11 @@ type TestConfig struct {
 	utils.CommonConfig
 }
 
-func NewTestConfig(name string, allOperations bool, operations []string) TestConfig {
+func NewTestConfig(name string, operations []string) TestConfig {
 	tc := TestConfig{
 		CommonConfig: utils.CommonConfig{
 			ComponentType: "secretstores",
 			ComponentName: name,
-			AllOperations: allOperations,
 			Operations:    utils.NewStringSet(operations...),
 		},
 	}
@@ -69,7 +68,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 	})
 
 	// Get
-	if config.HasOperation("get") {
+	t.Run("get", func(t *testing.T) {
 		getSecretRequest := secretstores.GetSecretRequest{
 			Name: "conftestsecret",
 		}
@@ -86,10 +85,10 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 			assert.NotNil(t, resp.Data, "expected value to be returned")
 			assert.Equal(t, getSecretResponse.Data, resp.Data, "expected values to be equal")
 		})
-	}
+	})
 
 	// Bulkget
-	if config.HasOperation("bulkget") {
+	t.Run("bulkGet", func(t *testing.T) {
 		bulkReq := secretstores.BulkGetSecretRequest{}
 		expectedData := map[string]map[string]string{
 			"conftestsecret": {
@@ -117,5 +116,5 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 				assert.Equal(t, m, resp.Data[k], "expected values to be equal")
 			}
 		})
-	}
+	})
 }

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -65,12 +65,11 @@ type TestConfig struct {
 	BadEtag string `mapstructure:"badEtag"`
 }
 
-func NewTestConfig(component string, allOperations bool, operations []string, configMap map[string]interface{}) (TestConfig, error) {
+func NewTestConfig(component string, operations []string, configMap map[string]interface{}) (TestConfig, error) {
 	testConfig := TestConfig{
 		CommonConfig: utils.CommonConfig{
 			ComponentType: "state",
 			ComponentName: component,
-			AllOperations: allOperations,
 			Operations:    utils.NewStringSet(operations...),
 		},
 		BadEtag: "bad-etag",

--- a/tests/conformance/utils/utils.go
+++ b/tests/conformance/utils/utils.go
@@ -30,7 +30,6 @@ import (
 type CommonConfig struct {
 	ComponentType string
 	ComponentName string
-	AllOperations bool
 	Operations    map[string]struct{}
 }
 
@@ -45,11 +44,7 @@ var (
 )
 
 func (cc CommonConfig) HasOperation(operation string) bool {
-	if cc.AllOperations {
-		return true
-	}
 	_, exists := cc.Operations[operation]
-
 	return exists
 }
 
@@ -58,7 +53,6 @@ func (cc CommonConfig) CopyMap(config map[string]string) map[string]string {
 	for k, v := range config {
 		m[k] = v
 	}
-
 	return m
 }
 
@@ -133,14 +127,4 @@ func NewStringSet(values ...string) map[string]struct{} {
 	}
 
 	return set
-}
-
-func Contains[V comparable](arr []V, str V) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
-		}
-	}
-
-	return false
 }

--- a/tests/conformance/utils/utils_test.go
+++ b/tests/conformance/utils/utils_test.go
@@ -21,14 +21,6 @@ import (
 )
 
 func TestHasOperation(t *testing.T) {
-	t.Run("all operations", func(t *testing.T) {
-		cc := CommonConfig{
-			ComponentType: "state",
-			ComponentName: "redis",
-			AllOperations: true,
-		}
-		assert.True(t, cc.HasOperation("op"))
-	})
 	t.Run("operations list", func(t *testing.T) {
 		cc := CommonConfig{
 			ComponentType: "state",
@@ -45,7 +37,6 @@ func TestCopyMap(t *testing.T) {
 	cc := CommonConfig{
 		ComponentType: "state",
 		ComponentName: "redis",
-		AllOperations: true,
 	}
 	in := map[string]string{
 		"k": "v",

--- a/tests/conformance/workflows/workflows.go
+++ b/tests/conformance/workflows/workflows.go
@@ -35,12 +35,11 @@ type TestConfig struct {
 	utils.CommonConfig
 }
 
-func NewTestConfig(component string, allOperations bool, operations []string, conf map[string]interface{}) TestConfig {
+func NewTestConfig(component string, operations []string, conf map[string]interface{}) TestConfig {
 	tc := TestConfig{
 		CommonConfig: utils.CommonConfig{
 			ComponentType: "workflows",
 			ComponentName: component,
-			AllOperations: allOperations,
 			Operations:    utils.NewStringSet(operations...),
 		},
 	}
@@ -59,7 +58,7 @@ func ConformanceTests(t *testing.T, props map[string]string, workflowItem workfl
 	})
 
 	// Everything is within the same task since the workflow needs to persist between operations
-	if config.HasOperation("start") {
+	t.Run("start", func(t *testing.T) {
 		testLogger.Info("Start test running...")
 
 		inputBytes, _ := json.Marshal(10) // Time that the activity within the workflow runs for
@@ -111,5 +110,5 @@ func ConformanceTests(t *testing.T, props map[string]string, workflowItem workfl
 			assert.Equal(t, "TestID", resp.Workflow.InstanceID)
 		})
 		testLogger.Info("Start test done.")
-	}
+	})
 }


### PR DESCRIPTION
In conformance tests, operations that are required in each component are always enabled (e.g. all secret stores must implement "get" and "bulkGet", so those shouldn't be optional).

Changes the meaning of "operations" in the YAMLs to indicate additional, optional operations.

Fixes #2846