### PR TITLE
deps: updates http-wasm to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/hashicorp/consul/api v1.13.0
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a
-	github.com/http-wasm/http-wasm-host-go v0.4.2
+	github.com/http-wasm/http-wasm-host-go v0.5.0
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.28
 	github.com/influxdata/influxdb-client-go v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a h1:j6SSiw7fWemWfrJL801xiQ6xRT7ZImika50xvmPN+tg=
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a/go.mod h1:VhwtcZ7sg3xq7REqGzEy7ylSWGKz4jZd05eCJropNzI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/http-wasm/http-wasm-host-go v0.4.2 h1:94839hsOFMO/zwIsEGZV2h/nvsG6WJ+/Agh98dZqVxI=
-github.com/http-wasm/http-wasm-host-go v0.4.2/go.mod h1:Z83VkMiDJRBoqTLWCiQoaRK8thbRBDaIVxMT9KSNaP8=
+github.com/http-wasm/http-wasm-host-go v0.5.0 h1:gEivjxSoBFeTWerGk9amBL21c54zhr3iSQYhu0OmAE0=
+github.com/http-wasm/http-wasm-host-go v0.5.0/go.mod h1:Z83VkMiDJRBoqTLWCiQoaRK8thbRBDaIVxMT9KSNaP8=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible h1:bSww59mgbqFRGCRvlvfQutsptE3lRjNiU5C0YNT/bWw=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.22.11+incompatible/go.mod h1:l7VUhRbTKCzdOacdT4oWCwATKyvZqUOlOqr0Ous3k4s=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.28 h1:2w2khA5uopaLcZactRuQFGtUgMbN92aWZdOuT4b9HxU=


### PR DESCRIPTION
# Description

@Taction noticed a pretty bad bug where request correlation could be out-of-sync. This is fixed in http-wasm v0.5.0.

## Issue reference

https://github.com/http-wasm/http-wasm-host-go/pull/69

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [n/a] Created/updated tests (tests are upstream)
* [n/a] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
