### PR TITLE
Conformance Tests: State- ` ttlExpireTime`

### DIFF
--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -194,7 +194,8 @@ func (e *Etcd) doSet(ctx context.Context, key string, val any, etag *string, ttl
 
 	var leaseID clientv3.LeaseID
 	if ttlInSeconds != nil {
-		resp, err := e.client.Grant(ctx, *ttlInSeconds)
+		var resp *clientv3.LeaseGrantResponse
+		resp, err = e.client.Grant(ctx, *ttlInSeconds)
 		if err != nil {
 			return fmt.Errorf("couldn't grant lease %s: %w", key, err)
 		}

--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -192,38 +192,28 @@ func (e *Etcd) doSet(ctx context.Context, key string, val any, etag *string, ttl
 		return err
 	}
 
+	var leaseID clientv3.LeaseID
 	if ttlInSeconds != nil {
 		resp, err := e.client.Grant(ctx, *ttlInSeconds)
 		if err != nil {
 			return fmt.Errorf("couldn't grant lease %s: %w", key, err)
 		}
-		if etag != nil {
-			etag, _ := strconv.ParseInt(*etag, 10, 64)
-			_, err = e.client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", etag)).
-				Then(clientv3.OpPut(key, reqVal, clientv3.WithLease(resp.ID))).
-				Commit()
-		} else {
-			_, err = e.client.Put(ctx, key, reqVal, clientv3.WithLease(resp.ID))
-		}
-		if err != nil {
-			return fmt.Errorf("couldn't set key %s: %w", key, err)
-		}
-	} else {
-		var err error
-		if etag != nil {
-			etag, _ := strconv.ParseInt(*etag, 10, 64)
-			_, err = e.client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", etag)).
-				Then(clientv3.OpPut(key, reqVal)).
-				Commit()
-		} else {
-			_, err = e.client.Put(ctx, key, reqVal)
-		}
-		if err != nil {
-			return fmt.Errorf("couldn't set key %s: %w", key, err)
-		}
+		leaseID = resp.ID
 	}
+
+	if etag != nil {
+		etag, _ := strconv.ParseInt(*etag, 10, 64)
+		_, err = e.client.Txn(ctx).
+			If(clientv3.Compare(clientv3.ModRevision(key), "=", etag)).
+			Then(clientv3.OpPut(key, reqVal, clientv3.WithLease(leaseID))).
+			Commit()
+	} else {
+		_, err = e.client.Put(ctx, key, reqVal, clientv3.WithLease(leaseID))
+	}
+	if err != nil {
+		return fmt.Errorf("couldn't set key %s: %w", key, err)
+	}
+
 	return nil
 }
 

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1030,7 +1030,6 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 				return res.Data == nil
 			}, time.Second*3, 200*time.Millisecond, "expected object to have been deleted in time")
 		})
-
 	} else {
 		t.Run("ttl feature not present", func(t *testing.T) {
 			// We skip this check for Cloudflare Workers KV

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1065,9 +1065,16 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 				return
 			}
 
-			if config.ComponentName == "redis.v6" || config.ComponentName == "redis.v7" {
-				// Redis does not support ttlExpireTime
-				return
+			unsupported := []string{
+				"redis.v6",
+				"redis.v7",
+				"etcd.v1",
+			}
+
+			for _, noSup := range unsupported {
+				if strings.Contains(config.ComponentName, noSup) {
+					t.Skipf("skipping test for unsupported state store %s", noSup)
+				}
 			}
 
 			t.Run("set and get expire time", func(t *testing.T) {

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1193,8 +1193,8 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 				assert.Equal(t, key+"-ttl-expire-time-bulk-1", res[0].Key)
 				assert.Equal(t, key+"-ttl-expire-time-bulk-2", res[1].Key)
-				assert.Equal(t, []byte("123"), res[0].Data)
-				assert.Equal(t, []byte("234"), res[1].Data)
+				assert.Equal(t, []byte(`"123"`), res[0].Data)
+				assert.Equal(t, []byte(`"234"`), res[1].Data)
 
 				for i := range res {
 					if config.HasOperation("transaction") {

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1068,11 +1068,9 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			assertEquals(t, "⏱️", res)
 
 			require.Containsf(t, res.Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
-			expireTime, err := strconv.ParseInt(res.Metadata["ttlExpireTime"], 10, 64)
+			expireTime, err := time.Parse(time.RFC3339, res.Metadata["ttlExpireTime"])
 			require.NoError(t, err)
-			// Check the expire time is returned and is in a 10 minute window. This
-			// window should be _more_ than enough.
-			assert.InDelta(t, now.Add(time.Hour).UnixMilli(), expireTime, float64(time.Minute*10))
+			assert.InDelta(t, now.Add(time.Hour).UnixMilli(), expireTime.UnixMilli(), float64(time.Minute*10))
 		})
 
 		t.Run("set and get expire time bulkGet", func(t *testing.T) {
@@ -1109,11 +1107,11 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			for i := range res {
 				require.Containsf(t, res[i].Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
 				require.Containsf(t, res[i].Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
-				expireTime, err := strconv.ParseInt(res[i].Metadata["ttlExpireTime"], 10, 64)
+				expireTime, err := time.Parse(time.RFC3339, res[i].Metadata["ttlExpireTime"])
 				require.NoError(t, err)
 				// Check the expire time is returned and is in a 10 minute window. This
 				// window should be _more_ than enough.
-				assert.InDelta(t, now.Add(time.Hour).UnixMilli(), expireTime, float64(time.Minute*10))
+				assert.InDelta(t, now.Add(time.Hour).UnixMilli(), expireTime.UnixMilli(), float64(time.Minute*10))
 			}
 		})
 	}

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1193,8 +1193,8 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 				assert.Equal(t, key+"-ttl-expire-time-bulk-1", res[0].Key)
 				assert.Equal(t, key+"-ttl-expire-time-bulk-2", res[1].Key)
-				assert.Equal(t, "123", res[0].Data)
-				assert.Equal(t, "234", res[1].Data)
+				assert.Equal(t, []byte("123"), res[0].Data)
+				assert.Equal(t, []byte("234"), res[1].Data)
 
 				for i := range res {
 					if config.HasOperation("transaction") {

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1141,7 +1141,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			assertEquals(t, "⏱️", res)
 			assert.Contains(t, res.Metadata, "ttlExpireTime")
 
-			// Remove TTL by ommiting the ttlInSeconds field.
+			// Remove TTL by omitting the ttlInSeconds field.
 			require.NoError(t, statestore.Set(context.Background(), req(map[string]string{})))
 			res, err = statestore.Get(context.Background(), &state.GetRequest{
 				Key: key + "-ttl-expire-time-minus-1",

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1068,11 +1068,11 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			assertEquals(t, "⏱️", res)
 
 			require.Containsf(t, res.Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
-			expireTime, err := time.Parse(time.RFC3339, res.Metadata["ttlExpireTime"])
+			expireTime, err := strconv.ParseInt(res.Metadata["ttlExpireTime"], 10, 64)
 			require.NoError(t, err)
 			// Check the expire time is returned and is in a 10 minute window. This
 			// window should be _more_ than enough.
-			assert.InDelta(t, now.Add(time.Hour).Unix(), expireTime.Unix(), 10*60)
+			assert.InDelta(t, now.Add(time.Hour).UnixMilli(), expireTime, float64(time.Minute*10))
 		})
 
 		t.Run("set and get expire time bulkGet", func(t *testing.T) {
@@ -1109,11 +1109,11 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			for i := range res {
 				require.Containsf(t, res[i].Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
 				require.Containsf(t, res[i].Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
-				expireTime, err := time.Parse(time.RFC3339, res[i].Metadata["ttlExpireTime"])
+				expireTime, err := strconv.ParseInt(res[i].Metadata["ttlExpireTime"], 10, 64)
 				require.NoError(t, err)
 				// Check the expire time is returned and is in a 10 minute window. This
 				// window should be _more_ than enough.
-				assert.InDelta(t, now.Add(time.Hour).Unix(), expireTime.Unix(), 10*60)
+				assert.InDelta(t, now.Add(time.Hour).UnixMilli(), expireTime, float64(time.Minute*10))
 			}
 		})
 	}

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1054,7 +1054,8 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 				Key:   key + "-ttl-expire-time",
 				Value: "⏱️",
 				Metadata: map[string]string{
-					"ttlInSeconds": "60",
+					// Expire in an hour.
+					"ttlInSeconds": "3600",
 				},
 			})
 			require.NoError(t, err)
@@ -1069,8 +1070,9 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			require.Containsf(t, res.Metadata, "ttlExpireTime", "expected metadata to contain ttlExpireTime")
 			expireTime, err := time.Parse(time.RFC3339, res.Metadata["ttlExpireTime"])
 			require.NoError(t, err)
-			// Check the expire time is returned, and is in a 10 second window. This window should be _more_ than enough.
-			assert.InDelta(t, now.Add(time.Minute-(5*time.Second)), expireTime.Add(time.Second*5), float64(time.Second*10))
+			// Check the expire time is returned and is in a 10 minute window. This
+			// window should be _more_ than enough.
+			assert.InDelta(t, now.Add(time.Hour).Unix(), expireTime.Unix(), 10*60)
 		})
 	}
 }

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1052,7 +1052,7 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 			require.NoError(t, err)
 
 			// Request immediately
-			res, err := statestore.Get(context.Background(), &state.GetRequest{Key: key + "-ttl"})
+			res, err := statestore.Get(context.Background(), &state.GetRequest{Key: key + "-no-ttl"})
 			require.NoError(t, err)
 			assertEquals(t, "⏱️", res)
 

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1061,11 +1061,13 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 
 		t.Run("ttlExpireTime", func(t *testing.T) {
 			if !config.HasOperation("transaction") {
-				t.Skip("state store does not support transactions")
+				// This test is only for state stores that support transactions
+				return
 			}
 
 			if config.ComponentName == "redis.v6" || config.ComponentName == "redis.v7" {
-				t.Skip("redis does not support ttlExpireTime")
+				// Redis does not support ttlExpireTime
+				return
 			}
 
 			t.Run("set and get expire time", func(t *testing.T) {


### PR DESCRIPTION
Add state store conformance tests to ensure that the `ttlExpireTime` metadata key is returned when Getting keys which have a `ttlInSeconds` set.

`ttlExpireTime` is needed for state clients (like actors) to have a copy of the expiry time of TTL keys expire so that they can update their local cache when appropriate.

PR shouldn't be merged until all `TTL` enabled state stores implement this metadata response.

See https://github.com/dapr/dapr/pull/6400 https://github.com/dapr/components-contrib/issues/2857 for more info.