### PR TITLE
ASB: ScheduledEnqueueTimeUtc improve date parsing and return err

### DIFF
--- a/internal/component/azure/servicebus/message.go
+++ b/internal/component/azure/servicebus/message.go
@@ -159,6 +159,13 @@ func addMetadataToMessage(asbMsg *azservicebus.Message, metadata map[string]stri
 			timeVal, err := time.Parse(http.TimeFormat, v)
 			if err == nil {
 				asbMsg.ScheduledEnqueueTime = &timeVal
+			} else {
+				timeVal, err2 := time.Parse(time.RFC3339, v)
+				if err2 == nil {
+					asbMsg.ScheduledEnqueueTime = &timeVal
+				} else {
+					return fmt.Errorf("invalid time format for %s: %s. Expect HTTP time format or RFC3339", k, v)
+				}
 			}
 
 		// Fallback: set as application property

--- a/internal/component/azure/servicebus/message.go
+++ b/internal/component/azure/servicebus/message.go
@@ -164,7 +164,7 @@ func addMetadataToMessage(asbMsg *azservicebus.Message, metadata map[string]stri
 				if err2 == nil {
 					asbMsg.ScheduledEnqueueTime = &timeVal
 				} else {
-					return fmt.Errorf("invalid time format for %s: %s. Expect HTTP time format or RFC3339", k, v)
+					return fmt.Errorf("invalid time format for %s; expected HTTP time format or RFC3339", k)
 				}
 			}
 

--- a/internal/component/azure/servicebus/metadata_test.go
+++ b/internal/component/azure/servicebus/metadata_test.go
@@ -14,8 +14,6 @@ limitations under the License.
 package servicebus
 
 import (
-	"fmt"
-	"net/http"
 	"testing"
 
 	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
@@ -517,8 +515,6 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		parseErr := addMetadataToMessage(&msg, metadata)
 		assert.NoError(t, parseErr)
 		assert.Equal(t, int64(1718459130000000), msg.ScheduledEnqueueTime.UnixMicro())
-
-		fmt.Println(msg.ScheduledEnqueueTime.Format(http.TimeFormat))
 
 		msg2 := azservicebus.Message{}
 		metadata2 := map[string]string{

--- a/internal/component/azure/servicebus/metadata_test.go
+++ b/internal/component/azure/servicebus/metadata_test.go
@@ -14,8 +14,11 @@ limitations under the License.
 package servicebus
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -504,5 +507,32 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		// assert.
 		assert.Nil(t, m.LockDurationInSec)
 		assert.Nil(t, err)
+	})
+
+	t.Run("Test add system metadata: ScheduledEnqueueTimeUtc", func(t *testing.T) {
+		msg := azservicebus.Message{}
+		metadata := map[string]string{
+			MessageKeyScheduledEnqueueTimeUtc: "2024-06-15T13:45:30.00000000Z",
+		}
+		parseErr := addMetadataToMessage(&msg, metadata)
+		assert.NoError(t, parseErr)
+		assert.Equal(t, int64(1718459130000000), msg.ScheduledEnqueueTime.UnixMicro())
+
+		fmt.Println(msg.ScheduledEnqueueTime.Format(http.TimeFormat))
+
+		msg2 := azservicebus.Message{}
+		metadata2 := map[string]string{
+			MessageKeyScheduledEnqueueTimeUtc: "Sat, 15 Jun 2024 13:45:30 GMT",
+		}
+		parseErr2 := addMetadataToMessage(&msg2, metadata2)
+		assert.NoError(t, parseErr2)
+		assert.Equal(t, int64(1718459130000000), msg2.ScheduledEnqueueTime.UnixMicro())
+
+		msg3 := azservicebus.Message{}
+		metadata3 := map[string]string{
+			MessageKeyScheduledEnqueueTimeUtc: "Sat 2024-06-15 12:13:14 UTC+4",
+		}
+		parseErr3 := addMetadataToMessage(&msg3, metadata3)
+		assert.Error(t, parseErr3)
 	})
 }


### PR DESCRIPTION
# Description

Azure Service Bus supports a delayed message sending feature. Today the time stamp must be provided in HTTP Date Format, but that is not very obvious. No error was returned when the provided timestamp was in the wrong format, and as such the delayed sending was not applied.

This PR surfaces the error, but it also attempts to use RFC 3339 as a fallback if the HTTP Date Format parsing failed.

Previously: "Sat, 15 Jun 2024 13:45:30 GMT" + no errors
Now: "2024-06-15T13:45:30.00000000Z" / "2024-06-15T13:45:30Z" or "Sat, 15 Jun 2024 13:45:30 GMT" + error if failed

Related: https://github.com/dapr/components-contrib/issues/2745

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
