### PR TITLE
[Release-1.11] fix metadata.yaml: rename binding to `azure.servicebus.queues`

### DIFF
--- a/bindings/azure/servicebusqueues/metadata.yaml
+++ b/bindings/azure/servicebusqueues/metadata.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../component-metadata-schema.json
 schemaVersion: v1
 type: bindings
-name: azure.servicebusqueues
+name: azure.servicebus.queues
 version: v1
 status: stable
 title: "Azure Service Bus Queues"


### PR DESCRIPTION
# Description

No need for RCs, but this needs to be in the release branch in case we make hotfixes etc.