### PR TITLE
memached: if tllInSeconds larger than 30 days, convert to unix timestamp

### DIFF
--- a/state/memcached/memcached.go
+++ b/state/memcached/memcached.go
@@ -141,7 +141,7 @@ func (m *Memcached) parseTTL(req *state.SetRequest) (*int32, error) {
 
 		// If ttl is more than 30 days, convert it to unix timestamp.
 		// https://github.com/memcached/memcached/wiki/Commands#standard-protocol
-		if parsedInt > 60*60*24*30 {
+		if parsedInt >= 60*60*24*30 {
 			parsedInt = int32(m.clock.Now().Unix()) + parsedInt
 		}
 

--- a/state/memcached/memcached_test.go
+++ b/state/memcached/memcached_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
@@ -85,6 +87,7 @@ func TestMemcachedMetadata(t *testing.T) {
 
 func TestParseTTL(t *testing.T) {
 	store := NewMemCacheStateStore(logger.NewLogger("test")).(*Memcached)
+	store.clock = clocktesting.NewFakeClock(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 	t.Run("TTL Not an integer", func(t *testing.T) {
 		ttlInSeconds := "not an integer"
 		ttl, err := store.parseTTL(&state.SetRequest{
@@ -139,5 +142,17 @@ func TestParseTTL(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, int(*ttl), ttlInSeconds)
+	})
+
+	t.Run("TTL is Unix time larger than a month", func(t *testing.T) {
+		ttlInSeconds := 2 * 30 * 24 * 60 * 60
+		ttl, err := store.parseTTL(&state.SetRequest{
+			Metadata: map[string]string{
+				"ttlInSeconds": strconv.Itoa(ttlInSeconds),
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2023, 2, 30, 0, 0, 0, 0, time.UTC).Unix(), int64(*ttl))
 	})
 }


### PR DESCRIPTION
Currently, we are always passing the `ttlInSeconds` value as-is to memcached however, any value over 30 days will be treated as a UInix timestamp by memcached so will probably mark the key for expiration immediately.

PR changed client to conver `ttlInSeconds` to Unix timestamp when value is larger than 30 days.

https://github.com/memcached/memcached/wiki/Commands#standard-protocol