### PR TITLE
[RabbitMQ] use metadata from request as header of the published message

### DIFF
--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -220,6 +220,11 @@ func (r *RabbitMQ) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bi
 		DeliveryMode: amqp.Persistent,
 		ContentType:  "text/plain",
 		Body:         req.Data,
+		Headers:      make(amqp.Table),
+	}
+
+	for k, v := range req.Metadata {
+		pub.Headers[k] = v
 	}
 
 	contentType, ok := metadata.TryGetContentType(req.Metadata)

--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -220,7 +220,7 @@ func (r *RabbitMQ) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bi
 		DeliveryMode: amqp.Persistent,
 		ContentType:  "text/plain",
 		Body:         req.Data,
-		Headers:      make(amqp.Table),
+		Headers:      make(amqp.Table, len(req.Metadata)),
 	}
 
 	for k, v := range req.Metadata {

--- a/bindings/rabbitmq/rabbitmq_integration_test.go
+++ b/bindings/rabbitmq/rabbitmq_integration_test.go
@@ -416,15 +416,15 @@ func TestPublishWithHeaders(t *testing.T) {
 
 	r := NewRabbitMQ(logger).(*RabbitMQ)
 	err := r.Init(context.Background(), metadata)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Assert that if waited too long, we won't see any message
 	conn, err := amqp.Dial(rabbitmqHost)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer conn.Close()
 
 	ch, err := conn.Channel()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer ch.Close()
 
 	const msgContent = "some content"
@@ -435,12 +435,12 @@ func TestPublishWithHeaders(t *testing.T) {
 		},
 		Data: []byte(msgContent),
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond)
 
 	msg, ok, err := getMessageWithRetries(ch, queueName, 1*time.Second)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, msgContent, string(msg.Body))
 	assert.Contains(t, msg.Header, "custom_header1")


### PR DESCRIPTION
# Description

RabbitMQ message header values can be used to set additional metadata on a message, e.g. a label or message id like in Azure ServiceBus' message properties. The metadata can already be defined when creating the message, but till these values are not set on the enqueued message and only define e.g. the priority, TTL ...
With this PR the passed in metadata values are also available on the message's header values.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: dapr/docs#3503

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#3503
