### PR TITLE
Fixed ttl capability in MySQL state store

### DIFF
--- a/state/mysql/metadata.yaml
+++ b/state/mysql/metadata.yaml
@@ -14,6 +14,7 @@ capabilities:
   - crud
   - transactional
   - etag
+  - ttl
 authenticationProfiles:
   - title: "Connection string"
     description: |
@@ -30,7 +31,6 @@ metadata:
     type: duration
     default: "1h"
     example: "20m"
-    # We do not expose TTL as a feature, but we have cleanupInterval :)
   - name: metadataTableName
     description: "Name of the table Dapr uses to store a few metadata properties"
     type: string


### PR DESCRIPTION
The metadata.yaml for MySQL was incorrect and was missing the TTL capability.