### PR TITLE
Azure Key Vault crypto: fixed JSON marshalling of public keys

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -14,6 +14,7 @@ limitations under the License.
 package crypto
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -64,6 +65,12 @@ func (k Key) isValidAtTime(t time.Time) bool {
 	}
 
 	return true
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (k Key) MarshalJSON() ([]byte, error) {
+	// Marshal the Key property only
+	return json.Marshal(k.Key)
 }
 
 // KeyCanPerformOperation returns true if the key can be used to perform a specific operation.

--- a/tests/conformance/crypto/crypto.go
+++ b/tests/conformance/crypto/crypto.go
@@ -16,6 +16,7 @@ package crypto
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -178,6 +179,23 @@ func ConformanceTests(t *testing.T, props map[string]string, component contribCr
 					require.NoError(t, err)
 					assert.NotNil(t, key)
 					requireKeyPublic(t, key)
+
+					// Test how keys are marshaled as JSON
+					// We first marshal as JSON and then unmarshal into a POJO to verify that the required keys (the public part of RSA keys) are present
+					// For now we test this with RSA only for simplicity
+					if algorithm == "RSA-OAEP" {
+						j, err := json.Marshal(key)
+						require.NoError(t, err)
+						require.NotEmpty(t, j)
+
+						keyDict := map[string]any{}
+						err = json.Unmarshal(j, &keyDict)
+						require.NoError(t, err)
+
+						assert.NotEmptyf(t, keyDict["e"], "missing 'e' property in dictionary: %#v", keyDict)
+						assert.NotEmptyf(t, keyDict["n"], "missing 'n' property in dictionary: %#v", keyDict)
+						assert.Equal(t, "RSA", keyDict["kty"], "invalid 'kty' property in dictionary: %#v", keyDict)
+					}
 				}
 			})
 		})


### PR DESCRIPTION
When marshalling the object returned by Azure Key Vault as JSON, it is now correctly formatted as JWK

This is blocking the completion of E2E tests for crypto: https://github.com/dapr/dapr/pull/6546