### PR TITLE
[Redis State] Component Metadata Schema: sets redisPassword to sensitive

### DIFF
--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -19,6 +19,7 @@ metadata:
     type: string
   - name: redisPassword
     required: true
+    sensitive: true
     description: |
       Password for Redis host. No Default. Can be "secretKeyRef" to use a secret reference
     example: '"KeFg23!"'

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -23,6 +23,7 @@ metadata:
     type: string
   - name: redisPassword
     required: false
+    sensitive: true
     description: Password for Redis host. No Default. Can be secretKeyRef to use a secret reference
     example:  "KeFg23!"
     type: string


### PR DESCRIPTION
# Description

[Redis State] Component Metadata Schema: sets `redisPassword` to sensitive.