### PR TITLE
Postgres binding: support parametrized queries

### DIFF
--- a/tests/certification/bindings/postgres/README.md
+++ b/tests/certification/bindings/postgres/README.md
@@ -17,6 +17,7 @@ The purpose of this module is to provide tests that certify the PostgreSQL Outpu
     * Run dapr application with component to store data in postgres as output binding.
     * Read stored data from postgres.
     * Ensure that read data is same as the data that was stored.
+    * Verify the ability to use named paramters in queries.
 * Verify reconnection to postgres for output binding.
     * Simulate a network error before sending any messages.
     * Run dapr application with the component.


### PR DESCRIPTION
Adds support for parametrized queries in the Postgres binding. These are queries that accept positional parameters such as `$1` and that are replaced while being executed.

Using parametrized queries is extremely important for security, as it prevents SQL Injection attacks.

This works by adding a new metadata option to the binding called `params`, which contains a JSON-encoded list of parameters. The query can then reference them in order. This works for both the "exec" and "query" operations.

Example:

```go
resp, err = client.InvokeBinding(ctx, &daprClient.InvokeBindingRequest{
	Name:      "mybinding",
	Operation: "query",
	Metadata: map[string]string{
		"sql":    "SELECT * FROM " + tableName + " WHERE key = $1 OR value = $2",
		"params": `[1, "foo"]`,
	},
})
```

Behavior is validated in certification tests.