### PR TITLE
MySQL binding: allow passing parameters for queries

### DIFF
--- a/bindings/mysql/metadata.yaml
+++ b/bindings/mysql/metadata.yaml
@@ -17,17 +17,17 @@ binding:
     - name: query
       description: "The query operation is used for SELECT statements, which returns the metadata along with data in a form of an array of row values."
     - name: close
-      description: "The close operation can be used to explicitly close the DB connection and return it to the pool. This operation doesn’t have any response."
+      description: "The close operation can be used to explicitly close the DB connection and return it to the pool. This operation doesn't have any response."
 metadata:
   - name: url
     required: true
-    description: "Represent a DB connection in Data Source Name (DNS) format."
-    example: "user:password@tcp(localhost:3306)/dbname"
+    description: "Represent a DB connection in Data Source Name (DNS) format"
+    example: '"user:password@tcp(localhost:3306)/dbname"'
     type: string
   - name: pemPath
     required: false
     description: "Path to the PEM file. Used with SSL connection"
-    example: "path/to/pem/file"
+    example: '"path/to/pem/file"'
     type: string
   - name: maxIdleConns
     required: false
@@ -49,8 +49,3 @@ metadata:
     description: "The max connection idel time."
     example: "12s"
     type: duration
-  - name: maxRetries
-    required: false
-    description: "MaxRetries is the maximum number of retries for a query."
-    example: "5"
-    type: number

--- a/bindings/mysql/mysql.go
+++ b/bindings/mysql/mysql.go
@@ -271,8 +271,9 @@ func initDB(url, pemPath string) (*sql.DB, error) {
 	}
 
 	if pemPath != "" {
+		var pem []byte
 		rootCertPool := x509.NewCertPool()
-		pem, err := os.ReadFile(pemPath)
+		pem, err = os.ReadFile(pemPath)
 		if err != nil {
 			return nil, fmt.Errorf("error reading PEM file from %s: %w", pemPath, err)
 		}

--- a/bindings/mysql/mysql_integration_test.go
+++ b/bindings/mysql/mysql_integration_test.go
@@ -77,14 +77,14 @@ func TestMysqlIntegration(t *testing.T) {
 			b  BOOLEAN,
 			ts TIMESTAMP,
 			data LONGTEXT)`
-		res, err := b.Invoke(context.TODO(), req)
+		res, err := b.Invoke(context.Background(), req)
 		assertResponse(t, res, err)
 	})
 
 	t.Run("Invoke delete", func(t *testing.T) {
 		req.Operation = execOperation
 		req.Metadata[commandSQLKey] = "DELETE FROM foo"
-		res, err := b.Invoke(context.TODO(), req)
+		res, err := b.Invoke(context.Background(), req)
 		assertResponse(t, res, err)
 	})
 
@@ -94,7 +94,7 @@ func TestMysqlIntegration(t *testing.T) {
 			req.Metadata[commandSQLKey] = fmt.Sprintf(
 				"INSERT INTO foo (id, v1, b, ts, data) VALUES (%d, 'test-%d', %t, '%v', '%s')",
 				i, i, true, time.Now().Format(mySQLDateTimeFormat), `{"key":"val"}`)
-			res, err := b.Invoke(context.TODO(), req)
+			res, err := b.Invoke(context.Background(), req)
 			assertResponse(t, res, err)
 		}
 	})
@@ -105,7 +105,7 @@ func TestMysqlIntegration(t *testing.T) {
 			req.Metadata[commandSQLKey] = fmt.Sprintf(
 				"UPDATE foo SET ts = '%v' WHERE id = %d",
 				time.Now().Format(mySQLDateTimeFormat), i)
-			res, err := b.Invoke(context.TODO(), req)
+			res, err := b.Invoke(context.Background(), req)
 			assertResponse(t, res, err)
 		}
 	})
@@ -113,7 +113,7 @@ func TestMysqlIntegration(t *testing.T) {
 	t.Run("Invoke select", func(t *testing.T) {
 		req.Operation = queryOperation
 		req.Metadata[commandSQLKey] = "SELECT * FROM foo WHERE id < 3"
-		res, err := b.Invoke(context.TODO(), req)
+		res, err := b.Invoke(context.Background(), req)
 		assertResponse(t, res, err)
 		t.Logf("received result: %s", res.Data)
 
@@ -121,7 +121,7 @@ func TestMysqlIntegration(t *testing.T) {
 		assert.Contains(t, string(res.Data), `"id":1`)
 		assert.Contains(t, string(res.Data), `"b":1`)
 		assert.Contains(t, string(res.Data), `"v1":"test-1"`)
-		assert.Contains(t, string(res.Data), `"data":"{"key":"val"}"`)
+		assert.Contains(t, string(res.Data), `"data":"{\"key\":\"val\"}"`)
 
 		result := make([]any, 0)
 		err = json.Unmarshal(res.Data, &result)
@@ -138,34 +138,18 @@ func TestMysqlIntegration(t *testing.T) {
 		t.Logf("time stamp is: %v", tt)
 	})
 
-	t.Run("Invoke select JSON_EXTRACT", func(t *testing.T) {
-		req.Operation = queryOperation
-		req.Metadata[commandSQLKey] = "SELECT JSON_EXTRACT(data, '$.key') AS `key` FROM foo WHERE id < 3"
-		res, err := b.Invoke(context.TODO(), req)
-		assertResponse(t, res, err)
-		t.Logf("received result: %s", res.Data)
-
-		// verify json extract string
-		assert.Contains(t, string(res.Data), `{"key":"\"val\"}`)
-
-		result := make([]any, 0)
-		err = json.Unmarshal(res.Data, &result)
-		require.NoError(t, err)
-		assert.Equal(t, 3, len(result))
-	})
-
 	t.Run("Invoke delete", func(t *testing.T) {
 		req.Operation = execOperation
 		req.Metadata[commandSQLKey] = "DELETE FROM foo"
 		req.Data = nil
-		res, err := b.Invoke(context.TODO(), req)
+		res, err := b.Invoke(context.Background(), req)
 		assertResponse(t, res, err)
 	})
 
 	t.Run("Invoke drop", func(t *testing.T) {
 		req.Operation = execOperation
 		req.Metadata[commandSQLKey] = "DROP TABLE foo"
-		res, err := b.Invoke(context.TODO(), req)
+		res, err := b.Invoke(context.Background(), req)
 		assertResponse(t, res, err)
 	})
 
@@ -173,7 +157,7 @@ func TestMysqlIntegration(t *testing.T) {
 		req.Operation = closeOperation
 		req.Metadata = nil
 		req.Data = nil
-		_, err := b.Invoke(context.TODO(), req)
+		_, err := b.Invoke(context.Background(), req)
 		assert.NoError(t, err)
 	})
 }

--- a/bindings/mysql/mysql_test.go
+++ b/bindings/mysql/mysql_test.go
@@ -42,7 +42,7 @@ func TestQuery(t *testing.T) {
 		assert.Nil(t, err)
 		t.Logf("query result: %s", ret)
 		assert.Contains(t, string(ret), "\"id\":1")
-		var result []interface{}
+		var result []any
 		err = json.Unmarshal(ret, &result)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(result))
@@ -65,13 +65,13 @@ func TestQuery(t *testing.T) {
 		assert.Contains(t, string(ret), "\"id\":1")
 		assert.Contains(t, string(ret), "\"value\":2.2")
 
-		var result []interface{}
+		var result []any
 		err = json.Unmarshal(ret, &result)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(result))
 
 		// verify timestamp
-		ts, ok := result[0].(map[string]interface{})["timestamp"].(string)
+		ts, ok := result[0].(map[string]any)["timestamp"].(string)
 		assert.True(t, ok)
 		var tt time.Time
 		tt, err = time.Parse(time.RFC3339, ts)
@@ -134,7 +134,7 @@ func TestInvoke(t *testing.T) {
 		}
 		resp, err := m.Invoke(context.Background(), req)
 		assert.Nil(t, err)
-		var data []interface{}
+		var data []any
 		err = json.Unmarshal(resp.Data, &data)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(data))


### PR DESCRIPTION
Fixes #2973 

Adds support for query parameters in the MySQL binding. This allows executing parametrized queries (such as `SELECT * FROM table WHERE id = ?`) which are extremely important to prevent SQL injections.

PS: this is an alpha component and doesn't have certification tests. The feature is being validated in the integration tests (which don't run in the CI but pass locally)