### PR TITLE
wasm: update benchmark to use `url` instead of `path`

### DIFF
--- a/middleware/http/wasm/benchmark_test.go
+++ b/middleware/http/wasm/benchmark_test.go
@@ -28,19 +28,19 @@ func BenchmarkNative(b *testing.B) {
 }
 
 func BenchmarkTinygo(b *testing.B) {
-	path := "./internal/e2e-guests/rewrite/main.wasm"
+	path := "file://internal/e2e-guests/rewrite/main.wasm"
 	benchmarkMiddleware(b, path)
 }
 
 // BenchmarkWat gives baseline performance for the same handler by
 // writing it directly in WebAssembly Text Format.
 func BenchmarkWat(b *testing.B) {
-	path := "./internal/testdata/rewrite.wasm"
-	benchmarkMiddleware(b, path)
+	url := "file://internal/testdata/rewrite.wasm"
+	benchmarkMiddleware(b, url)
 }
 
 func benchmarkMiddleware(b *testing.B, path string) {
-	md := metadata.Base{Properties: map[string]string{"path": path}}
+	md := metadata.Base{Properties: map[string]string{"url": path}}
 
 	l := logger.NewLogger(b.Name())
 	l.SetOutput(io.Discard)

--- a/state/requests.go
+++ b/state/requests.go
@@ -17,7 +17,7 @@ import (
 	"github.com/dapr/components-contrib/state/query"
 )
 
-// GetRequest is the object describing a state fetch request.
+// GetRequest is the object describing a state "fetch request.
 type GetRequest struct {
 	Key      string            `json:"key"`
 	Metadata map[string]string `json:"metadata"`

--- a/state/requests.go
+++ b/state/requests.go
@@ -17,7 +17,7 @@ import (
 	"github.com/dapr/components-contrib/state/query"
 )
 
-// GetRequest is the object describing a state "fetch request.
+// GetRequest is the object describing a state "fetch" request.
 type GetRequest struct {
 	Key      string            `json:"key"`
 	Metadata map[string]string `json:"metadata"`


### PR DESCRIPTION
Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>

# Description

https://github.com/dapr/components-contrib/pull/2817/ updated to use `url` instead of `path`, however the companion benchmark was not update. Related: https://github.com/dapr/samples/pull/154

## Issue reference

I haven't opened an issue since the change is trivial, but will do if requested.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: (n/a)
