### PR TITLE
Add support for wasi-http in the wasm binding.

### DIFF
--- a/bindings/wasm/output.go
+++ b/bindings/wasm/output.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/stealthrocket/wasi-go/imports/wasi_http"
+	"github.com/stealthrocket/wasi-go/imports/wasi_http/default_http"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
@@ -77,16 +79,27 @@ func (out *outputBinding) Init(ctx context.Context, metadata bindings.Metadata) 
 		return fmt.Errorf("wasm: error compiling binary: %w", err)
 	}
 
-	switch detectImports(out.module.ImportedFunctions()) {
-	case modeWasiP1:
+	imports := detectImports(out.module.ImportedFunctions())
+
+	if _, found := imports[modeWasiP1]; found {
 		_, err = wasi_snapshot_preview1.Instantiate(ctx, out.runtime)
 	}
-
 	if err != nil {
 		_ = out.runtime.Close(context.Background())
-		return fmt.Errorf("wasm: error instantiating host functions: %w", err)
+		return fmt.Errorf("wasm: error instantiating host wasi functions: %w", err)
 	}
-	return
+	if _, found := imports[modeWasiHTTP]; found {
+		if out.meta.StrictSandbox {
+			_ = out.runtime.Close(context.Background())
+			return fmt.Errorf("can not instantiate wasi-http with strict sandbox")
+		}
+		err = wasi_http.Instantiate(ctx, out.runtime)
+	}
+	if err != nil {
+		_ = out.runtime.Close(context.Background())
+		return fmt.Errorf("wasm: error instantiating host wasi-http functions: %w", err)
+	}
+	return nil
 }
 
 func (out *outputBinding) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
@@ -152,19 +165,23 @@ func (out *outputBinding) Close() error {
 const (
 	modeDefault importMode = iota
 	modeWasiP1
+	modeWasiHTTP
 )
 
 type importMode uint
 
-func detectImports(imports []api.FunctionDefinition) importMode {
+func detectImports(imports []api.FunctionDefinition) map[importMode]bool {
+	result := make(map[importMode]bool)
 	for _, f := range imports {
 		moduleName, _, _ := f.Import()
 		switch moduleName {
 		case wasi_snapshot_preview1.ModuleName:
-			return modeWasiP1
+			result[modeWasiP1] = true
+		case default_http.ModuleName:
+			result[modeWasiHTTP] = true
 		}
 	}
-	return modeDefault
+	return result
 }
 
 // GetComponentMetadata returns the metadata of the component.

--- a/bindings/wasm/testdata/http/Makefile
+++ b/bindings/wasm/testdata/http/Makefile
@@ -1,0 +1,4 @@
+default: main.wasm
+
+main.wasm: main.go
+	tinygo build -target wasi -o main.wasm main.go

--- a/bindings/wasm/testdata/http/main.go
+++ b/bindings/wasm/testdata/http/main.go
@@ -1,0 +1,35 @@
+package main
+
+// Building main.wasm:
+// go get github.com/dev-wasm/dev-wasm-go/http/client
+// tinygo build -target wasi -o main.wasm main.go
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	wasiclient "github.com/dev-wasm/dev-wasm-go/http/client"
+)
+
+func printResponse(r *http.Response) {
+	fmt.Printf("Status: %d\n", r.StatusCode)
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("Body: \n%s\n", body)
+}
+
+func main() {
+	client := http.Client{
+		Transport: wasiclient.WasiRoundTripper{},
+	}
+	res, err := client.Get(os.Args[1])
+	if err != nil {
+		panic(err.Error())
+	}
+	defer res.Body.Close()
+	printResponse(res)
+}

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/sendgrid/sendgrid-go v3.12.0+incompatible
 	github.com/sijms/go-ora/v2 v2.7.9
 	github.com/spf13/cast v1.5.1
+	github.com/stealthrocket/wasi-go v0.7.6-0.20230718231108-c3d30af59057
 	github.com/stretchr/testify v1.8.4
 	github.com/supplyon/gremcos v0.1.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.608

--- a/go.sum
+++ b/go.sum
@@ -1861,6 +1861,9 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
+github.com/stealthrocket/wasi-go v0.7.6-0.20230718231108-c3d30af59057 h1:BaBBX206PM1+qF5WQx7Ug7mbKqzizBONDMv4ST5EVNg=
+github.com/stealthrocket/wasi-go v0.7.6-0.20230718231108-c3d30af59057/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
+github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=


### PR DESCRIPTION
# Description

Add support for `wasi-http` client calls from the WASM binding. This enables developers of WASM bindings to make calls into Dapr (e.g. storage) or any other URL.

I will add documentation once there is agreement that this PR is ready to merge, but prior to merging it.

## Issue reference

See discussion in #2990 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
