### PR TITLE
Added `MultiMaxSize` to Cosmos DB state store

### DIFF
--- a/state/azure/cosmosdb/cosmosdb.go
+++ b/state/azure/cosmosdb/cosmosdb.go
@@ -485,6 +485,12 @@ func (c *StateStore) Delete(ctx context.Context, req *state.DeleteRequest) error
 	return nil
 }
 
+// MultiMaxSize returns the maximum number of operations allowed in a transaction.
+// For Azure Cosmos DB, that's 100.
+func (c StateStore) MultiMaxSize() int {
+	return 100
+}
+
 // Multi performs a transactional operation. Succeeds only if all operations succeed, and fails if one or more operations fail.
 // Note that all operations must be in the same partition.
 func (c *StateStore) Multi(ctx context.Context, request *state.TransactionalStateRequest) (err error) {

--- a/state/store.go
+++ b/state/store.go
@@ -43,8 +43,8 @@ type TransactionalStore interface {
 	Multi(ctx context.Context, request *TransactionalStateRequest) error
 }
 
-// TransactionalStoreMaxMultiSize is an optional interface transactional state stores can implement to indicate the maximum size for a transaction.
-type TransactionalStoreMaxMultiSize interface {
+// TransactionalStoreMultiMaxSize is an optional interface transactional state stores can implement to indicate the maximum size for a transaction.
+type TransactionalStoreMultiMaxSize interface {
 	MultiMaxSize() int
 }
 

--- a/state/store.go
+++ b/state/store.go
@@ -43,6 +43,11 @@ type TransactionalStore interface {
 	Multi(ctx context.Context, request *TransactionalStateRequest) error
 }
 
+// TransactionalStoreMaxMultiSize is an optional interface transactional state stores can implement to indicate the maximum size for a transaction.
+type TransactionalStoreMaxMultiSize interface {
+	MultiMaxSize() int
+}
+
 // Querier is an interface to execute queries.
 type Querier interface {
 	Query(ctx context.Context, req *QueryRequest) (*QueryResponse, error)


### PR DESCRIPTION
This indicates the maximum number of operations allowed in a transaction. The interface is optional.