### PR TITLE
Add closer to consul state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/hamba/avro/v2 v2.13.0
 	github.com/hashicorp/consul/api v1.22.0
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/golang-lru/v2 v2.0.4
 	github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a
 	github.com/http-wasm/http-wasm-host-go v0.5.1
@@ -248,7 +249,6 @@ require (
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -36,8 +36,7 @@ type Consul struct {
 	client        *api.Client
 	keyPrefixPath string
 	logger        logger.Logger
-
-	transport *http.Transport
+	transport     *http.Transport
 }
 
 type consulConfig struct {

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -162,3 +162,11 @@ func (c *Consul) GetComponentMetadata() (metadataInfo metadata.MetadataMap) {
 	metadata.GetMetadataInfoFromStructType(reflect.TypeOf(metadataStruct), &metadataInfo, metadata.StateStoreType)
 	return
 }
+
+func (c *Consul) Close() error {
+	// no persistent connection to close. It only uses http api calls.
+	// There is an http Transport Pool created during init by the default configuration that could accumulate if
+	// it is called multiple times.  An option, if needed, would be to create a custom http transport or use a non-pool one but that
+	// is discouraged by the go http client docs.
+	return nil
+}

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-cleanhttp"
@@ -37,6 +38,7 @@ type Consul struct {
 	keyPrefixPath string
 	logger        logger.Logger
 	transport     *http.Transport
+	closed        atomic.Bool
 }
 
 type consulConfig struct {
@@ -171,7 +173,7 @@ func (c *Consul) GetComponentMetadata() (metadataInfo metadata.MetadataMap) {
 }
 
 func (c *Consul) Close() error {
-	if c != nil && c.transport != nil {
+	if c.closed.CompareAndSwap(false, true) && c.transport != nil {
 		c.transport.CloseIdleConnections()
 	}
 	return nil

--- a/state/hashicorp/consul/consul.go
+++ b/state/hashicorp/consul/consul.go
@@ -76,7 +76,8 @@ func (c *Consul) Init(_ context.Context, metadata state.Metadata) error {
 		Token:      consulConfig.ACLToken,
 		Scheme:     consulConfig.Scheme,
 	}
-	// DefaultPooledTransport is the default transport used when Config.Transport is nil. vendor/github.com/hashicorp/consul/api/api.go:405
+	// DefaultPooledTransport is the default transport used when Config.Transport is nil.
+	// https://pkg.go.dev/github.com/hashicorp/consul/api#DefaultConfig
 	c.transport = cleanhttp.DefaultPooledTransport()
 	config.Transport = c.transport
 


### PR DESCRIPTION
# Description

Adds a consul closer to shutdown idle connections. Injected default transport into struct to be able to access the transport methods.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2952 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
