### PR TITLE
#3018: Add `get-embedding` operation to Azure OpenAI

### DIFF
--- a/bindings/azure/openai/metadata.yaml
+++ b/bindings/azure/openai/metadata.yaml
@@ -33,6 +33,10 @@ metadata:
     description: "Endpoint of the Azure OpenAI service"
     example: '"https://myopenai.openai.azure.com"'
   - name: deploymentID
-    required: true
-    description: "ID of the model deployment in the Azure OpenAI service"
+    required: false
+    description: "ID of the model deployment that supports completion and chat completion in the Azure OpenAI service"
     example: '"my-model"'
+  - name: embeddingDeploymentID
+    required: false
+    description: "ID of the model deployment that supports text embedding operation in the Azure OpenAI service"
+    example: '"my-embedding-model"'

--- a/bindings/azure/openai/metadata.yaml
+++ b/bindings/azure/openai/metadata.yaml
@@ -32,11 +32,3 @@ metadata:
     required: true
     description: "Endpoint of the Azure OpenAI service"
     example: '"https://myopenai.openai.azure.com"'
-  - name: deploymentID
-    required: false
-    description: "ID of the model deployment that supports completion and chat completion in the Azure OpenAI service"
-    example: '"my-model"'
-  - name: embeddingDeploymentID
-    required: false
-    description: "ID of the model deployment that supports text embedding operation in the Azure OpenAI service"
-    example: '"my-embedding-model"'


### PR DESCRIPTION
# Description

This PR adds `get-embedding` operation to get embeddings of any string to the Azure OpenAI output binding

## Issue reference

Please reference the issue this PR will close: #3018 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
