### PR TITLE
Add metadata for dequeued message in bindings.azure.storagequeues

### DIFF
--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -38,6 +38,12 @@ const (
 	defaultTTL               = 10 * time.Minute
 	defaultVisibilityTimeout = 30 * time.Second
 	defaultPollingInterval   = 10 * time.Second
+	dequeueCount             = "dequeueCount"
+	insertionTime            = "insertionTime"
+	expirationTime           = "expirationTime"
+	nextVisibleTime          = "nextVisibleTime"
+	popReceipt               = "popReceipt"
+	messageId                = "messageId"
 )
 
 type consumer struct {
@@ -178,8 +184,15 @@ func (d *AzureQueueHelper) Read(ctx context.Context, consumer *consumer) error {
 	}
 
 	_, err = consumer.callback(ctx, &bindings.ReadResponse{
-		Data:     data,
-		Metadata: map[string]string{},
+		Data: data,
+		Metadata: map[string]string{
+			messageId:       *res.Messages[0].MessageID,
+			insertionTime:   res.Messages[0].InsertionTime.Format("2006-01-02 15:04:05"),
+			expirationTime:  res.Messages[0].ExpirationTime.Format("2006-01-02 15:04:05"),
+			popReceipt:      *res.Messages[0].PopReceipt,
+			nextVisibleTime: res.Messages[0].TimeNextVisible.Format("2006-01-02 15:04:05"),
+			dequeueCount:    strconv.FormatInt(*res.Messages[0].DequeueCount, 10),
+		},
 	})
 	if err != nil {
 		return err

--- a/bindings/azure/storagequeues/storagequeues.go
+++ b/bindings/azure/storagequeues/storagequeues.go
@@ -183,19 +183,27 @@ func (d *AzureQueueHelper) Read(ctx context.Context, consumer *consumer) error {
 		}
 	}
 
-	metadata := make(map[string]string)
-
-	metadata[insertionTime] = res.Messages[0].InsertionTime.Format(time.RFC3339)
-	metadata[expirationTime] = res.Messages[0].ExpirationTime.Format(time.RFC3339)
-	metadata[nextVisibleTime] = res.Messages[0].TimeNextVisible.Format(time.RFC3339)
-	metadata[dequeueCount] = strconv.FormatInt(*res.Messages[0].DequeueCount, 10)
+	metadata := make(map[string]string, 6)
 
 	if res.Messages[0].MessageID != nil {
 		metadata[messageID] = *res.Messages[0].MessageID
 	}
-	if res.Messages[0].MessageID != nil {
+	if res.Messages[0].PopReceipt != nil {
 		metadata[popReceipt] = *res.Messages[0].PopReceipt
 	}
+	if res.Messages[0].InsertionTime != nil {
+		metadata[insertionTime] = res.Messages[0].InsertionTime.Format(time.RFC3339)
+	}
+	if res.Messages[0].ExpirationTime != nil {
+		metadata[expirationTime] = res.Messages[0].ExpirationTime.Format(time.RFC3339)
+	}
+	if res.Messages[0].TimeNextVisible != nil {
+		metadata[nextVisibleTime] = res.Messages[0].TimeNextVisible.Format(time.RFC3339)
+	}
+	if res.Messages[0].DequeueCount != nil {
+		metadata[dequeueCount] = strconv.FormatInt(*res.Messages[0].DequeueCount, 10)
+	}
+
 	_, err = consumer.callback(ctx, &bindings.ReadResponse{
 		Data:     data,
 		Metadata: metadata,


### PR DESCRIPTION
# Description

Add metadata for dequeued message in bindings.azure.storagequeues

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/components-contrib/issues/2375

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
