### PR TITLE
Bearer middleware: add "infer algorithm from key"

### DIFF
--- a/middleware/http/bearer/bearer_middleware.go
+++ b/middleware/http/bearer/bearer_middleware.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/lestrrat-go/httprc"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/dapr/components-contrib/internal/httputils"
@@ -112,7 +113,7 @@ func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadat
 			_, err = jwt.Parse([]byte(rawToken),
 				jwt.WithContext(r.Context()),
 				jwt.WithAcceptableSkew(allowedClockSkew),
-				jwt.WithKeySet(keyset),
+				jwt.WithKeySet(keyset, jws.WithInferAlgorithmFromKey(true)),
 				jwt.WithAudience(meta.Audience),
 				jwt.WithIssuer(meta.Issuer),
 			)


### PR DESCRIPTION
Fixes (maybe) #3025, as the JWKS from Azure AD is known for omitting the `alg` property.

I say "maybe" because I am not able to reproduce #3025 correctly. However, I've seen in other cases that this property was needed for the jwx library when verifying tokens from Azure AD. The JWKS document that Azure AD uses does not include the `alg` property ([example](https://login.microsoftonline.com/common/discovery/v2.0/keys)), so this helps the jwx library do hints.
