### PR TITLE
DecodeMetadata: add support for aliases via "mapstructurealiases" struct tag

### DIFF
--- a/metadata/utils_test.go
+++ b/metadata/utils_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 )
 
 func TestIsRawPayload(t *testing.T) {
@@ -111,6 +113,9 @@ func TestMetadataDecode(t *testing.T) {
 
 			MyRegularDurationDefaultValueUnset time.Duration `mapstructure:"myregulardurationdefaultvalueunset"`
 			MyRegularDurationDefaultValueEmpty time.Duration `mapstructure:"myregulardurationdefaultvalueempty"`
+
+			AliasedFieldA string `mapstructure:"aliasA1" mapstructurealiases:"aliasA2"`
+			AliasedFieldB string `mapstructure:"aliasB1" mapstructurealiases:"aliasB2"`
 		}
 
 		var m testMetadata
@@ -131,6 +136,9 @@ func TestMetadataDecode(t *testing.T) {
 			"mydurationarray":                    "1s,2s,3s,10",
 			"mydurationarraypointer":             "1s,10,2s,20,3s,30",
 			"mydurationarraypointerempty":        ",",
+			"aliasA2":                            "hello",
+			"aliasB1":                            "ciao",
+			"aliasB2":                            "bonjour",
 		}
 
 		err := DecodeMetadata(testData, &m)
@@ -149,6 +157,8 @@ func TestMetadataDecode(t *testing.T) {
 		assert.Equal(t, []time.Duration{time.Second, time.Second * 2, time.Second * 3, time.Second * 10}, m.MyDurationArray)
 		assert.Equal(t, []time.Duration{time.Second, time.Second * 10, time.Second * 2, time.Second * 20, time.Second * 3, time.Second * 30}, *m.MyDurationArrayPointer)
 		assert.Equal(t, []time.Duration{}, *m.MyDurationArrayPointerEmpty)
+		assert.Equal(t, "hello", m.AliasedFieldA)
+		assert.Equal(t, "ciao", m.AliasedFieldB)
 	})
 
 	t.Run("Test metadata decode hook for truthy values", func(t *testing.T) {
@@ -302,4 +312,115 @@ func TestMetadataStructToStringMap(t *testing.T) {
 			assert.True(t, metadatainfo["ignored"].Ignored) &&
 			assert.Empty(t, metadatainfo["ignored"].Aliases)
 	})
+}
+
+func TestResolveAliases(t *testing.T) {
+	tests := []struct {
+		name    string
+		md      map[string]string
+		result  any
+		wantErr bool
+		wantMd  map[string]string
+	}{
+		{
+			name: "no aliases",
+			md: map[string]string{
+				"hello": "world",
+				"ciao":  "mondo",
+			},
+			result: struct {
+				Hello   string `mapstructure:"hello"`
+				Ciao    string `mapstructure:"ciao"`
+				Bonjour string `mapstructure:"bonjour"`
+			}{},
+			wantMd: map[string]string{
+				"hello": "world",
+				"ciao":  "mondo",
+			},
+		},
+		{
+			name: "set with aliased field",
+			md: map[string]string{
+				"ciao": "mondo",
+			},
+			result: struct {
+				Hello   string `mapstructure:"hello" mapstructurealiases:"ciao"`
+				Bonjour string `mapstructure:"bonjour"`
+			}{},
+			wantMd: map[string]string{
+				"hello": "mondo",
+				"ciao":  "mondo",
+			},
+		},
+		{
+			name: "do not overwrite existing fields with aliases",
+			md: map[string]string{
+				"hello": "world",
+				"ciao":  "mondo",
+			},
+			result: struct {
+				Hello   string `mapstructure:"hello" mapstructurealiases:"ciao"`
+				Bonjour string `mapstructure:"bonjour"`
+			}{},
+			wantMd: map[string]string{
+				"hello": "world",
+				"ciao":  "mondo",
+			},
+		},
+		{
+			name: "no fields with aliased value",
+			md: map[string]string{
+				"bonjour": "monde",
+			},
+			result: struct {
+				Hello   string `mapstructure:"hello" mapstructurealiases:"ciao"`
+				Bonjour string `mapstructure:"bonjour"`
+			}{},
+			wantMd: map[string]string{
+				"bonjour": "monde",
+			},
+		},
+		{
+			name: "multiple aliases",
+			md: map[string]string{
+				"bonjour": "monde",
+			},
+			result: struct {
+				Hello string `mapstructure:"hello" mapstructurealiases:"ciao,bonjour"`
+			}{},
+			wantMd: map[string]string{
+				"hello":   "monde",
+				"bonjour": "monde",
+			},
+		},
+		{
+			name: "first alias wins",
+			md: map[string]string{
+				"ciao":    "mondo",
+				"bonjour": "monde",
+			},
+			result: struct {
+				Hello string `mapstructure:"hello" mapstructurealiases:"ciao,bonjour"`
+			}{},
+			wantMd: map[string]string{
+				"hello":   "mondo",
+				"ciao":    "mondo",
+				"bonjour": "monde",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := maps.Clone(tt.md)
+			err := resolveAliases(md, tt.result)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMd, md)
+		})
+	}
 }


### PR DESCRIPTION
This helps renaming metadata properties while maintaining aliases for backwards-compatibility