### PR TITLE
Adding client negotiate support for signalr binding

### DIFF
--- a/bindings/azure/signalr/metadata.yaml
+++ b/bindings/azure/signalr/metadata.yaml
@@ -14,6 +14,8 @@ binding:
   operations:
     - name: "create"
       description: "Send a message to SignalR"
+    - name: "clientNegotiate"
+      description: "Get the SignalR client negotiation response"
 capabilities: []
 authenticationProfiles:
   - title: "Connection string with access key"
@@ -73,7 +75,7 @@ metadata:
   - name: "hub"
     description: |
       Defines the hub in which the message will be sent.
-      This value can also be set for each invocation of the binding by passing the metadata option `hub`` with the invocation request.
+      This value can also be set for each invocation of the binding by passing the metadata option `hub` with the invocation request.
     example: |
       "myhub"
 

--- a/bindings/azure/signalr/signalr_test.go
+++ b/bindings/azure/signalr/signalr_test.go
@@ -25,13 +25,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 func TestConfigurationValid(t *testing.T) {
@@ -193,7 +194,7 @@ func TestConfigurationValid(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSignalR(logger.NewLogger("test")).(*SignalR)
 			err := s.parseMetadata(tt.properties)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedEndpoint, s.endpoint)
 			assert.Equal(t, tt.expectedAccessKey, s.accessKey)
 			assert.Equal(t, tt.expectedHub, s.hub)
@@ -331,7 +332,7 @@ func TestWriteShouldFail(t *testing.T) {
 			},
 		})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), httpErr.Error())
 	})
 
@@ -370,7 +371,7 @@ func TestWriteShouldSucceed(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		actualAuthorization := httpTransport.request.Header.Get("Authorization")
 		assert.NotEmpty(t, actualAuthorization)
 		assert.Truef(t, strings.HasPrefix(actualAuthorization, "Bearer "), "expecting to start with 'Bearer ', but was '%s'", actualAuthorization)
@@ -431,7 +432,7 @@ func TestGetShouldSucceed(t *testing.T) {
 	}
 
 	t.Run("Can get negotiate response with accessKey", func(t *testing.T) {
-		s.aadToken = nil;
+		s.aadToken = nil
 		s.accessKey = "AAbbcCsGEQKoLEH6oodDR0jK104Fu1c39Qgk+AA8D+M="
 		res, err := s.Invoke(context.Background(), &bindings.InvokeRequest{
 			Metadata: map[string]string{
@@ -461,7 +462,7 @@ func TestGetShouldSucceed(t *testing.T) {
 	})
 
 	t.Run("Can get negotiate response with accessKey and userId", func(t *testing.T) {
-		s.aadToken = nil;
+		s.aadToken = nil
 		s.accessKey = "AAbbcCsGEQKoLEH6oodDR0jK104Fu1c39Qgk+AA8D+M="
 		res, err := s.Invoke(context.Background(), &bindings.InvokeRequest{
 			Metadata: map[string]string{

--- a/bindings/azure/signalr/signalr_test.go
+++ b/bindings/azure/signalr/signalr_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -408,7 +407,7 @@ func TestGetShouldSucceed(t *testing.T) {
 	}
 	payloadBytes, _ := json.Marshal(payload)
 	httpTransport := &mockTransport{
-		response: &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(bytes.NewBuffer(payloadBytes))},
+		response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(payloadBytes))},
 	}
 
 	s := NewSignalR(logger.NewLogger("test")).(*SignalR)
@@ -476,7 +475,7 @@ func TestGetShouldSucceed(t *testing.T) {
 		assert.NoError(t, err)
 		audience := claims.Audience()
 		assert.Equal(t, []string{"https://fake.service.signalr.net/client/?hub=testhub"}, audience)
-		userId := claims.Subject()
-		assert.Equal(t, "user1", userId)
+		user := claims.Subject()
+		assert.Equal(t, "user1", user)
 	})
 }


### PR DESCRIPTION
# Description

1. Update the "send message" related actions to use the latest api version 2022-11-01
2. Try to improve the 'negotiate' experience described in #2012 with a new operation type `clientNegotiate`, this method **calculates** the token when AccessKey is provided in the `connectionString`, and **invokes **the `generateToken` REST API when AAD auth is used. Users can invoke this output binding to get the `negotiate` response and return back to the SignalR client. With this change, the overall SignalR experience described by https://github.com/dapr/components-contrib/issues/2012#issuecomment-1229992939 can be simplified to:
    ```javascript
    import { DaprClient } from '@dapr/dapr';
    import express from 'express';
    
    const client = new DaprClient(process.env.DAPR_HOST || 'http://localhost', process.env.DAPR_HTTP_PORT || '3500');
    const hub = 'chat';
    let app = express();
    app.get('/send', (req, res) => {
      client.binding.send('signalr', 'create', {
        Target: 'foo',
        Arguments: ['bar']
      });
      res.send('done');
    }).post('/chat/negotiate', async (req, res) => {
      const response = await client.binding.send('signalr', 'clientNegotiate')
      res.json(response.data);
    });
    app.listen(5000, () => console.log('server started'));
    ```
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2012 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
