### PR TITLE
Fixed a large number of errors in metadata.yaml

### DIFF
--- a/bindings/rabbitmq/metadata.yaml
+++ b/bindings/rabbitmq/metadata.yaml
@@ -14,28 +14,21 @@ binding:
   operations:
     - name: create
       description: "Publish a new message in the queue."
-capabilities: []
 authenticationProfiles:
   - title: "Connection string"
-    description: "The RabbitMQ Connection/Authentication."
+    description: "Use a connection string"
     metadata:
       - name: host
         required: true
         sensitive: true
-        description: "The RabbitMQ host address."
-        example: '"amqp://[username][:password]@host.domain[:port]" "amqps://[username][:password]@host.domain[:port]"'
-        binding:
-          output: true
-          input: true
+        description: "RabbitMQ host address."
+        example: '"amqp://[username][:password]@host.domain[:port]", "amqps://[username][:password]@host.domain[:port]"'
 metadata:
   - name: queueName
     required: true
-    description: "The RabbitMQ queue name."
+    description: "RabbitMQ queue name."
     type: string
     example: '"myqueue"'
-    binding:
-      input: true
-      output: true
   - name: durable
     type: bool
     description: |
@@ -49,14 +42,11 @@ metadata:
     description: "Enables or disables auto-delete."
     default: 'false'
     example: '"true", "false"'
-    binding:
-      input: true
-      output: true
   - name: ttlInSeconds
     type: number
     description: |
       Set the default message time to live at RabbitMQ queue level.
-      If this parameter is omitted, messages won’t expire, continuing
+      If this parameter is omitted, messages won't expire, continuing
       to exist on the queue until processed.
     example: '60'
     url:
@@ -67,10 +57,10 @@ metadata:
   - name: prefetchCount
     type: number
     description: |
-      Set the Channel Prefetch Setting (QoS). If this parameter is omiited, 
+      Set the Channel Prefetch Setting (QoS). If this parameter is omitted, 
       QoS would set value to 0 as no limit.
-    default: 'false'
-    example: '"true", "false"'
+    default: '0'
+    example: '0'
     url:
       title: "RabbitMQ Channel Prefetch Setting (QoS)"
       url: "https://www.rabbitmq.com/confirms.html#channel-qos-prefetch"
@@ -79,34 +69,25 @@ metadata:
   - name: exclusive
     type: bool
     description: |
-      Determines whether the topic will be an exclusive topic or not.
+      If true, the topic is treated as exclusive.
     default: 'false'
     example: '"true", "false"'
-    binding:
-      input: true
-      output: true
   - name: maxPriority
     type: number
     description: |
       Parameter to set the priority queue. If this parameter is omitted, 
       queue will be created as a general queue instead of a priority queue. 
       Value is between 1 and 255.
-    default: 'false'
-    example: '"true", "false"'
+    default: '1'
+    example: '"1", "10"'
     url:
       title: "RabbitMQ Priority Queue Support"
       url: "https://www.rabbitmq.com/priority.html"
-    binding:
-      input: true
-      output: true
   - name: contentType
     type: string
     description: "The content type of the message."
     default: '“text/plain”'
     example: '"text/plain", "application/cloudevent+json"'
-    binding:
-      input: true
-      output: true
   - name: reconnectWaitInSeconds
     type: number
     description: |
@@ -114,36 +95,21 @@ metadata:
       wait before attempting to reconnect to the server after a disconnection occurs.
     default: '5'
     example: '"5", "10"'
-    binding:
-      input: true
-      output: true
   - name: caCert
     type: string
     description: |
       Certificate authority certificate, required for using TLS.
-      Can be secretKeyRef to use a secret reference.
     example: "-----BEGIN CERTIFICATE-----\n<base64-encoded DER>\n-----END CERTIFICATE-----"
-    binding:
-      input: true
-      output: true
   - name: clientCert
     type: string
     description: |
-      Client certificate, required for authType mtls.
-      Can be secretKeyRef to use a secret reference.
+      Client certificate, required when "authType" is "mtls".
     example: "-----BEGIN CERTIFICATE-----\n<base64-encoded DER>\n-----END CERTIFICATE-----"
-    binding:
-      input: true
-      output: true
   - name: clientKey
     type: string
     description: |
-      Client key, required for authType mtls.
-      Can be secretKeyRef to use a secret reference.
-    example: "-----BEGIN RSA PRIVATE KEY-----\n<base64-encoded DER>\n-----END RSA PRIVATE KEY-----"
-    binding:
-      input: true
-      output: true
+      Client key, required when "authType" is "mtls".
+    example: "-----BEGIN PRIVATE KEY-----\n<base64-encoded DER>\n-----END PRIVATE KEY-----"
   - name: externalSasl
     type: string
     description: |
@@ -153,8 +119,5 @@ metadata:
     url:
       title: "RabbitMQ Authentication Mechanisms"
       url: "https://www.rabbitmq.com/access-control.html#mechanisms"
-    default: '“text/plain”'
-    example: '"text/plain", "application/cloudevent+json"'
-    binding:
-      input: true
-      output: true
+    default: 'false'
+    example: '"true", "false"'

--- a/pubsub/gcp/pubsub/metadata.yaml
+++ b/pubsub/gcp/pubsub/metadata.yaml
@@ -8,26 +8,25 @@ title: "GCP Pub/Sub"
 urls:
   - title: Reference
     url: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-gcp-pubsub/
-capabilities: []
 builtinAuthenticationProfiles:
   - name: "gcp"
 metadata:
-  - name: orderingKey
-    description: |
-      The key provided in the request. It’s used when enableMessageOrdering 
-      is set to true to order messages based on such key.   
-    type: string
-    example: '"my-orderingkey"'
   - name: enableMessageOrdering
     description: |
       When set to "true", subscribed messages will be received in order, 
-      depending on publishing and permissions configuration.    
+      depending on publishing and permissions configuration.
     type: bool
     default: 'false'
     example: '"true", "false"'
+  - name: orderingKey
+    description: |
+      The key provided in the request. It's used when "enableMessageOrdering" 
+      is set to true to order messages based on such key.
+    type: string
+    example: '"my-orderingkey"'
   - name: disableEntityManagement
     description: |
-      When set to "true", topics and subscriptions do not get created automatically.  
+      When set to true, topics and subscriptions do not get created automatically.  
     type: bool
     default: 'false'
     example: '"true", "false"'
@@ -45,19 +44,19 @@ metadata:
     example: '2'
   - name: deadLetterTopic
     description: |
-      Name of the GCP Pub/Sub Topic. This topic must exist before using this component.   
+      Name of the GCP Pub/Sub Topic. The topic must exist before using this component.
     type: string
     example: '"myapp-dlq"'
   - name: endpoint
     description: |
-      GCP endpoint for the component to use. Only used for local development (for example)
-      with GCP Pub/Sub Emulator. The endpoint is unnecessary when running against the GCP production API.
+      GCP endpoint for the component to use.
+      Only used for local development, for example with the GCP Pub/Sub Emulator. The endpoint is unnecessary when running against the GCP production API.
     type: string
     example: '"http://localhost:8085"'
   - name: maxDeliveryAttempts
     description: |
       Maximum number of attempts to deliver the message.
-      If "deadLetterTopic" is specified as well,  "maxDeliveryAttempts" is the maximum number of attempts before messages are moved to the dead-letter queue.
+      If "deadLetterTopic" is specified as well, "maxDeliveryAttempts" is the maximum number of attempts before messages are moved to the dead-letter queue.
     type: number
     default: '5'
     example: '5'

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../../../component-metadata-schema.json
+# yaml-language-server: $schema=../../component-metadata-schema.json
 schemaVersion: v1
 type: pubsub
 name: pulsar
@@ -9,17 +9,55 @@ urls:
   - title: Reference
     url: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-pulsar/
 authenticationProfiles:
-  - title: "Connection string"
-    description: "Authenticate using a Connection String"
+  - title: "Shared token"
+    description: "Authenticate using a shared token"
     metadata:
-      - name: host
+      - name: token
+        description: "Shared JWT token for authentication"
         type: string
-        required: true
         sensitive: true
-        description: "Address of the Pulsar broker."
-        example: |
-          "localhost:6650" OR "http://pulsar-pj54qwwdpz4b-pulsar.ap-sg.public.pulsar.com:8080"
+        url:
+          title: "JWT Token Authentication"
+          url: "https://pulsar.apache.org/docs/3.0.x/security-jwt/#generate-tokens"
+  - title: "OAuth2"
+    description: "Authenticate using OAuth2 or OpenID Connect"
+    metadata:
+      - name: oauth2Audiences
+        type: string
+        description: |
+          The OAuth 2.0 "resource server" identifier for a Pulsar cluster.
+      - name: oauth2ClientSecret
+        type: string
+        sensitive: true
+        description: |
+          The OAuth Client Secret.
+      - name: oauth2TokenCAPEM
+        type: string
+        description: |
+          The OAuth Token Certificate Authority PEM.
+      - name: oauth2ClientID
+        type: string
+        description: |
+          The OAuth Client ID.
+      - name: oauth2TokenURL
+        type: string
+        description: |
+          The OAuth Client URL.
+      - name: oauth2Scopes
+        type: string
+        description: |
+          The scope of an access request. For more information, see Access Token Scope.
+        url:
+          title: "Access Token Scope"
+          url: "https://datatracker.ietf.org/doc/html/rfc6749#section-3.3"
 metadata:
+  - name: host
+    type: string
+    required: true
+    sensitive: true
+    description: "Address of the Pulsar broker."
+    example: |
+      "localhost:6650", "http://pulsar-pj54qwwdpz4b-pulsar.ap-sg.public.pulsar.com:8080"
   - name: consumerID
     type: string
     description: "Used to set the subscription name or consumer ID."
@@ -84,13 +122,6 @@ metadata:
       a local PEM cert, or the cert data string value.
     example: |
       "-----BEGIN PRIVATE KEY-----\n<base64-encoded DER>\n-----END PRIVATE KEY-----" or "/path/to/key.pem"
-  - name: token
-    description: "Enable token authentication."
-    type: string
-    sensitive: true
-    url:
-      title: "JWT Token Authentication"
-      url: "https://pulsar.apache.org/docs/3.0.x/security-jwt/#generate-tokens"
   - name: keys
     type: string
     description: |
@@ -112,32 +143,4 @@ metadata:
       Specifies the delay after which to redeliver the messages that failed to be processed.
     default: '"30s"'
     example: '"30s"'
-  - name: oauth2Audiences
-    type: string
-    description: |
-      The OAuth 2.0 "resource server" identifier for a Pulsar cluster.
-  - name: oauth2ClientSecret
-    type: string
-    sensitive: true
-    description: |
-      The OAuth Client Secret.
-  - name: oauth2TokenCAPEM
-    type: string
-    description: |
-      The OAuth Token Certificate Authority PEM.
-  - name: oauth2ClientID
-    type: string
-    description: |
-      The OAuth Client ID.
-  - name: oauth2TokenURL
-    type: string
-    description: |
-      The OAuth Client URL.
-  - name: oauth2Scopes
-    type: string
-    description: |
-      The scope of an access request. For more information, see Access Token Scope.
-    url:
-      title: "Access Token Scope"
-      url: "https://datatracker.ietf.org/doc/html/rfc6749#section-3.3"
 # TODO: ADD .avroschema and .jsonschema

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -140,3 +140,4 @@ metadata:
     url:
       title: "Access Token Scope"
       url: "https://datatracker.ietf.org/doc/html/rfc6749#section-3.3"
+# TODO: ADD .avroschema and .jsonschema

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -143,4 +143,31 @@ metadata:
       Specifies the delay after which to redeliver the messages that failed to be processed.
     default: '"30s"'
     example: '"30s"'
-# TODO: ADD .avroschema and .jsonschema
+  - name: "<topic-name>.avroschema"
+    type: string
+    description: |
+      Enforces Avro schema validation for the configured topic. The value is a string containing a JSON object.
+    example: |
+      {
+        "type": "record",
+        "name": "Example",
+        "namespace": "test",
+        "fields": [
+          {"name": "ID","type": "int"},
+          {"name": "Name","type": "string"}
+        ]
+      }
+  - name: "<topic-name>.jsonschema"
+    type: string
+    description: |
+      Enforces JSON schema validation for the configured topic. The value is a string containing a JSON object.
+    example: |
+      {
+        "type": "record",
+        "name": "Example",
+        "namespace": "test",
+        "fields": [
+          {"name": "ID","type": "int"},
+          {"name": "Name","type": "string"}
+        ]
+      }

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -15,6 +15,7 @@ authenticationProfiles:
       - name: host
         type: string
         required: true
+        sensitive: true
         description: "Address of the Pulsar broker."
         example: |
           "localhost:6650" OR "http://pulsar-pj54qwwdpz4b-pulsar.ap-sg.public.pulsar.com:8080"
@@ -22,7 +23,7 @@ metadata:
   - name: consumerID
     type: string
     description: "Used to set the subscription name or consumer ID."
-    example: "channel1"
+    example: '"channel1"'
   - name: namespace
     description: |
       The administrative unit of the topic, which acts as a grouping mechanism for related topics.
@@ -35,25 +36,6 @@ metadata:
       Enable TLS.
     default: 'false'
     example: '"true", "false"'
-  - name: disableBatching
-    type: bool
-    description: |
-      When batching is enabled default batch delay is set to 10 ms and default
-      batch size is 1000 messages,Setting disableBatching: true will make the producer to send
-      messages individually.
-    default: 'false'
-    example: '"true", "false"'
-  - name: batchingMaxPublishDelay
-    type: duration
-    description: |
-      Sets the time period within which the messages sent will be batched,
-      if batch messages are enabled. If set to a non zero value, messages will be queued until this
-      time interval or batchingMaxMessages (see below) or batchingMaxSize (see below). There are two
-      valid formats, one is the fraction with a unit suffix format, and the other is the pure digital
-      format that is processed as milliseconds. Valid time units are “ns”, “us” (or “µs”), “ms”, “s”,
-      “m”, “h”.
-    default: '"10ms"'
-    example: '"10ms"'
   - name: tenant
     description: |
       The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread
@@ -61,52 +43,64 @@ metadata:
     type: string
     default: '"public"'
     example: '"public"'
+  - name: disableBatching
+    type: bool
+    description: |
+      When enabled, the producer will send messages in a batch.
+    default: 'false'
+    example: '"true", "false"'
+  - name: batchingMaxPublishDelay
+    type: duration
+    description: |
+      If batching is enabled, this sets the time window within messages are batched.
+      If set to a non-zero value, messages will be queued until this time interval has passed, or the batchingMaxMessages or batchingMaxSize conditions have been met.
+    default: '"10ms"'
+    example: '"10ms"'
   - name: batchingMaxMessages
     type: number
     description: |
-      Sets the maximum number of messages permitted in a batch. If set to a value greater
-      than 1, messages will be queued until this threshold is reached or batchingMaxSize (see below) has been
-      reached or the batch interval has elapsed.
+      Sets the maximum number of messages permitted in a batch.
+      If set to a value greater than 1, messages will be queued until this threshold is reached, batchingMaxSize has been reached, or the batch interval has elapsed.
     default: '"1000"'
     example: '"1000"'
   - name: batchingMaxSize
     description: |
-      Sets the maximum number of bytes permitted in a batch. If set to a value greater than 1,
-      messages will be queued until this threshold is reached or batchingMaxMessages (see above) has been reached
-      or the batch interval has elapsed.
+      Sets the maximum number of bytes permitted in a batch
+      If set to a value greater than 1, messages will be queued until this threshold is reached, batchingMaxMessages has been reached, or the batch interval has elapsed.
     type: number
-    default: '"131072"'
+    default: '"131072" (128 KB)'
     example: '"131072"'
   - name: publicKey
     type: string
     description: |
       A public key to be used for publisher and consumer encryption. Value can be one of two options:
        file path for a local PEM cert, or the cert data string value.
-    example: '"-----BEGIN PUBLIC KEY-----\n<base64-encoded DER>\n-----END PUBLIC KEY-----"'
+    example: |
+      "-----BEGIN PUBLIC KEY-----\n<base64-encoded DER>\n-----END PUBLIC KEY-----" or "/path/to/key.pem"
   - name: privateKey
     type: string
     description: |
       A private key to be used for consumer encryption. Value can be one of two options: file path for
       a local PEM cert, or the cert data string value.
-    example: '"-----BEGIN RSA PRIVATE KEY-----\n<base64-encoded DER>\n-----END RSA PRIVATE KEY-----"'
+    example: |
+      "-----BEGIN PRIVATE KEY-----\n<base64-encoded DER>\n-----END PRIVATE KEY-----" or "/path/to/key.pem"
   - name: token
-    description: "Enable Authentication."
+    description: "Enable token authentication."
     type: string
-    example: '"https://pulsar.apache.org/docs/3.0.x/security-jwt/#generate-tokens"'
+    sensitive: true
+    url:
+      title: "JWT Token Authentication"
+      url: "https://pulsar.apache.org/docs/3.0.x/security-jwt/#generate-tokens"
   - name: keys
     type: string
     description: |
       A comma delimited string containing names of Pulsar session keys. Used in conjunction with publicKey
       for publisher encryption.
-    example: '"-----BEGIN RSA PRIVATE KEY-----\n<base64-encoded DER>\n-----END RSA PRIVATE KEY-----"'
   - name: persistent
     type: bool
     description: |
       Pulsar supports two kinds of topics: persistent and non-persistent.
-      With persistent topics, all messages are durably persisted on
-      disks (if the broker is not standalone, messages are durably persisted on
-      multiple disks), whereas data for non-persistent topics is
-      not persisted to storage disks.
+      With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
     url:
       title: "Pulsar Persistent Storage"
       url: "https://pulsar.apache.org/docs/3.0.x/concepts-architecture-overview/#persistent-storage"
@@ -124,6 +118,7 @@ metadata:
       The OAuth 2.0 "resource server" identifier for a Pulsar cluster.
   - name: oauth2ClientSecret
     type: string
+    sensitive: true
     description: |
       The OAuth Client Secret.
   - name: oauth2TokenCAPEM

--- a/state/memcached/metadata.yaml
+++ b/state/memcached/metadata.yaml
@@ -16,16 +16,17 @@ metadata:
     type: string
     required: true
     description: |
-      Comma delimited endpoints
+      Comma-delimited list of endpoints
     example: '"memcached.default.svc.cluster.local:11211"'
   - name: maxIdleConnections
     type: number
     default: '2'
     description: |
-      The max number of idle connections.
+      Max number of idle connections.
     example: '"3"'
   - name: timeout
     type: duration
     description: |
-      The timeout for the calls. Defaults to "1000ms"
-    example: '"1000ms"'
+      Timeout for calls to the service.
+    default: '"1s"'
+    example: '"5s"'


### PR DESCRIPTION
PRs #3057, #3066, #3071, #3061 contained a large number of factual errors, such as:

- Missing metadata properties
- Mismatched type and examples (description indicated a number, but example was for booleans)
- Missing `sensitive: true`
- Incorrect grouping of metadata options for auth profiles
- Typos and other bad wording