### PR TITLE
WIP: Azure App Config: Conformance test

### DIFF
--- a/.github/infrastructure/conformance/azure/setup-azure-conf-test.sh
+++ b/.github/infrastructure/conformance/azure/setup-azure-conf-test.sh
@@ -240,6 +240,7 @@ STORAGE_CONTAINER_VAR_NAME="AzureBlobStorageContainer"
 STORAGE_QUEUE_VAR_NAME="AzureBlobStorageQueue"
 
 AZURE_APP_CONFIG_NAME_VAR_NAME="AzureAppConfigName"
+AZURE_APP_CONFIG_HOST_VAR_NAME="AzureAppConfigHost"
 
 # Derived variables
 if [[ -z "${ADMIN_ID}" ]]; then
@@ -767,6 +768,9 @@ az keyvault secret set --name "${EVENT_HUBS_PUBSUB_CONTAINER_VAR_NAME}" --vault-
 # ------------------------------
 echo export ${AZURE_APP_CONFIG_NAME_VAR_NAME}=\"${AZURE_APP_CONFIG_NAME}\" >> "${ENV_CONFIG_FILENAME}"
 az keyvault secret set --name "${AZURE_APP_CONFIG_NAME_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${AZURE_APP_CONFIG_NAME}"
+AZURE_APP_CONFIG_HOST="$(az appconfig show -n dapr3-conf-test-cfg -g ${AZURE_APP_CONFIG_NAME} -otsv --query 'endpoint')"
+echo export ${AZURE_APP_CONFIG_HOST_VAR_NAME}=\"${AZURE_APP_CONFIG_HOST}\" >> "${ENV_CONFIG_FILENAME}"
+az keyvault secret set --name "${AZURE_APP_CONFIG_HOST_VAR_NAME}" --vault-name "${KEYVAULT_NAME}" --value "${AZURE_APP_CONFIG_HOST}"
 # ----------------------------------
 # Populate IoT Hub test settings
 # ----------------------------------

--- a/configuration/azure/appconfig/appconfig.go
+++ b/configuration/azure/appconfig/appconfig.go
@@ -58,7 +58,7 @@ type azAppConfigClient interface {
 // ConfigurationStore is a Azure App Configuration store.
 type ConfigurationStore struct {
 	client                azAppConfigClient
-	metadata              metadata
+	metadata              AppConfigMetadata
 	subscribeCancelCtxMap sync.Map
 
 	logger logger.Logger
@@ -75,7 +75,7 @@ func NewAzureAppConfigurationStore(logger logger.Logger) configuration.Store {
 
 // Init does metadata and connection parsing.
 func (r *ConfigurationStore) Init(_ context.Context, md configuration.Metadata) error {
-	r.metadata = metadata{}
+	r.metadata = AppConfigMetadata{}
 	err := r.metadata.Parse(r.logger, md)
 	if err != nil {
 		return err
@@ -302,7 +302,7 @@ func (r *ConfigurationStore) Unsubscribe(ctx context.Context, req *configuration
 
 // GetComponentMetadata returns the metadata of the component.
 func (r *ConfigurationStore) GetComponentMetadata() (metadataInfo contribMetadata.MetadataMap) {
-	metadataStruct := metadata{}
+	metadataStruct := AppConfigMetadata{}
 	contribMetadata.GetMetadataInfoFromStructType(reflect.TypeOf(metadataStruct), &metadataInfo, contribMetadata.ConfigurationStoreType)
 	return
 }

--- a/configuration/azure/appconfig/appconfig_test.go
+++ b/configuration/azure/appconfig/appconfig_test.go
@@ -259,7 +259,7 @@ func TestParseMetadata(t *testing.T) {
 			Properties: testProperties,
 		}}
 
-		want := metadata{
+		want := AppConfigMetadata{
 			Host:                  "testHost",
 			MaxRetries:            3,
 			RetryDelay:            time.Second * 4,
@@ -268,7 +268,7 @@ func TestParseMetadata(t *testing.T) {
 			RequestTimeout:        time.Second * 30,
 		}
 
-		m := metadata{}
+		m := AppConfigMetadata{}
 		err := m.Parse(logger.NewLogger("test"), meta)
 		require.NoError(t, err)
 		assert.Equal(t, want.Host, m.Host)
@@ -292,7 +292,7 @@ func TestParseMetadata(t *testing.T) {
 			Properties: testProperties,
 		}}
 
-		want := metadata{
+		want := AppConfigMetadata{
 			ConnectionString:      "testConnectionString",
 			MaxRetries:            3,
 			RetryDelay:            time.Second * 4,
@@ -301,7 +301,7 @@ func TestParseMetadata(t *testing.T) {
 			RequestTimeout:        time.Second * 30,
 		}
 
-		m := metadata{}
+		m := AppConfigMetadata{}
 		err := m.Parse(logger.NewLogger("test"), meta)
 		require.NoError(t, err)
 		assert.Equal(t, want.ConnectionString, m.ConnectionString)
@@ -326,7 +326,7 @@ func TestParseMetadata(t *testing.T) {
 			Properties: testProperties,
 		}}
 
-		m := metadata{}
+		m := AppConfigMetadata{}
 		err := m.Parse(logger.NewLogger("test"), meta)
 		require.Error(t, err)
 	})
@@ -345,7 +345,7 @@ func TestParseMetadata(t *testing.T) {
 			Properties: testProperties,
 		}}
 
-		m := metadata{}
+		m := AppConfigMetadata{}
 		err := m.Parse(logger.NewLogger("test"), meta)
 		require.Error(t, err)
 	})

--- a/configuration/azure/appconfig/metadata.go
+++ b/configuration/azure/appconfig/metadata.go
@@ -22,7 +22,7 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-type metadata struct {
+type AppConfigMetadata struct {
 	Host                  string        `mapstructure:"host"`
 	ConnectionString      string        `mapstructure:"connectionString"`
 	MaxRetries            int           `mapstructure:"maxRetries"`
@@ -32,7 +32,7 @@ type metadata struct {
 	RequestTimeout        time.Duration `mapstructure:"requestTimeout"`
 }
 
-func (m *metadata) Parse(log logger.Logger, meta configuration.Metadata) error {
+func (m *AppConfigMetadata) Parse(log logger.Logger, meta configuration.Metadata) error {
 	// Set defaults
 	m.MaxRetries = defaultMaxRetries
 	m.MaxRetryDelay = defaultMaxRetryDelay

--- a/tests/config/configuration/azure/appconfig/configstore.yml
+++ b/tests/config/configuration/azure/appconfig/configstore.yml
@@ -1,0 +1,16 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: configstore
+spec:
+  type: configuration.postgresql
+  version: v1
+  metadata:
+    - name: host
+      value: "https://dapr3-conf-test-cfg.azconfig.io"
+    - name: azureClientId
+      value: "${{AzureCertificationServicePrincipalClientId}}"
+    - name: azureClientSecret
+      value: "${{AzureCertificationServicePrincipalClientSecret}}"
+    - name: azureTenantId
+      value: "${{AzureCertificationTenantId}}"

--- a/tests/config/configuration/azure/appconfig/configstore.yml
+++ b/tests/config/configuration/azure/appconfig/configstore.yml
@@ -7,7 +7,7 @@ spec:
   version: v1
   metadata:
     - name: host
-      value: "https://dapr3-conf-test-cfg.azconfig.io"
+      value: "${{AzureAppConfigHost}}"
     - name: azureClientId
       value: "${{AzureCertificationServicePrincipalClientId}}"
     - name: azureClientSecret

--- a/tests/config/configuration/tests.yml
+++ b/tests/config/configuration/tests.yml
@@ -9,3 +9,5 @@ components:
     operations: []
   - component: postgresql.docker
     operations: []
+  - component: azure.appconfig
+    operations: []

--- a/tests/conformance/common.go
+++ b/tests/conformance/common.go
@@ -59,6 +59,7 @@ import (
 	b_postgres "github.com/dapr/components-contrib/bindings/postgres"
 	b_rabbitmq "github.com/dapr/components-contrib/bindings/rabbitmq"
 	b_redis "github.com/dapr/components-contrib/bindings/redis"
+	c_azure_appconfig "github.com/dapr/components-contrib/configuration/azure/appconfig"
 	c_postgres "github.com/dapr/components-contrib/configuration/postgres"
 	c_redis "github.com/dapr/components-contrib/configuration/redis"
 	cr_azurekeyvault "github.com/dapr/components-contrib/crypto/azure/keyvault"
@@ -113,6 +114,7 @@ import (
 	conf_state "github.com/dapr/components-contrib/tests/conformance/state"
 	conf_workflows "github.com/dapr/components-contrib/tests/conformance/workflows"
 	"github.com/dapr/components-contrib/tests/utils/configupdater"
+	cu_azure_appconfig "github.com/dapr/components-contrib/tests/utils/configupdater/azure/appconfig"
 	cu_postgres "github.com/dapr/components-contrib/tests/utils/configupdater/postgres"
 	cu_redis "github.com/dapr/components-contrib/tests/utils/configupdater/redis"
 	wf_temporal "github.com/dapr/components-contrib/workflows/temporal"
@@ -122,6 +124,7 @@ const (
 	eventhubs                 = "azure.eventhubs"
 	redisv6                   = "redis.v6"
 	redisv7                   = "redis.v7"
+	appconfig                 = "azure.appconfig"
 	kafka                     = "kafka"
 	generateUUID              = "$((uuid))"
 	generateEd25519PrivateKey = "$((ed25519PrivateKey))"
@@ -449,6 +452,9 @@ func loadConfigurationStore(tc TestComponent) (configuration.Store, configupdate
 	case "postgresql.docker", "postgresql.azure":
 		store = c_postgres.NewPostgresConfigurationStore(testLogger)
 		updater = cu_postgres.NewPostgresConfigUpdater(testLogger)
+	case "azure.appconfig", "azure.appconfiguration":
+		store = c_azure_appconfig.NewAzureAppConfigurationStore(testLogger)
+		updater = cu_azure_appconfig.NewAzureAppconfigConfigUpdater(testLogger)
 	default:
 		return nil, nil
 	}

--- a/tests/utils/configupdater/azure/appconfig/appconfig.go
+++ b/tests/utils/configupdater/azure/appconfig/appconfig.go
@@ -72,7 +72,6 @@ func (r *ConfigUpdater) AddKey(items map[string]*configuration.Item) error {
 			&azappconfig.AddSettingOptions{
 				Label: to.Ptr(item.Metadata["label"]),
 			})
-
 		if err != nil {
 			return err
 		}
@@ -87,7 +86,6 @@ func (r *ConfigUpdater) UpdateKey(items map[string]*configuration.Item) error {
 			&azappconfig.SetSettingOptions{
 				Label: to.Ptr(item.Metadata["label"]),
 			})
-
 		if err != nil {
 			return err
 		}
@@ -96,7 +94,6 @@ func (r *ConfigUpdater) UpdateKey(items map[string]*configuration.Item) error {
 }
 
 func (r *ConfigUpdater) DeleteKey(keys []string) error {
-
 	for _, key := range keys {
 		_, err := r.client.DeleteSetting(context.TODO(), key, nil)
 		if err != nil {

--- a/tests/utils/configupdater/azure/appconfig/appconfig.go
+++ b/tests/utils/configupdater/azure/appconfig/appconfig.go
@@ -1,0 +1,107 @@
+package redis
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
+
+	"github.com/dapr/components-contrib/configuration"
+	"github.com/dapr/components-contrib/configuration/azure/appconfig"
+	azauth "github.com/dapr/components-contrib/internal/authentication/azure"
+	contribMetadata "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/components-contrib/tests/utils/configupdater"
+	"github.com/dapr/kit/logger"
+)
+
+type ConfigUpdater struct {
+	client   *azappconfig.Client
+	metadata appconfig.AppConfigMetadata
+	logger   logger.Logger
+}
+
+func NewAzureAppconfigConfigUpdater(logger logger.Logger) configupdater.Updater {
+	return &ConfigUpdater{
+		logger: logger,
+	}
+}
+
+func NewRedisConfigUpdater(logger logger.Logger) configupdater.Updater {
+	return &ConfigUpdater{
+		logger: logger,
+	}
+}
+
+func (r *ConfigUpdater) Init(props map[string]string) error {
+	err := r.metadata.Parse(r.logger, configuration.Metadata{Base: contribMetadata.Base{Properties: props}})
+	if err != nil {
+		return err
+	}
+
+	if r.metadata.ConnectionString != "" {
+		r.client, err = azappconfig.NewClientFromConnectionString(r.metadata.ConnectionString, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		var settings azauth.EnvironmentSettings
+		settings, err = azauth.NewEnvironmentSettings(props)
+		if err != nil {
+			return err
+		}
+
+		var cred azcore.TokenCredential
+		cred, err = settings.GetTokenCredential()
+		if err != nil {
+			return err
+		}
+
+		r.client, err = azappconfig.NewClient(r.metadata.Host, cred, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ConfigUpdater) AddKey(items map[string]*configuration.Item) error {
+	for key, item := range items {
+		_, err := r.client.AddSetting(
+			context.TODO(), key, to.Ptr(item.Value),
+			&azappconfig.AddSettingOptions{
+				Label: to.Ptr(item.Metadata["label"]),
+			})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ConfigUpdater) UpdateKey(items map[string]*configuration.Item) error {
+	for key, item := range items {
+		_, err := r.client.SetSetting(
+			context.TODO(), key, to.Ptr(item.Value),
+			&azappconfig.SetSettingOptions{
+				Label: to.Ptr(item.Metadata["label"]),
+			})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ConfigUpdater) DeleteKey(keys []string) error {
+
+	for _, key := range keys {
+		_, err := r.client.DeleteSetting(context.TODO(), key, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Conformance test for Azure App Config. This test is not yet activated in the GitHub workflow.

This test also currently doesn't pass due to an issue with key versioning and sentinel keys in the metadata.

To run this test, create an Azure App Config store (Free tier is sufficient). Set the host (endpoint) and provide a service principal with Configuration Data owner role via the environment variables (which must be set):
- AzureAppConfigHost
- AzureCertificationServicePrincipalClientId
- AzureCertificationServicePrincipalClientSecret
- AzureCertificationTenantId

Next run the test with:
`go test -v -tags=conftests --count=1 ./tests/conformance -run="TestConfigurationConformance/azure.appconfig"`