### PR TITLE
Add insecureskipverify warnings

### DIFF
--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -127,6 +127,8 @@ func (s *AWSS3) Init(_ context.Context, metadata bindings.Metadata) error {
 			Transport: customTransport,
 		}
 		cfg = cfg.WithHTTPClient(client)
+
+		s.logger.Infof("aws s3: you are using 'insecureSSL' to skip server config verify which is unsafe!")
 	}
 
 	s.metadata = m

--- a/nameresolution/consul/consul.go
+++ b/nameresolution/consul/consul.go
@@ -97,6 +97,10 @@ func (r *resolver) Init(metadata nr.Metadata) (err error) {
 		return err
 	}
 
+	if r.config.Client.TLSConfig.InsecureSkipVerify {
+		r.logger.Infof("hashicorp consul: you are using 'insecureSkipVerify' to skip server config verify which is unsafe!")
+	}
+
 	err = r.client.InitClient(r.config.Client)
 	if err != nil {
 		return fmt.Errorf("failed to init consul client: %w", err)

--- a/secretstores/hashicorp/vault/vault.go
+++ b/secretstores/hashicorp/vault/vault.go
@@ -423,7 +423,7 @@ func (v *vaultSecretStore) initVaultToken() error {
 func (v *vaultSecretStore) createHTTPClient(config *tlsConfig) (*http.Client, error) {
 	tlsClientConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
-	if config.vaultSkipVerify {
+	if config != nil && config.vaultSkipVerify {
 		v.logger.Infof("hashicorp vault: you are using 'skipVerify' to skip server config verify which is unsafe!")
 	}
 

--- a/secretstores/hashicorp/vault/vault.go
+++ b/secretstores/hashicorp/vault/vault.go
@@ -423,6 +423,10 @@ func (v *vaultSecretStore) initVaultToken() error {
 func (v *vaultSecretStore) createHTTPClient(config *tlsConfig) (*http.Client, error) {
 	tlsClientConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
+	if config.vaultSkipVerify {
+		v.logger.Infof("hashicorp vault: you are using 'skipVerify' to skip server config verify which is unsafe!")
+	}
+
 	tlsClientConfig.InsecureSkipVerify = config.vaultSkipVerify
 	if !config.vaultSkipVerify {
 		rootCAPools, err := v.getRootCAsPools(config.vaultCAPem, config.vaultCAPath, config.vaultCACert)

--- a/secretstores/hashicorp/vault/vault_test.go
+++ b/secretstores/hashicorp/vault/vault_test.go
@@ -118,7 +118,9 @@ func TestVaultTLSConfig(t *testing.T) {
 
 func TestVaultEnginePath(t *testing.T) {
 	t.Run("without engine path config", func(t *testing.T) {
-		v := vaultSecretStore{}
+		v := vaultSecretStore{
+			logger: logger.NewLogger("test"),
+		}
 
 		err := v.Init(context.Background(), secretstores.Metadata{Base: metadata.Base{Properties: map[string]string{componentVaultToken: expectedTok, "skipVerify": "true"}}})
 		assert.Nil(t, err)
@@ -126,7 +128,9 @@ func TestVaultEnginePath(t *testing.T) {
 	})
 
 	t.Run("with engine path config", func(t *testing.T) {
-		v := vaultSecretStore{}
+		v := vaultSecretStore{
+			logger: logger.NewLogger("test"),
+		}
 
 		err := v.Init(context.Background(), secretstores.Metadata{Base: metadata.Base{Properties: map[string]string{componentVaultToken: expectedTok, "skipVerify": "true", vaultEnginePath: "kv"}}})
 		assert.Nil(t, err)
@@ -332,7 +336,7 @@ func TestVaultValueType(t *testing.T) {
 
 		target := &vaultSecretStore{
 			client: nil,
-			logger: nil,
+			logger: logger.NewLogger("test"),
 		}
 
 		err := target.Init(context.Background(), m)
@@ -353,7 +357,7 @@ func TestVaultValueType(t *testing.T) {
 
 		target := &vaultSecretStore{
 			client: nil,
-			logger: nil,
+			logger: logger.NewLogger("test"),
 		}
 
 		err := target.Init(context.Background(), m)
@@ -373,7 +377,7 @@ func TestVaultValueType(t *testing.T) {
 
 		target := &vaultSecretStore{
 			client: nil,
-			logger: nil,
+			logger: logger.NewLogger("test"),
 		}
 
 		err := target.Init(context.Background(), m)
@@ -422,7 +426,7 @@ func TestGetFeatures(t *testing.T) {
 
 		target := &vaultSecretStore{
 			client: nil,
-			logger: nil,
+			logger: logger.NewLogger("test"),
 		}
 
 		// This call will throw an error on Windows systems because of the of


### PR DESCRIPTION
Log usage of TLS skipped verification at info level the same as done for Kafka.
