### PR TITLE
Define DynamoDB Transaction limit

### DIFF
--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -338,6 +338,12 @@ func (d *StateStore) parseTTL(req *state.SetRequest) (*int64, error) {
 	return nil, nil
 }
 
+// MultiMaxSize returns the maximum number of operations allowed in a transaction.
+// For AWS DynamoDB, that's 100.
+func (d *StateStore) MultiMaxSize() int {
+	return 100
+}
+
 // Multi performs a transactional operation. succeeds only if all operations succeed, and fails if one or more operations fail.
 func (d *StateStore) Multi(ctx context.Context, request *state.TransactionalStateRequest) error {
 	opns := len(request.Operations)


### PR DESCRIPTION
# Description

Defines the DynamoDB Transaction limit of 100 operations in a single transaction, similar to the way it is defined for CosmosDB.

This is necessary for Workflow, so it can be inferred what the max parallel operation batch size should be.