### PR TITLE
Add `\rerun <ID>` command for failed jobs in workflows

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -94,6 +94,10 @@ async function handleIssueCommentCreate({ github, context }) {
         case '/ok-to-test':
             await cmdOkToTest(github, issue, isFromPulls)
             break
+        case command.match(/^\/rerun /)?.input:
+            const workflowrunid = command.match(/\d+/)[0];
+            await rerunWorkflow(github, issue, workflowrunid)
+            break
         default:
             console.log(
                 `[handleIssueCommentCreate] command ${command} not found, exiting.`
@@ -233,4 +237,19 @@ async function cmdOkToTest(github, issue, isFromPulls) {
             )}`
         )
     }
+}
+
+/**
+ * Rerun all failed jobs of a given workflow run ID.
+ * @param {*} github GitHub object reference
+ * @param {*} issue GitHub issue object
+ * @param {int} workflowrunid the workflow run ID for which to rerun all failed jobs
+ */
+async function rerunWorkflow(github, issue, workflowrunid) {
+    // Get pull request
+    const pull = await github.rest.actions.reRunWorkflowFailedJobs({
+       owner: issue.owner,
+       repo: issue.repo,
+       run_id: workflowrunid,
+    });
 }

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -246,7 +246,7 @@ async function cmdOkToTest(github, issue, isFromPulls) {
  * @param {int} workflowrunid the workflow run ID for which to rerun all failed jobs
  */
 async function rerunWorkflow(github, issue, workflowrunid) {
-    // Get pull request
+    // Rerun all failed jobs of the specified workflow run
     const pull = await github.rest.actions.reRunWorkflowFailedJobs({
        owner: issue.owner,
        repo: issue.repo,

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -94,7 +94,7 @@ async function handleIssueCommentCreate({ github, context }) {
         case '/ok-to-test':
             await cmdOkToTest(github, issue, isFromPulls)
             break
-        case command.match(/^\/rerun /)?.input:
+        case command.match(/^\/rerun \d+/)?.input:
             const workflowrunid = command.match(/\d+/)[0];
             await rerunWorkflow(github, issue, workflowrunid)
             break


### PR DESCRIPTION
# Description

This adds a command which allows rerunning of just the failed jobs on an existing workflow run ID.

This can help with reducing unnecessary workflow runs. It also allows trusted community members who are not approvers to perform this action (the same people who can run `/ok-to-test`).

Usage:
`\rerun <ID>`, where the ID is obtained from URL of a given workflow run