### PR TITLE
[PubSub][Metadata] The consumerID is Repeated in metadata-component-bundle.json for PubSub Components

### DIFF
--- a/internal/component/azure/eventhubs/metadata.go
+++ b/internal/component/azure/eventhubs/metadata.go
@@ -28,7 +28,7 @@ import (
 type AzureEventHubsMetadata struct {
 	ConnectionString        string `json:"connectionString" mapstructure:"connectionString"`
 	EventHubNamespace       string `json:"eventHubNamespace" mapstructure:"eventHubNamespace"`
-	ConsumerID              string `json:"consumerID" mapstructure:"consumerID"`
+	ConsumerID              string `json:"consumerID" mapstructure:"consumerID" mdignore:"true"`
 	StorageConnectionString string `json:"storageConnectionString" mapstructure:"storageConnectionString"`
 	StorageAccountName      string `json:"storageAccountName" mapstructure:"storageAccountName"`
 	StorageAccountKey       string `json:"storageAccountKey" mapstructure:"storageAccountKey"`

--- a/internal/component/azure/servicebus/metadata.go
+++ b/internal/component/azure/servicebus/metadata.go
@@ -30,7 +30,7 @@ import (
 type Metadata struct {
 	/** For bindings and pubsubs **/
 	ConnectionString                string `mapstructure:"connectionString"`
-	ConsumerID                      string `mapstructure:"consumerID"` // Only topics
+	ConsumerID                      string `mapstructure:"consumerID" mdignore:"true"` // Only topics
 	TimeoutInSec                    int    `mapstructure:"timeoutInSec"`
 	HandlerTimeoutInSec             int    `mapstructure:"handlerTimeoutInSec"`
 	LockRenewalInSec                int    `mapstructure:"lockRenewalInSec"`

--- a/internal/component/redis/settings.go
+++ b/internal/component/redis/settings.go
@@ -84,7 +84,7 @@ type Settings struct {
 
 	// == pubsub only properties ==
 	// The consumer identifier
-	ConsumerID string `mapstructure:"consumerID" mdonly:"pubsub"`
+	ConsumerID string `mapstructure:"consumerID" mdonly:"pubsub" mdignore:"true"`
 	// The interval between checking for pending messages to redelivery (0 disables redelivery)
 	RedeliverInterval time.Duration `mapstructure:"-" mdonly:"pubsub"`
 	// The amount time a message must be pending before attempting to redeliver it (0 disables redelivery)

--- a/pubsub/azure/eventhubs/metadata.yaml
+++ b/pubsub/azure/eventhubs/metadata.yaml
@@ -97,9 +97,3 @@ metadata:
     description: |
       Storage container name.
     example: '"myeventhubstoragecontainer"'
-  - name: consumerId
-    type: string
-    required: true # consumerGroup is an alias for this field, let's promote this to default
-    description: |
-      The name of the Event Hubs Consumer Group to listen on.
-    example: '"group1"'

--- a/pubsub/azure/servicebus/topics/metadata.yaml
+++ b/pubsub/azure/servicebus/topics/metadata.yaml
@@ -35,11 +35,6 @@ builtinAuthenticationProfiles:
           output: true
           input: true
 metadata:
-  - name: consumerID
-    description: "Consumer ID (a.k.a consumer tag) organizes one or more consumers into a group. Consumers with the same consumer ID work as one virtual consumer, i.e. a message is processed only once by one of the consumers in the group. If the consumer ID is not set, the dapr runtime will set it to the dapr application ID."
-    type: string
-    default: "The ID of the app"
-    example: "myconsumer"
   - name: maxRetriableErrorsPerSec
     description: "Maximum number of retriable errors that are processed per second. If a message fails to be processed with a retriable error, the component adds a delay before it starts processing another message, to avoid immediately re-processing messages that have failed"
     type: number

--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -21,7 +21,7 @@ import (
 
 type pulsarMetadata struct {
 	Host                    string                    `mapstructure:"host"`
-	ConsumerID              string                    `mapstructure:"consumerID"`
+	ConsumerID              string                    `mapstructure:"consumerID" mdignore:"true"`
 	EnableTLS               bool                      `mapstructure:"enableTLS"`
 	DisableBatching         bool                      `mapstructure:"disableBatching"`
 	BatchingMaxPublishDelay time.Duration             `mapstructure:"batchingMaxPublishDelay"`

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -58,10 +58,6 @@ metadata:
     description: "Address of the Pulsar broker."
     example: |
       "localhost:6650", "http://pulsar-pj54qwwdpz4b-pulsar.ap-sg.public.pulsar.com:8080"
-  - name: consumerID
-    type: string
-    description: "Used to set the subscription name or consumer ID."
-    example: '"channel1"'
   - name: namespace
     description: |
       The administrative unit of the topic, which acts as a grouping mechanism for related topics.

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -29,11 +29,6 @@ metadata:
     description: Username for Redis host. Defaults to empty. Make sure your redis server version is 6 or above, and have created acl rule correctly.
     example: "default"
     type: string
-  - name: consumerID
-    required: false
-    description: The consumer group ID
-    example: "myGroup"
-    type: string
   - name: enableTLS
     required: false
     description: |


### PR DESCRIPTION
The consumerID is Repeated in metadata-component-bundle.json for PubSub Components. This PR removes it from the `metadata.yaml` as it will be added automatically.

For example, the Pubsub/Redis conmponent metadata:
```
{
  {
      "name": "consumerID",
      "description": "The consumer group ID",
      "type": "string",
      "example": "myGroup"
  },
  {
      "name": "consumerID",
      "description": "Set the consumer ID to control namespacing. Defaults to the app's ID.",
      "type": "string",
      "example": "\"{namespace}\"",
      "url": {
          "title": "Documentation",
          "url": "https://docs.dapr.io/developing-applications/building-blocks/pubsub/howto-namespace/"
      }
  }
}
```

# Description

_Please explain the changes you've made_

## Issue reference

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
