### PR TITLE
Postgres components: Adds `queryExecMode` option

### DIFF
--- a/bindings/postgres/metadata.yaml
+++ b/bindings/postgres/metadata.yaml
@@ -79,3 +79,16 @@ metadata:
     sensitive: true
     example: |
       "user=dapr password=secret host=dapr.example.com port=5432 dbname=dapr sslmode=verify-ca"
+  - name: queryExecMode
+    required: false
+    description: |
+      Controls the default mode for executing queries. By default Dapr uses the extended protocol and automatically prepares and caches prepared statements.
+      However, this may be incompatible with proxies such as PGBouncer. In this case it may be preferrable to use `exec` or `simple_protocol`.
+    allowedValues:
+      - "cache_statement"
+      - "cache_describe"
+      - "describe_exec"
+      - "exec"
+      - "simple_protocol"
+    example: "cache_describe"
+    default: ""

--- a/configuration/postgres/metadata.yaml
+++ b/configuration/postgres/metadata.yaml
@@ -68,3 +68,16 @@ metadata:
       Deprecated alias for 'connectionMaxIdleTime'.
     example:  "5m"
     type: duration
+  - name: queryExecMode
+    required: false
+    description: |
+      Controls the default mode for executing queries. By default Dapr uses the extended protocol and automatically prepares and caches prepared statements.
+      However, this may be incompatible with proxies such as PGBouncer. In this case it may be preferrable to use `exec` or `simple_protocol`.
+    allowedValues:
+      - "cache_statement"
+      - "cache_describe"
+      - "describe_exec"
+      - "exec"
+      - "simple_protocol"
+    example: "cache_describe"
+    default: ""

--- a/internal/authentication/postgresql/metadata.go
+++ b/internal/authentication/postgresql/metadata.go
@@ -93,6 +93,8 @@ func (m *PostgresAuthMetadata) GetPgxPoolConfig() (*pgxpool.Config, error) {
 		}
 		if mode, ok := queryExecModes[m.QueryExecMode]; ok {
 			config.ConnConfig.DefaultQueryExecMode = mode
+		} else {
+			return nil, fmt.Errorf("invalid queryExecMode metadata value: %s", m.QueryExecMode)
 		}
 	}
 

--- a/state/postgresql/metadata.yaml
+++ b/state/postgresql/metadata.yaml
@@ -93,3 +93,16 @@ metadata:
       database driver to choose.
     example:  "5m"
     type: duration
+  - name: queryExecMode
+    required: false
+    description: |
+      Controls the default mode for executing queries. By default Dapr uses the extended protocol and automatically prepares and caches prepared statements.
+      However, this may be incompatible with proxies such as PGBouncer. In this case it may be preferrable to use `exec` or `simple_protocol`.
+    allowedValues:
+      - "cache_statement"
+      - "cache_describe"
+      - "describe_exec"
+      - "exec"
+      - "simple_protocol"
+    example: "cache_describe"
+    default: ""


### PR DESCRIPTION
# Description

Fixes #3002

Adds a metadata property `queryExecMode`, which exposes the low level Statement Query Execution mode. In certain advanced scenarios, for example when using **pgBouncer** the correct mode must be chosen by the user for the Postgres components to work.

Allowed values:
```yaml
      - "cache_statement"
      - "cache_describe"
      - "describe_exec"
      - "exec"
      - "simple_protocol"
```

See also https://github.com/jackc/pgx/issues/602#issuecomment-532236718 for reference.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
~* [ ] Created/updated tests~
~* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~
