### PR TITLE
rm unused code

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -142,8 +142,6 @@ jobs:
     - name: Configure conformance test and source path
       run: |
         TEST_COMPONENT=$(echo ${{ matrix.component }} | sed -E 's/\./\//g')
-        export TEST_PATH="tests/certification/${TEST_COMPONENT}"
-        echo "TEST_PATH=$TEST_PATH" >> $GITHUB_ENV
         export SOURCE_PATH="github.com/dapr/components-contrib/${TEST_COMPONENT}"
         echo "SOURCE_PATH=$SOURCE_PATH" >> $GITHUB_ENV
         # converts slashes to dots in this string, so that it doesn't consider them sub-folders


### PR DESCRIPTION
Noticed in our yaml files that the `conformance.yml` workflow was referencing the `certification` test path, which is just confusing because that's the wrong test path. It's a copy pasta error. It should be removed to avoid confusion as well as since it's not even being used.