### PR TITLE
[Release 1.10 only] Fix Redis Binding Get Op for unknown keys

### DIFF
--- a/bindings/redis/redis.go
+++ b/bindings/redis/redis.go
@@ -82,6 +82,9 @@ func (r *Redis) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindi
 		case bindings.GetOperation:
 			data, err := r.client.Get(ctx, key)
 			if err != nil {
+				if err.Error() == "redis: nil" {
+					return &bindings.InvokeResponse{}, nil
+				}
 				return nil, err
 			}
 			rep := &bindings.InvokeResponse{}

--- a/bindings/redis/redis_test.go
+++ b/bindings/redis/redis_test.go
@@ -77,6 +77,13 @@ func TestInvokeGet(t *testing.T) {
 	})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, true, string(bindingRes.Data) == testData)
+
+	bindingRes2, err2 := bind.Invoke(context.TODO(), &bindings.InvokeRequest{
+		Metadata:  map[string]string{"key": "doesnotexist"},
+		Operation: bindings.GetOperation,
+	})
+	assert.NoError(t, err2)
+	assert.Nil(t, bindingRes2.Data)
 }
 
 func TestInvokeDelete(t *testing.T) {


### PR DESCRIPTION
# Description

The Redis SDK returns a special value `redis: nil` when a key does not exist. This was not handled correctly by the binding.

It was already fixed in Dapr 1.11, but not in Dapr 1.10.X

Fixes #3140 