### PR TITLE
[GCP Certification Tests] renames GCP WIF pool/provider names

### DIFF
--- a/.github/infrastructure/terraform/infra-setup/gcp/dapr-gh-gcp-wif/README.md
+++ b/.github/infrastructure/terraform/infra-setup/gcp/dapr-gh-gcp-wif/README.md
@@ -54,16 +54,16 @@ Before this module can be used on a project, you must ensure that the following 
 $ terraform init
 
 $ terraform refresh -var="gh_repo=dapr/components-contrib" \
-                 -var="project_id=dapr-tests" -var="service_account=comp-contrib-wif" \
-                 -var="wif_pool_name=contrib-cert-tests"
+                 -var="project_id=dapr-tests" -var="service_account=dapr-contrib-wif-sa" \
+                 -var="wif_pool_name=dapr-contrib-cert-tests"
 
 $ terraform plan -var="gh_repo=dapr/components-contrib" \
-                 -var="project_id=dapr-tests" -var="service_account=comp-contrib-wif" \
-                 -var="wif_pool_name=contrib-cert-tests"
+                 -var="project_id=dapr-tests" -var="service_account=dapr-contrib-wif-sa" \
+                 -var="wif_pool_name=dapr-contrib-cert-tests"
 
 $ terraform apply --auto-approve -var="gh_repo=dapr/components-contrib" \
-                 -var="project_id=dapr-tests" -var="service_account=comp-contrib-wif" \
-                 -var="wif_pool_name=contrib-cert-tests"
+                 -var="project_id=dapr-tests" -var="service_account=dapr-contrib-wif-sa" \
+                 -var="wif_pool_name=dapr-contrib-cert-tests"
 ```
 
 
@@ -72,7 +72,7 @@ $ terraform apply --auto-approve -var="gh_repo=dapr/components-contrib" \
 ```
 $ terraform output                                                   
     
-pool_name = "projects/***/locations/global/workloadIdentityPools/contrib-cert-tests-gh-pool"
-provider_name = "projects/***/locations/global/workloadIdentityPools/contrib-cert-tests-gh-pool/providers/contrib-cert-tests-gh-provider"
+pool_name = "projects/***/locations/global/workloadIdentityPools/dapr-contrib-cert-tests-pool"
+provider_name = "projects/***/locations/global/workloadIdentityPools/dapr-contrib-cert-tests-pool/providers/dapr-contrib-cert-tests-provider"
 sa_email = "***"
 ```

--- a/.github/infrastructure/terraform/infra-setup/gcp/dapr-gh-gcp-wif/main.tf
+++ b/.github/infrastructure/terraform/infra-setup/gcp/dapr-gh-gcp-wif/main.tf
@@ -17,8 +17,8 @@ module "oidc" {
   source      = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
   version     = "~> 3.1.1"
   project_id  = var.project_id
-  pool_id     = "${var.wif_pool_name}-gh-pool"
-  provider_id = "${var.wif_pool_name}-gh-provider"
+  pool_id     = "${var.wif_pool_name}-pool"
+  provider_id = "${var.wif_pool_name}-provider"
   sa_mapping = {
     (google_service_account.sa.account_id) = {
       sa_name   = google_service_account.sa.name


### PR DESCRIPTION
# Description

This PR renames GCP WIF pool/provider names.
The previous GCP WIF used for the GHA workflows was not working correctly, so I needed to recreate it with a new name.
The Terraform script that creates these resources have been executed and the output will be supplied to
`components-contrib` maintainer to modify the GHA secrets:
```golang
  workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER_NAME }}
  service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
```
Once the GHA secrets have been updated, we can run the GCP Certification tests.
