### PR TITLE
[AWS Secret Store] Adds Endpoint

### DIFF
--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -45,6 +45,7 @@ type SecretManagerMetaData struct {
 	AccessKey    string `json:"accessKey"`
 	SecretKey    string `json:"secretKey"`
 	SessionToken string `json:"sessionToken"`
+	Endpoint     string `json:"endpoint"`
 }
 
 type smSecretStore struct {
@@ -137,7 +138,7 @@ func (s *smSecretStore) BulkGetSecret(ctx context.Context, req secretstores.Bulk
 }
 
 func (s *smSecretStore) getClient(metadata *SecretManagerMetaData) (*secretsmanager.SecretsManager, error) {
-	sess, err := awsAuth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, "")
+	sess, err := awsAuth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/secretstores/aws/secretmanager/secretmanager_integ_test.go
+++ b/secretstores/aws/secretmanager/secretmanager_integ_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secretmanager
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -25,21 +26,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestIntegrationGetSecret requires AWS specific environments for authentication AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID,
-// AWS_SECRET_ACCESS_KkEY and AWS_SESSION_TOKEN
+// TestIntegrationGetSecret requires either:
+//   - Secret to exist with the key "/aws/secret/testing"
+//   - AWS specific environments for authentication AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID,
+//     AWS_SECRET_ACCESS_KkEY and AWS_SESSION_TOKEN
+//   - or Localstack https://docs.localstack.cloud/getting-started/quickstart/ with
+//     AWS_ENDPOINT=http://localhost:4566
+//     AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID,
+//     AWS_SECRET_ACCESS_KkEY and AWS_SESSION_TOKEN
 func TestIntegrationGetSecret(t *testing.T) {
 	secretName := "/aws/secret/testing"
 	sm := NewSecretManager(logger.NewLogger("test"))
-	err := sm.Init(secretstores.Metadata{
-		Properties: map[string]string{
-			"Region":       os.Getenv("AWS_DEFAULT_REGION"),
-			"AccessKey":    os.Getenv("AWS_ACCESS_KEY_ID"),
-			"SecretKey":    os.Getenv("AWS_SECRET_ACCESS_KEY"),
-			"SessionToken": os.Getenv("AWS_SESSION_TOKEN"),
-		},
-	})
+	m := secretstores.Metadata{}
+	m.Properties = map[string]string{
+		"Region":       os.Getenv("AWS_DEFAULT_REGION"),
+		"AccessKey":    os.Getenv("AWS_ACCESS_KEY_ID"),
+		"SecretKey":    os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		"SessionToken": os.Getenv("AWS_SESSION_TOKEN"),
+		"Endpoint":     os.Getenv("AWS_ENDPOINT"),
+	}
+	err := sm.Init(context.Background(), m)
 	assert.Nil(t, err)
-	response, err := sm.GetSecret(secretstores.GetSecretRequest{
+	response, err := sm.GetSecret(context.Background(), secretstores.GetSecretRequest{
 		Name:     secretName,
 		Metadata: map[string]string{},
 	})
@@ -48,18 +56,18 @@ func TestIntegrationGetSecret(t *testing.T) {
 }
 
 func TestIntegrationBulkGetSecret(t *testing.T) {
-	secretName := "/aws/secret/testing"
 	sm := NewSecretManager(logger.NewLogger("test"))
-	err := sm.Init(secretstores.Metadata{
-		Properties: map[string]string{
-			"Region":       os.Getenv("AWS_DEFAULT_REGION"),
-			"AccessKey":    os.Getenv("AWS_ACCESS_KEY_ID"),
-			"SecretKey":    os.Getenv("AWS_SECRET_ACCESS_KEY"),
-			"SessionToken": os.Getenv("AWS_SESSION_TOKEN"),
-		},
-	})
+	m := secretstores.Metadata{}
+	m.Properties = map[string]string{
+		"Region":       os.Getenv("AWS_DEFAULT_REGION"),
+		"AccessKey":    os.Getenv("AWS_ACCESS_KEY_ID"),
+		"SecretKey":    os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		"SessionToken": os.Getenv("AWS_SESSION_TOKEN"),
+		"Endpoint":     os.Getenv("AWS_ENDPOINT"),
+	}
+	err := sm.Init(context.Background(), m)
 	assert.Nil(t, err)
-	response, err := sm.BulkGetSecret(secretstores.BulkGetSecretRequest{})
+	response, err := sm.BulkGetSecret(context.Background(), secretstores.BulkGetSecretRequest{})
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 }


### PR DESCRIPTION
# Description
[AWS Secret Store] Adds Endpoint so that component can be used locally with [Localstack](https://docs.localstack.cloud/references/coverage/coverage_secretsmanager/)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
