### PR TITLE
Disable broken GCP cert tests

### DIFF
--- a/.github/scripts/test-info.mjs
+++ b/.github/scripts/test-info.mjs
@@ -310,13 +310,13 @@ const components = {
             'conformance-pubsub.aws.snssqs.terraform-destroy.sh',
         sourcePkg: 'pubsub/aws/snssqs',
     },
-    'pubsub.gcp.pubsub': {
-        certification: true,
-        requireTerraform: true,
-        requireGCPCredentials: true,
-        certificationSetup: 'certification-pubsub.gcp.pubsub-setup.sh',
-        certificationDestroy: 'certification-pubsub.gcp.pubsub-destroy.sh',
-    },
+    // 'pubsub.gcp.pubsub': {
+    //     certification: true,
+    //     requireTerraform: true,
+    //     requireGCPCredentials: true,
+    //     certificationSetup: 'certification-pubsub.gcp.pubsub-setup.sh',
+    //     certificationDestroy: 'certification-pubsub.gcp.pubsub-destroy.sh',
+    // },
     // 'pubsub.gcp.pubsub.docker': {
     //     conformance: true,
     //     conformanceSetup: 'docker-compose.sh gcp-pubsub',
@@ -709,11 +709,11 @@ const components = {
         requireGCPCredentials: true,
         conformanceSetup: 'conformance-state.gcp.firestore-setup.sh',
     },
-    'state.gcp.firestore': {
-        certification: true,
-        requireGCPCredentials: true,
-        certificationSetup: 'certification-state.gcp.firestore-setup.sh',
-    },
+    // 'state.gcp.firestore': {
+    //     certification: true,
+    //     requireGCPCredentials: true,
+    //     certificationSetup: 'certification-state.gcp.firestore-setup.sh',
+    // },
     'workflows.temporal': {
         conformance: true,
         conformanceSetup: 'docker-compose.sh temporal',


### PR DESCRIPTION
GCP certification tests have been broken for many weeks due to failed auth.

Disabling them for now to avoid wasting CI cycles and causing noise.