### PR TITLE
Fixes GCP components failing to authenticate

### DIFF
--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -124,7 +124,7 @@ func (g *GCPPubSub) getPubSubClient(ctx context.Context, metadata *metadata) (*g
 	var pubsubClient *gcppubsub.Client
 	var err error
 
-	// context.Background is used here, as this the context used to Dial the
+	// context.Background is used here, as the context used to Dial the
 	// server in the gRPC DialPool. Callers should always call `Close` on the
 	// component to ensure all resources are released.
 	if metadata.PrivateKeyID != "" {

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -124,6 +124,9 @@ func (g *GCPPubSub) getPubSubClient(ctx context.Context, metadata *metadata) (*g
 	var pubsubClient *gcppubsub.Client
 	var err error
 
+	// context.Background is used here, as this the context used to Dial the
+	// server in the gRPC DialPool. Callers should always call `Close` on the
+	// component to ensure all resources are released.
 	if metadata.PrivateKeyID != "" {
 		// TODO: validate that all auth json fields are filled
 		authJSON := &GCPAuthJSON{
@@ -141,7 +144,7 @@ func (g *GCPPubSub) getPubSubClient(ctx context.Context, metadata *metadata) (*g
 		gcpCompatibleJSON, _ := json.Marshal(authJSON)
 		g.logger.Debugf("Using explicit credentials for GCP")
 		clientOptions := option.WithCredentialsJSON(gcpCompatibleJSON)
-		pubsubClient, err = gcppubsub.NewClient(ctx, metadata.ProjectID, clientOptions)
+		pubsubClient, err = gcppubsub.NewClient(context.Background(), metadata.ProjectID, clientOptions)
 		if err != nil {
 			return pubsubClient, err
 		}
@@ -156,7 +159,7 @@ func (g *GCPPubSub) getPubSubClient(ctx context.Context, metadata *metadata) (*g
 			g.logger.Debugf("setting GCP PubSub Emulator environment variable to 'PUBSUB_EMULATOR_HOST=%s'", metadata.ConnectionEndpoint)
 			os.Setenv("PUBSUB_EMULATOR_HOST", metadata.ConnectionEndpoint)
 		}
-		pubsubClient, err = gcppubsub.NewClient(ctx, metadata.ProjectID)
+		pubsubClient, err = gcppubsub.NewClient(context.Background(), metadata.ProjectID)
 		if err != nil {
 			return pubsubClient, err
 		}

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -211,10 +211,21 @@ func getFirestoreMetadata(meta state.Metadata) (*firestoreMetadata, error) {
 	return &m, nil
 }
 
+func (f *Firestore) Close() error {
+	if f.client != nil {
+		return f.client.Close()
+	}
+
+	return nil
+}
+
 func getGCPClient(ctx context.Context, metadata *firestoreMetadata, l logger.Logger) (*datastore.Client, error) {
 	var gcpClient *datastore.Client
 	var err error
 
+	// context.Background is used here, as this the context used to Dial the
+	// server in the gRPC DialPool. Callers should always call `Close` on the
+	// component to ensure all resources are released.
 	if metadata.PrivateKeyID != "" {
 		var b []byte
 		b, err = json.Marshal(metadata)
@@ -223,7 +234,7 @@ func getGCPClient(ctx context.Context, metadata *firestoreMetadata, l logger.Log
 		}
 
 		opt := option.WithCredentialsJSON(b)
-		gcpClient, err = datastore.NewClient(ctx, metadata.ProjectID, opt)
+		gcpClient, err = datastore.NewClient(context.Background(), metadata.ProjectID, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -238,7 +249,7 @@ func getGCPClient(ctx context.Context, metadata *firestoreMetadata, l logger.Log
 			l.Debugf("setting GCP Datastore Emulator environment variable to 'DATASTORE_EMULATOR_HOST=%s'", metadata.ConnectionEndpoint)
 			os.Setenv("DATASTORE_EMULATOR_HOST", metadata.ConnectionEndpoint)
 		}
-		gcpClient, err = datastore.NewClient(ctx, metadata.ProjectID)
+		gcpClient, err = datastore.NewClient(context.Background(), metadata.ProjectID)
 		if err != nil {
 			return nil, err
 		}

--- a/state/gcp/firestore/firestore.go
+++ b/state/gcp/firestore/firestore.go
@@ -223,7 +223,7 @@ func getGCPClient(ctx context.Context, metadata *firestoreMetadata, l logger.Log
 	var gcpClient *datastore.Client
 	var err error
 
-	// context.Background is used here, as this the context used to Dial the
+	// context.Background is used here, as the context used to Dial the
 	// server in the gRPC DialPool. Callers should always call `Close` on the
 	// component to ensure all resources are released.
 	if metadata.PrivateKeyID != "" {


### PR DESCRIPTION
# Description

GCP cert tests were failing after switching to dapr/dapr master, due to the way the context used for initialising the connection to GCP was managed.

## Issue reference

This PR closes https://github.com/dapr/components-contrib/issues/3129

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests - N/A
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
