### PR TITLE
fix typo to direct users to proper part on docs page

### DIFF
--- a/.build-tools/pkg/metadataschema/validators.go
+++ b/.build-tools/pkg/metadataschema/validators.go
@@ -259,7 +259,7 @@ func (c *ComponentMetadata) AppendBuiltin() error {
 						Example:     `"/custom-path"`,
 						URL: &URL{
 							Title: "Documentation",
-							URL:   "https://docs.dapr.io/developing-applications/building-blocks/bindings/howto-triggers/#specifying-a-custom-route",
+							URL:   "https://docs.dapr.io/developing-applications/building-blocks/bindings/howto-triggers/#specify-a-custom-route",
 						},
 					},
 				)


### PR DESCRIPTION
# Description

Updating the route documentation link to direct users to the proper part on the docs page. Currently they are taken to the top of the page, but its just bc the link is for `specifying` when it should just be `specify` for: https://docs.dapr.io/developing-applications/building-blocks/bindings/howto-triggers/#specify-a-custom-route
