### PR TITLE
[1.12] pubsub/rabbitmq: return error if reconnect errors in Init

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -154,10 +154,10 @@ func (r *rabbitMQ) Init(_ context.Context, metadata pubsub.Metadata) error {
 
 	r.metadata = meta
 
-	r.reconnect(0)
-	// We do not return error on reconnect because it can cause problems if init() happens
-	// right at the restart window for service. So, we try it now but there is logic in the
-	// code to reconnect as many times as needed.
+	if err := r.reconnect(0); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Backport of https://github.com/dapr/components-contrib/pull/3198