### PR TITLE
Fixes first-write-wins with SQLite and MySQL

### DIFF
--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -615,7 +615,6 @@ func (m *MySQL) setValue(parentCtx context.Context, querier querier, req *state.
 					CURRENT_TIMESTAMP AS updateDate,
 					? AS eTag,
 					` + ttlQuery + ` AS expiredate
-				FROM ` + m.tableName + `
 				WHERE NOT EXISTS (
 					SELECT 1
 					FROM ` + m.tableName + `


### PR DESCRIPTION
#3159 introduced a regression that caused sets with first-write-wins fail if the table was empty

The issue was due to a "FROM" statement in the CTE that should not have been there.

Also improved how the SQLite component detects etag failures when FWW is used
