### PR TITLE
Azure BlobStorage components: Add `disableEntityManagement` metadata option

### DIFF
--- a/bindings/azure/blobstorage/metadata.yaml
+++ b/bindings/azure/blobstorage/metadata.yaml
@@ -89,7 +89,7 @@ metadata:
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.
   - name: disableEntityManagement
-    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Entra ID permissions."
+    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Azure AD permissions."
     example: "true"
     default: '"false"'
     type: bool

--- a/bindings/azure/blobstorage/metadata.yaml
+++ b/bindings/azure/blobstorage/metadata.yaml
@@ -88,3 +88,8 @@ metadata:
     description: |
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.
+  - name: disableEntityManagement
+    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Entra ID permissions."
+    example: "true"
+    default: '"false"'
+    type: bool

--- a/internal/component/azure/blobstorage/client.go
+++ b/internal/component/azure/blobstorage/client.go
@@ -62,16 +62,19 @@ func CreateContainerStorageClient(parentCtx context.Context, log logger.Logger, 
 		return nil, nil, err
 	}
 
-	// Create the container if it doesn't already exist
-	var accessLevel *azblob.PublicAccessType
-	if m.PublicAccessLevel != "" && m.PublicAccessLevel != "none" {
-		accessLevel = &m.PublicAccessLevel
-	}
-	ctx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
-	defer cancel()
-	err = m.EnsureContainer(ctx, client, accessLevel)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create Azure Storage container %s: %w", m.ContainerName, err)
+	// if entity management is disabled, do not attempt to create the container
+	if !m.DisableEntityManagement {
+		// Create the container if it doesn't already exist
+		var accessLevel *azblob.PublicAccessType
+		if m.PublicAccessLevel != "" && m.PublicAccessLevel != "none" {
+			accessLevel = &m.PublicAccessLevel
+		}
+		ctx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
+		defer cancel()
+		err = m.EnsureContainer(ctx, client, accessLevel)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create Azure Storage container %s: %w", m.ContainerName, err)
+		}
 	}
 
 	return client, m, nil

--- a/internal/component/azure/blobstorage/metadata.go
+++ b/internal/component/azure/blobstorage/metadata.go
@@ -25,9 +25,10 @@ import (
 )
 
 type BlobStorageMetadata struct {
-	ContainerClientOpts `json:",inline" mapstructure:",squash"`
-	DecodeBase64        bool `json:"decodeBase64,string" mapstructure:"decodeBase64" mdonly:"bindings"`
-	PublicAccessLevel   azblob.PublicAccessType
+	ContainerClientOpts     `json:",inline" mapstructure:",squash"`
+	DecodeBase64            bool `json:"decodeBase64,string" mapstructure:"decodeBase64" mdonly:"bindings"`
+	PublicAccessLevel       azblob.PublicAccessType
+	DisableEntityManagement bool `json:"disableEntityManagement,string" mapstructure:"disableEntityManagement"`
 }
 
 type ContainerClientOpts struct {

--- a/state/azure/blobstorage/v1/metadata.yaml
+++ b/state/azure/blobstorage/v1/metadata.yaml
@@ -74,3 +74,8 @@ metadata:
     description: |
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.
+  - name: disableEntityManagement
+    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Entra ID permissions."
+    example: "true"
+    default: '"false"'
+    type: bool

--- a/state/azure/blobstorage/v1/metadata.yaml
+++ b/state/azure/blobstorage/v1/metadata.yaml
@@ -75,7 +75,7 @@ metadata:
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.
   - name: disableEntityManagement
-    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Entra ID permissions."
+    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Azure AD permissions."
     example: "true"
     default: '"false"'
     type: bool

--- a/state/azure/blobstorage/v2/metadata.yaml
+++ b/state/azure/blobstorage/v2/metadata.yaml
@@ -74,3 +74,8 @@ metadata:
     description: |
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.
+  - name: disableEntityManagement
+    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Entra ID permissions."
+    example: "true"
+    default: '"false"'
+    type: bool

--- a/state/azure/blobstorage/v2/metadata.yaml
+++ b/state/azure/blobstorage/v2/metadata.yaml
@@ -75,7 +75,7 @@ metadata:
       Specifies the maximum number of HTTP requests that will be made to retry blob operations.
       A value of zero means that no additional attempts will be made after a failure.
   - name: disableEntityManagement
-    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Entra ID permissions."
+    description: "Disable entity management. Skips the attempt to create the specified storage container. This is useful when operating with minimal Azure AD permissions."
     example: "true"
     default: '"false"'
     type: bool


### PR DESCRIPTION
# Description

Adds a new metadata option `disableEntityManagement` to use Azure Blob Storage components with minimal Entra ID permissions.

Fixes #3208