### PR TITLE
Adds TLS support to Cassandra State Store

### DIFF
--- a/state/cassandra/cassandra.go
+++ b/state/cassandra/cassandra.go
@@ -62,15 +62,16 @@ type Cassandra struct {
 }
 
 type cassandraMetadata struct {
-	Hosts             []string
-	Port              int
-	ProtoVersion      int
-	ReplicationFactor int
-	Username          string
-	Password          string
-	Consistency       string
-	Table             string
-	Keyspace          string
+	Hosts                  []string
+	Port                   int
+	ProtoVersion           int
+	ReplicationFactor      int
+	Username               string
+	Password               string
+	Consistency            string
+	Table                  string
+	Keyspace               string
+	EnableHostVerification bool
 }
 
 // NewCassandraStateStore returns a new cassandra state store.
@@ -135,6 +136,11 @@ func (c *Cassandra) createClusterConfig(metadata *cassandraMetadata) (*gocql.Clu
 	clusterConfig := gocql.NewCluster(metadata.Hosts...)
 	if metadata.Username != "" && metadata.Password != "" {
 		clusterConfig.Authenticator = gocql.PasswordAuthenticator{Username: metadata.Username, Password: metadata.Password}
+	}
+	if metadata.EnableHostVerification {
+		clusterConfig.SslOpts = &gocql.SslOptions{
+			EnableHostVerification: true,
+		}
 	}
 	clusterConfig.Port = metadata.Port
 	clusterConfig.ProtoVersion = metadata.ProtoVersion

--- a/state/cassandra/metadata.yaml
+++ b/state/cassandra/metadata.yaml
@@ -38,6 +38,11 @@ metadata:
     description: "Port for communication."
     default: "9042"
     example: "8080"
+  - name: enableHostVerification
+    type: bool
+    description: "Enables host verification. Secures the traffic between client server with TLS."
+    default: "false"
+    example: "true"
   - name: table
     type: string
     description: "The name of the table to use."


### PR DESCRIPTION
Adds TLS (SSL) support Cassandra State store via `EnableHostVerification` metadata option.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
