### PR TITLE
SQLite: when connecting to an in-memory database, limit to 1 concurrent connection

### DIFF
--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -84,12 +84,15 @@ func (a *sqliteDBAccess) Init(ctx context.Context, md state.Metadata) error {
 		return err
 	}
 
-	db, err := sql.Open("sqlite", connString)
+	a.db, err = sql.Open("sqlite", connString)
 	if err != nil {
 		return fmt.Errorf("failed to create connection: %w", err)
 	}
 
-	a.db = db
+	// If the database is in-memory, we can't have more than 1 open connection
+	if a.metadata.IsInMemoryDB() {
+		a.db.SetMaxOpenConns(1)
+	}
 
 	err = a.Ping(ctx)
 	if err != nil {


### PR DESCRIPTION
By default the Go database/sql package opens multiple connections to a database.

However, when using SQLite with an in-memory database, this can cause conflicts if two transactions are executed at the same time.

When the SQLite database is stored on disk, the WAL allows multiple operations in parallel and keeps them pending for up to "busyTimeout". However when the database is in-memory, based on some real-world data, a transaction blocks the database and busyTimeout isn't respected.

Using a single connection makes it so Go never tries to create 2 transactions in parallel.