### PR TITLE
[release-1.12] Fixup from #3272: support case-sensitive SERVER collation

### DIFF
--- a/state/sqlserver/migration.go
+++ b/state/sqlserver/migration.go
@@ -289,7 +289,7 @@ func (m *migration) ensureUpsertStoredProcedureExists(ctx context.Context, db *s
 						IF (@RowVersion IS NOT NULL)
 							BEGIN
 								BEGIN TRANSACTION;
-								IF NOT EXISTS (SELECT * FROM [%[3]s] WHERE [Key]=@KEY AND RowVersion = @RowVersion)
+								IF NOT EXISTS (SELECT * FROM [%[3]s] WHERE [Key]=@Key AND RowVersion = @RowVersion)
 									BEGIN
 										THROW 2601, ''FIRST-WRITE: COMPETING RECORD ALREADY WRITTEN.'', 1
 									END
@@ -303,7 +303,7 @@ func (m *migration) ensureUpsertStoredProcedureExists(ctx context.Context, db *s
 						ELSE
 							BEGIN
 								BEGIN TRANSACTION;
-								IF EXISTS (SELECT * FROM [%[3]s] WHERE [Key]=@KEY)
+								IF EXISTS (SELECT * FROM [%[3]s] WHERE [Key]=@Key)
 									BEGIN
 										THROW 2601, ''FIRST-WRITE: COMPETING RECORD ALREADY WRITTEN.'', 1
 									END


### PR DESCRIPTION
The fix in #3272 allowed support for case-sensitive database collations, but wasn't enough for server collations

Fixes #3271