### PR TITLE
state.dynamodb: validate AWS connection

### DIFF
--- a/common/authentication/aws/aws.go
+++ b/common/authentication/aws/aws.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+	
 	"github.com/dapr/kit/logger"
 )
 

--- a/common/authentication/aws/aws.go
+++ b/common/authentication/aws/aws.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
-	
+
 	"github.com/dapr/kit/logger"
 )
 

--- a/common/authentication/aws/aws.go
+++ b/common/authentication/aws/aws.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/dapr/kit/logger"
 )
 
@@ -42,12 +41,6 @@ func GetClient(accessKey string, secretKey string, sessionToken string, region s
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
-		return nil, err
-	}
-
-	// Use AWS Security Token Service (STS) to validate credentials
-	stsSvc := sts.New(awsSession)
-	if _, err = stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{}); err != nil {
 		return nil, err
 	}
 

--- a/common/authentication/aws/aws.go
+++ b/common/authentication/aws/aws.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
-
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/dapr/kit/logger"
 )
 
@@ -42,6 +42,12 @@ func GetClient(accessKey string, secretKey string, sessionToken string, region s
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	// Use AWS Security Token Service (STS) to validate credentials
+	stsSvc := sts.New(awsSession)
+	if _, err = stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{}); err != nil {
 		return nil, err
 	}
 

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -83,11 +83,10 @@ func (d *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 
 	// We have this check because we need to set the client to  a mock in tests
 	if d.client == nil {
-		client, err := d.getClient(meta)
+		d.client, err = d.getClient(meta)
 		if err != nil {
 			return err
 		}
-		d.client = client
 	}
 	d.table = meta.Table
 	d.ttlAttributeName = meta.TTLAttributeName
@@ -104,8 +103,8 @@ func (d *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 // as well as validating that the table exists, and we have access to it
 func (d *StateStore) validateTableAccess(ctx context.Context) error {
 	input := &dynamodb.GetItemInput{
-		ConsistentRead: aws.Bool(false),
-		TableName:      aws.String(d.table),
+		ConsistentRead: ptr.Of(false),
+		TableName:      ptr.Of(d.table),
 		Key: map[string]*dynamodb.AttributeValue{
 			d.partitionKey: {
 				S: aws.String(uuid.NewString()),

--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -85,6 +85,17 @@ func (d *StateStore) Init(_ context.Context, metadata state.Metadata) error {
 		return err
 	}
 
+	// Run a scan to validate the table exists and we have access to it
+	// The scan has a limit of 1, so it's not a heavy operation
+	scanInput := &dynamodb.ScanInput{
+		TableName: aws.String(meta.Table), // Set your table name
+		Limit:     aws.Int64(1),           // Limit the number of items returned
+	}
+	_, err = client.Scan(scanInput)
+	if err != nil {
+		return err
+	}
+
 	d.client = client
 	d.table = meta.Table
 	d.ttlAttributeName = meta.TTLAttributeName

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -17,6 +17,7 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -76,6 +77,12 @@ func TestInit(t *testing.T) {
 	m := state.Metadata{}
 	s := &StateStore{
 		partitionKey: defaultPartitionKeyName,
+		client: &mockedDynamoDB{
+			// We're adding this so we can pass the connection check on Init
+			GetItemWithContextFn: func(ctx context.Context, input *dynamodb.GetItemInput, op ...request.Option) (*dynamodb.GetItemOutput, error) {
+				return nil, nil
+			},
+		},
 	}
 
 	t.Run("NewDynamoDBStateStore Default Partition Key", func(t *testing.T) {
@@ -123,6 +130,23 @@ func TestInit(t *testing.T) {
 		err := s.Init(context.Background(), m)
 		require.NoError(t, err)
 		assert.Equal(t, s.partitionKey, pkey)
+	})
+
+	t.Run("Init with bad table name or permissions", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"Table":  "does not exist",
+			"Region": "eu-west-1",
+		}
+
+		s.client = &mockedDynamoDB{
+			GetItemWithContextFn: func(ctx context.Context, input *dynamodb.GetItemInput, op ...request.Option) (*dynamodb.GetItemOutput, error) {
+				return nil, errors.New("Requested resource not found")
+			},
+		}
+
+		err := s.Init(context.Background(), m)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "Requested resource not found")
 	})
 }
 

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -146,7 +146,7 @@ func TestInit(t *testing.T) {
 
 		err := s.Init(context.Background(), m)
 		require.Error(t, err)
-		require.Equal(t, "error validating DynamoDB table 'does-not-exist' access: Requested resource not found", err.Error())
+		require.EqualError(t, err, "error validating DynamoDB table 'does-not-exist' access: Requested resource not found")
 	})
 }
 

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -146,7 +146,7 @@ func TestInit(t *testing.T) {
 
 		err := s.Init(context.Background(), m)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), "error validating DynamoDB table 'does-not-exist' access: Requested resource not found")
+		require.Equal(t, "error validating DynamoDB table 'does-not-exist' access: Requested resource not found", err.Error())
 	})
 }
 

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -134,7 +134,7 @@ func TestInit(t *testing.T) {
 
 	t.Run("Init with bad table name or permissions", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"Table":  "does not exist",
+			"Table":  "does-not-exist",
 			"Region": "eu-west-1",
 		}
 
@@ -146,7 +146,7 @@ func TestInit(t *testing.T) {
 
 		err := s.Init(context.Background(), m)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), "Requested resource not found")
+		require.Equal(t, err.Error(), "error validating DynamoDB table 'does-not-exist' access: Requested resource not found")
 	})
 }
 


### PR DESCRIPTION
# Description

I added a Get check to a dummy key on component Init for aws Dynamodb. This will prevent Dapr from initialising if we have wrong component info (credentials/table name).

## Issue reference
https://github.com/dapr/components-contrib/issues/3190

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation - N/A
