### PR TITLE
kafka awsiam authtype fix name

### DIFF
--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -147,10 +147,10 @@ authenticationProfiles:
         required: true
         description: |
           Authentication type.
-          This must be set to "awsIAM" for this authentication profile.
-        example: '"awsIAM"'
+          This must be set to "awsiam" for this authentication profile.
+        example: '"awsiam"'
         allowedValues:
-          - "awsIAM"
+          - "awsiam"
       - name: awsRegion
         type: string
         required: true

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -15,6 +15,7 @@ package kafka
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -91,7 +92,7 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 		return err
 	}
 
-	switch k.authType {
+	switch strings.ToLower(k.authType) {
 	case oidcAuthType:
 		k.logger.Info("Configuring SASL OAuth2/OIDC authentication")
 		err = updateOidcAuthInfo(config, meta)

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -230,7 +230,7 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		k.logger.Debug("Configuring root certificate authentication.")
 	case awsIAMAuthType:
 		if m.AWSRegion == "" {
-			return nil, errors.New("missing AWS region property 'awsRegion' for authType 'awsIAM'")
+			return nil, errors.New("missing AWS region property 'awsRegion' for authType 'awsiam'")
 		}
 		k.logger.Debug("Configuring AWS IAM authentication.")
 	default:

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -141,10 +141,10 @@ authenticationProfiles:
         required: true
         description: |
           Authentication type.
-          This must be set to "awsIAM" for this authentication profile.
-        example: '"awsIAM"'
+          This must be set to "awsiam" for this authentication profile.
+        example: '"awsiam"'
         allowedValues:
-          - "awsIAM"
+          - "awsiam"
       - name: awsRegion
         type: string
         required: true


### PR DESCRIPTION
# Description

I've had issues using the AWS IAM auth type I added until I realized the problem was that I was using the authType `awsIAM` but the component implementation was looking for `awsiam`...

This PR fixes that making the official name of the auth type `awsiam` going forward. Additionally I changed the switch statement to lowercase the authType so the switch statements located in kafka.go and metadata.go behave the same way

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
