### PR TITLE
Improve Multi perf on SQL state stores with 1 op only

### DIFF
--- a/common/component/postgresql/v1/postgresql.go
+++ b/common/component/postgresql/v1/postgresql.go
@@ -451,7 +451,7 @@ func (p *PostgreSQL) Multi(parentCtx context.Context, request *state.Transaction
 	default:
 		_, err := pgtransactions.ExecuteInTransaction[struct{}](parentCtx, p.logger, p.db, p.metadata.Timeout, func(ctx context.Context, tx pgx.Tx) (res struct{}, err error) {
 			for _, op := range request.Operations {
-				err = p.execMultiOperation(parentCtx, op, tx)
+				err = p.execMultiOperation(ctx, op, tx)
 				if err != nil {
 					return res, err
 				}

--- a/common/component/postgresql/v1/postgresql.go
+++ b/common/component/postgresql/v1/postgresql.go
@@ -438,29 +438,40 @@ func (p *PostgreSQL) doDelete(parentCtx context.Context, db pginterfaces.DBQueri
 }
 
 func (p *PostgreSQL) Multi(parentCtx context.Context, request *state.TransactionalStateRequest) error {
-	_, err := pgtransactions.ExecuteInTransaction[struct{}](parentCtx, p.logger, p.db, p.metadata.Timeout, func(ctx context.Context, tx pgx.Tx) (res struct{}, err error) {
-		for _, o := range request.Operations {
-			switch x := o.(type) {
-			case state.SetRequest:
-				err = p.doSet(parentCtx, tx, &x)
+	if request == nil {
+		return nil
+	}
+
+	// If there's only 1 operation, skip starting a transaction
+	switch len(request.Operations) {
+	case 0:
+		return nil
+	case 1:
+		return p.execMultiOperation(parentCtx, request.Operations[0], p.db)
+	default:
+		_, err := pgtransactions.ExecuteInTransaction[struct{}](parentCtx, p.logger, p.db, p.metadata.Timeout, func(ctx context.Context, tx pgx.Tx) (res struct{}, err error) {
+			for _, op := range request.Operations {
+				err = p.execMultiOperation(parentCtx, op, tx)
 				if err != nil {
 					return res, err
 				}
-
-			case state.DeleteRequest:
-				err = p.doDelete(parentCtx, tx, &x)
-				if err != nil {
-					return res, err
-				}
-
-			default:
-				return res, fmt.Errorf("unsupported operation: %s", o.Operation())
 			}
-		}
 
-		return res, nil
-	})
-	return err
+			return res, nil
+		})
+		return err
+	}
+}
+
+func (p *PostgreSQL) execMultiOperation(ctx context.Context, op state.TransactionalStateOperation, db pginterfaces.DBQuerier) error {
+	switch x := op.(type) {
+	case state.SetRequest:
+		return p.doSet(ctx, db, &x)
+	case state.DeleteRequest:
+		return p.doDelete(ctx, db, &x)
+	default:
+		return fmt.Errorf("unsupported operation: %s", op.Operation())
+	}
 }
 
 func (p *PostgreSQL) CleanupExpired() error {

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -481,7 +481,7 @@ func (p *PostgreSQL) Multi(parentCtx context.Context, request *state.Transaction
 	default:
 		_, err := pgtransactions.ExecuteInTransaction[struct{}](parentCtx, p.logger, p.db, p.metadata.Timeout, func(ctx context.Context, tx pgx.Tx) (res struct{}, err error) {
 			for _, op := range request.Operations {
-				err = p.execMultiOperation(parentCtx, op, tx)
+				err = p.execMultiOperation(ctx, op, tx)
 				if err != nil {
 					return res, err
 				}

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -468,29 +468,40 @@ func (p *PostgreSQL) doDelete(parentCtx context.Context, db pginterfaces.DBQueri
 }
 
 func (p *PostgreSQL) Multi(parentCtx context.Context, request *state.TransactionalStateRequest) error {
-	_, err := pgtransactions.ExecuteInTransaction[struct{}](parentCtx, p.logger, p.db, p.metadata.Timeout, func(ctx context.Context, tx pgx.Tx) (res struct{}, err error) {
-		for _, o := range request.Operations {
-			switch x := o.(type) {
-			case state.SetRequest:
-				err = p.doSet(parentCtx, tx, x)
+	if request == nil {
+		return nil
+	}
+
+	// If there's only 1 operation, skip starting a transaction
+	switch len(request.Operations) {
+	case 0:
+		return nil
+	case 1:
+		return p.execMultiOperation(parentCtx, request.Operations[0], p.db)
+	default:
+		_, err := pgtransactions.ExecuteInTransaction[struct{}](parentCtx, p.logger, p.db, p.metadata.Timeout, func(ctx context.Context, tx pgx.Tx) (res struct{}, err error) {
+			for _, op := range request.Operations {
+				err = p.execMultiOperation(parentCtx, op, tx)
 				if err != nil {
 					return res, err
 				}
-
-			case state.DeleteRequest:
-				err = p.doDelete(parentCtx, tx, x)
-				if err != nil {
-					return res, err
-				}
-
-			default:
-				return res, fmt.Errorf("unsupported operation: %s", o.Operation())
 			}
-		}
 
-		return res, nil
-	})
-	return err
+			return res, nil
+		})
+		return err
+	}
+}
+
+func (p *PostgreSQL) execMultiOperation(ctx context.Context, op state.TransactionalStateOperation, db pginterfaces.DBQuerier) error {
+	switch x := op.(type) {
+	case state.SetRequest:
+		return p.doSet(ctx, db, x)
+	case state.DeleteRequest:
+		return p.doDelete(ctx, db, x)
+	default:
+		return fmt.Errorf("unsupported operation: %s", op.Operation())
+	}
 }
 
 func (p *PostgreSQL) CleanupExpired() error {

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -173,34 +173,49 @@ func (s *SQLServer) Features() []state.Feature {
 	return s.features
 }
 
-// Multi performs multiple updates on a Sql server store.
+// Multi performs batched updates on a SQL Server store.
 func (s *SQLServer) Multi(ctx context.Context, request *state.TransactionalStateRequest) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	defer tx.Rollback()
-	if err != nil {
-		return err
+	if request == nil {
+		return nil
 	}
 
-	for _, o := range request.Operations {
-		switch req := o.(type) {
-		case state.SetRequest:
-			err = s.executeSet(ctx, tx, &req)
-			if err != nil {
-				return err
-			}
-
-		case state.DeleteRequest:
-			err = s.executeDelete(ctx, tx, &req)
-			if err != nil {
-				return err
-			}
-
-		default:
-			return fmt.Errorf("unsupported operation: %s", o.Operation())
+	// If there's only 1 operation, skip starting a transaction
+	switch len(request.Operations) {
+	case 0:
+		return nil
+	case 1:
+		return s.execMultiOperation(ctx, request.Operations[0], s.db)
+	default:
+		tx, err := s.db.Begin()
+		if err != nil {
+			return err
 		}
-	}
+		defer func() {
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				s.logger.Errorf("Error rolling back transaction: %v", rollbackErr)
+			}
+		}()
 
-	return tx.Commit()
+		for _, op := range request.Operations {
+			err = s.execMultiOperation(ctx, op, tx)
+			if err != nil {
+				return err
+			}
+		}
+		return tx.Commit()
+	}
+}
+
+func (s *SQLServer) execMultiOperation(ctx context.Context, op state.TransactionalStateOperation, db dbExecutor) error {
+	switch req := op.(type) {
+	case state.SetRequest:
+		return s.executeSet(ctx, db, &req)
+	case state.DeleteRequest:
+		return s.executeDelete(ctx, db, &req)
+	default:
+		return fmt.Errorf("unsupported operation: %s", op.Operation())
+	}
 }
 
 // Delete removes an entity from the store.


### PR DESCRIPTION
When Multi is invoked with a single operation, on SQL state stores (Postgres v1/v2, CockroachDB, MySQL, SQLite, MS SQL Server) we can omit starting a transaction, as a single operation is going to be executed atomically regardless.

This should offer some non-insignificant perf benefits thanks to:

- Reducing the number of round-trips to the DB from 3 to 1
- Reducing locks used inside the DB server