### PR TITLE
Create shared auth package for SQL Server

### DIFF
--- a/common/authentication/sqlserver/metadata.go
+++ b/common/authentication/sqlserver/metadata.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"unicode"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
+
+	"github.com/dapr/components-contrib/common/authentication/azure"
+)
+
+// SQLServerAuthMetadata contains the auth metadata for a SQL Server component.
+type SQLServerAuthMetadata struct {
+	ConnectionString string `mapstructure:"connectionString" mapstructurealiases:"url"`
+	DatabaseName     string `mapstructure:"databaseName" mapstructurealiases:"database"`
+	SchemaName       string `mapstructure:"schemaName" mapstructurealiases:"schema"`
+	UseAzureAD       bool   `mapstructure:"useAzureAD"`
+
+	azureEnv azure.EnvironmentSettings
+}
+
+// Reset the object
+func (m *SQLServerAuthMetadata) Reset() {
+	m.ConnectionString = ""
+	m.DatabaseName = "dapr"
+	m.SchemaName = "dbo"
+	m.UseAzureAD = false
+}
+
+// Validate the auth metadata and returns an error if it's not valid.
+func (m *SQLServerAuthMetadata) Validate(meta map[string]string) (err error) {
+	// Validate and sanitize input
+	if m.ConnectionString == "" {
+		return errors.New("missing connection string")
+	}
+	if !IsValidSQLName(m.DatabaseName) {
+		return fmt.Errorf("invalid database name, accepted characters are (A-Z, a-z, 0-9, _)")
+	}
+	if !IsValidSQLName(m.SchemaName) {
+		return fmt.Errorf("invalid schema name, accepted characters are (A-Z, a-z, 0-9, _)")
+	}
+
+	// If using Azure AD
+	if m.UseAzureAD {
+		m.azureEnv, err = azure.NewEnvironmentSettings(meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetConnector returns the connector from the connection string or Azure AD.
+// The returned connector can be used with sql.OpenDB.
+func (m *SQLServerAuthMetadata) GetConnector(setDatabase bool) (*mssql.Connector, bool, error) {
+	// Parse the connection string
+	config, err := msdsn.Parse(m.ConnectionString)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	// If setDatabase is true and the configuration (i.e. the connection string) does not contain a database, add it
+	// This is for backwards-compatibility reasons
+	if setDatabase && config.Database == "" {
+		config.Database = m.DatabaseName
+	}
+
+	// We need to check if the configuration has a database because the migrator needs it
+	hasDatabase := config.Database != ""
+
+	// Configure Azure AD authentication if needed
+	if m.UseAzureAD {
+		tokenCred, errToken := m.azureEnv.GetTokenCredential()
+		if errToken != nil {
+			return nil, false, errToken
+		}
+
+		conn, err := mssql.NewSecurityTokenConnector(config, func(ctx context.Context) (string, error) {
+			at, err := tokenCred.GetToken(ctx, policy.TokenRequestOptions{
+				Scopes: []string{
+					m.azureEnv.Cloud.Services[azure.ServiceAzureSQL].Audience,
+				},
+			})
+			if err != nil {
+				return "", err
+			}
+			return at.Token, nil
+		})
+		return conn, hasDatabase, err
+	}
+
+	conn := mssql.NewConnectorConfig(config)
+	return conn, hasDatabase, nil
+}
+
+func IsLetterOrNumber(c rune) bool {
+	return unicode.IsNumber(c) || unicode.IsLetter(c)
+}
+
+func IsValidSQLName(s string) bool {
+	for _, c := range s {
+		if !(IsLetterOrNumber(c) || (c == '_')) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/state/sqlserver/metadata.go
+++ b/state/sqlserver/metadata.go
@@ -14,67 +14,45 @@ limitations under the License.
 package sqlserver
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
-	"unicode"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	mssql "github.com/microsoft/go-mssqldb"
-	"github.com/microsoft/go-mssqldb/msdsn"
-
-	"github.com/dapr/components-contrib/common/authentication/azure"
+	sqlserverAuth "github.com/dapr/components-contrib/common/authentication/sqlserver"
 	"github.com/dapr/kit/metadata"
 	"github.com/dapr/kit/ptr"
 )
 
 const (
-	connectionStringKey  = "connectionString"
-	tableNameKey         = "tableName"
-	metadataTableNameKey = "metadataTableName"
-	schemaKey            = "schema"
-	keyTypeKey           = "keyType"
-	keyLengthKey         = "keyLength"
-	indexedPropertiesKey = "indexedProperties"
 	keyColumnName        = "Key"
 	rowVersionColumnName = "RowVersion"
-	databaseNameKey      = "databaseName"
-	cleanupIntervalKey   = "cleanupIntervalInSeconds"
 
 	defaultKeyLength       = 200
-	defaultSchema          = "dbo"
-	defaultDatabase        = "dapr"
 	defaultTable           = "state"
 	defaultMetaTable       = "dapr_metadata"
 	defaultCleanupInterval = time.Hour
 )
 
 type sqlServerMetadata struct {
-	ConnectionString  string
-	DatabaseName      string
+	sqlserverAuth.SQLServerAuthMetadata `mapstructure:",squash"`
+
 	TableName         string
 	MetadataTableName string
-	Schema            string
 	KeyType           string
 	KeyLength         int
 	IndexedProperties string
-	CleanupInterval   *time.Duration `mapstructure:"cleanupIntervalInSeconds"`
-	UseAzureAD        bool           `mapstructure:"useAzureAD"`
+	CleanupInterval   *time.Duration `mapstructure:"cleanupInterval" mapstructurealiases:"cleanupIntervalInSeconds"`
 
 	// Internal properties
 	keyTypeParsed           KeyType
 	keyLengthParsed         int
 	indexedPropertiesParsed []IndexedProperty
-	azureEnv                azure.EnvironmentSettings
 }
 
 func newMetadata() sqlServerMetadata {
 	return sqlServerMetadata{
 		TableName:         defaultTable,
-		Schema:            defaultSchema,
-		DatabaseName:      defaultDatabase,
 		KeyLength:         defaultKeyLength,
 		MetadataTableName: defaultMetaTable,
 		CleanupInterval:   ptr.Of(defaultCleanupInterval),
@@ -82,35 +60,33 @@ func newMetadata() sqlServerMetadata {
 }
 
 func (m *sqlServerMetadata) Parse(meta map[string]string) error {
+	// Reset first
+	m.SQLServerAuthMetadata.Reset()
+
+	// Decode the metadata
 	err := metadata.DecodeMetadata(meta, &m)
 	if err != nil {
 		return err
 	}
-	if m.ConnectionString == "" {
-		return errors.New("missing connection string")
+
+	// Validate and parse the auth metadata
+	err = m.SQLServerAuthMetadata.Validate(meta)
+	if err != nil {
+		return err
 	}
 
-	if !isValidSQLName(m.TableName) {
+	// Validate and sanitize more values
+	if !sqlserverAuth.IsValidSQLName(m.TableName) {
 		return fmt.Errorf("invalid table name, accepted characters are (A-Z, a-z, 0-9, _)")
 	}
-
-	if !isValidSQLName(m.MetadataTableName) {
+	if !sqlserverAuth.IsValidSQLName(m.MetadataTableName) {
 		return fmt.Errorf("invalid metadata table name, accepted characters are (A-Z, a-z, 0-9, _)")
-	}
-
-	if !isValidSQLName(m.DatabaseName) {
-		return fmt.Errorf("invalid database name, accepted characters are (A-Z, a-z, 0-9, _)")
 	}
 
 	err = m.setKeyType()
 	if err != nil {
 		return err
 	}
-
-	if !isValidSQLName(m.Schema) {
-		return fmt.Errorf("invalid schema name, accepted characters are (A-Z, a-z, 0-9, _)")
-	}
-
 	err = m.setIndexedProperties()
 	if err != nil {
 		return err
@@ -120,7 +96,8 @@ func (m *sqlServerMetadata) Parse(meta map[string]string) error {
 	if m.CleanupInterval != nil {
 		// Non-positive value from meta means disable auto cleanup.
 		if *m.CleanupInterval <= 0 {
-			if meta[cleanupIntervalKey] == "" {
+			val, _ := metadata.GetMetadataProperty(meta, "cleanupInterval", "cleanupIntervalInSeconds")
+			if val == "" {
 				// Unfortunately the mapstructure decoder decodes an empty string to 0, a missing key would be nil however
 				m.CleanupInterval = ptr.Of(defaultCleanupInterval)
 			} else {
@@ -129,58 +106,7 @@ func (m *sqlServerMetadata) Parse(meta map[string]string) error {
 		}
 	}
 
-	// If using Azure AD
-	if m.UseAzureAD {
-		m.azureEnv, err = azure.NewEnvironmentSettings(meta)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
-}
-
-// GetConnector returns the connector from the connection string or Azure AD.
-// The returned connector can be used with sql.OpenDB.
-func (m *sqlServerMetadata) GetConnector(setDatabase bool) (*mssql.Connector, bool, error) {
-	// Parse the connection string
-	config, err := msdsn.Parse(m.ConnectionString)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse connection string: %w", err)
-	}
-
-	// If setDatabase is true and the configuration (i.e. the connection string) does not contain a database, add it
-	// This is for backwards-compatibility reasons
-	if setDatabase && config.Database == "" {
-		config.Database = m.DatabaseName
-	}
-
-	// We need to check if the configuration has a database because the migrator needs it
-	hasDatabase := config.Database != ""
-
-	// Configure Azure AD authentication if needed
-	if m.UseAzureAD {
-		tokenCred, errToken := m.azureEnv.GetTokenCredential()
-		if errToken != nil {
-			return nil, false, errToken
-		}
-
-		conn, err := mssql.NewSecurityTokenConnector(config, func(ctx context.Context) (string, error) {
-			at, err := tokenCred.GetToken(ctx, policy.TokenRequestOptions{
-				Scopes: []string{
-					m.azureEnv.Cloud.Services[azure.ServiceAzureSQL].Audience,
-				},
-			})
-			if err != nil {
-				return "", err
-			}
-			return at.Token, nil
-		})
-		return conn, hasDatabase, err
-	}
-
-	conn := mssql.NewConnectorConfig(config)
-	return conn, hasDatabase, nil
 }
 
 // Validates and returns the key type.
@@ -247,7 +173,7 @@ func (m *sqlServerMetadata) validateIndexedProperties(indexedProperties []Indexe
 			return errors.New("indexed property type cannot be empty")
 		}
 
-		if !isValidSQLName(p.ColumnName) {
+		if !sqlserverAuth.IsValidSQLName(p.ColumnName) {
 			return fmt.Errorf("invalid indexed property column name, accepted characters are (A-Z, a-z, 0-9, _)")
 		}
 
@@ -263,23 +189,9 @@ func (m *sqlServerMetadata) validateIndexedProperties(indexedProperties []Indexe
 	return nil
 }
 
-func isLetterOrNumber(c rune) bool {
-	return unicode.IsNumber(c) || unicode.IsLetter(c)
-}
-
-func isValidSQLName(s string) bool {
-	for _, c := range s {
-		if !(isLetterOrNumber(c) || (c == '_')) {
-			return false
-		}
-	}
-
-	return true
-}
-
 func isValidIndexedPropertyName(s string) bool {
 	for _, c := range s {
-		if !(isLetterOrNumber(c) || (c == '_') || (c == '.') || (c == '[') || (c == ']')) {
+		if !(sqlserverAuth.IsLetterOrNumber(c) || (c == '_') || (c == '.') || (c == '[') || (c == ']')) {
 			return false
 		}
 	}
@@ -289,7 +201,7 @@ func isValidIndexedPropertyName(s string) bool {
 
 func isValidIndexedPropertyType(s string) bool {
 	for _, c := range s {
-		if !(isLetterOrNumber(c) || (c == '(') || (c == ')')) {
+		if !(sqlserverAuth.IsLetterOrNumber(c) || (c == '(') || (c == ')')) {
 			return false
 		}
 	}

--- a/state/sqlserver/metadata.yaml
+++ b/state/sqlserver/metadata.yaml
@@ -62,7 +62,7 @@ metadata:
       "dapr_metadata"
     default: |
       "dapr_metadata"
-  - name: schema
+  - name: schemaName
     description: |
       The schema to use.
     example: |
@@ -93,7 +93,7 @@ metadata:
       List of indexed properties, as a string containing a JSON document.
     example: |
       '[{"column": "transactionid", "property": "id", "type": "int"}, {"column": "customerid", "property": "customer", "type": "nvarchar(100)"}]'
-  - name: cleanupIntervalInSeconds
+  - name: cleanupInterval
     type: number
     description: |
       Interval, in seconds, to clean up rows with an expired TTL. Default: 3600 (i.e. 1 hour).

--- a/state/sqlserver/sqlserver.go
+++ b/state/sqlserver/sqlserver.go
@@ -151,11 +151,11 @@ END TRY
 BEGIN CATCH
 UPDATE [%[1]s].[%[2]s] SET [Value] = CONVERT(nvarchar(MAX), GETDATE(), 21) WHERE [Key] = 'last-cleanup' AND Datediff_big(MS, [Value], GETUTCDATE()) > @Interval
 END CATCH
-COMMIT TRANSACTION;`, s.metadata.Schema, s.metadata.MetadataTableName), sql.Named("Interval", arg)
+COMMIT TRANSACTION;`, s.metadata.SchemaName, s.metadata.MetadataTableName), sql.Named("Interval", arg)
 		},
 		DeleteExpiredValuesQuery: fmt.Sprintf(
 			`DELETE FROM [%s].[%s] WHERE [ExpireDate] IS NOT NULL AND [ExpireDate] < GETDATE()`,
-			s.metadata.Schema, s.metadata.TableName,
+			s.metadata.SchemaName, s.metadata.TableName,
 		),
 		CleanupInterval: *s.metadata.CleanupInterval,
 		DB:              commonsql.AdaptDatabaseSQLConn(s.db),

--- a/state/sqlserver/sqlserver_integration_test.go
+++ b/state/sqlserver/sqlserver_integration_test.go
@@ -96,16 +96,16 @@ func getUniqueDBSchema(t *testing.T) string {
 func createMetadata(schema string, kt KeyType, indexedProperties string) state.Metadata {
 	metadata := state.Metadata{Base: metadata.Base{
 		Properties: map[string]string{
-			connectionStringKey: os.Getenv(connectionStringEnvKey),
-			schemaKey:           schema,
-			tableNameKey:        usersTableName,
-			keyTypeKey:          string(kt),
-			databaseNameKey:     "dapr_test",
+			"connectionString": os.Getenv(connectionStringEnvKey),
+			"schema":           schema,
+			"tableName":        usersTableName,
+			"keyType":          string(kt),
+			"databaseName":     "dapr_test",
 		},
 	}}
 
 	if indexedProperties != "" {
-		metadata.Properties[indexedPropertiesKey] = indexedProperties
+		metadata.Properties["indexedProperties"] = indexedProperties
 	}
 
 	return metadata
@@ -170,7 +170,7 @@ func assertDBQuery(t *testing.T, store *SQLServer, query string, assertReader fu
 
 /* #nosec. */
 func assertUserCountIsEqualTo(t *testing.T, store *SQLServer, expected int) {
-	tsql := fmt.Sprintf("SELECT count(*) FROM [%s].[%s]", store.metadata.Schema, store.metadata.TableName)
+	tsql := fmt.Sprintf("SELECT count(*) FROM [%s].[%s]", store.metadata.SchemaName, store.metadata.TableName)
 	assertDBQuery(t, store, tsql, func(t *testing.T, rows *sql.Rows) {
 		assert.True(t, rows.Next())
 		var actual int
@@ -289,7 +289,7 @@ func testIndexedProperties(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the database for computed columns
-	assertDBQuery(t, store, fmt.Sprintf("SELECT count(*) from [%s].[%s] WHERE PetsCount < 3", store.metadata.Schema, usersTableName), func(t *testing.T, rows *sql.Rows) {
+	assertDBQuery(t, store, fmt.Sprintf("SELECT count(*) from [%s].[%s] WHERE PetsCount < 3", store.metadata.SchemaName, usersTableName), func(t *testing.T, rows *sql.Rows) {
 		assert.True(t, rows.Next())
 
 		var c int
@@ -298,7 +298,7 @@ func testIndexedProperties(t *testing.T) {
 	})
 
 	// Ensure we can get by beverage
-	assertDBQuery(t, store, fmt.Sprintf("SELECT count(*) from [%s].[%s] WHERE FavoriteBeverage = '%s'", store.metadata.Schema, usersTableName, "Coffee"), func(t *testing.T, rows *sql.Rows) {
+	assertDBQuery(t, store, fmt.Sprintf("SELECT count(*) from [%s].[%s] WHERE FavoriteBeverage = '%s'", store.metadata.SchemaName, usersTableName, "Coffee"), func(t *testing.T, rows *sql.Rows) {
 		assert.True(t, rows.Next())
 
 		var c int
@@ -497,7 +497,7 @@ func testInsertAndUpdateSetRecordDates(t *testing.T) {
 	require.NoError(t, err)
 
 	var originalInsertTime time.Time
-	getUserTsql := fmt.Sprintf("SELECT [InsertDate], [UpdateDate] from [%s].[%s] WHERE [Key]='%s'", store.metadata.Schema, store.metadata.TableName, u.ID)
+	getUserTsql := fmt.Sprintf("SELECT [InsertDate], [UpdateDate] from [%s].[%s] WHERE [Key]='%s'", store.metadata.SchemaName, store.metadata.TableName, u.ID)
 	assertDBQuery(t, store, getUserTsql, func(t *testing.T, rows *sql.Rows) {
 		assert.True(t, rows.Next())
 
@@ -593,7 +593,7 @@ func testMultipleInitializations(t *testing.T) {
 				migratorFactory: newMigration,
 			}
 			store2.BulkStore = state.NewDefaultBulkStore(store2)
-			err := store2.Init(context.Background(), createMetadata(store.metadata.Schema, test.kt, test.indexedProperties))
+			err := store2.Init(context.Background(), createMetadata(store.metadata.SchemaName, test.kt, test.indexedProperties))
 			require.NoError(t, err)
 		})
 	}

--- a/state/sqlserver/sqlserver_test.go
+++ b/state/sqlserver/sqlserver_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -390,6 +391,123 @@ func TestInvalidConfiguration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanupInterval(t *testing.T) {
+	t.Run("cleanupInterval not set", func(t *testing.T) {
+		properties := map[string]string{
+			"url": "test",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		assert.Equal(t, "test", md.ConnectionString)
+		require.NotNil(t, md.CleanupInterval)
+		assert.Equal(t, defaultCleanupInterval, *md.CleanupInterval)
+	})
+
+	t.Run("cleanupInterval as Go duration", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString": "test",
+			"cleanupInterval":  "1m",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		assert.Equal(t, "test", md.ConnectionString)
+		require.NotNil(t, md.CleanupInterval)
+		assert.Equal(t, time.Minute, *md.CleanupInterval)
+	})
+
+	t.Run("cleanupInterval as seconds", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString": "test",
+			"cleanupInterval":  "10",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		assert.Equal(t, "test", md.ConnectionString)
+		require.NotNil(t, md.CleanupInterval)
+		assert.Equal(t, 10*time.Second, *md.CleanupInterval)
+	})
+
+	t.Run("cleanupIntervalInSeconds as Go duration", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString":         "test",
+			"cleanupIntervalInSeconds": "1m",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		require.NotNil(t, md.CleanupInterval)
+		assert.Equal(t, time.Minute, *md.CleanupInterval)
+	})
+
+	t.Run("cleanupIntervalInSeconds as seconds", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString":         "test",
+			"cleanupIntervalInSeconds": "10",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		require.NotNil(t, md.CleanupInterval)
+		assert.Equal(t, 10*time.Second, *md.CleanupInterval)
+	})
+
+	t.Run("cleanupInterval as 0", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString": "test",
+			"cleanupInterval":  "0",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		require.Nil(t, md.CleanupInterval)
+	})
+
+	t.Run("cleanupIntervallInSeconds as 0", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString":         "test",
+			"cleanupIntervalInSeconds": "0",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		require.Nil(t, md.CleanupInterval)
+	})
+
+	t.Run("cleanupInterval negative", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString": "test",
+			"cleanupInterval":  "-1",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		require.Nil(t, md.CleanupInterval)
+	})
+
+	t.Run("cleanupIntervallInSeconds negative", func(t *testing.T) {
+		properties := map[string]string{
+			"connectionString":         "test",
+			"cleanupIntervalInSeconds": "-1",
+		}
+
+		md := newMetadata()
+		err := md.Parse(properties)
+		require.NoError(t, err)
+		require.Nil(t, md.CleanupInterval)
+	})
 }
 
 // Test that if the migration fails the error is reported.

--- a/state/sqlserver/sqlserver_test.go
+++ b/state/sqlserver/sqlserver_test.go
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sqlserver
 
 import (
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/components-contrib/common/authentication/sqlserver"
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
@@ -30,6 +32,8 @@ import (
 const (
 	sampleConnectionString = "server=localhost;user id=sa;password=Pass@Word1;port=1433;database=sample;"
 	sampleUserTableName    = "Users"
+	defaultDatabase        = "dapr"
+	defaultSchema          = "dbo"
 )
 
 type mockMigrator struct{}
@@ -54,162 +58,184 @@ func TestValidConfiguration(t *testing.T) {
 		expected SQLServer
 	}{
 		"No schema": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         sampleUserTableName,
-					Schema:            defaultSchema,
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   defaultKeyLength,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Custom schema": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, schemaKey: "mytest"},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "schema": "mytest"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       "mytest",
+					},
 					TableName:         sampleUserTableName,
-					Schema:            "mytest",
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   defaultKeyLength,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"String key type": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, keyTypeKey: "string"},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "keyType": "string"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
-					Schema:            defaultSchema,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         sampleUserTableName,
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   defaultKeyLength,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Unique identifier key type": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, keyTypeKey: "uuid"},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "keyType": "uuid"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
-					Schema:            defaultSchema,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         sampleUserTableName,
 					keyTypeParsed:     UUIDKeyType,
 					keyLengthParsed:   0,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Integer identifier key type": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, keyTypeKey: "integer"},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "keyType": "integer"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
-					Schema:            defaultSchema,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         sampleUserTableName,
 					keyTypeParsed:     IntegerKeyType,
 					keyLengthParsed:   0,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Custom key length": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, keyLengthKey: "100"},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "keyLength": "100"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
-					Schema:            defaultSchema,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         sampleUserTableName,
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   100,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Single indexed property": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, indexedPropertiesKey: `[{"column": "Age","property":"age", "type":"int"}]`},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "indexedProperties": `[{"column": "Age","property":"age", "type":"int"}]`},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString: sampleConnectionString,
-					Schema:           defaultSchema,
-					TableName:        sampleUserTableName,
-					keyTypeParsed:    StringKeyType,
-					keyLengthParsed:  defaultKeyLength,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
+					TableName:       sampleUserTableName,
+					keyTypeParsed:   StringKeyType,
+					keyLengthParsed: defaultKeyLength,
 					indexedPropertiesParsed: []IndexedProperty{
 						{ColumnName: "Age", Property: "age", Type: "int"},
 					},
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Multiple indexed properties": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, indexedPropertiesKey: `[{"column": "Age","property":"age", "type":"int"}, {"column": "Name","property":"name", "type":"nvarchar(100)"}]`},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "indexedProperties": `[{"column": "Age","property":"age", "type":"int"}, {"column": "Name","property":"name", "type":"nvarchar(100)"}]`},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString: sampleConnectionString,
-					Schema:           defaultSchema,
-					TableName:        sampleUserTableName,
-					keyTypeParsed:    StringKeyType,
-					keyLengthParsed:  defaultKeyLength,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
+					TableName:       sampleUserTableName,
+					keyTypeParsed:   StringKeyType,
+					keyLengthParsed: defaultKeyLength,
 					indexedPropertiesParsed: []IndexedProperty{
 						{ColumnName: "Age", Property: "age", Type: "int"},
 						{ColumnName: "Name", Property: "name", Type: "nvarchar(100)"},
 					},
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Custom database": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, databaseNameKey: "dapr_test_table"},
+			props: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "databaseName": "dapr_test_table"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
-					Schema:            defaultSchema,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     "dapr_test_table",
+						SchemaName:       defaultSchema,
+					},
 					TableName:         sampleUserTableName,
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   defaultKeyLength,
-					DatabaseName:      "dapr_test_table",
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"No table": {
-			props: map[string]string{connectionStringKey: sampleConnectionString},
+			props: map[string]string{"connectionString": sampleConnectionString},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         defaultTable,
-					Schema:            defaultSchema,
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   defaultKeyLength,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: defaultMetaTable,
 				},
 			},
 		},
 		"Custom meta table": {
-			props: map[string]string{connectionStringKey: sampleConnectionString, "metadataTableName": "dapr_test_meta_table"},
+			props: map[string]string{"connectionString": sampleConnectionString, "metadataTableName": "dapr_test_meta_table"},
 			expected: SQLServer{
 				metadata: sqlServerMetadata{
-					ConnectionString:  sampleConnectionString,
+					SQLServerAuthMetadata: sqlserver.SQLServerAuthMetadata{
+						ConnectionString: sampleConnectionString,
+						DatabaseName:     defaultDatabase,
+						SchemaName:       defaultSchema,
+					},
 					TableName:         defaultTable,
-					Schema:            defaultSchema,
 					keyTypeParsed:     StringKeyType,
 					keyLengthParsed:   defaultKeyLength,
-					DatabaseName:      defaultDatabase,
 					MetadataTableName: "dapr_test_meta_table",
 				},
 			},
@@ -233,7 +259,7 @@ func TestValidConfiguration(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected.metadata.ConnectionString, sqlStore.metadata.ConnectionString)
 			assert.Equal(t, tt.expected.metadata.TableName, sqlStore.metadata.TableName)
-			assert.Equal(t, tt.expected.metadata.Schema, sqlStore.metadata.Schema)
+			assert.Equal(t, tt.expected.metadata.SchemaName, sqlStore.metadata.SchemaName)
 			assert.Equal(t, tt.expected.metadata.keyTypeParsed, sqlStore.metadata.keyTypeParsed)
 			assert.Equal(t, tt.expected.metadata.keyLengthParsed, sqlStore.metadata.keyLengthParsed)
 			assert.Equal(t, tt.expected.metadata.DatabaseName, sqlStore.metadata.DatabaseName)
@@ -261,87 +287,87 @@ func TestInvalidConfiguration(t *testing.T) {
 			expectedErr: "missing connection string",
 		},
 		"Empty connection string": {
-			props:       map[string]string{connectionStringKey: ""},
+			props:       map[string]string{"connectionString": ""},
 			expectedErr: "missing connection string",
 		},
 		"Negative maxKeyLength value": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", keyLengthKey: "-1"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "keyLength": "-1"},
 			expectedErr: "invalid key length value of -1",
 		},
 		"Indexes properties are not valid json": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: "no_json"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": "no_json"},
 			expectedErr: "invalid character",
 		},
 		"Invalid table name with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test;"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test;"},
 			expectedErr: "invalid table name",
 		},
 		"Invalid table name with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test GO DROP DATABASE dapr_test"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test GO DROP DATABASE dapr_test"},
 			expectedErr: "invalid table name",
 		},
 		"Invalid metadata table name with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, "tableName": "test", "metadataTableName": "test;"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "metadataTableName": "test;"},
 			expectedErr: "invalid metadata table name",
 		},
 		"Invalid metadata table name with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, "tableName": "test", "metadataTableName": "test GO DROP DATABASE dapr_test"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "metadataTableName": "test GO DROP DATABASE dapr_test"},
 			expectedErr: "invalid metadata table name",
 		},
 		"Invalid schema name with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", schemaKey: "test;"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "schema": "test;"},
 			expectedErr: "invalid schema name",
 		},
 		"Invalid schema name with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", schemaKey: "test GO DROP DATABASE dapr_test"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "schema": "test GO DROP DATABASE dapr_test"},
 			expectedErr: "invalid schema name",
 		},
 		"Invalid index property column name with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"test;", "property": "age", "type": "INT"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"test;", "property": "age", "type": "INT"}]`},
 			expectedErr: "invalid indexed property column name",
 		},
 		"Invalid index property column name with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"test GO DROP DATABASE dapr_test", "property": "age", "type": "INT"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"test GO DROP DATABASE dapr_test", "property": "age", "type": "INT"}]`},
 			expectedErr: "invalid indexed property column name",
 		},
 		"Invalid index property name with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"age", "property": "test;", "type": "INT"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"age", "property": "test;", "type": "INT"}]`},
 			expectedErr: "invalid indexed property name",
 		},
 		"Invalid index property name with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"age", "property": "test GO DROP DATABASE dapr_test", "type": "INT"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"age", "property": "test GO DROP DATABASE dapr_test", "type": "INT"}]`},
 			expectedErr: "invalid indexed property name",
 		},
 		"Invalid index property type with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"age", "property": "age", "type": "INT;"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"age", "property": "age", "type": "INT;"}]`},
 			expectedErr: "invalid indexed property type",
 		},
 		"Invalid index property type with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"age", "property": "age", "type": "INT GO DROP DATABASE dapr_test"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"age", "property": "age", "type": "INT GO DROP DATABASE dapr_test"}]`},
 			expectedErr: "invalid indexed property type",
 		},
 		"Index property column cannot be empty": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"", "property": "age", "type": "INT"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"", "property": "age", "type": "INT"}]`},
 			expectedErr: "indexed property column cannot be empty",
 		},
 		"Invalid property name cannot be empty": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"age", "property": "", "type": "INT"}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"age", "property": "", "type": "INT"}]`},
 			expectedErr: "indexed property name cannot be empty",
 		},
 		"Invalid property type cannot be empty": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", indexedPropertiesKey: `[{"column":"age", "property": "age", "type": ""}]`},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "indexedProperties": `[{"column":"age", "property": "age", "type": ""}]`},
 			expectedErr: "indexed property type cannot be empty",
 		},
 		"Invalid database name with ;": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", databaseNameKey: "test;"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "databaseName": "test;"},
 			expectedErr: "invalid database name",
 		},
 		"Invalid database name with space": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", databaseNameKey: "test GO DROP DATABASE dapr_test"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "databaseName": "test GO DROP DATABASE dapr_test"},
 			expectedErr: "invalid database name",
 		},
 		"Invalid key type invalid": {
-			props:       map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: "test", keyTypeKey: "invalid"},
+			props:       map[string]string{"connectionString": sampleConnectionString, "tableName": "test", "keyType": "invalid"},
 			expectedErr: "invalid key type",
 		},
 	}
@@ -376,7 +402,7 @@ func TestExecuteMigrationFails(t *testing.T) {
 	}
 
 	metadata := state.Metadata{
-		Base: metadata.Base{Properties: map[string]string{connectionStringKey: sampleConnectionString, tableNameKey: sampleUserTableName, databaseNameKey: "dapr_test_table"}},
+		Base: metadata.Base{Properties: map[string]string{"connectionString": sampleConnectionString, "tableName": sampleUserTableName, "databaseName": "dapr_test_table"}},
 	}
 
 	err := sqlStore.Init(context.Background(), metadata)

--- a/tests/certification/state/sqlserver/components/docker/customschemawithindex/sqlserver.yaml
+++ b/tests/certification/state/sqlserver/components/docker/customschemawithindex/sqlserver.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   type: state.sqlserver
   metadata:
-  - name: connectionString
+  - name: url
     value: "server=localhost;user id=sa;password=Pass@Word1;port=1433;Connection Timeout=30;"
   - name: databaseName
     value: certificationtest
-  - name: schema
+  - name: schemaName
     value: customschema
   - name: tableName
     value: mystates

--- a/tests/certification/state/sqlserver/sqlserver_test.go
+++ b/tests/certification/state/sqlserver/sqlserver_test.go
@@ -263,23 +263,22 @@ func TestSqlServer(t *testing.T) {
 	ttlTest := func(connString string) func(ctx flow.Context) error {
 		return func(ctx flow.Context) error {
 			log := logger.NewLogger("dapr.components")
-			md := state.Metadata{
-				Base: metadata.Base{
-					Name: "ttltest",
-					Properties: map[string]string{
-						"connectionString":  connString,
-						"databaseName":      "certificationtest",
-						"tableName":         "ttltest",
-						"metadataTableName": "ttltest_metadata",
-						"schema":            "ttlschema",
-					},
-				},
-			}
 
 			ctx.T.Run("parse cleanupIntervalInSeconds", func(t *testing.T) {
 				t.Run("default value", func(t *testing.T) {
 					// Default value is 1 hr
-					md.Properties["cleanupIntervalInSeconds"] = ""
+					md := state.Metadata{
+						Base: metadata.Base{
+							Name: "ttltest",
+							Properties: map[string]string{
+								"connectionString":  connString,
+								"databaseName":      "certificationtest",
+								"tableName":         "ttltest",
+								"metadataTableName": "ttltest_metadata",
+								"schema":            "ttlschema",
+							},
+						},
+					}
 					storeObj := state_sqlserver.New(log).(*state_sqlserver.SQLServer)
 
 					err := storeObj.Init(context.Background(), md)
@@ -293,7 +292,19 @@ func TestSqlServer(t *testing.T) {
 
 				t.Run("positive value", func(t *testing.T) {
 					// A positive value is interpreted in seconds
-					md.Properties["cleanupIntervalInSeconds"] = "10"
+					md := state.Metadata{
+						Base: metadata.Base{
+							Name: "ttltest",
+							Properties: map[string]string{
+								"connectionString":  connString,
+								"databaseName":      "certificationtest",
+								"tableName":         "ttltest",
+								"metadataTableName": "ttltest_metadata",
+								"schema":            "ttlschema",
+								"cleanupInterval":   "10",
+							},
+						},
+					}
 					storeObj := state_sqlserver.New(log).(*state_sqlserver.SQLServer)
 
 					err := storeObj.Init(context.Background(), md)
@@ -307,7 +318,19 @@ func TestSqlServer(t *testing.T) {
 
 				t.Run("disabled", func(t *testing.T) {
 					// A value of <=0 means that the cleanup is disabled
-					md.Properties["cleanupIntervalInSeconds"] = "0"
+					md := state.Metadata{
+						Base: metadata.Base{
+							Name: "ttltest",
+							Properties: map[string]string{
+								"connectionString":         connString,
+								"databaseName":             "certificationtest",
+								"tableName":                "ttltest",
+								"metadataTableName":        "ttltest_metadata",
+								"schema":                   "ttlschema",
+								"cleanupIntervalInSeconds": "0",
+							},
+						},
+					}
 					storeObj := state_sqlserver.New(log).(*state_sqlserver.SQLServer)
 
 					err := storeObj.Init(context.Background(), md)
@@ -325,7 +348,19 @@ func TestSqlServer(t *testing.T) {
 
 				t.Run("automatically delete expiredate records", func(t *testing.T) {
 					// Run every second
-					md.Properties["cleanupIntervalInSeconds"] = "1"
+					md := state.Metadata{
+						Base: metadata.Base{
+							Name: "ttltest",
+							Properties: map[string]string{
+								"connectionString":  connString,
+								"databaseName":      "certificationtest",
+								"tableName":         "ttltest",
+								"metadataTableName": "ttltest_metadata",
+								"schema":            "ttlschema",
+								"cleanupInterval":   "1",
+							},
+						},
+					}
 
 					storeObj := state_sqlserver.New(log).(*state_sqlserver.SQLServer)
 					err := storeObj.Init(context.Background(), md)
@@ -339,7 +374,7 @@ func TestSqlServer(t *testing.T) {
 					require.NoError(t, err, "failed to seed records")
 
 					cleanupInterval := storeObj.GetCleanupInterval()
-					assert.NotNil(t, cleanupInterval)
+					require.NotNil(t, cleanupInterval)
 					assert.Equal(t, time.Duration(time.Second), *cleanupInterval)
 
 					// Wait up to 3 seconds then verify we have only 10 rows left
@@ -371,7 +406,19 @@ func TestSqlServer(t *testing.T) {
 				t.Run("cleanup concurrency", func(t *testing.T) {
 					// Set to run every hour
 					// (we'll manually trigger more frequent iterations)
-					md.Properties["cleanupIntervalInSeconds"] = "3600"
+					md := state.Metadata{
+						Base: metadata.Base{
+							Name: "ttltest",
+							Properties: map[string]string{
+								"connectionString":  connString,
+								"databaseName":      "certificationtest",
+								"tableName":         "ttltest",
+								"metadataTableName": "ttltest_metadata",
+								"schema":            "ttlschema",
+								"cleanupInterval":   "1h",
+							},
+						},
+					}
 
 					storeObj := state_sqlserver.New(log).(*state_sqlserver.SQLServer)
 					err := storeObj.Init(context.Background(), md)


### PR DESCRIPTION
Similarly to other databases like Postgres and SQLite, moving auth code for MS SQL Server to a shared package.