### PR TITLE
Kafka: Removed the AWS creds check from kafka metadata

### DIFF
--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -246,9 +246,6 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		if m.AWSRegion == "" {
 			return nil, errors.New("missing AWS region property 'awsRegion' for authType 'awsiam'")
 		}
-		if m.AWSIamRoleArn == "" && m.AWSSecretKey == "" && m.AWSAccessKey == "" {
-			return nil, errors.New("missing AWS credentials or IAM role properties for authType 'awsiam'")
-		}
 		k.logger.Debug("Configuring AWS IAM authentication.")
 	default:
 		return nil, errors.New("kafka error: invalid value for 'authType' attribute")

--- a/common/component/kafka/metadata_test.go
+++ b/common/component/kafka/metadata_test.go
@@ -381,17 +381,6 @@ func TestAwsIam(t *testing.T) {
 
 		require.Equal(t, "missing AWS region property 'awsRegion' for authType 'awsiam'", err.Error())
 	})
-
-	t.Run("missing aws credentials", func(t *testing.T) {
-		m := getBaseMetadata()
-		m[authType] = awsIAMAuthType
-		m["awsRegion"] = "us-east-1"
-		meta, err := k.getKafkaMetadata(m)
-		require.Error(t, err)
-		require.Nil(t, meta)
-
-		require.Equal(t, "missing AWS credentials or IAM role properties for authType 'awsiam'", err.Error())
-	})
 }
 
 func TestMetadataConsumerFetchValues(t *testing.T) {


### PR DESCRIPTION
# Description

This is a follow-up PR based on the comment https://github.com/dapr/components-contrib/pull/3310#discussion_r1447069372

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
