### PR TITLE
fix(build): fix broken workflow by setting up go first

### DIFF
--- a/.github/workflows/generate-component-metadata-for-tag.yml
+++ b/.github/workflows/generate-component-metadata-for-tag.yml
@@ -9,6 +9,11 @@ jobs:
   upload-bundle:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: 'false'
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Build component-metadata-bundle.json


### PR DESCRIPTION
# Description

Updated the github workflow by installing Go first to then run Go commands with the rebuilding and bundling of the metadata.

If you execute the workflow as is, then you will see an issue due to upgrading go versions to 1.21, as the toolchain is not present in Go 1.20.
```
go: errors parsing go.mod:
... unknown directive: toolchain
...
```

Follow up question: Are there other workflows not executing that need this same update? should this workflow be added to execute main to catch in future?

## Issue reference

Figured I'd just open PR with fix rq.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
