### PR TITLE
Enable configurable concurrency for pulsar

### DIFF
--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -35,6 +35,7 @@ type pulsarMetadata struct {
 	PublicKey               string                    `mapstructure:"publicKey"`
 	PrivateKey              string                    `mapstructure:"privateKey"`
 	Keys                    string                    `mapstructure:"keys"`
+	Concurrency             uint                      `mapstructure:"concurrency"`
 
 	Token                            string `mapstructure:"token"`
 	oauth2.ClientCredentialsMetadata `mapstructure:",squash"`

--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -35,7 +35,7 @@ type pulsarMetadata struct {
 	PublicKey               string                    `mapstructure:"publicKey"`
 	PrivateKey              string                    `mapstructure:"privateKey"`
 	Keys                    string                    `mapstructure:"keys"`
-	Concurrency             uint                      `mapstructure:"concurrency"`
+	MaxConcurrentHandlers   uint                      `mapstructure:"maxConcurrentHandlers"`
 
 	Token                            string `mapstructure:"token"`
 	oauth2.ClientCredentialsMetadata `mapstructure:",squash"`

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -171,7 +171,7 @@ metadata:
           {"name": "Name","type": "string"}
         ]
       }
-  - name: concurrency
+  - name: maxConcurrentHandlers
     type: number
     description: |
       Sets the maximum number of concurrent messages sent to the application. Default is 100.

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -171,3 +171,9 @@ metadata:
           {"name": "Name","type": "string"}
         ]
       }
+  - name: concurrency
+    type: number
+    description: |
+      Sets the maximum number of concurrent messages sent to the application. Default is 100.
+    default: '"100"'
+    example: '"100"'

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -124,7 +124,7 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		BatchingMaxMessages:     defaultMaxMessages,
 		BatchingMaxSize:         defaultMaxBatchSize,
 		RedeliveryDelay:         defaultRedeliveryDelay,
-		Concurrency:             defaultConcurrency,
+		MaxConcurrentHandlers:   defaultConcurrency,
 	}
 
 	if err := kitmd.DecodeMetadata(meta.Properties, &m); err != nil {
@@ -395,7 +395,7 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 		return errors.New("component is closed")
 	}
 
-	channel := make(chan pulsar.ConsumerMessage, p.metadata.Concurrency)
+	channel := make(chan pulsar.ConsumerMessage, p.metadata.MaxConcurrentHandlers)
 
 	topic := p.formatTopic(req.Topic)
 

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -78,6 +78,8 @@ const (
 	defaultMaxBatchSize = 128 * 1024
 	// defaultRedeliveryDelay init default for redelivery delay.
 	defaultRedeliveryDelay = 30 * time.Second
+	// defaultConcurrency controls the number of concurrent messages sent to the app.
+	defaultConcurrency = 100
 
 	subscribeTypeKey = "subscribeType"
 
@@ -122,6 +124,7 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		BatchingMaxMessages:     defaultMaxMessages,
 		BatchingMaxSize:         defaultMaxBatchSize,
 		RedeliveryDelay:         defaultRedeliveryDelay,
+		Concurrency:             defaultConcurrency,
 	}
 
 	if err := kitmd.DecodeMetadata(meta.Properties, &m); err != nil {
@@ -392,7 +395,7 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 		return errors.New("component is closed")
 	}
 
-	channel := make(chan pulsar.ConsumerMessage, 100)
+	channel := make(chan pulsar.ConsumerMessage, p.metadata.Concurrency)
 
 	topic := p.formatTopic(req.Topic)
 

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -33,6 +33,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 		"batchingMaxPublishDelay": "5s",
 		"batchingMaxSize":         "100",
 		"batchingMaxMessages":     "200",
+		"concurrency":             "333",
 	}
 	meta, err := parsePulsarMetadata(m)
 
@@ -45,6 +46,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 	assert.Equal(t, 5*time.Second, meta.BatchingMaxPublishDelay)
 	assert.Equal(t, uint(100), meta.BatchingMaxSize)
 	assert.Equal(t, uint(200), meta.BatchingMaxMessages)
+	assert.Equal(t, uint(333), meta.Concurrency)
 	assert.Empty(t, meta.internalTopicSchemas)
 }
 

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -33,7 +33,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 		"batchingMaxPublishDelay": "5s",
 		"batchingMaxSize":         "100",
 		"batchingMaxMessages":     "200",
-		"concurrency":             "333",
+		"maxConcurrentHandlers":   "333",
 	}
 	meta, err := parsePulsarMetadata(m)
 
@@ -46,7 +46,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 	assert.Equal(t, 5*time.Second, meta.BatchingMaxPublishDelay)
 	assert.Equal(t, uint(100), meta.BatchingMaxSize)
 	assert.Equal(t, uint(200), meta.BatchingMaxMessages)
-	assert.Equal(t, uint(333), meta.Concurrency)
+	assert.Equal(t, uint(333), meta.MaxConcurrentHandlers)
 	assert.Empty(t, meta.internalTopicSchemas)
 }
 


### PR DESCRIPTION
Reported by users, the Pulsar component has hardcoded concurrency settings which provides very limited performance at moderate to high scale scenarios, causing bottlenecks and issues.

I'm targeting this for 1.13 as Pulsar is a stable component and this is an issue that prevents a lot of production scenarios. Will merge if we have consensus for a 1.13 release, otherwise i'll target the PR against main branch for 1.14.
