### PR TITLE
Azure Service Bus: enforce `autodeleteonidlesec` minimum 300

### DIFF
--- a/common/component/azure/servicebus/metadata.go
+++ b/common/component/azure/servicebus/metadata.go
@@ -204,6 +204,10 @@ func ParseMetadata(md map[string]string, logger logger.Logger, mode byte) (m *Me
 		return m, errors.New("defaultMessageTimeToLiveInSec must be greater than 0")
 	}
 
+	if m.AutoDeleteOnIdleInSec != nil && *m.AutoDeleteOnIdleInSec < 300 {
+		return m, errors.New("autoDeleteOnIdleInSec must be greater than or equal to 300")
+	}
+
 	return m, nil
 }
 

--- a/common/component/azure/servicebus/metadata_test.go
+++ b/common/component/azure/servicebus/metadata_test.go
@@ -32,7 +32,7 @@ func getFakeProperties() map[string]string {
 		keyTimeoutInSec:                  "90",
 		keyHandlerTimeoutInSec:           "30",
 		keyMaxDeliveryCount:              "10",
-		keyAutoDeleteOnIdleInSec:         "240",
+		keyAutoDeleteOnIdleInSec:         "340",
 		keyDefaultMessageTimeToLiveInSec: "2400",
 		keyLockDurationInSec:             "120",
 		keyLockRenewalInSec:              "15",
@@ -71,7 +71,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 50, m.MaxRetriableErrorsPerSec)
 
 		assert.NotNil(t, m.AutoDeleteOnIdleInSec)
-		assert.Equal(t, 240, *m.AutoDeleteOnIdleInSec)
+		assert.Equal(t, 340, *m.AutoDeleteOnIdleInSec)
 		assert.NotNil(t, m.MaxDeliveryCount)
 		assert.Equal(t, int32(10), *m.MaxDeliveryCount)
 		assert.NotNil(t, m.DefaultMessageTimeToLiveInSec)
@@ -106,7 +106,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 50, m.MaxRetriableErrorsPerSec)
 
 		assert.NotNil(t, m.AutoDeleteOnIdleInSec)
-		assert.Equal(t, 240, *m.AutoDeleteOnIdleInSec)
+		assert.Equal(t, 340, *m.AutoDeleteOnIdleInSec)
 		assert.NotNil(t, m.MaxDeliveryCount)
 		assert.Equal(t, int32(10), *m.MaxDeliveryCount)
 		assert.NotNil(t, m.DefaultMessageTimeToLiveInSec)
@@ -142,7 +142,7 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		assert.Equal(t, 50, m.MaxRetriableErrorsPerSec)
 
 		assert.NotNil(t, m.AutoDeleteOnIdleInSec)
-		assert.Equal(t, 240, *m.AutoDeleteOnIdleInSec)
+		assert.Equal(t, 340, *m.AutoDeleteOnIdleInSec)
 		assert.NotNil(t, m.MaxDeliveryCount)
 		assert.Equal(t, int32(10), *m.MaxDeliveryCount)
 		assert.NotNil(t, m.DefaultMessageTimeToLiveInSec)
@@ -494,6 +494,16 @@ func TestParseServiceBusMetadata(t *testing.T) {
 		// assert.
 		assert.Nil(t, m.AutoDeleteOnIdleInSec)
 		require.NoError(t, err)
+	})
+
+	t.Run("autoDeleteOnIdleInSec too small", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		delete(fakeProperties, keyAutoDeleteOnIdleInSec)
+		fakeProperties[keyAutoDeleteOnIdleInSec] = "299"
+
+		// act.
+		_, err := ParseMetadata(fakeProperties, nil, 0)
+		require.Error(t, err)
 	})
 
 	t.Run("missing nullable lockDurationInSec", func(t *testing.T) {


### PR DESCRIPTION
# Description

ASB `autodeleteonidlesec` should throw a warning if the value provided is less than 300 (5 minutes). This is the minimum duration required for this feature.

See https://learn.microsoft.com/en-us/azure/service-bus-messaging/advanced-features-overview#autodelete-on-idle

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
