### PR TITLE
[1.13] Fix Kafka consumer cancellation

### DIFF
--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -211,7 +211,7 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 }
 
 func (k *Kafka) Close() (err error) {
-	k.closeSubscriptionResources()
+	k.CloseSubscriptionResources()
 
 	if k.producer != nil {
 		err = k.producer.Close()

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -90,6 +90,7 @@ func (p *PubSub) subscribeUtil(ctx context.Context, req pubsub.SubscribeRequest,
 		// Wait for context cancelation
 		select {
 		case <-ctx.Done():
+			p.kafka.CloseSubscriptionResources()
 		case <-p.closeCh:
 		}
 


### PR DESCRIPTION
Reported by Dapr Kafka users trying out 1.13-rc.2: Upon receiving a sigterm, Dapr would continue to consume events and deliver them to be the app, causing the graceful draining process to be not work as expected and keep the app busy.

This PR was tested in a pre-production environment at large scale and was confirmed to solve the issue.
