### PR TITLE
fix: create table for migration only if not exists

### DIFF
--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -158,7 +158,7 @@ func (p *PostgreSQL) performMigrations(ctx context.Context) error {
 			p.logger.Infof("Creating state table: '%s'", stateTable)
 			_, err := p.db.Exec(ctx,
 				fmt.Sprintf(`
-CREATE TABLE %[1]s (
+CREATE TABLE %[1]s IF NOT EXISTS (
   key text NOT NULL PRIMARY KEY,
   value bytea NOT NULL,
   etag uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -158,7 +158,7 @@ func (p *PostgreSQL) performMigrations(ctx context.Context) error {
 			p.logger.Infof("Creating state table: '%s'", stateTable)
 			_, err := p.db.Exec(ctx,
 				fmt.Sprintf(`
-CREATE TABLE %[1]s IF NOT EXISTS (
+CREATE TABLE IF NOT EXISTS %[1]s (
   key text NOT NULL PRIMARY KEY,
   value bytea NOT NULL,
   etag uuid NOT NULL DEFAULT gen_random_uuid(),


### PR DESCRIPTION
# Description

Currently, for postgres v2 users if the sidecar restarts, then they will see this err due to the setup for the migrations:
```
failed to perform migration 0: failed to create state table: ERROR: relation \"<tablename>\" already exists
```

Question:
- are other v2 components at risk of seeing this err?
- how was this not caught in a test?
- should a follow up issue for tests to catch this be created for the future?

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
