### PR TITLE
[1.13] fix: create table for migration only if not exists (#3356)

### DIFF
--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -158,7 +158,7 @@ func (p *PostgreSQL) performMigrations(ctx context.Context) error {
 			p.logger.Infof("Creating state table: '%s'", stateTable)
 			_, err := p.db.Exec(ctx,
 				fmt.Sprintf(`
-CREATE TABLE %[1]s (
+CREATE TABLE IF NOT EXISTS %[1]s (
   key text NOT NULL PRIMARY KEY,
   value bytea NOT NULL,
   etag uuid NOT NULL DEFAULT gen_random_uuid(),


### PR DESCRIPTION
Cherry pick of #3356 to 1.13.
