### PR TITLE
PubSub Kafka: Respect Subscribe context

### DIFF
--- a/common/component/kafka/mocks/consumergroup.go
+++ b/common/component/kafka/mocks/consumergroup.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/IBM/sarama"
+)
+
+type FakeConsumerGroup struct {
+	consumerFn  func(context.Context, []string, sarama.ConsumerGroupHandler) error
+	errorsFn    func() <-chan error
+	closeFn     func() error
+	pauseFn     func(map[string][]int32)
+	resumeFn    func(map[string][]int32)
+	pauseAllFn  func()
+	resumeAllFn func()
+}
+
+func NewConsumerGroup() *FakeConsumerGroup {
+	return &FakeConsumerGroup{
+		consumerFn: func(context.Context, []string, sarama.ConsumerGroupHandler) error {
+			return nil
+		},
+		errorsFn: func() <-chan error {
+			return nil
+		},
+		closeFn: func() error {
+			return nil
+		},
+		pauseFn: func(map[string][]int32) {
+		},
+		resumeFn: func(map[string][]int32) {
+		},
+		pauseAllFn: func() {
+		},
+		resumeAllFn: func() {
+		},
+	}
+}
+
+func (f *FakeConsumerGroup) WithConsumeFn(fn func(context.Context, []string, sarama.ConsumerGroupHandler) error) *FakeConsumerGroup {
+	f.consumerFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) WithErrorsFn(fn func() <-chan error) *FakeConsumerGroup {
+	f.errorsFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) WithCloseFn(fn func() error) *FakeConsumerGroup {
+	f.closeFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) WithPauseFn(fn func(map[string][]int32)) *FakeConsumerGroup {
+	f.pauseFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) WithResumeFn(fn func(map[string][]int32)) *FakeConsumerGroup {
+	f.resumeFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) WithPauseAllFn(fn func()) *FakeConsumerGroup {
+	f.pauseAllFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) WithResumeAllFn(fn func()) *FakeConsumerGroup {
+	f.resumeAllFn = fn
+	return f
+}
+
+func (f *FakeConsumerGroup) Consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+	return f.consumerFn(ctx, topics, handler)
+}
+
+func (f *FakeConsumerGroup) Errors() <-chan error {
+	return f.errorsFn()
+}
+
+func (f *FakeConsumerGroup) Close() error {
+	return f.closeFn()
+}
+
+func (f *FakeConsumerGroup) Pause(partitions map[string][]int32) {
+	f.pauseFn(partitions)
+}
+
+func (f *FakeConsumerGroup) Resume(partitions map[string][]int32) {
+	f.resumeFn(partitions)
+}
+
+func (f *FakeConsumerGroup) PauseAll() {
+	f.pauseAllFn()
+}
+
+func (f *FakeConsumerGroup) ResumeAll() {
+	f.resumeAllFn()
+}

--- a/common/component/kafka/mocks/mock_ISchemaRegistryClient.go
+++ b/common/component/kafka/mocks/mock_ISchemaRegistryClient.go
@@ -2,7 +2,7 @@
 // Source: /Users/patrick.assuied/go/pkg/mod/github.com/riferrei/srclient@v0.6.0/schemaRegistryClient.go
 
 // Package mock_srclient is a generated GoMock package.
-package mock_srclient
+package mocks
 
 import (
 	reflect "reflect"

--- a/common/component/kafka/subscriber.go
+++ b/common/component/kafka/subscriber.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Subscribe adds a handler and configuration for a topic, and subscribes.
+// Unsubscribes to the topic on context cancel.
+func (k *Kafka) Subscribe(ctx context.Context, handlerConfig SubscriptionHandlerConfig, topics ...string) {
+	k.subscribeLock.Lock()
+	defer k.subscribeLock.Unlock()
+	for _, topic := range topics {
+		k.subscribeTopics[topic] = handlerConfig
+	}
+
+	k.logger.Debugf("Subscribing to topic: %v", topics)
+
+	k.reloadConsumerGroup()
+
+	k.wg.Add(1)
+	go func() {
+		defer k.wg.Done()
+		select {
+		case <-ctx.Done():
+		case <-k.closeCh:
+		}
+
+		k.subscribeLock.Lock()
+		defer k.subscribeLock.Unlock()
+
+		k.logger.Debugf("Unsubscribing to topic: %v", topics)
+
+		for _, topic := range topics {
+			delete(k.subscribeTopics, topic)
+		}
+
+		k.reloadConsumerGroup()
+	}()
+}
+
+// reloadConsumerGroup reloads the consumer group with the new topics.
+func (k *Kafka) reloadConsumerGroup() {
+	if k.consumerCancel != nil {
+		k.consumerCancel()
+		k.consumerCancel = nil
+		k.consumerWG.Wait()
+	}
+
+	if len(k.subscribeTopics) == 0 || k.closed.Load() {
+		return
+	}
+
+	topics := k.subscribeTopics.TopicList()
+
+	k.logger.Debugf("Subscribed and listening to topics: %s", topics)
+
+	consumer := &consumer{k: k}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	k.consumerCancel = cancel
+
+	k.consumerWG.Add(1)
+	go func() {
+		defer k.consumerWG.Done()
+		k.consume(ctx, topics, consumer)
+		k.logger.Debugf("Closing ConsumerGroup for topics: %v", topics)
+	}()
+}
+
+func (k *Kafka) consume(ctx context.Context, topics []string, consumer *consumer) {
+	for {
+		err := k.cg.Consume(ctx, topics, consumer)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		if err != nil {
+			k.logger.Errorf("Error consuming %v. Retrying...: %v", topics, err)
+		}
+
+		select {
+		case <-k.closeCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-time.After(k.consumeRetryInterval):
+		}
+	}
+}

--- a/common/component/kafka/subscriber_test.go
+++ b/common/component/kafka/subscriber_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/common/component/kafka/mocks"
+	"github.com/dapr/kit/logger"
+)
+
+func Test_reloadConsumerGroup(t *testing.T) {
+	t.Run("if reload called with no topics and not closed, expect return and cancel called", func(t *testing.T) {
+		var consumeCalled atomic.Bool
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(context.Context, []string, sarama.ConsumerGroupHandler) error {
+			consumeCalled.Store(true)
+			return nil
+		})
+
+		k := &Kafka{
+			logger:          logger.NewLogger("test"),
+			cg:              cg,
+			subscribeTopics: nil,
+			closeCh:         make(chan struct{}),
+			consumerCancel:  cancel,
+		}
+
+		k.reloadConsumerGroup()
+
+		require.Error(t, ctx.Err())
+		assert.False(t, consumeCalled.Load())
+	})
+
+	t.Run("if reload called with topics but is closed, expect return and cancel called", func(t *testing.T) {
+		var consumeCalled atomic.Bool
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(context.Context, []string, sarama.ConsumerGroupHandler) error {
+			consumeCalled.Store(true)
+			return nil
+		})
+		k := &Kafka{
+			logger:          logger.NewLogger("test"),
+			cg:              cg,
+			consumerCancel:  cancel,
+			closeCh:         make(chan struct{}),
+			subscribeTopics: TopicHandlerConfig{"foo": SubscriptionHandlerConfig{}},
+		}
+
+		k.closed.Store(true)
+
+		k.reloadConsumerGroup()
+
+		require.Error(t, ctx.Err())
+		assert.False(t, consumeCalled.Load())
+	})
+
+	t.Run("if reload called with topics, expect Consume to be called. If cancelled return", func(t *testing.T) {
+		var consumeCalled atomic.Bool
+		var consumeCancel atomic.Bool
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Store(true)
+			<-ctx.Done()
+			consumeCancel.Store(true)
+			return nil
+		})
+		k := &Kafka{
+			logger:          logger.NewLogger("test"),
+			cg:              cg,
+			consumerCancel:  nil,
+			closeCh:         make(chan struct{}),
+			subscribeTopics: TopicHandlerConfig{"foo": SubscriptionHandlerConfig{}},
+		}
+
+		k.reloadConsumerGroup()
+
+		assert.Eventually(t, consumeCalled.Load, time.Second, time.Millisecond)
+		assert.False(t, consumeCancel.Load())
+		assert.NotNil(t, k.consumerCancel)
+
+		k.consumerCancel()
+		k.consumerWG.Wait()
+	})
+
+	t.Run("Consume retries if returns non-context cancel error", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			return errors.New("some error")
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      TopicHandlerConfig{"foo": SubscriptionHandlerConfig{}},
+			consumeRetryInterval: time.Millisecond,
+		}
+
+		k.reloadConsumerGroup()
+
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() > 10
+		}, time.Second, time.Millisecond)
+
+		assert.NotNil(t, k.consumerCancel)
+
+		called := consumeCalled.Load()
+		k.consumerCancel()
+		k.consumerWG.Wait()
+		assert.InDelta(t, called, consumeCalled.Load(), 1)
+	})
+
+	t.Run("Consume return immediately if returns a context cancelled error", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			if consumeCalled.Load() == 5 {
+				return context.Canceled
+			}
+			return errors.New("some error")
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{"foo": {}},
+			consumeRetryInterval: time.Millisecond,
+		}
+
+		k.reloadConsumerGroup()
+
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 5
+		}, time.Second, time.Millisecond)
+
+		k.consumerWG.Wait()
+		assert.Equal(t, int64(5), consumeCalled.Load())
+	})
+
+	t.Run("Calling reloadConsumerGroup causes context to be cancelled and Consume called again (close by closed)", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{"foo": {}},
+			consumeRetryInterval: time.Millisecond,
+		}
+
+		k.reloadConsumerGroup()
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 1
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(0), cancelCalled.Load())
+
+		k.reloadConsumerGroup()
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 2
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(1), cancelCalled.Load())
+
+		k.closed.Store(true)
+		k.reloadConsumerGroup()
+		assert.Equal(t, int64(2), cancelCalled.Load())
+		assert.Equal(t, int64(2), consumeCalled.Load())
+	})
+
+	t.Run("Calling reloadConsumerGroup causes context to be cancelled and Consume called again (close by no subscriptions)", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{"foo": {}},
+			consumeRetryInterval: time.Millisecond,
+		}
+
+		k.reloadConsumerGroup()
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 1
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(0), cancelCalled.Load())
+
+		k.reloadConsumerGroup()
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 2
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(1), cancelCalled.Load())
+
+		k.subscribeTopics = nil
+		k.reloadConsumerGroup()
+		assert.Equal(t, int64(2), cancelCalled.Load())
+		assert.Equal(t, int64(2), consumeCalled.Load())
+	})
+}
+
+func Test_Subscribe(t *testing.T) {
+	t.Run("Calling subscribe with no topics should not consume", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			consumeRetryInterval: time.Millisecond,
+			subscribeTopics:      make(TopicHandlerConfig),
+		}
+
+		k.Subscribe(context.Background(), SubscriptionHandlerConfig{})
+
+		assert.Nil(t, k.consumerCancel)
+		assert.Equal(t, int64(0), consumeCalled.Load())
+		assert.Equal(t, int64(0), cancelCalled.Load())
+	})
+
+	t.Run("Calling subscribe when closed should not consume", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			consumeRetryInterval: time.Millisecond,
+			subscribeTopics:      make(TopicHandlerConfig),
+		}
+
+		k.closed.Store(true)
+
+		k.Subscribe(context.Background(), SubscriptionHandlerConfig{}, "abc")
+
+		assert.Nil(t, k.consumerCancel)
+		assert.Equal(t, int64(0), consumeCalled.Load())
+		assert.Equal(t, int64(0), cancelCalled.Load())
+	})
+
+	t.Run("Subscribe should subscribe to a topic until context is cancelled", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		var consumeTopics atomic.Value
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, topics []string, _ sarama.ConsumerGroupHandler) error {
+			consumeTopics.Store(topics)
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			consumeRetryInterval: time.Millisecond,
+			subscribeTopics:      make(TopicHandlerConfig),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		k.Subscribe(ctx, SubscriptionHandlerConfig{}, "abc")
+
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 1
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(0), cancelCalled.Load())
+
+		cancel()
+
+		assert.Eventually(t, func() bool {
+			return cancelCalled.Load() == 1
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(1), consumeCalled.Load())
+
+		assert.Equal(t, []string{"abc"}, consumeTopics.Load())
+	})
+
+	t.Run("Calling subscribe multiple times with new topics should re-consume will full topics list", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		var consumeTopics atomic.Value
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, topics []string, _ sarama.ConsumerGroupHandler) error {
+			consumeTopics.Store(topics)
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			consumeRetryInterval: time.Millisecond,
+			subscribeTopics:      make(TopicHandlerConfig),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		k.Subscribe(ctx, SubscriptionHandlerConfig{}, "abc")
+
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 1
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(0), cancelCalled.Load())
+		assert.Equal(t, []string{"abc"}, consumeTopics.Load())
+		assert.Equal(t, TopicHandlerConfig{"abc": SubscriptionHandlerConfig{}}, k.subscribeTopics)
+
+		k.Subscribe(ctx, SubscriptionHandlerConfig{}, "def")
+		assert.Equal(t, TopicHandlerConfig{
+			"abc": SubscriptionHandlerConfig{},
+			"def": SubscriptionHandlerConfig{},
+		}, k.subscribeTopics)
+
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 2
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(1), cancelCalled.Load())
+		assert.ElementsMatch(t, []string{"abc", "def"}, consumeTopics.Load())
+
+		cancel()
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 3
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, int64(3), cancelCalled.Load())
+
+		k.Subscribe(ctx, SubscriptionHandlerConfig{})
+		assert.Nil(t, k.consumerCancel)
+		assert.Empty(t, k.subscribeTopics)
+	})
+
+	t.Run("Consume return immediately if returns a context cancelled error", func(t *testing.T) {
+		var consumeCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+			consumeCalled.Add(1)
+			if consumeCalled.Load() == 5 {
+				return context.Canceled
+			}
+			return errors.New("some error")
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      make(TopicHandlerConfig),
+			consumeRetryInterval: time.Millisecond,
+		}
+
+		k.Subscribe(context.Background(), SubscriptionHandlerConfig{}, "foo")
+		assert.Equal(t, TopicHandlerConfig{"foo": SubscriptionHandlerConfig{}}, k.subscribeTopics)
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 5
+		}, time.Second, time.Millisecond)
+		k.consumerWG.Wait()
+		assert.Equal(t, int64(5), consumeCalled.Load())
+		assert.Equal(t, TopicHandlerConfig{"foo": SubscriptionHandlerConfig{}}, k.subscribeTopics)
+	})
+
+	t.Run("Consume dynamically changes topics which are being consumed", func(t *testing.T) {
+		var consumeTopics atomic.Value
+		var consumeCalled atomic.Int64
+		var cancelCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithConsumeFn(func(ctx context.Context, topics []string, _ sarama.ConsumerGroupHandler) error {
+			consumeTopics.Store(topics)
+			consumeCalled.Add(1)
+			<-ctx.Done()
+			cancelCalled.Add(1)
+			return nil
+		})
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			cg:                   cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      make(TopicHandlerConfig),
+			consumeRetryInterval: time.Millisecond,
+		}
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		k.Subscribe(ctx1, SubscriptionHandlerConfig{}, "abc")
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 1
+		}, time.Second, time.Millisecond)
+		assert.ElementsMatch(t, []string{"abc"}, consumeTopics.Load())
+		assert.Equal(t, int64(0), cancelCalled.Load())
+
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		k.Subscribe(ctx2, SubscriptionHandlerConfig{}, "def")
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 2
+		}, time.Second, time.Millisecond)
+		assert.ElementsMatch(t, []string{"abc", "def"}, consumeTopics.Load())
+		assert.Equal(t, int64(1), cancelCalled.Load())
+
+		ctx3, cancel3 := context.WithCancel(context.Background())
+		k.Subscribe(ctx3, SubscriptionHandlerConfig{}, "123")
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 3
+		}, time.Second, time.Millisecond)
+		assert.ElementsMatch(t, []string{"abc", "def", "123"}, consumeTopics.Load())
+		assert.Equal(t, int64(2), cancelCalled.Load())
+
+		cancel2()
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 4
+		}, time.Second, time.Millisecond)
+		assert.ElementsMatch(t, []string{"abc", "123"}, consumeTopics.Load())
+		assert.Equal(t, int64(3), cancelCalled.Load())
+
+		ctx2, cancel2 = context.WithCancel(context.Background())
+		k.Subscribe(ctx2, SubscriptionHandlerConfig{}, "456")
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 5
+		}, time.Second, time.Millisecond)
+		assert.ElementsMatch(t, []string{"abc", "123", "456"}, consumeTopics.Load())
+		assert.Equal(t, int64(4), cancelCalled.Load())
+
+		cancel1()
+		cancel3()
+
+		assert.Eventually(t, func() bool {
+			return consumeCalled.Load() == 7
+		}, time.Second, time.Millisecond)
+		assert.ElementsMatch(t, []string{"456"}, consumeTopics.Load())
+		assert.Equal(t, int64(6), cancelCalled.Load())
+
+		cancel2()
+		assert.Eventually(t, func() bool {
+			return cancelCalled.Load() == 7
+		}, time.Second, time.Millisecond)
+		assert.Empty(t, k.subscribeTopics)
+		assert.Equal(t, int64(7), consumeCalled.Load())
+	})
+}

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cloudwego/kitex v0.5.0
 	github.com/cloudwego/kitex-examples v0.1.1
-	github.com/dapr/components-contrib v1.13.0-rc.3
-	github.com/dapr/dapr v1.13.0-rc.2
+	github.com/dapr/components-contrib v1.13.0-rc.6
+	github.com/dapr/dapr v1.13.0-rc.7
 	github.com/dapr/go-sdk v1.6.1-0.20231102031149-87bbb8cd690a
 	github.com/dapr/kit v0.13.0
 	github.com/eclipse/paho.mqtt.golang v1.4.3

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -388,8 +388,8 @@ github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53E
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/dapr v1.13.0-rc.2 h1:Y5tQ07KB856aSWXxVjb/Lob4AT8Gy/hJxZtwODI21CI=
-github.com/dapr/dapr v1.13.0-rc.2/go.mod h1:QvxJ5htwv17PeRfFMGkHznEVRkpnt35re7TpF4CsCc8=
+github.com/dapr/dapr v1.13.0-rc.7 h1:Z3r+eCPlWK6reJcfNuSL5Gu2+V81qyOIBgvY6EV8ZP4=
+github.com/dapr/dapr v1.13.0-rc.7/go.mod h1:NHMC48qz9yEwIRDT1apo3GO+2SVoz5Ae7ejtg2B48RM=
 github.com/dapr/go-sdk v1.6.1-0.20231102031149-87bbb8cd690a h1:Sapb/wyFdMRDxn6PYYNh/P3WW3WcOIrpRSUdW+LT3bE=
 github.com/dapr/go-sdk v1.6.1-0.20231102031149-87bbb8cd690a/go.mod h1:DtFOk+AKGMho/vDTECVVX7WgovkGw64X30nyaEmRGXw=
 github.com/dapr/kit v0.13.0 h1:4S+5QqDCreva+MBONtIgxeg6B2b1W89bB8F5lqKgTa0=


### PR DESCRIPTION
Updates the kafka consumer group to correctly respect context cancellation for individual topic subscriptions. The consumer will be reloaded for every topic subscription, or un-subscription, using the same consumer group. Ensures there are no infinite tight loops, and only a singular consumer is run at a time. Ensures all go routines have returned on close.