### PR TITLE
S3 add storage class to metadata

### DIFF
--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -203,10 +203,10 @@ func (s *AWSS3) create(ctx context.Context, req *bindings.InvokeRequest) (*bindi
 	}
 
 	resultUpload, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
-		Bucket:      ptr.Of(metadata.Bucket),
-		Key:         ptr.Of(key),
-		Body:        r,
-		ContentType: contentType,
+		Bucket:       ptr.Of(metadata.Bucket),
+		Key:          ptr.Of(key),
+		Body:         r,
+		ContentType:  contentType,
 		StorageClass: storageClass,
 	})
 	if err != nil {

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -50,6 +50,7 @@ const (
 	metadataEncodeBase64 = "encodeBase64"
 	metadataFilePath     = "filePath"
 	metadataPresignTTL   = "presignTTL"
+	metadataStorageClass = "storageClass"
 
 	metatadataContentType = "Content-Type"
 	metadataKey           = "key"
@@ -83,6 +84,7 @@ type s3Metadata struct {
 	InsecureSSL    bool   `json:"insecureSSL,string" mapstructure:"insecureSSL"`
 	FilePath       string `json:"filePath" mapstructure:"filePath"   mdignore:"true"`
 	PresignTTL     string `json:"presignTTL" mapstructure:"presignTTL"  mdignore:"true"`
+	StorageClass   string `json:"storageClass" mapstructure:"storageClass"  mdignore:"true"`
 }
 
 type createResponse struct {
@@ -195,11 +197,17 @@ func (s *AWSS3) create(ctx context.Context, req *bindings.InvokeRequest) (*bindi
 		r = b64.NewDecoder(b64.StdEncoding, r)
 	}
 
+	var storageClass *string
+	if metadata.StorageClass != "" {
+		storageClass = aws.String(metadata.StorageClass)
+	}
+
 	resultUpload, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		Bucket:      ptr.Of(metadata.Bucket),
 		Key:         ptr.Of(key),
 		Body:        r,
 		ContentType: contentType,
+		StorageClass: storageClass,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("s3 binding error: uploading failed: %w", err)
@@ -434,6 +442,10 @@ func (metadata s3Metadata) mergeWithRequestMetadata(req *bindings.InvokeRequest)
 
 	if val, ok := req.Metadata[metadataPresignTTL]; ok && val != "" {
 		merged.PresignTTL = val
+	}
+
+	if val, ok := req.Metadata[metadataStorageClass]; ok && val != "" {
+		merged.StorageClass = val
 	}
 
 	return merged, nil

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -83,6 +83,7 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 			"encodeBase64": "false",
 			"filePath":     "/usr/vader.darth",
 			"presignTTL":   "15s",
+			"storageClass": "STANDARD_IA",
 		}
 
 		mergedMeta, err := meta.mergeWithRequestMetadata(&request)
@@ -99,6 +100,7 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 		assert.False(t, mergedMeta.EncodeBase64)
 		assert.Equal(t, "/usr/vader.darth", mergedMeta.FilePath)
 		assert.Equal(t, "15s", mergedMeta.PresignTTL)
+		assert.Equal(t, "STANDARD_IA", mergedMeta.StorageClass)
 	})
 
 	t.Run("Has invalid merged metadata decodeBase64", func(t *testing.T) {


### PR DESCRIPTION
# Description

Added support to define storage class while using the `create` operation in AWS S3 binding.
To use it we need to pass the `storageClass` field to the `binding_metadata` at the `create` operation, like the `PresignTTL` metadata.

For example:
`
 curl -d '{ "operation": "create", "data": "YOUR_BASE_64_CONTENT", "metadata": { "storageClass": "STANDARD_IA" } }' http://localhost:<dapr-port>/v1.0/bindings/<binding-name>
`

Or using the Python SDK:
`
response = client.invoke_binding("s3binding", "create", data="some data", binding_metadata={"storageClass": "STANDARD_IA"})
`
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
