### PR TITLE
kafka: bugfix possible nil pointer error on close

### DIFF
--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -249,7 +249,9 @@ func (k *Kafka) Close() error {
 		}
 		k.subscribeLock.Unlock()
 
-		errs[1] = k.cg.Close()
+		if k.cg != nil {
+			errs[1] = k.cg.Close()
+		}
 	}
 
 	return errors.Join(errs...)


### PR DESCRIPTION
# Description

Fixes a possible nil pointer reference error when closing a Kafka componet, the `cg` field can be nil.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
