### PR TITLE
Replace unsupported zeebe form key header

### DIFF
--- a/bindings/zeebe/jobworker/jobworker.go
+++ b/bindings/zeebe/jobworker/jobworker.go
@@ -198,6 +198,13 @@ func (h *jobHandler) handleJob(client worker.JobClient, job entities.Job) {
 		return
 	}
 
+	// Make sure to replace the formKey header with a custom header.
+	// The HTTP Client doesn't like the custom header.
+	if headers["io.camunda.zeebe:formKey"] != "" {
+		headers["X-Zeebe-Form-Key"] = headers["io.camunda.zeebe:formKey"]
+		delete(headers, "io.camunda.zeebe:formKey")
+	}
+
 	headers["X-Zeebe-Job-Key"] = strconv.FormatInt(job.Key, 10)
 	headers["X-Zeebe-Job-Type"] = job.Type
 	headers["X-Zeebe-Process-Instance-Key"] = strconv.FormatInt(job.ProcessInstanceKey, 10)

--- a/bindings/zeebe/jobworker/jobworker.go
+++ b/bindings/zeebe/jobworker/jobworker.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -201,7 +202,7 @@ func (h *jobHandler) handleJob(client worker.JobClient, job entities.Job) {
 	// Make sure to replace the formKey header with a custom header.
 	// The HTTP Client doesn't like the custom header.
 	if headers["io.camunda.zeebe:formKey"] != "" {
-		headers["X-Zeebe-Form-Key"] = headers["io.camunda.zeebe:formKey"]
+		headers["X-Zeebe-Form-Key"] = strings.Clone(headers["io.camunda.zeebe:formKey"])
 		delete(headers, "io.camunda.zeebe:formKey")
 	}
 


### PR DESCRIPTION
When handling user tasks, Zeebe sends a custom io.camunda.zeebe:formKey header that's not supported over HTTP. This fix replaces the custom header with a X-Zeebe-Form-Key header.

# Description

Add code to detect the `io.camunda.zeebe:formKey` header and replace it with `X-Zeebe-Form-Key` header instead so that
the callback to the microservice doesn't fail.

## Issue reference

Closes #3385

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
