### PR TITLE
build: fix github wf to generate metadata bundle

### DIFF
--- a/.github/workflows/generate-component-metadata-for-tag.yml
+++ b/.github/workflows/generate-component-metadata-for-tag.yml
@@ -9,13 +9,13 @@ jobs:
   upload-bundle:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: 'false'
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Build component-metadata-bundle.json
         run: make bundle-component-metadata
       - name: Upload component-metadata-bundle.json

--- a/common/component/azure/servicebus/message_pubsub.go
+++ b/common/component/azure/servicebus/message_pubsub.go
@@ -15,9 +15,10 @@ package servicebus
 
 import (
 	"encoding/base64"
-	"github.com/spf13/cast"
 	"net/http"
 	"strconv"
+
+	"github.com/spf13/cast"
 
 	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/google/uuid"


### PR DESCRIPTION
# Description

If we leave the workflow definition file as is, then it will not work. It will err with `The specified go version file at: go.mod does not exist`. This is because the workflow steps set up Go referencing a go mod file before actually downloading the repo code that contains the go mod file that the precursor step needs. This PR fixes that issue, and bumps setup-go versions.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
