### PR TITLE
ASB: Add support for ApplicationProperties in subscriptions

### DIFF
--- a/common/component/azure/servicebus/message_pubsub.go
+++ b/common/component/azure/servicebus/message_pubsub.go
@@ -15,7 +15,7 @@ package servicebus
 
 import (
 	"encoding/base64"
-	"fmt"
+	"github.com/spf13/cast"
 	"net/http"
 	"strconv"
 
@@ -60,7 +60,7 @@ func addMessageAttributesToMetadata(metadata map[string]string, asbMsg *azservic
 	}
 
 	for key, val := range asbMsg.ApplicationProperties {
-		metadata["metadata."+key] = fmt.Sprintf("%v", val)
+		metadata["metadata."+key] = cast.ToString(val)
 	}
 
 	// We are not concerned about key conflicts here as we do not allow custom properties that match well-known property names

--- a/common/component/azure/servicebus/message_pubsub.go
+++ b/common/component/azure/servicebus/message_pubsub.go
@@ -15,6 +15,7 @@ package servicebus
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -57,6 +58,12 @@ func addMessageAttributesToMetadata(metadata map[string]string, asbMsg *azservic
 	if metadata == nil {
 		metadata = map[string]string{}
 	}
+
+	for key, val := range asbMsg.ApplicationProperties {
+		metadata["metadata."+key] = fmt.Sprintf("%v", val)
+	}
+
+	// We are not concerned about key conflicts here as we do not allow custom properties that match well-known property names
 
 	if asbMsg.MessageID != "" {
 		metadata["metadata."+MessageKeyMessageID] = asbMsg.MessageID

--- a/common/component/azure/servicebus/message_pubsub_test.go
+++ b/common/component/azure/servicebus/message_pubsub_test.go
@@ -44,6 +44,10 @@ func TestAddMessageAttributesToMetadata(t *testing.T) {
 				ScheduledEnqueueTime: &testSampleTime,
 				PartitionKey:         &testPartitionKey,
 				LockedUntil:          &testSampleTime,
+				ApplicationProperties: map[string]interface{}{
+					"hello":   "world",
+					"numeric": 1,
+				},
 			},
 			expectedMetadata: map[string]string{
 				"metadata." + MessageKeyMessageID:               testMessageID,
@@ -60,6 +64,8 @@ func TestAddMessageAttributesToMetadata(t *testing.T) {
 				"metadata." + MessageKeyScheduledEnqueueTimeUtc: testSampleTimeHTTPFormat,
 				"metadata." + MessageKeyPartitionKey:            testPartitionKey,
 				"metadata." + MessageKeyLockedUntilUtc:          testSampleTimeHTTPFormat,
+				"metadata.hello":                                "world",
+				"metadata.numeric":                              "1",
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Service Bus PubSub (and Bindings) Components: Add `ApplicationProperties` to metadata payload on subscription (in the same way these are set from metadata when publishing through Dapr)

## Issue reference

#3428

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
~* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~
