### PR TITLE
Add RabbitMQ single active consumer argument

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/utils"
 )
 
 const (
@@ -435,15 +436,8 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 	}
 
 	// Applying x-single-active-consumer if defined at subscription level
-	if val := req.Metadata[reqMetadataSingleActiveConsumerKey]; val != "" {
-		parsedVal, pErr := strconv.ParseBool(val)
-		if pErr != nil {
-			r.logger.Errorf("%s invalid boolean value for %s on subscription metadata for topic/queue `%s/%s`: %s", logMessagePrefix, reqMetadataSingleActiveConsumerKey, req.Topic, queueName, pErr)
-			return nil, pErr
-		}
-		if parsedVal {
-			args[argSingleActiveConsumer] = parsedVal
-		}
+	if val := req.Metadata[reqMetadataSingleActiveConsumerKey]; utils.IsTruthy(val) {
+		args[argSingleActiveConsumer] = true
 	}
 
 	// Applying x-max-length-bytes if defined at subscription level

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -139,7 +139,6 @@ func TestPublishAndSubscribeWithPriorityQueue(t *testing.T) {
 	<-processed
 	assert.Equal(t, 5, messageCount)
 	assert.Equal(t, "dummy data", lastMessage)
-
 }
 
 func TestConcurrencyMode(t *testing.T) {

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -129,6 +129,11 @@ func TestPublishAndSubscribeWithPriorityQueue(t *testing.T) {
 	<-processed
 	assert.Equal(t, 4, messageCount)
 	assert.Equal(t, "foo bar", lastMessage)
+
+	// subscribe using single active consumer
+	err = pubsubRabbitMQ.Subscribe(context.Background(), pubsub.SubscribeRequest{Topic: topic, Metadata: map[string]string{reqMetadataSingleActiveConsumerKey: "true"}}, handler)
+	require.NoError(t, err)
+
 }
 
 func TestConcurrencyMode(t *testing.T) {

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -134,6 +134,12 @@ func TestPublishAndSubscribeWithPriorityQueue(t *testing.T) {
 	err = pubsubRabbitMQ.Subscribe(context.Background(), pubsub.SubscribeRequest{Topic: topic, Metadata: map[string]string{reqMetadataSingleActiveConsumerKey: "true"}}, handler)
 	require.NoError(t, err)
 
+	err = pubsubRabbitMQ.Publish(context.Background(), &pubsub.PublishRequest{Topic: topic, Data: []byte("dummy data"), Metadata: map[string]string{reqMetadataSingleActiveConsumerKey: "true"}})
+	require.NoError(t, err)
+	<-processed
+	assert.Equal(t, 5, messageCount)
+	assert.Equal(t, "dummy data", lastMessage)
+
 }
 
 func TestConcurrencyMode(t *testing.T) {


### PR DESCRIPTION
# Description

Added a new RabbitMQ subscription argument to enable [Single Active Consumer](https://www.rabbitmq.com/docs/consumers#single-active-consumer) (`x-single-active-consumer`)

Usage with declarative subscription
```yaml
apiVersion: dapr.io/v2alpha1
kind: Subscription
metadata:
  name: orders
spec:
  topic: orders
  routes:
    default: /orders
  pubsubname: orderpubsub
  metadata:
    queueName: "foo-queue-quorum"
    queueType: quorum
    singleActiveConsumer: "true"
scopes:
- order-processor-sdk

```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3120

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
