### PR TITLE
Support configurable MaxOutstanding* and NumGoroutines settings for GCP PubSub component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Thank you for your interest in Dapr!
 
-This project welcomes contributions and suggestions. Most contributions require you to signoff on your commits via 
-the Developer Certificate of Origin (DCO). When you submit a pull request, a DCO-bot will automatically determine 
-whether you need to provide signoff for your commit. Please follow the instructions provided by DCO-bot, as pull 
+This project welcomes contributions and suggestions. Most contributions require you to signoff on your commits via
+the Developer Certificate of Origin (DCO). When you submit a pull request, a DCO-bot will automatically determine
+whether you need to provide signoff for your commit. Please follow the instructions provided by DCO-bot, as pull
 requests cannot be merged until the author(s) have provided signoff to fulfill the DCO requirement.
 You may find more information on the DCO requirements [below](#developer-certificate-of-origin-signing-your-work).
 
@@ -64,7 +64,7 @@ All contributions come through pull requests. To submit a proposed change, we re
 
 #### Use work-in-progress PRs for early feedback
 
-A good way to communicate before investing too much time is to create a "Work-in-progress" PR and share it with your reviewers. The standard way of doing this is to add a "[WIP]" prefix in your PR's title and assign the **do-not-merge** label. This will let people looking at your PR know that it is not well baked yet.
+A good way to communicate before investing too much time is to create a "Work-in-progress" PR and share it with your reviewers. The standard way of doing this is to open your PR as a draft, add a "[WIP]" prefix in your PR's title, and assign the **do-not-merge** label. This will let people looking at your PR know that it is not well baked yet.
 
 ### Developer Certificate of Origin: Signing your work
 

--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -37,4 +37,6 @@ type metadata struct {
 	OrderingKey             string `mapstructure:"orderingKey"`
 	DeadLetterTopic         string `mapstructure:"deadLetterTopic"`
 	MaxDeliveryAttempts     int    `mapstructure:"maxDeliveryAttempts"`
+	MaxOutstandingMessages  int    `mapstructure:"maxOutstandingMessages"`
+	MaxOutstandingBytes     int    `mapstructure:"maxOutstandingBytes"`
 }

--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -29,15 +29,15 @@ type metadata struct {
 	AuthProviderCertURL string `mapstructure:"authProviderX509CertUrl" mdignore:"true"`
 	ClientCertURL       string `mapstructure:"clientX509CertUrl"       mdignore:"true"`
 
-	DisableEntityManagement bool   `mapstructure:"disableEntityManagement"`
-	EnableMessageOrdering   bool   `mapstructure:"enableMessageOrdering"`
-	MaxReconnectionAttempts int    `mapstructure:"maxReconnectionAttempts"`
-	ConnectionRecoveryInSec int    `mapstructure:"connectionRecoveryInSec"`
-	ConnectionEndpoint      string `mapstructure:"endpoint"`
-	OrderingKey             string `mapstructure:"orderingKey"`
-	DeadLetterTopic         string `mapstructure:"deadLetterTopic"`
-	MaxDeliveryAttempts     int    `mapstructure:"maxDeliveryAttempts"`
-	MaxOutstandingMessages  int    `mapstructure:"maxOutstandingMessages"`
-	MaxOutstandingBytes     int    `mapstructure:"maxOutstandingBytes"`
-	NumGoroutines           int    `mapstructure:"numGoroutines"`
+	DisableEntityManagement  bool   `mapstructure:"disableEntityManagement"`
+	EnableMessageOrdering    bool   `mapstructure:"enableMessageOrdering"`
+	MaxReconnectionAttempts  int    `mapstructure:"maxReconnectionAttempts"`
+	ConnectionRecoveryInSec  int    `mapstructure:"connectionRecoveryInSec"`
+	ConnectionEndpoint       string `mapstructure:"endpoint"`
+	OrderingKey              string `mapstructure:"orderingKey"`
+	DeadLetterTopic          string `mapstructure:"deadLetterTopic"`
+	MaxDeliveryAttempts      int    `mapstructure:"maxDeliveryAttempts"`
+	MaxOutstandingMessages   int    `mapstructure:"maxOutstandingMessages"`
+	MaxOutstandingBytes      int    `mapstructure:"maxOutstandingBytes"`
+	MaxConcurrentConnections int    `mapstructure:"maxConcurrentConnections"`
 }

--- a/pubsub/gcp/pubsub/metadata.go
+++ b/pubsub/gcp/pubsub/metadata.go
@@ -39,4 +39,5 @@ type metadata struct {
 	MaxDeliveryAttempts     int    `mapstructure:"maxDeliveryAttempts"`
 	MaxOutstandingMessages  int    `mapstructure:"maxOutstandingMessages"`
 	MaxOutstandingBytes     int    `mapstructure:"maxOutstandingBytes"`
+	NumGoroutines           int    `mapstructure:"numGoroutines"`
 }

--- a/pubsub/gcp/pubsub/metadata.yaml
+++ b/pubsub/gcp/pubsub/metadata.yaml
@@ -13,32 +13,32 @@ builtinAuthenticationProfiles:
 metadata:
   - name: enableMessageOrdering
     description: |
-      When set to "true", subscribed messages will be received in order, 
+      When set to "true", subscribed messages will be received in order,
       depending on publishing and permissions configuration.
     type: bool
     default: 'false'
     example: '"true", "false"'
   - name: orderingKey
     description: |
-      The key provided in the request. It's used when "enableMessageOrdering" 
+      The key provided in the request. It's used when "enableMessageOrdering"
       is set to true to order messages based on such key.
     type: string
     example: '"my-orderingkey"'
   - name: disableEntityManagement
     description: |
-      When set to true, topics and subscriptions do not get created automatically.  
+      When set to true, topics and subscriptions do not get created automatically.
     type: bool
     default: 'false'
     example: '"true", "false"'
   - name: maxReconnectionAttempts
     description: |
-      Defines the maximum number of reconnect attempts.   
+      Defines the maximum number of reconnect attempts.
     type: number
     default: '30'
     example: '30'
   - name: connectionRecoveryInSec
     description: |
-      Time in seconds to wait between connection recovery attempts.   
+      Time in seconds to wait between connection recovery attempts.
     type: number
     default: '2'
     example: '2'
@@ -60,3 +60,13 @@ metadata:
     type: number
     default: '5'
     example: '5'
+  - name: maxOutstandingMessages
+    description: |
+      Maximum number of messages the GCP streaming-pull connection is allowed to have outstanding
+    type: number
+    example: '1000'
+  - name: maxOutstandingBytes
+    description: |
+      Maximum number of bytes the GCP streaming-pull connection is allowed to have outstanding
+    type: number
+    example: '1e9'

--- a/pubsub/gcp/pubsub/metadata.yaml
+++ b/pubsub/gcp/pubsub/metadata.yaml
@@ -70,8 +70,8 @@ metadata:
       Maximum number of bytes a GCP streaming-pull connection is allowed to have outstanding
     type: number
     example: '1e9'
-  - name: numGoroutines
+  - name: maxConcurrentConnections
     description: |
-      Number of concurrent streaming-pull connections to maintain
+      Max number of concurrent streaming-pull connections to maintain
     type: number
     example: '10'

--- a/pubsub/gcp/pubsub/metadata.yaml
+++ b/pubsub/gcp/pubsub/metadata.yaml
@@ -62,11 +62,16 @@ metadata:
     example: '5'
   - name: maxOutstandingMessages
     description: |
-      Maximum number of messages the GCP streaming-pull connection is allowed to have outstanding
+      Maximum number of messages a GCP streaming-pull connection is allowed to have outstanding
     type: number
     example: '1000'
   - name: maxOutstandingBytes
     description: |
-      Maximum number of bytes the GCP streaming-pull connection is allowed to have outstanding
+      Maximum number of bytes a GCP streaming-pull connection is allowed to have outstanding
     type: number
     example: '1e9'
+  - name: numGoroutines
+    description: |
+      Number of concurrent streaming-pull connections to maintain
+    type: number
+    example: '10'

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -324,16 +324,13 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 	//  in the GCP pubsub library that no limit should be applied. Zero values result in the package
 	//  default being used: 1000 messages and 1e9 (1G) bytes respectively.
 	if g.metadata.MaxOutstandingMessages != 0 {
-		g.logger.Debugf("Overriding MaxOutstandingMessages: %d to %d", sub.ReceiveSettings.MaxOutstandingMessages, g.metadata.MaxOutstandingMessages)
 		sub.ReceiveSettings.MaxOutstandingMessages = g.metadata.MaxOutstandingMessages
 	}
 	if g.metadata.MaxOutstandingBytes != 0 {
-		g.logger.Debugf("Overriding MaxOutstandingBytes: %d to %d", sub.ReceiveSettings.MaxOutstandingBytes, g.metadata.MaxOutstandingBytes)
 		sub.ReceiveSettings.MaxOutstandingBytes = g.metadata.MaxOutstandingBytes
 	}
 	// NOTE: For MaxConcurrentConnections, negative values are not allowed so only override if the value is greater than 0
 	if g.metadata.MaxConcurrentConnections > 0 {
-		g.logger.Debugf("Overriding MaxConcurrentConnections: %d to %d", sub.ReceiveSettings.NumGoroutines, g.metadata.MaxConcurrentConnections)
 		sub.ReceiveSettings.NumGoroutines = g.metadata.MaxConcurrentConnections
 	}
 

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -319,7 +319,7 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 
 	readReconnectAttemptsRemaining := func() int { return len(reconnAttempts) }
 
-	// Apply configured limits for MaxOutstandingMessages, MaxOutstandingBytes, and NumGoroutines
+	// Apply configured limits for MaxOutstandingMessages, MaxOutstandingBytes, and MaxConcurrentConnections
 	// NOTE: negative MaxOutstandingMessages and MaxOutstaningBytes values are allowed and indicate
 	//  in the GCP pubsub library that no limit should be applied. Zero values result in the package
 	//  default being used: 1000 messages and 1e9 (1G) bytes respectively.
@@ -331,10 +331,10 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 		g.logger.Debugf("Overriding MaxOutstandingBytes: %d to %d", sub.ReceiveSettings.MaxOutstandingBytes, g.metadata.MaxOutstandingBytes)
 		sub.ReceiveSettings.MaxOutstandingBytes = g.metadata.MaxOutstandingBytes
 	}
-	// NOTE: For NumGoroutines, negative values are not allowed so only override if the value is greater than 0
-	if g.metadata.NumGoroutines > 0 {
-		g.logger.Debugf("Overriding NumGoroutines: %d to %d", sub.ReceiveSettings.NumGoroutines, g.metadata.NumGoroutines)
-		sub.ReceiveSettings.NumGoroutines = g.metadata.NumGoroutines
+	// NOTE: For MaxConcurrentConnections, negative values are not allowed so only override if the value is greater than 0
+	if g.metadata.MaxConcurrentConnections > 0 {
+		g.logger.Debugf("Overriding MaxConcurrentConnections: %d to %d", sub.ReceiveSettings.NumGoroutines, g.metadata.MaxConcurrentConnections)
+		sub.ReceiveSettings.NumGoroutines = g.metadata.MaxConcurrentConnections
 	}
 
 	// Periodically refill the reconnect attempts channel to avoid

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -319,6 +319,17 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 
 	readReconnectAttemptsRemaining := func() int { return len(reconnAttempts) }
 
+	// Apply configured limits for MaxOutstandingMessages and MaxOutstandingBytes
+	// NOTE: negative MaxOutstandingMessages and MaxOutstaningBytes values are allowed and indicate
+	//  in the GCP pubsub library that no limit should be applied. Zero values result in the package
+	//  default being used: 1000 messages and 1e9 (1G) bytes respectively.
+	if g.metadata.MaxOutstandingMessages != 0 {
+		sub.ReceiveSettings.MaxOutstandingMessages = g.metadata.MaxOutstandingMessages
+	}
+	if g.metadata.MaxOutstandingBytes != 0 {
+		sub.ReceiveSettings.MaxOutstandingBytes = g.metadata.MaxOutstandingBytes
+	}
+
 	// Periodically refill the reconnect attempts channel to avoid
 	// exhausting all the refill attempts due to intermittent issues
 	// occurring over a longer period of time.

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -319,7 +319,7 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 
 	readReconnectAttemptsRemaining := func() int { return len(reconnAttempts) }
 
-	// Apply configured limits for MaxOutstandingMessages and MaxOutstandingBytes
+	// Apply configured limits for MaxOutstandingMessages, MaxOutstandingBytes, and NumGoroutines
 	// NOTE: negative MaxOutstandingMessages and MaxOutstaningBytes values are allowed and indicate
 	//  in the GCP pubsub library that no limit should be applied. Zero values result in the package
 	//  default being used: 1000 messages and 1e9 (1G) bytes respectively.
@@ -331,7 +331,8 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 		g.logger.Debugf("Overriding MaxOutstandingBytes: %d to %d", sub.ReceiveSettings.MaxOutstandingBytes, g.metadata.MaxOutstandingBytes)
 		sub.ReceiveSettings.MaxOutstandingBytes = g.metadata.MaxOutstandingBytes
 	}
-	if g.metadata.NumGoroutines != 0 {
+	// NOTE: For NumGoroutines, negative values are not allowed so only override if the value is greater than 0
+	if g.metadata.NumGoroutines > 0 {
 		g.logger.Debugf("Overriding NumGoroutines: %d to %d", sub.ReceiveSettings.NumGoroutines, g.metadata.NumGoroutines)
 		sub.ReceiveSettings.NumGoroutines = g.metadata.NumGoroutines
 	}

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -324,10 +324,16 @@ func (g *GCPPubSub) handleSubscriptionMessages(parentCtx context.Context, topic 
 	//  in the GCP pubsub library that no limit should be applied. Zero values result in the package
 	//  default being used: 1000 messages and 1e9 (1G) bytes respectively.
 	if g.metadata.MaxOutstandingMessages != 0 {
+		g.logger.Debugf("Overriding MaxOutstandingMessages: %d to %d", sub.ReceiveSettings.MaxOutstandingMessages, g.metadata.MaxOutstandingMessages)
 		sub.ReceiveSettings.MaxOutstandingMessages = g.metadata.MaxOutstandingMessages
 	}
 	if g.metadata.MaxOutstandingBytes != 0 {
+		g.logger.Debugf("Overriding MaxOutstandingBytes: %d to %d", sub.ReceiveSettings.MaxOutstandingBytes, g.metadata.MaxOutstandingBytes)
 		sub.ReceiveSettings.MaxOutstandingBytes = g.metadata.MaxOutstandingBytes
+	}
+	if g.metadata.NumGoroutines != 0 {
+		g.logger.Debugf("Overriding NumGoroutines: %d to %d", sub.ReceiveSettings.NumGoroutines, g.metadata.NumGoroutines)
+		sub.ReceiveSettings.NumGoroutines = g.metadata.NumGoroutines
 	}
 
 	// Periodically refill the reconnect attempts channel to avoid

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -128,4 +128,98 @@ func TestInit(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "connectionRecoveryInSec")
 	})
+
+	t.Run("valid optional maxOutstandingMessages", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":              "test-project",
+			"maxOutstandingMessages": "50",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, 50, md.MaxOutstandingMessages, "MaxOutstandingMessages should match the provided configuration")
+	})
+
+	t.Run("missing optional maxOutstandingMessages", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId": "test-project",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, 0, md.MaxOutstandingMessages)
+	})
+
+	t.Run("valid negative optional maxOutstandingMessages", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":              "test-project",
+			"maxOutstandingMessages": "-1",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, -1, md.MaxOutstandingMessages, "MaxOutstandingMessages should match the provided configuration")
+	})
+
+	t.Run("invalid optional maxOutstandingMessages", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":              "test-project",
+			"maxOutstandingMessages": "foobar",
+		}
+
+		_, err := createMetadata(m)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "maxOutstandingMessages")
+	})
+
+	t.Run("valid optional maxOutstandingBytes", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":           "test-project",
+			"maxOutstandingBytes": "1000000000",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, 1000000000, md.MaxOutstandingBytes, "MaxOutstandingBytes should match the provided configuration")
+	})
+
+	t.Run("missing optional maxOutstandingBytes", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId": "test-project",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, 0, md.MaxOutstandingBytes)
+	})
+
+	t.Run("valid negative optional maxOutstandingBytes", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":           "test-project",
+			"maxOutstandingBytes": "-1",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, -1, md.MaxOutstandingBytes, "MaxOutstandingBytes should match the provided configuration")
+	})
+
+	t.Run("invalid optional maxOutstandingBytes", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":           "test-project",
+			"maxOutstandingBytes": "foobar",
+		}
+
+		_, err := createMetadata(m)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "maxOutstandingBytes")
+	})
 }

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -222,4 +222,39 @@ func TestInit(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "maxOutstandingBytes")
 	})
+
+	t.Run("valid optional numGoroutines", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":     "test-project",
+			"numGoroutines": "2",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, 2, md.NumGoroutines, "NumGoroutines should match the provided configuration")
+	})
+
+	t.Run("missing optional numGoroutines", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId": "test-project",
+		}
+
+		md, err := createMetadata(m)
+		require.NoError(t, err)
+		assert.Equal(t, 0, md.NumGoroutines)
+	})
+
+	t.Run("invalid optional numGoroutines", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"projectId":     "test-project",
+			"numGoroutines": "foobar",
+		}
+
+		_, err := createMetadata(m)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "numGoroutines")
+	})
 }

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -223,19 +223,19 @@ func TestInit(t *testing.T) {
 		require.ErrorContains(t, err, "maxOutstandingBytes")
 	})
 
-	t.Run("valid optional numGoroutines", func(t *testing.T) {
+	t.Run("valid optional maxConcurrentConnections", func(t *testing.T) {
 		m := pubsub.Metadata{}
 		m.Properties = map[string]string{
-			"projectId":     "test-project",
-			"numGoroutines": "2",
+			"projectId":                "test-project",
+			"maxConcurrentConnections": "2",
 		}
 
 		md, err := createMetadata(m)
 		require.NoError(t, err)
-		assert.Equal(t, 2, md.NumGoroutines, "NumGoroutines should match the provided configuration")
+		assert.Equal(t, 2, md.MaxConcurrentConnections, "MaxConcurrentConnections should match the provided configuration")
 	})
 
-	t.Run("missing optional numGoroutines", func(t *testing.T) {
+	t.Run("missing optional maxConcurrentConnections", func(t *testing.T) {
 		m := pubsub.Metadata{}
 		m.Properties = map[string]string{
 			"projectId": "test-project",
@@ -243,18 +243,18 @@ func TestInit(t *testing.T) {
 
 		md, err := createMetadata(m)
 		require.NoError(t, err)
-		assert.Equal(t, 0, md.NumGoroutines)
+		assert.Equal(t, 0, md.MaxConcurrentConnections)
 	})
 
-	t.Run("invalid optional numGoroutines", func(t *testing.T) {
+	t.Run("invalid optional maxConcurrentConnections", func(t *testing.T) {
 		m := pubsub.Metadata{}
 		m.Properties = map[string]string{
-			"projectId":     "test-project",
-			"numGoroutines": "foobar",
+			"projectId":                "test-project",
+			"maxConcurrentConnections": "foobar",
 		}
 
 		_, err := createMetadata(m)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "numGoroutines")
+		require.ErrorContains(t, err, "maxConcurrentConnections")
 	})
 }


### PR DESCRIPTION
# Description

Adds metadata settings for GCP PubSub component to configure the `MaxOutstandingMessages`, `MaxOutstandingBytes`, and `NumGoroutines` settings in the underlying [Google Cloud pubsub package](https://pkg.go.dev/cloud.google.com/go/pubsub).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: [#3441](https://github.com/dapr/components-contrib/issues/3441)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
