### PR TITLE
fix workflow stable component cert - state.mysql

### DIFF
--- a/tests/certification/state/mysql/docker-compose.yaml
+++ b/tests/certification/state/mysql/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   mysql:
     image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password --port 3306
+    command: --mysql-native-password=ON --port 3306
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
# Description

This changes the flag used to use the mysql_native_password plugin

## Issue reference

Does not fully close the issue but arose from/is tracked by #3449 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
