### PR TITLE
fix: pubsub.solace.amqp metadata.yaml name/title fix

### DIFF
--- a/pubsub/solace/amqp/metadata.yaml
+++ b/pubsub/solace/amqp/metadata.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../component-metadata-schema.json
 schemaVersion: v1
 type: pubsub
-name: "solace.amqp"
+name: solace.amqp
 version: v1
 status: beta
 title: "Solace-AMQP"

--- a/pubsub/solace/amqp/metadata.yaml
+++ b/pubsub/solace/amqp/metadata.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=../../../component-metadata-schema.json
 schemaVersion: v1
 type: pubsub
-name: Solace-AMQP
+name: "solace.amqp"
 version: v1
 status: beta
-title: "solace-amqp"
+title: "Solace-AMQP"
 urls:
   - title: Reference
     url: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-solace-amqp/


### PR DESCRIPTION
# Description

`pubsub.solace.amqp`'s `metadata.yaml` now has a name and type reflective of its component `spec.type`, aligned with all other `metadata.yaml` files. It's title also now is the proper formatting of the component.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/components-contrib/issues/3451

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
