### PR TITLE
fix workflow stable component cert - bindings.rabbitmq

### DIFF
--- a/tests/certification/bindings/rabbitmq/components/exclusive/rabbitmq.yaml
+++ b/tests/certification/bindings/rabbitmq/components/exclusive/rabbitmq.yaml
@@ -1,0 +1,19 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: exclusive-binding
+spec:
+  type: bindings.rabbitmq
+  version: v1
+  metadata:
+  - name: queueName
+    value: exclusiveQueue
+  - name: host
+    value: "amqp://test:test@localhost:5672"
+  - name: prefetchCount
+    value: 0
+  - name: exclusive
+    value: true
+  - name: contentType
+    value: "text/plain"
+  ignoreErrors: true


### PR DESCRIPTION
# Description

Create a missing component spec - ensuring that the sidecar continues running after component failure.

## Issue reference

Does not fully close the issue but arose from/is tracked by https://github.com/dapr/components-contrib/issues/3449

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

Successful run: https://github.com/dapr/components-contrib/actions/runs/9604165214

Latest merge from main was blocked by a dockerhub registry outage