### PR TITLE
fix: conformance - state.mysql.mysql

### DIFF
--- a/.github/infrastructure/docker-compose-mysql.yml
+++ b/.github/infrastructure/docker-compose-mysql.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   db:
     image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password
+    command: --mysql_native_password=ON
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
# Description

Applies the same update as #3450, this time to the docker manifest used for component conformance test.

There are no more instances of the deprecated flag `--default-authentication-plugin` existing in this repo.

## Issue reference

Does not close but arose from/is tracked by #3457 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
