### PR TITLE
change topicArns to map safe for concurrent access

### DIFF
--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -30,7 +30,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/puzpuzpuz/xsync/v3"
 
 	"github.com/dapr/kit/retry"
 
@@ -45,7 +44,7 @@ import (
 type snsSqs struct {
 	topicsLocker TopicsLocker
 	// key is the sanitized topic name
-	topicArns *xsync.MapOf[string, string]
+	topicArns sync.Map
 	// key is the topic name, value holds the ARN of the queue and its url.
 	queues map[string]*sqsQueueInfo
 	// key is a composite key of queue ARN and topic ARN mapping to subscription ARN.
@@ -172,7 +171,7 @@ func (s *snsSqs) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	s.subscriptionManager = NewSubscriptionMgmt(s.logger)
 	s.topicsLocker = NewLockManager()
 
-	s.topicArns = xsync.NewMapOf[string, string]()
+	s.topicArns = sync.Map{}
 	s.queues = make(map[string]*sqsQueueInfo)
 	s.subscriptions = make(map[string]string)
 
@@ -240,8 +239,9 @@ func (s *snsSqs) getTopicArn(parentCtx context.Context, topic string) (string, e
 func (s *snsSqs) getOrCreateTopic(ctx context.Context, topic string) (topicArn string, sanitizedTopic string, err error) {
 	sanitizedTopic = nameToAWSSanitizedName(topic, s.metadata.Fifo)
 
-	var loadOK bool
-	if topicArn, loadOK = s.topicArns.Load(sanitizedTopic); loadOK {
+	if topicArnValue, loadOK := s.topicArns.Load(sanitizedTopic); loadOK {
+		topicArn = topicArnValue.(string)
+
 		if len(topicArn) > 0 {
 			s.logger.Debugf("Found existing topic ARN for topic %s: %s", topic, topicArn)
 

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -840,6 +840,9 @@ func (s *snsSqs) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 		return errors.New("component is closed")
 	}
 
+	s.topicsLocker.Lock(req.Topic)
+	defer s.topicsLocker.Unlock(req.Topic)
+
 	topicArn, _, err := s.getOrCreateTopic(ctx, req.Topic)
 	if err != nil {
 		s.logger.Errorf("error getting topic ARN for %s: %v", req.Topic, err)

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/puzpuzpuz/xsync/v3"
 
 	"github.com/dapr/kit/retry"
 
@@ -44,7 +45,7 @@ import (
 type snsSqs struct {
 	topicsLocker TopicsLocker
 	// key is the sanitized topic name
-	topicArns sync.Map
+	topicArns *xsync.MapOf[string, string]
 	// key is the topic name, value holds the ARN of the queue and its url.
 	queues map[string]*sqsQueueInfo
 	// key is a composite key of queue ARN and topic ARN mapping to subscription ARN.
@@ -171,7 +172,7 @@ func (s *snsSqs) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	s.subscriptionManager = NewSubscriptionMgmt(s.logger)
 	s.topicsLocker = NewLockManager()
 
-	s.topicArns = sync.Map{}
+	s.topicArns = xsync.NewMapOf[string, string]()
 	s.queues = make(map[string]*sqsQueueInfo)
 	s.subscriptions = make(map[string]string)
 
@@ -239,9 +240,8 @@ func (s *snsSqs) getTopicArn(parentCtx context.Context, topic string) (string, e
 func (s *snsSqs) getOrCreateTopic(ctx context.Context, topic string) (topicArn string, sanitizedTopic string, err error) {
 	sanitizedTopic = nameToAWSSanitizedName(topic, s.metadata.Fifo)
 
-	if topicArnValue, loadOK := s.topicArns.Load(sanitizedTopic); loadOK {
-		topicArn = topicArnValue.(string)
-
+	var loadOK bool
+	if topicArn, loadOK = s.topicArns.Load(sanitizedTopic); loadOK {
 		if len(topicArn) > 0 {
 			s.logger.Debugf("Found existing topic ARN for topic %s: %s", topic, topicArn)
 

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -234,8 +234,10 @@ func (s *snsSqs) getTopicArn(parentCtx context.Context, topic string) (string, e
 	return *getTopicOutput.Attributes["TopicArn"], nil
 }
 
-// get the topic ARN from the topics map. If it doesn't exist in the map, try to fetch it from AWS, if it doesn't exist
+// Get the topic ARN from the topics map. If it doesn't exist in the map, try to fetch it from AWS, if it doesn't exist
 // at all, issue a request to create the topic.
+// NOTE: This method potentially reads and writes to the topicArns map, which may end up being accessed by multiple goroutines concurrently,
+// therefore it is necessary for its caller to lock the topic.
 func (s *snsSqs) getOrCreateTopic(ctx context.Context, topic string) (topicArn string, sanitizedTopic string, err error) {
 	sanitizedTopic = nameToAWSSanitizedName(topic, s.metadata.Fifo)
 

--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/puzpuzpuz/xsync/v3"
 
 	"github.com/dapr/kit/retry"
 
@@ -44,7 +45,7 @@ import (
 type snsSqs struct {
 	topicsLocker TopicsLocker
 	// key is the sanitized topic name
-	topicArns map[string]string
+	topicArns *xsync.MapOf[string, string]
 	// key is the topic name, value holds the ARN of the queue and its url.
 	queues map[string]*sqsQueueInfo
 	// key is a composite key of queue ARN and topic ARN mapping to subscription ARN.
@@ -171,7 +172,7 @@ func (s *snsSqs) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	s.subscriptionManager = NewSubscriptionMgmt(s.logger)
 	s.topicsLocker = NewLockManager()
 
-	s.topicArns = make(map[string]string)
+	s.topicArns = xsync.NewMapOf[string, string]()
 	s.queues = make(map[string]*sqsQueueInfo)
 	s.subscriptions = make(map[string]string)
 
@@ -240,7 +241,7 @@ func (s *snsSqs) getOrCreateTopic(ctx context.Context, topic string) (topicArn s
 	sanitizedTopic = nameToAWSSanitizedName(topic, s.metadata.Fifo)
 
 	var loadOK bool
-	if topicArn, loadOK = s.topicArns[sanitizedTopic]; loadOK {
+	if topicArn, loadOK = s.topicArns.Load(sanitizedTopic); loadOK {
 		if len(topicArn) > 0 {
 			s.logger.Debugf("Found existing topic ARN for topic %s: %s", topic, topicArn)
 
@@ -272,7 +273,7 @@ func (s *snsSqs) getOrCreateTopic(ctx context.Context, topic string) (topicArn s
 	}
 
 	// record topic ARN.
-	s.topicArns[sanitizedTopic] = topicArn
+	s.topicArns.Store(sanitizedTopic, topicArn)
 
 	return topicArn, sanitizedTopic, err
 }


### PR DESCRIPTION
# Description

Changed native map to xsync.MapOf which is safe for concurrent access

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3430 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
