### PR TITLE
bindings/http: Use Go Default Transport as base Transport

### DIFF
--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -122,11 +122,10 @@ func (h *HTTPSource) Init(_ context.Context, meta bindings.Metadata) error {
 	dialer := &net.Dialer{
 		Timeout: 15 * time.Second,
 	}
-	netTransport := &http.Transport{
-		Dial:                dialer.Dial,
-		TLSHandshakeTimeout: 15 * time.Second,
-		TLSClientConfig:     tlsConfig,
-	}
+	netTransport := http.DefaultTransport.(*http.Transport).Clone()
+	netTransport.Dial = dialer.Dial
+	netTransport.TLSHandshakeTimeout = 15 * time.Second
+	netTransport.TLSClientConfig = tlsConfig
 
 	h.client = &http.Client{
 		Timeout:   0, // no time out here, we use request timeouts instead


### PR DESCRIPTION
Updates the HTTP client's transport to be based from the Go's default transport to inherit the default settings.

See https://github.com/dapr/dapr/pull/7833