### PR TITLE
Adds EntraID auth support to all Redis Components

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/dapr/components-contrib/build-tools
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.4
 
 require (
 	github.com/dapr/components-contrib v0.0.0

--- a/.github/workflows/components-contrib-all.yml
+++ b/.github/workflows/components-contrib-all.yml
@@ -65,7 +65,7 @@ jobs:
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
-      GOLANGCI_LINT_VER: "v1.55.2"
+      GOLANGCI_LINT_VER: "v1.59.1"
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -143,7 +143,7 @@ jobs:
         run: make check-component-metadata-schema-diff
       - name: Run golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: ${{ env.GOLANGCI_LINT_VER }}
           skip-cache: true

--- a/.github/workflows/components-contrib-all.yml
+++ b/.github/workflows/components-contrib-all.yml
@@ -147,6 +147,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VER }}
           skip-cache: true
+          only-new-issues: true
           args: --timeout 15m
       - name: Run go mod tidy check diff
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && steps.skip_check.outputs.should_skip != 'true'

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -33,7 +33,7 @@ jobs:
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
-      GOLANGCI_LINT_VER: "v1.55.2"
+      GOLANGCI_LINT_VER: "v1.59.1"
     steps:
       - name: Check out code into the Go module directory
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -62,7 +62,7 @@ jobs:
         run: make check-component-metadata
       - name: Run golangci-lint
         if: steps.skip_check.outputs.should_skip != 'true'
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: ${{ env.GOLANGCI_LINT_VER }}
           skip-cache: true

--- a/.github/workflows/components-contrib.yml
+++ b/.github/workflows/components-contrib.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VER }}
           skip-cache: true
+          only-new-issues: true
           args: --timeout 15m
       - name: Run go mod tidy check diff
         if: steps.skip_check.outputs.should_skip != 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,9 +71,6 @@ linters-settings:
     statements: 40
 
   govet:
-    # report about shadowed variables
-    check-shadowing: true
-
     # settings per analyzer
     settings:
       printf: # analyzer name, run `go tool vet help` to see all analyzers
@@ -86,6 +83,7 @@ linters-settings:
     # enable or disable analyzers by name
     enable:
       - atomicalign
+      - shadow
     enable-all: false
     disable:
       - shadow
@@ -106,9 +104,6 @@ linters-settings:
   gocognit:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   dupl:
     # tokens count to trigger issue, 150 by default
     threshold: 100
@@ -121,6 +116,10 @@ linters-settings:
     rules:
       main:
         deny:
+          - pkg: "github.com/golang-jwt/jwt/v5"
+            desc: "must use github.com/lestrrat-go/jwx/v2/jwt"
+          - pkg: "github.com/golang-jwt/jwt/v4"
+            desc: "must use github.com/lestrrat-go/jwx/v2/jwt"
           - pkg: "github.com/Sirupsen/logrus"
             desc: "must use github.com/dapr/kit/logger"
           - pkg: "github.com/agrea/ptr"
@@ -277,28 +276,24 @@ linters:
     - gocyclo
     - gocognit
     - godox
-    - interfacer
     - lll
-    - maligned
-    - scopelint
     - unparam
     - wsl
+    - mnd
     - gomnd
     - testpackage
-    - goerr113
+    - err113
     - nestif
     - nlreturn
     - exhaustive
     - exhaustruct
     - noctx
     - gci
-    - golint
     - tparallel
     - paralleltest
     - wrapcheck
     - tagliatelle
     - ireturn
-    - exhaustivestruct
     - errchkjson
     - contextcheck
     - gomoddirectives
@@ -307,7 +302,6 @@ linters:
     - varnamelen
     - errorlint
     - forcetypeassert
-    - ifshort
     - maintidx
     - nilnil
     - predeclared
@@ -320,10 +314,6 @@ linters:
     - asasalint
     - rowserrcheck
     - sqlclosecheck
-    - structcheck
-    - deadcode
-    - nosnakecase
-    - varcheck
     - goconst
     - tagalign
     - inamedparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,7 @@ run:
   # default value is empty list, but next dirs are always skipped independently
   # from this option's value:
   #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs:
+  issues.exclude-dirs:
     - ^vendor$
 
   # which files to skip: they will be analyzed, but issues from them
@@ -37,7 +37,7 @@ run:
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  format: tab
+  formats: tab
 
   # print lines of code with issue, default is true
   print-issued-lines: true

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ export GH_LINT_VERSION := $(shell grep 'GOLANGCI_LINT_VER:' .github/workflows/co
 ifeq (,$(LINTER_BINARY))
     INSTALLED_LINT_VERSION := "v0.0.0"
 else
-	INSTALLED_LINT_VERSION=v$(shell $(LINTER_BINARY) version | grep -Eo '([0-9]+\.)+[0-9]+' - || "")
+	INSTALLED_LINT_VERSION=v$(shell $(LINTER_BINARY) version | grep -Eo '([0-9]+\.)+[0-9]+' - | head -1 || "")
 endif
 
 # Build tools

--- a/bindings/redis/metadata.yaml
+++ b/bindings/redis/metadata.yaml
@@ -195,7 +195,8 @@ metadata:
     example: "10m"
   - name: useEntraID
     required: false
-    default: false
+    default: "false"
+    example: "true"
     type: bool
     description: |
       If set, enables authentication to Azure Cache for Redis using Azure Managed Identity

--- a/bindings/redis/metadata.yaml
+++ b/bindings/redis/metadata.yaml
@@ -193,12 +193,18 @@ metadata:
       "-1" disables idle timeout check.
     default: "5m"
     example: "10m"
-  - name: useEntraID
-    required: false
-    default: "false"
-    example: "true"
-    type: bool
-    description: |
-      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
-      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
-      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.
+builtinAuthenticationProfiles:
+  - name: "azuread"
+    metadata:
+      - name: useEntraID
+        required: false
+        default: "false"
+        example: "true"
+        type: bool
+        description: |
+          If set, enables authentication to Azure Cache for Redis using Microsoft EntraID. The Redis server must explicitly enable EntraID authentication. Note that
+          Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set. No username or password should be set.
+      - name: enableTLS
+        required: true
+        description: Must be set to true if using EntraID
+        example: "true"

--- a/bindings/redis/metadata.yaml
+++ b/bindings/redis/metadata.yaml
@@ -193,3 +193,11 @@ metadata:
       "-1" disables idle timeout check.
     default: "5m"
     example: "10m"
+  - name: useEntraID
+    required: false
+    default: false
+    type: bool
+    description: |
+      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
+      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
+      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.

--- a/bindings/redis/redis.go
+++ b/bindings/redis/redis.go
@@ -44,7 +44,7 @@ func NewRedis(logger logger.Logger) bindings.OutputBinding {
 
 // Init performs metadata parsing and connection creation.
 func (r *Redis) Init(ctx context.Context, meta bindings.Metadata) (err error) {
-	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(meta.Properties, metadata.BindingType)
+	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(meta.Properties, metadata.BindingType, ctx, &r.logger)
 	if err != nil {
 		return err
 	}

--- a/bindings/redis/redis_test.go
+++ b/bindings/redis/redis_test.go
@@ -143,7 +143,7 @@ func TestInvokeDelete(t *testing.T) {
 
 	rgetRep, err := c.DoRead(context.Background(), "GET", testKey)
 	assert.Equal(t, redis.Nil, err)
-	assert.Equal(t, nil, rgetRep)
+	assert.Nil(t, rgetRep)
 }
 
 func TestCreateExpire(t *testing.T) {

--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -232,8 +232,8 @@ func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username stri
 		backoffConfig.Policy = kitretry.PolicyExponential
 
 		var backoffManager backoff.BackOff
-		var refreshGracePeriod time.Duration = 2 * time.Minute
-		var tokenRefreshDuration time.Duration = time.Until(nextExpiration.Add(-refreshGracePeriod))
+		var refreshGracePeriod = 2 * time.Minute
+		var tokenRefreshDuration = time.Until(nextExpiration.Add(-refreshGracePeriod))
 
 		(*logger).Debugf("redis client: starting entraID token refresh loop")
 

--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -232,8 +232,8 @@ func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username stri
 		backoffConfig.Policy = kitretry.PolicyExponential
 
 		var backoffManager backoff.BackOff
-		var refreshGracePeriod = 2 * time.Minute
-		var tokenRefreshDuration = time.Until(nextExpiration.Add(-refreshGracePeriod))
+		refreshGracePeriod := 2 * time.Minute
+		tokenRefreshDuration := time.Until(nextExpiration.Add(-refreshGracePeriod))
 
 		(*logger).Debugf("redis client: starting entraID token refresh loop")
 

--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -17,13 +17,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/golang-jwt/jwt/v5"
-	"strconv"
-	"strings"
-	"time"
 
 	"golang.org/x/mod/semver"
 
@@ -223,7 +224,6 @@ func ParseClientFromProperties(properties map[string]string, componentType metad
 }
 
 func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username string, nextExpiration time.Time, cred *azcore.TokenCredential, logger *kitlogger.Logger) {
-
 	go func(cred *azcore.TokenCredential, username string, logger *kitlogger.Logger) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -302,7 +302,6 @@ func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username stri
 }
 
 func (s *Settings) GetEntraIDCredentialAndSetInitialTokenAsPassword(ctx context.Context, properties *map[string]string) (*time.Time, *azcore.TokenCredential, error) {
-
 	if len(s.Password) > 0 || len(s.Username) > 0 {
 		return nil, nil, errors.New(
 			"redis client configuration error: username or password must not be specified when using Entra ID authentication")

--- a/common/component/redis/redis_test.go
+++ b/common/component/redis/redis_test.go
@@ -105,6 +105,7 @@ func TestParseRedisMetadata(t *testing.T) {
 		assert.Equal(t, 1*time.Second, time.Duration(m.IdleCheckFrequency))
 		assert.True(t, m.Failover)
 		assert.Equal(t, "master", m.SentinelMasterName)
+		assert.False(t, m.UseEntraID)
 	})
 
 	// TODO: Refactor shared redis code to throw error for missing properties

--- a/common/component/redis/settings.go
+++ b/common/component/redis/settings.go
@@ -101,6 +101,10 @@ type Settings struct {
 
 	// The max len of stream
 	MaxLenApprox int64 `mapstructure:"maxLenApprox" mdonly:"pubsub"`
+
+	// EntraID / AzureAD Authentication based on the shared code which essentially uses the DefaultAzureCredential
+	// from the official Azure Identity SDK for Go
+	UseEntraID bool `mapstructure:"useEntraID" mapstructurealiases:"useAzureAD"`
 }
 
 func (s *Settings) Decode(in interface{}) error {

--- a/common/component/redis/v8client.go
+++ b/common/component/redis/v8client.go
@@ -316,12 +316,10 @@ func (c v8Client) TTLResult(ctx context.Context, key string) (time.Duration, err
 	return c.client.TTL(writeCtx, key).Result()
 }
 
-func (c v8Client) Auth(ctx context.Context, password string) error {
-	return c.Auth(ctx, password)
-}
-
 func (c v8Client) AuthACL(ctx context.Context, username, password string) error {
-	return c.AuthACL(ctx, username, password)
+	pipeline := c.client.Pipeline()
+	statusCmd := pipeline.AuthACL(ctx, username, password)
+	return statusCmd.Err()
 }
 
 func newV8FailoverClient(s *Settings) (RedisClient, error) {

--- a/common/component/redis/v8client.go
+++ b/common/component/redis/v8client.go
@@ -346,10 +346,9 @@ func newV8FailoverClient(s *Settings) (RedisClient, error) {
 		IdleTimeout:        time.Duration(s.IdleTimeout),
 	}
 
-	/* #nosec */
 	if s.EnableTLS {
 		opts.TLSConfig = &tls.Config{
-			InsecureSkipVerify: s.EnableTLS,
+			InsecureSkipVerify: s.EnableTLS, //nolint:gosec
 		}
 		err := s.SetCertificate(func(cert *tls.Certificate) {
 			opts.TLSConfig.Certificates = []tls.Certificate{*cert}
@@ -403,7 +402,7 @@ func newV8Client(s *Settings) (RedisClient, error) {
 		/* #nosec */
 		if s.EnableTLS {
 			options.TLSConfig = &tls.Config{
-				InsecureSkipVerify: s.EnableTLS,
+				InsecureSkipVerify: s.EnableTLS, //nolint:gosec
 			}
 			err := s.SetCertificate(func(cert *tls.Certificate) {
 				options.TLSConfig.Certificates = []tls.Certificate{*cert}
@@ -443,7 +442,7 @@ func newV8Client(s *Settings) (RedisClient, error) {
 	/* #nosec */
 	if s.EnableTLS {
 		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: s.EnableTLS,
+			InsecureSkipVerify: s.EnableTLS, //nolint:gosec
 		}
 		err := s.SetCertificate(func(cert *tls.Certificate) {
 			options.TLSConfig.Certificates = []tls.Certificate{*cert}

--- a/common/component/redis/v8client.go
+++ b/common/component/redis/v8client.go
@@ -316,6 +316,14 @@ func (c v8Client) TTLResult(ctx context.Context, key string) (time.Duration, err
 	return c.client.TTL(writeCtx, key).Result()
 }
 
+func (c v8Client) Auth(ctx context.Context, password string) error {
+	return c.Auth(ctx, password)
+}
+
+func (c v8Client) AuthACL(ctx context.Context, username, password string) error {
+	return c.AuthACL(ctx, username, password)
+}
+
 func newV8FailoverClient(s *Settings) (RedisClient, error) {
 	if s == nil {
 		return nil, nil

--- a/common/component/redis/v9client.go
+++ b/common/component/redis/v9client.go
@@ -317,12 +317,10 @@ func (c v9Client) TTLResult(ctx context.Context, key string) (time.Duration, err
 	return c.client.TTL(writeCtx, key).Result()
 }
 
-func (c v9Client) Auth(ctx context.Context, password string) error {
-	return c.Auth(ctx, password)
-}
-
 func (c v9Client) AuthACL(ctx context.Context, username, password string) error {
-	return c.AuthACL(ctx, username, password)
+	pipeline := c.client.Pipeline()
+	statusCmd := pipeline.AuthACL(ctx, username, password)
+	return statusCmd.Err()
 }
 
 func newV9FailoverClient(s *Settings) (RedisClient, error) {

--- a/common/component/redis/v9client.go
+++ b/common/component/redis/v9client.go
@@ -317,6 +317,14 @@ func (c v9Client) TTLResult(ctx context.Context, key string) (time.Duration, err
 	return c.client.TTL(writeCtx, key).Result()
 }
 
+func (c v9Client) Auth(ctx context.Context, password string) error {
+	return c.Auth(ctx, password)
+}
+
+func (c v9Client) AuthACL(ctx context.Context, username, password string) error {
+	return c.AuthACL(ctx, username, password)
+}
+
 func newV9FailoverClient(s *Settings) (RedisClient, error) {
 	if s == nil {
 		return nil, nil

--- a/common/component/redis/v9client.go
+++ b/common/component/redis/v9client.go
@@ -350,7 +350,7 @@ func newV9FailoverClient(s *Settings) (RedisClient, error) {
 	/* #nosec */
 	if s.EnableTLS {
 		opts.TLSConfig = &tls.Config{
-			InsecureSkipVerify: s.EnableTLS,
+			InsecureSkipVerify: s.EnableTLS, //nolint:gosec
 		}
 		err := s.SetCertificate(func(cert *tls.Certificate) {
 			opts.TLSConfig.Certificates = []tls.Certificate{*cert}
@@ -406,7 +406,7 @@ func newV9Client(s *Settings) (RedisClient, error) {
 		if s.EnableTLS {
 			/* #nosec */
 			options.TLSConfig = &tls.Config{
-				InsecureSkipVerify: s.EnableTLS,
+				InsecureSkipVerify: s.EnableTLS, //nolint:gosec
 			}
 			err := s.SetCertificate(func(cert *tls.Certificate) {
 				options.TLSConfig.Certificates = []tls.Certificate{*cert}
@@ -446,7 +446,7 @@ func newV9Client(s *Settings) (RedisClient, error) {
 	if s.EnableTLS {
 		/* #nosec */
 		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: s.EnableTLS,
+			InsecureSkipVerify: s.EnableTLS, //nolint:gosec
 		}
 		err := s.SetCertificate(func(cert *tls.Certificate) {
 			options.TLSConfig.Certificates = []tls.Certificate{*cert}

--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -181,3 +181,11 @@ metadata:
       "-1" disables idle timeout check.
     default: "5m"
     example: "10m"
+  - name: useEntraID
+    required: false
+    default: false
+    type: bool
+    description: |
+      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
+      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
+      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.

--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -183,7 +183,8 @@ metadata:
     example: "10m"
   - name: useEntraID
     required: false
-    default: false
+    default: "false"
+    example: "true"
     type: bool
     description: |
       If set, enables authentication to Azure Cache for Redis using Azure Managed Identity

--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -181,12 +181,18 @@ metadata:
       "-1" disables idle timeout check.
     default: "5m"
     example: "10m"
-  - name: useEntraID
-    required: false
-    default: "false"
-    example: "true"
-    type: bool
-    description: |
-      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
-      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
-      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.
+builtinAuthenticationProfiles:
+  - name: "azuread"
+    metadata:
+      - name: useEntraID
+        required: false
+        default: "false"
+        example: "true"
+        type: bool
+        description: |
+          If set, enables authentication to Azure Cache for Redis using Microsoft EntraID. The Redis server must explicitly enable EntraID authentication. Note that
+          Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set. No username or password should be set.
+      - name: enableTLS
+        required: true
+        description: Must be set to true if using EntraID
+        example: "true"

--- a/configuration/redis/redis.go
+++ b/configuration/redis/redis.go
@@ -64,7 +64,7 @@ func NewRedisConfigurationStore(logger logger.Logger) configuration.Store {
 // Init does metadata and connection parsing.
 func (r *ConfigurationStore) Init(ctx context.Context, metadata configuration.Metadata) error {
 	var err error
-	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, contribMetadata.ConfigurationStoreType)
+	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, contribMetadata.ConfigurationStoreType, ctx, &r.logger)
 	if err != nil {
 		return err
 	}

--- a/configuration/redis/redis_test.go
+++ b/configuration/redis/redis_test.go
@@ -302,7 +302,8 @@ func Test_parseRedisMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, got, err := redisComponent.ParseClientFromProperties(tt.args.meta.Properties, contribMetadata.ConfigurationStoreType)
+			ctx := context.Background()
+			_, got, err := redisComponent.ParseClientFromProperties(tt.args.meta.Properties, contribMetadata.ConfigurationStoreType, ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("edisComponent.ParseClientFromProperties error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -321,6 +322,7 @@ func Test_parseRedisMetadata(t *testing.T) {
 }
 
 func setupMiniredis() (*miniredis.Miniredis, redisComponent.RedisClient) {
+	ctx := context.Background()
 	s, err := miniredis.Run()
 	if err != nil {
 		panic(err)
@@ -329,7 +331,7 @@ func setupMiniredis() (*miniredis.Miniredis, redisComponent.RedisClient) {
 		"redisHost": s.Addr(),
 		"redisDB":   "0",
 	}
-	redisClient, _, _ := redisComponent.ParseClientFromProperties(props, contribMetadata.ConfigurationStoreType)
+	redisClient, _, _ := redisComponent.ParseClientFromProperties(props, contribMetadata.ConfigurationStoreType, ctx)
 
 	return s, redisClient
 }

--- a/configuration/redis/redis_test.go
+++ b/configuration/redis/redis_test.go
@@ -303,7 +303,8 @@ func Test_parseRedisMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			_, got, err := redisComponent.ParseClientFromProperties(tt.args.meta.Properties, contribMetadata.ConfigurationStoreType, ctx)
+			log := logger.NewLogger("dapr.components")
+			_, got, err := redisComponent.ParseClientFromProperties(tt.args.meta.Properties, contribMetadata.ConfigurationStoreType, ctx, &log)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("edisComponent.ParseClientFromProperties error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -323,6 +324,7 @@ func Test_parseRedisMetadata(t *testing.T) {
 
 func setupMiniredis() (*miniredis.Miniredis, redisComponent.RedisClient) {
 	ctx := context.Background()
+	log := logger.NewLogger("dapr.components")
 	s, err := miniredis.Run()
 	if err != nil {
 		panic(err)
@@ -331,7 +333,7 @@ func setupMiniredis() (*miniredis.Miniredis, redisComponent.RedisClient) {
 		"redisHost": s.Addr(),
 		"redisDB":   "0",
 	}
-	redisClient, _, _ := redisComponent.ParseClientFromProperties(props, contribMetadata.ConfigurationStoreType, ctx)
+	redisClient, _, _ := redisComponent.ParseClientFromProperties(props, contribMetadata.ConfigurationStoreType, ctx, &log)
 
 	return s, redisClient
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/dapr/components-contrib
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.4
 
 require (
 	cloud.google.com/go/datastore v1.15.0
@@ -66,7 +64,6 @@ require (
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/go-zookeeper/zk v1.0.3
 	github.com/gocql/gocql v1.5.2
-	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.0
@@ -244,6 +241,7 @@ require (
 	github.com/gogap/stack v0.0.0-20150131034635-fef68dddd4f8 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/go-zookeeper/zk v1.0.3
 	github.com/gocql/gocql v1.5.2
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.0
@@ -243,7 +244,6 @@ require (
 	github.com/gogap/stack v0.0.0-20150131034635-fef68dddd4f8 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/lock/redis/standalone.go
+++ b/lock/redis/standalone.go
@@ -50,7 +50,7 @@ func NewStandaloneRedisLock(logger logger.Logger) lock.Store {
 // Init StandaloneRedisLock.
 func (r *StandaloneRedisLock) InitLockStore(ctx context.Context, metadata lock.Metadata) (err error) {
 	// Create the client
-	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, contribMetadata.LockStoreType)
+	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, contribMetadata.LockStoreType, ctx, &r.logger)
 	if err != nil {
 		return err
 	}

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -169,3 +169,11 @@ metadata:
     description: Maximum number of items inside a stream.The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited.
     example: "10000"
     type: number
+  - name: useEntraID
+    required: false
+    default: false
+    type: bool
+    description: |
+      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
+      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
+      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -171,7 +171,8 @@ metadata:
     type: number
   - name: useEntraID
     required: false
-    default: false
+    example: "true"
+    default: "false"
     type: bool
     description: |
       If set, enables authentication to Azure Cache for Redis using Azure Managed Identity

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -169,12 +169,18 @@ metadata:
     description: Maximum number of items inside a stream.The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited.
     example: "10000"
     type: number
-  - name: useEntraID
-    required: false
-    example: "true"
-    default: "false"
-    type: bool
-    description: |
-      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
-      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
-      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.
+builtinAuthenticationProfiles:
+  - name: "azuread"
+    metadata:
+      - name: useEntraID
+        required: false
+        default: "false"
+        example: "true"
+        type: bool
+        description: |
+          If set, enables authentication to Azure Cache for Redis using Microsoft EntraID. The Redis server must explicitly enable EntraID authentication. Note that
+          Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set. No username or password should be set.
+      - name: enableTLS
+        required: true
+        description: Must be set to true if using EntraID
+        example: "true"

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -76,7 +76,7 @@ func NewRedisStreams(logger logger.Logger) pubsub.PubSub {
 
 func (r *redisStreams) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	var err error
-	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, contribMetadata.PubSubType)
+	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, contribMetadata.PubSubType, ctx, &r.logger)
 	if err != nil {
 		return err
 	}

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -164,12 +164,18 @@ metadata:
     description: Indexing schemas for querying JSON objects
     example: "see Querying JSON objects"
     type: string
-  - name: useEntraID
-    required: false
-    default: "false"
-    example: "true"
-    type: bool
-    description: |
-      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
-      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
-      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.
+builtinAuthenticationProfiles:
+  - name: "azuread"
+    metadata:
+    - name: useEntraID
+      required: false
+      default: "false"
+      example: "true"
+      type: bool
+      description: |
+        If set, enables authentication to Azure Cache for Redis using Microsoft EntraID. The Redis server must explicitly enable EntraID authentication. Note that
+        Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set. No username or password should be set.
+    - name: enableTLS
+      required: true
+      description: Must be set to true if using EntraID
+      example: "true"

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -166,7 +166,8 @@ metadata:
     type: string
   - name: useEntraID
     required: false
-    default: false
+    default: "false"
+    example: "true"
     type: bool
     description: |
       If set, enables authentication to Azure Cache for Redis using Azure Managed Identity

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -164,3 +164,11 @@ metadata:
     description: Indexing schemas for querying JSON objects
     example: "see Querying JSON objects"
     type: string
+  - name: useEntraID
+    required: false
+    default: false
+    type: bool
+    description: |
+      If set, enables authentication to Azure Cache for Redis using Azure Managed Identity
+      or Azure CLI Credential. The Redis server must explicitly enable EntraID authentication. Note that
+      Azure Cache for Redis also requires the use of TLS, so `enableTLS` should be set.

--- a/state/redis/redis.go
+++ b/state/redis/redis.go
@@ -131,7 +131,7 @@ func (r *StateStore) Ping(ctx context.Context) error {
 // Init does metadata and connection parsing.
 func (r *StateStore) Init(ctx context.Context, metadata state.Metadata) error {
 	var err error
-	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, daprmetadata.StateStoreType)
+	r.client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(metadata.Properties, daprmetadata.StateStoreType, ctx, &r.logger)
 	if err != nil {
 		return err
 	}

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -1,8 +1,6 @@
 module github.com/dapr/components-contrib/tests/certification
 
-go 1.22.3
-
-toolchain go1.22.4
+go 1.22.4
 
 require (
 	cloud.google.com/go/pubsub v1.36.1

--- a/tests/e2e/pubsub/jetstream/go.mod
+++ b/tests/e2e/pubsub/jetstream/go.mod
@@ -1,8 +1,6 @@
 module github.com/dapr/components-contrib/tests/e2e/pubsub/jetstream
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.4
 
 require (
 	github.com/dapr/components-contrib v1.10.6-0.20230403162214-9ee9d56cb7ea

--- a/tests/utils/configupdater/redis/redis.go
+++ b/tests/utils/configupdater/redis/redis.go
@@ -48,7 +48,8 @@ func getRedisValuesFromItems(items map[string]*configuration.Item) []interface{}
 
 func (r *ConfigUpdater) Init(props map[string]string) error {
 	var err error
-	r.Client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(props, metadata.ConfigurationStoreType)
+	ctx := context.Background()
+	r.Client, r.clientSettings, err = rediscomponent.ParseClientFromProperties(props, metadata.ConfigurationStoreType, ctx, &r.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Implements EntraID / AAD support for Azure Cache for Redis across all components

For a component yaml file to use Azure Cache for Redis with Entra ID see this:

This will assume that either your UserPrincipal (via AzureCLICredential) or the SystemAssigned Managed Identity have the RedisDataOwner role permission. If a user-assigned identity is to be used the `azureClientID` property needs to be specified.

```
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: statestore
spec:
  type: state.redis
  initTimeout: 30s
  metadata:
    - name: redisHost
      value: MYHOSTNAME.redis.cache.windows.net:6380
    - name: useEntraID
      value: "true"
    - name: enableTLS
      value: "true"
```


## Issue reference

Adds #3088

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

## Testing

Manually modified certification and conformance tests to run again Azure Cache for Redis using modified component configurations to exercise the new auth mechanism.