### PR TITLE
Update linter command to support diff linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,12 @@ test:
 ################################################################################
 .PHONY: lint
 lint: verify-linter-installed verify-linter-version
+ifdef LINT_BASE
+	@echo "LINT_BASE is set to "$(LINT_BASE)". Linter will only check diff."
+	$(GOLANGCI_LINT) run --timeout=20m --new-from-rev $(shell git rev-parse $(LINT_BASE))
+else
 	$(GOLANGCI_LINT) run --timeout=20m
+endif
 
 ################################################################################
 # Target: modtidy-all                                                          #


### PR DESCRIPTION
# Description

Now instead of `make lint` which will complain about historical lint errors, you can also run:

```
get fetch upstream # update your upstream references
LINT_BASE=upstream/main make lint
```

This will only lint the commits you added since the commit pointed to by `LINT_BASE`. Under the hood this uses `git rev-parse` so you can use friendly names like tags, branch names or simply commit IDs.
