### PR TITLE
Fix kafka metadata to HTTP headers conversion of invalid characters

### DIFF
--- a/common/component/kafka/metadata_test.go
+++ b/common/component/kafka/metadata_test.go
@@ -15,6 +15,7 @@ package kafka
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -555,5 +556,32 @@ func TestGetEventMetadata(t *testing.T) {
 	t.Run("null message", func(t *testing.T) {
 		act := GetEventMetadata(nil)
 		require.Nil(t, act)
+	})
+
+	t.Run("key with invalid value escaped", func(t *testing.T) {
+		keyValue := "key1\xFF"
+		escapedKeyValue := url.QueryEscape(keyValue)
+
+		m := sarama.ConsumerMessage{
+			Headers: nil, Timestamp: ts, Key: []byte(keyValue), Value: []byte("MyValue"), Partition: 0, Offset: 123, Topic: "TestTopic",
+		}
+		act := GetEventMetadata(&m)
+		require.Equal(t, escapedKeyValue, act[keyMetadataKey])
+	})
+
+	t.Run("header with invalid value escaped", func(t *testing.T) {
+		headerKey := "key1"
+		headerValue := "value1\xFF"
+		escapedHeaderValue := url.QueryEscape(headerValue)
+
+		headers := []*sarama.RecordHeader{
+			{Key: []byte(headerKey), Value: []byte(headerValue)},
+		}
+		m := sarama.ConsumerMessage{
+			Headers: headers, Timestamp: ts, Key: []byte("MyKey"), Value: []byte("MyValue"), Partition: 0, Offset: 123, Topic: "TestTopic",
+		}
+		act := GetEventMetadata(&m)
+		require.Len(t, act, 6)
+		require.Equal(t, escapedHeaderValue, act[headerKey])
 	})
 }


### PR DESCRIPTION
# Description

Sending special characters in Kafka message metadata will cause an error when metadata is converted to HTTP headers.
Error: 
```
WARN[0009] Error processing Kafka message: topic/0/13 [key=]. Error: error returned from app channel while sending pub/sub event to app: retriable error occurred: Post "http://127.0.0.1:56012/handle-message": net/http: invalid header field value for "My-Header". Retrying...
```

Go validates header value using the function `ValidHeaderFieldValue`, for reference and allowed format, see more [here](https://github.com/golang/net/blob/4542a42604cd159f1adb93c58368079ae37b3bf6/http/httpguts/httplex.go#L303)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3503

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
