### PR TITLE
1.13 Fix kafka metadata to HTTP headers conversion of invalid characters

### DIFF
--- a/common/component/kafka/consumer.go
+++ b/common/component/kafka/consumer.go
@@ -16,6 +16,7 @@ package kafka
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -205,14 +206,14 @@ func GetEventMetadata(message *sarama.ConsumerMessage) map[string]string {
 	if message != nil {
 		metadata := make(map[string]string, len(message.Headers)+5)
 		if message.Key != nil {
-			metadata[keyMetadataKey] = string(message.Key)
+			metadata[keyMetadataKey] = url.QueryEscape(string(message.Key))
 		}
 		metadata[offsetMetadataKey] = strconv.FormatInt(message.Offset, 10)
 		metadata[topicMetadataKey] = message.Topic
 		metadata[timestampMetadataKey] = strconv.FormatInt(message.Timestamp.UnixMilli(), 10)
 		metadata[partitionMetadataKey] = strconv.FormatInt(int64(message.Partition), 10)
 		for _, header := range message.Headers {
-			metadata[string(header.Key)] = string(header.Value)
+			metadata[string(header.Key)] = url.QueryEscape(string(header.Value))
 		}
 		return metadata
 	}


### PR DESCRIPTION
# Description

Sending special characters in Kafka message metadata will cause an error when metadata is converted to HTTP headers.
Error: 
```
WARN[0009] Error processing Kafka message: topic/0/13 [key=]. Error: error returned from app channel while sending pub/sub event to app: retriable error occurred: Post "http://127.0.0.1:56012/handle-message": net/http: invalid header field value for "My-Header". Retrying...
```

Go validates header value using the function `ValidHeaderFieldValue`, for reference and allowed format, see more [here](https://github.com/golang/net/blob/4542a42604cd159f1adb93c58368079ae37b3bf6/http/httpguts/httplex.go#L303)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3503

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
