### PR TITLE
aws/snssqs: fix unlock without lock error

### DIFF
--- a/pubsub/aws/snssqs/topics_locker.go
+++ b/pubsub/aws/snssqs/topics_locker.go
@@ -39,6 +39,6 @@ func (lm *TopicsLockManager) Unlock(key string) {
 			oldValue.Unlock()
 		}
 		// we return to comply with the Compute signature, but not using the returned values
-		return oldValue, false
+		return oldValue, exists
 	})
 }

--- a/pubsub/aws/snssqs/topics_locker_test.go
+++ b/pubsub/aws/snssqs/topics_locker_test.go
@@ -1,0 +1,22 @@
+package snssqs
+
+import (
+	"testing"
+)
+
+func TestTopicsLockManager_Lock(t *testing.T) {
+	lm := NewLockManager()
+
+	topic := "topic"
+
+	go func() {
+		lm.Lock(topic)
+		lm.Unlock(topic)
+	}()
+
+	go func() {
+		lm.Lock(topic)
+		lm.Unlock(topic)
+	}()
+
+}


### PR DESCRIPTION
# Description

Spotted in prod when trying to publish to an SNS/SQS topic

```
{"app_id":"group-service","component":"aws-pub-sub (pubsub.aws.snssqs/v1)","instance":"sidecar-385042-385046-848b89584b-tz2jh","level":"debug","msg":"No SNS topic ARN found for topic: group-subscription-topic. creating SNS with (sanitized) topic: group-subscription-topic","scope":"dapr.contrib","time":"2024-08-29T09:57:06.733516076Z","type":"log","ver":"unknown"}
fatal error: sync: unlock of unlocked mutex

goroutine 1744 [running]:
sync.fatal({0x3903dfa?, 0x15?})
/usr/local/go/src/runtime/panic.go:1007 +0x18
sync.(*Mutex).unlockSlow(0xc00087a220, 0xffffffff)
/usr/local/go/src/sync/mutex.go:229 +0x35
sync.(*Mutex).Unlock(...)
/usr/local/go/src/sync/mutex.go:223
github.com/dapr/components-contrib/pubsub/aws/snssqs.(*TopicsLockManager).Unlock.func1(0xc00087a220, 0x18?)
/go/pkg/mod/github.com/diagridio/dapr-components-contrib@v1.14.0-rc.4-catalyst.2/pubsub/aws/snssqs/topics_locker.go:39 +0x2e
github.com/puzpuzpuz/xsync/v3.(*MapOf[...]).doCompute(0x42d7c00, {0xc00007bad0, 0x18}, 0x3a6a6f0, 0x0, 0x1)
/go/pkg/mod/github.com/puzpuzpuz/xsync/v3@v3.0.0/mapof.go:307 +0x472
github.com/puzpuzpuz/xsync/v3.(*MapOf[...]).Compute(...)
/go/pkg/mod/github.com/puzpuzpuz/xsync/v3@v3.0.0/mapof.go:215
github.com/dapr/components-contrib/pubsub/aws/snssqs.(*TopicsLockManager).Unlock(0x48?, {0xc00007bad0?, 0xc0007eb820?})
/go/pkg/mod/github.com/diagridio/dapr-components-contrib@v1.14.0-rc.4-catalyst.2/pubsub/aws/snssqs/topics_locker.go:36 +0x3b
github.com/dapr/components-contrib/pubsub/aws/snssqs.(*snsSqs).Publish(0xc000dc7d40, {0x4281a40, 0xc000723740}, 0xc00091ac80)
/go/pkg/mod/github.com/diagridio/dapr-components-contrib@v1.14.0-rc.4-catalyst.2/pubsub/aws/snssqs/snssqs.go:871 +0x534
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/cmd/cra/components/pubsub.(*pubsubProxy).Publish(0xc001034780, {0x4281a40, 0xc000723740}, 0xc00091ac80)
/dataplane/catalyst/sidecar/cmd/cra/components/pubsub/proxy.go:40 +0xe7
github.com/dapr/dapr/pkg/runtime/pubsub/publisher.(*publisher).Publish.func1({0x4281a40?, 0xc000723740?})
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/runtime/pubsub/publisher/publisher.go:73 +0x36
github.com/dapr/dapr/pkg/runtime/pubsub/publisher.(*publisher).Publish.NewRunner[...].func3()
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/resiliency/policy.go:205 +0x44b
github.com/dapr/dapr/pkg/runtime/pubsub/publisher.(*publisher).Publish(0xc000f3fec0, {0x4281a40, 0xc000723740}, 0xc00091ac80)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/runtime/pubsub/publisher/publisher.go:72 +0x27e
github.com/dapr/dapr/pkg/api/grpc.(*api).PublishEvent(0xc001058480, {0x4281a40, 0xc000723740}, 0xc000dd9a80)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/api/grpc/grpc.go:227 +0x6ae
github.com/dapr/dapr/pkg/proto/runtime/v1._Dapr_PublishEvent_Handler.func1({0x4281a40?, 0xc000723740?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/proto/runtime/v1/dapr_grpc.pb.go:1333 +0xce
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCUnaryServerInterceptors.UnaryServerInterceptor.func1({0x4281a40, 0xc000723740}, {0x365f160, 0xc000dd9a80}, 0x7efccf578438?, 0xc0010500f0)
/dataplane/catalyst/sidecar/pkg/daprd/middleware/grpc/workflow/workflow.go:29 +0x92
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCMiddlewareFactory.func1.ChainUnaryServer.2.1({0x4281a40?, 0xc000723740?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCUnaryServerInterceptors.UnaryServerInterceptor.func2({0x4281a40, 0xc000723740}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0xc0007f0b00)
/dataplane/catalyst/sidecar/pkg/daprd/middleware/grpc/tap/tap.go:42 +0xa2
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCMiddlewareFactory.func1.ChainUnaryServer.2.1({0x4281a40?, 0xc000723740?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCUnaryServerInterceptors.UnaryServerInterceptor.func3({0x4281a40, 0xc0007236e0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0xc0007f0b40)
/dataplane/catalyst/sidecar/pkg/daprd/middleware/grpc/logs/logs.go:28 +0xc7
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCMiddlewareFactory.func1.ChainUnaryServer.2.1({0x4281a40?, 0xc0007236e0?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCUnaryServerInterceptors.UnaryServerInterceptor.UnaryServerInterceptor.func4({0x4281a40, 0xc0007236e0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0xc0007f0b80)
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/ratelimit/ratelimit.go:27 +0x122
github.com/diagridio/cloudgrid/dataplane/catalyst/sidecar/pkg/daprd/middleware.CustomGRPCMiddlewareFactory.func1.ChainUnaryServer.2({0x4281a40, 0xc0007236e0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0x49e32f?)
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x123
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.ChainUnaryServer.func11.1({0x4281a40?, 0xc0007236e0?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.(*grpcMetrics).UnaryServerInterceptor.func5({0x4281a40, 0xc0007236e0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0xc0007f09c0)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/diagnostics/grpc_monitoring.go:224 +0xa2
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.ChainUnaryServer.func11.1({0x4281a40?, 0xc0007236e0?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.GRPCTraceUnaryServerInterceptor.func3({0x4281a40, 0xc0007235f0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0xc0007f0a00)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/diagnostics/grpc_tracing.go:70 +0x25a
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.ChainUnaryServer.func11.1({0x4281a40?, 0xc0007235f0?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.getAPIAuthenticationMiddlewares.func1({0x4281a40, 0xc0007235f0}, {0x365f160, 0xc000dd9a80}, 0xc0010b30b8?, 0xc0007f0a40)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/api/grpc/auth.go:19 +0x78
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.ChainUnaryServer.func11.1({0x4281a40?, 0xc0007235f0?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/dapr/dapr/pkg/api/grpc.setAPIEndpointsMiddlewares.func1({0x4281a40, 0xc0007235f0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0xc0007f0a80)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/api/grpc/endpoints.go:158 +0x19d
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.ChainUnaryServer.func11.1({0x4281a40?, 0xc0007235f0?}, {0x365f160?, 0xc000dd9a80?})
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/dapr/dapr/pkg/api/grpc/metadata.SetMetadataInContextUnary({0x4281a40, 0xc0007230b0}, {0x365f160, 0xc000dd9a80}, 0x0?, 0xc0007f0ac0)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/api/grpc/metadata/metadata.go:46 +0x99
github.com/dapr/dapr/pkg/api/grpc.(*server).getMiddlewareOptions.ChainUnaryServer.func11({0x4281a40, 0xc0007230b0}, {0x365f160, 0xc000dd9a80}, 0xc000ddc9e0, 0x80?)
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x123
github.com/dapr/dapr/pkg/proto/runtime/v1._Dapr_PublishEvent_Handler({0x3879fc0, 0xc001058480}, {0x4281a40, 0xc0007230b0}, 0xc000dd9a00, 0xc000b2e4b0)
/go/pkg/mod/github.com/diagridio/dapr-dapr@v1.14.0-rc.11-catalyst.1/pkg/proto/runtime/v1/dapr_grpc.pb.go:1335 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000954200, {0x4281a40, 0xc000722f90}, {0x429ade0, 0xc001022000}, 0xc00077dc20, 0xc000b2e960, 0x63762c0, 0x0)
/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1379 +0xdf8
google.golang.org/grpc.(*Server).handleStream(0xc000954200, {0x429ade0, 0xc001022000}, 0xc00077dc20)
/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1790 +0xe8b
google.golang.org/grpc.(*Server).serveStreams.func2.1()
/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 1724
/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1040 +0x125
```




Per `github.com/puzpuzpuz/xsync` doc of `Compute` function:

```
// Compute either sets the computed new value for the key or deletes
// the value for the key. When the delete result of the valueFn function
// is set to true, the value will be deleted, if it exists. When delete
// is set to false, the value is updated to the newValue.
// The ok result indicates whether value was computed and stored, thus, is
// present in the map. The actual result contains the new value in cases where
// the value was computed and stored. See the example for a few use cases.
```

When unlocking we were always returning false thus never deleting the value, when running concurrently it is possible to re-use an already unlocked mutex thus leading to the error.

## Issue reference

https://github.com/diagridio/issues/issues/4572

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
