### PR TITLE
Removes check for dummy key in secret store

### DIFF
--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -16,7 +16,6 @@ package secretmanager
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -24,11 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 
 	awsAuth "github.com/dapr/components-contrib/common/authentication/aws"
-	"github.com/dapr/components-contrib/common/utils"
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/ptr"
 )
 
 const (
@@ -62,32 +59,12 @@ func (s *smSecretStore) Init(ctx context.Context, metadata secretstores.Metadata
 		return err
 	}
 
-	// This check is needed because d.client is set to a mock in tests
-	if s.client == nil {
-		s.client, err = s.getClient(meta)
-		if err != nil {
-			return err
-		}
-	}
+	s.client, err = s.getClient(meta)
 	if err != nil {
 		return err
 	}
 
-	var notFoundErr *secretsmanager.ResourceNotFoundException
-	if err := s.validateConnection(ctx); err != nil && !errors.As(err, &notFoundErr) {
-		return fmt.Errorf("error validating access to the aws.secretmanager secret store: %w", err)
-	}
 	return nil
-}
-
-// validateConnection runs a dummy GetSecretValueWithContext operation
-// to validate the connection credentials
-func (s *smSecretStore) validateConnection(ctx context.Context) error {
-	_, err := s.client.GetSecretValueWithContext(ctx, &secretsmanager.GetSecretValueInput{
-		SecretId: ptr.Of(utils.GetRandOrDefaultString("dapr-test-secret")),
-	})
-
-	return err
 }
 
 // GetSecret retrieves a secret using a key and returns a map of decrypted string/string values.

--- a/secretstores/aws/secretmanager/secretmanager_test.go
+++ b/secretstores/aws/secretmanager/secretmanager_test.go
@@ -43,12 +43,6 @@ func (m *mockedSM) GetSecretValueWithContext(ctx context.Context, input *secrets
 func TestInit(t *testing.T) {
 	m := secretstores.Metadata{}
 	s := NewSecretManager(logger.NewLogger("test"))
-	s.(*smSecretStore).client = &mockedSM{
-		GetSecretValueFn: func(ctx context.Context, input *secretsmanager.GetSecretValueInput, option ...request.Option) (*secretsmanager.GetSecretValueOutput, error) {
-			// Simulate a non error response
-			return nil, nil
-		},
-	}
 
 	t.Run("Init with valid metadata", func(t *testing.T) {
 		m.Properties = map[string]string{
@@ -60,19 +54,6 @@ func TestInit(t *testing.T) {
 		}
 		err := s.Init(context.Background(), m)
 		require.NoError(t, err)
-	})
-
-	t.Run("Init with invalid connection details", func(t *testing.T) {
-		s.(*smSecretStore).client = &mockedSM{
-			GetSecretValueFn: func(ctx context.Context, input *secretsmanager.GetSecretValueInput, option ...request.Option) (*secretsmanager.GetSecretValueOutput, error) {
-				// Simulate a failure that resembles what AWS SM would return
-				return nil, fmt.Errorf("wrong-credentials")
-			},
-		}
-
-		err := s.Init(context.Background(), m)
-		require.Error(t, err)
-		require.EqualError(t, err, "error validating access to the aws.secretmanager secret store: wrong-credentials")
 	})
 }
 


### PR DESCRIPTION
# Description

Removes the writing to a dummy key to check for access, because that might be disallowed for some policies.
This needs to be patched into 1.13 and 1.14.

## Issue reference
https://github.com/dapr/components-contrib/issues/3516

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests

