### PR TITLE
Removes the dummy check for AWS Parameter Store access validation

### DIFF
--- a/secretstores/aws/parameterstore/parameterstore.go
+++ b/secretstores/aws/parameterstore/parameterstore.go
@@ -15,7 +15,6 @@ package parameterstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 
 	awsAuth "github.com/dapr/components-contrib/common/authentication/aws"
-	"github.com/dapr/components-contrib/common/utils"
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/kit/logger"
@@ -67,30 +65,13 @@ func (s *ssmSecretStore) Init(ctx context.Context, metadata secretstores.Metadat
 		return err
 	}
 
-	// This check is needed because d.client is set to a mock in tests
-	if s.client == nil {
-		s.client, err = s.getClient(meta)
-		if err != nil {
-			return err
-		}
+	s.client, err = s.getClient(meta)
+	if err != nil {
+		return err
 	}
 	s.prefix = meta.Prefix
 
-	// Validate client connection
-	var notFoundErr *ssm.ParameterNotFound
-	if err := s.validateConnection(ctx); err != nil && !errors.As(err, &notFoundErr) {
-		return fmt.Errorf("error validating access to the aws.parameterstore secret store: %w", err)
-	}
 	return nil
-}
-
-// validateConnection runs a dummy GetParameterWithContext operation
-// to validate the connection credentials
-func (s *ssmSecretStore) validateConnection(ctx context.Context) error {
-	_, err := s.client.GetParameterWithContext(ctx, &ssm.GetParameterInput{
-		Name: ptr.Of(s.prefix + utils.GetRandOrDefaultString("dapr-test-param")),
-	})
-	return err
 }
 
 // GetSecret retrieves a secret using a key and returns a map of decrypted string/string values.

--- a/secretstores/aws/parameterstore/parameterstore_test.go
+++ b/secretstores/aws/parameterstore/parameterstore_test.go
@@ -50,12 +50,6 @@ func (m *mockedSSM) DescribeParametersWithContext(ctx context.Context, input *ss
 func TestInit(t *testing.T) {
 	m := secretstores.Metadata{}
 	s := NewParameterStore(logger.NewLogger("test"))
-	s.(*ssmSecretStore).client = &mockedSSM{
-		GetParameterFn: func(ctx context.Context, input *ssm.GetParameterInput, option ...request.Option) (*ssm.GetParameterOutput, error) {
-			// Simulate a non error response from AWS SSM
-			return nil, nil
-		},
-	}
 
 	t.Run("Init with valid metadata", func(t *testing.T) {
 		m.Properties = map[string]string{
@@ -67,19 +61,6 @@ func TestInit(t *testing.T) {
 		}
 		err := s.Init(context.Background(), m)
 		require.NoError(t, err)
-	})
-
-	t.Run("Init with invalid connection details", func(t *testing.T) {
-		s.(*ssmSecretStore).client = &mockedSSM{
-			GetParameterFn: func(ctx context.Context, input *ssm.GetParameterInput, option ...request.Option) (*ssm.GetParameterOutput, error) {
-				// Simulate a failure that resembles what AWS SSM would return
-				return nil, fmt.Errorf("wrong-credentials")
-			},
-		}
-
-		err := s.Init(context.Background(), m)
-		require.Error(t, err)
-		require.EqualError(t, err, "error validating access to the aws.parameterstore secret store: wrong-credentials")
 	})
 }
 


### PR DESCRIPTION
# Description

Removes the writing to a dummy key to check for access, because that might be disallowed for some policies.
The change was introduced in 1.13 (https://github.com/dapr/components-contrib/pull/3301).
This needs to be patched into 1.13 and 1.14.

## Issue reference
[This issue](https://github.com/dapr/components-contrib/issues/3516) was related to AWS Secrets manager, but the same applies for parameter store too.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests

