### PR TITLE
fix: drop duplicate aws auth field in postgresql

### DIFF
--- a/.build-tools/pkg/metadataschema/validators.go
+++ b/.build-tools/pkg/metadataschema/validators.go
@@ -67,7 +67,7 @@ func (c *ComponentMetadata) IsValid() error {
 
 	// Append built-in authentication profiles
 	for _, profile := range c.BuiltInAuthenticationProfiles {
-		appendProfiles, err := ParseBuiltinAuthenticationProfile(profile)
+		appendProfiles, err := ParseBuiltinAuthenticationProfile(profile, c.Title)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

If choose postgresql `AWS: Access Key ID and Secret Access Key` as the Authentication Profile, there are multiple fields for `AWS AccessKey, AWS Region, and AWS Secret Key" .` 

The reason is bc for PostgreSQL itself has `awsIAM` as the metadata,  which already include accessKey, secretKey and awsRegion. But during the building it will append built-in auth profile again, which bring these duplicated fields.  This PR tweak the logic of the building process, which filters out those fields for the postgres component. 


Before the change:
```
    {
          "title": "AWS: Access Key ID and Secret Access Key",
          "description": "Authenticate using an Access Key ID and Secret Access Key included in the metadata",
          "metadata": [
            {
              "name": "useAWSIAM",
              "description": "Must be set to `true` to enable the component to retrieve access tokens from AWS IAM.\nThis authentication method only works with AWS Relational Database Service for PostgreSQL databases.",
              "required": true,
              "type": "bool",
              "example": "\"true\""
            },
            {
              "name": "connectionString",
              "description": "The connection string for the PostgreSQL database\nThis must contain the user, which corresponds to the name of the user created inside PostgreSQL that maps to the AWS IAM policy. This connection string should not contain any password. Note that the database name field is denoted by dbname with AWS.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"host=mydb.postgres.database.aws.com user=myapplication port=5432 dbname=dapr_test sslmode=require\"\n"
            },
            {
              "name": "awsRegion",
              "description": "The AWS Region where the AWS Relational Database Service is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "awsAccessKey",
              "description": "AWS access key associated with an IAM account.",
              "required": true,
              "type": "string",
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "awsSecretKey",
              "description": "The secret key associated with the access key.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "awsRegion",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "accessKey",
              "description": "AWS access key associated with an IAM account",
              "required": true,
              "sensitive": true,
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "secretKey",
              "description": "The secret key associated with the access key",
              "required": true,
              "sensitive": true,
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "sessionToken",
              "description": "AWS session token to use. A session token is only required if you are using\ntemporary security credentials.",
              "sensitive": true,
              "type": "string",
              "example": "\"TOKEN\""
            }
          ]
        }
```

After the change:
```
        {
          "title": "AWS: Access Key ID and Secret Access Key",
          "description": "Authenticate using an Access Key ID and Secret Access Key included in the metadata",
          "metadata": [
            {
              "name": "useAWSIAM",
              "description": "Must be set to `true` to enable the component to retrieve access tokens from AWS IAM.\nThis authentication method only works with AWS Relational Database Service for PostgreSQL databases.",
              "required": true,
              "type": "bool",
              "example": "\"true\""
            },
            {
              "name": "connectionString",
              "description": "The connection string for the PostgreSQL database\nThis must contain the user, which corresponds to the name of the user created inside PostgreSQL that maps to the AWS IAM policy. This connection string should not contain any password. Note that the database name field is denoted by dbname with AWS.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"host=mydb.postgres.database.aws.com user=myapplication port=5432 dbname=dapr_test sslmode=require\"\n"
            },
            {
              "name": "awsRegion",
              "description": "The AWS Region where the AWS Relational Database Service is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "awsAccessKey",
              "description": "AWS access key associated with an IAM account.",
              "type": "string",
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "awsSecretKey",
              "description": "The secret key associated with the access key.",
              "sensitive": true,
              "type": "string",
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "sessionToken",
              "description": "AWS session token to use. A session token is only required if you are using\ntemporary security credentials.",
              "sensitive": true,
              "type": "string",
              "example": "\"TOKEN\""
            }
          ]
        },


```

This aligns with aws auth of other components.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
