### PR TITLE
CI: correct upgrade lint path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ verify-linter-version:
 	  echo "[!] Yours:  $(INSTALLED_LINT_VERSION)"; \
 		echo "[!] Theirs: $(GH_LINT_VERSION)"; \
 		echo "[!] Upgrade: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $(GH_LINT_VERSION)"; \
+                GOLANGCI_LINT=$(go env GOPATH)/bin/$(GOLANGCI_LINT)
 	  sleep 3; \
 	fi;
 


### PR DESCRIPTION
# Description

We install lint under GOPATH while if users install one under `/usr/local/bin` which is front of the GOPATH, even we upgrade, users still use old lint.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
