### PR TITLE
Addressed issue in Kafka-pubsub for avro null messages

### DIFF
--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -356,7 +356,7 @@ func (k *Kafka) getSchemaRegistyClient() (srclient.ISchemaRegistryClient, error)
 
 func (k *Kafka) SerializeValue(topic string, data []byte, metadata map[string]string) ([]byte, error) {
 	// Null Data is valid and a tombstone record. It shouldn't be serialized
-	if bytes.Equal(data, []byte("null")) {
+	if bytes.Equal(data, []byte("null")) || data == nil {
 		return nil, nil
 	}
 

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -264,7 +264,9 @@ func getSchemaSubject(topic string) string {
 }
 
 func (k *Kafka) DeserializeValue(message *sarama.ConsumerMessage, config SubscriptionHandlerConfig) ([]byte, error) {
-	// Null Data is valid and a tombstone record. It shouldn't be serialized
+	// Null Data is valid and a tombstone record.
+	// It shouldn't be going through schema validation and decoding
+	// Instead directly convert to JSON `null`
 	if message.Value == nil {
 		return []byte("null"), nil
 	}
@@ -355,7 +357,8 @@ func (k *Kafka) getSchemaRegistyClient() (srclient.ISchemaRegistryClient, error)
 }
 
 func (k *Kafka) SerializeValue(topic string, data []byte, metadata map[string]string) ([]byte, error) {
-	// Null Data is valid and a tombstone record. It shouldn't be serialized
+	// Null Data is valid and a tombstone record.
+	// It should be converted to NULL and not go through schema validation & encoding
 	if bytes.Equal(data, []byte("null")) || data == nil {
 		return nil, nil
 	}

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -14,6 +14,7 @@ limitations under the License.
 package kafka
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -355,7 +356,7 @@ func (k *Kafka) getSchemaRegistyClient() (srclient.ISchemaRegistryClient, error)
 
 func (k *Kafka) SerializeValue(topic string, data []byte, metadata map[string]string) ([]byte, error) {
 	// Null Data is valid and a tombstone record. It shouldn't be serialized
-	if data == nil {
+	if bytes.Equal(data, []byte("null")) {
 		return nil, nil
 	}
 

--- a/common/component/kafka/kafka_test.go
+++ b/common/component/kafka/kafka_test.go
@@ -219,8 +219,15 @@ func TestSerializeValueCachingDisabled(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("value published null, no error", func(t *testing.T) {
+	t.Run("value published 'null', no error", func(t *testing.T) {
 		act, err := k.SerializeValue("my-topic", []byte("null"), map[string]string{"valueSchemaType": "Avro"})
+
+		require.Nil(t, act)
+		require.NoError(t, err)
+	})
+
+	t.Run("value published nil, no error", func(t *testing.T) {
+		act, err := k.SerializeValue("my-topic", nil, map[string]string{"valueSchemaType": "Avro"})
 
 		require.Nil(t, act)
 		require.NoError(t, err)

--- a/common/component/kafka/kafka_test.go
+++ b/common/component/kafka/kafka_test.go
@@ -220,7 +220,7 @@ func TestSerializeValueCachingDisabled(t *testing.T) {
 	})
 
 	t.Run("value published null, no error", func(t *testing.T) {
-		act, err := k.SerializeValue("my-topic", nil, map[string]string{"valueSchemaType": "Avro"})
+		act, err := k.SerializeValue("my-topic", []byte("null"), map[string]string{"valueSchemaType": "Avro"})
 
 		require.Nil(t, act)
 		require.NoError(t, err)


### PR DESCRIPTION
# Description

Addressed issue in Kafka-pubsub for avro null messages
- was not properly tested end to end so the value never comes as NULL but as `"null"` which is the JSON representation


## Issue reference

#3510


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation (N/A)
