### PR TITLE
mongodb: fix goroutine leak on failed server connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/xdg-go/scram v1.1.2
 	go.etcd.io/etcd/client/v3 v3.5.9
 	go.mongodb.org/mongo-driver v1.12.1
+	go.uber.org/goleak v1.2.1
 	go.uber.org/multierr v1.11.0
 	go.uber.org/ratelimit v0.3.0
 	golang.org/x/crypto v0.24.0

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -139,11 +139,11 @@ func (m *MongoDB) Init(ctx context.Context, metadata state.Metadata) (err error)
 		return fmt.Errorf("error in creating mongodb client: %s", err)
 	}
 
+	m.client = client
+
 	if err = client.Ping(ctx, nil); err != nil {
 		return fmt.Errorf("error in connecting to mongodb, host: %s error: %s", m.metadata.Host, err)
 	}
-
-	m.client = client
 
 	// get the write concern
 	wc, err := getWriteConcernObject(m.metadata.Writeconcern)


### PR DESCRIPTION
# Description

By not keeping the client when `Ping` fails we're later unable to properly invoke `Disconnect` which leads to leaked resources, most notably goroutines created on the mongo-go-driver.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
