### PR TITLE
fix(metadata): add missing field to http binding

### DIFF
--- a/bindings/http/metadata.yaml
+++ b/bindings/http/metadata.yaml
@@ -75,3 +75,7 @@ metadata:
     required: false
     description: "The header name on an outgoing HTTP request for a security token"
     example: '"X-Security-Token"'
+  - name: errorIfNot2XX
+    required: false
+    default: 'true'
+    description: "Create an error if a non-2XX status code is returned"


### PR DESCRIPTION
# Description

We are missing this field on the http binding. It is in the logic, and docs:
https://github.com/dapr/components-contrib/commit/9e9d7086e171ee0c99ba295ddf445287effd62f7#diff-50e6b52eb3eded23c24e7ac1117cb029862ee7ead109191d65cc1b13d54ed8daR185

https://docs.dapr.io/reference/components-reference/supported-bindings/http/

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
