### PR TITLE
fix(metadata): make access/secret keys optional

### DIFF
--- a/common/authentication/postgresql/metadata.go
+++ b/common/authentication/postgresql/metadata.go
@@ -91,14 +91,10 @@ func (m *PostgresAuthMetadata) ValidateAwsIamFields() (string, string, string, e
 	if awsRegion == "" {
 		return "", "", "", errors.New("metadata property AWSRegion is missing")
 	}
+	// Note: access key and secret keys can be optional
+	// in the event users are leveraging the credential files for an access token.
 	awsAccessKey, _ := metadata.GetMetadataProperty(m.awsEnv.Metadata, "AWSAccessKey")
-	if awsAccessKey == "" {
-		return "", "", "", errors.New("metadata property AWSAccessKey is missing")
-	}
 	awsSecretKey, _ := metadata.GetMetadataProperty(m.awsEnv.Metadata, "AWSSecretKey")
-	if awsSecretKey == "" {
-		return "", "", "", errors.New("metadata property AWSSecretKey is missing")
-	}
 	return awsRegion, awsAccessKey, awsSecretKey, nil
 }
 


### PR DESCRIPTION
# Description

In the event someone is using AWS IAM authentication, then they can leverage the loading of default credentials here: https://github.com/dapr/components-contrib/blob/9012bdce7f0eb67c1c22fa1928a657b27d4bdd31/common/authentication/aws/aws.go#L105

Alternatively, they can supply the access key and secret key. Therefore, the accesskey and secretkey fields are optional, not required.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
