### PR TITLE
fix(redis): make auth profiles consistent for username/pwd

### DIFF
--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -10,24 +10,33 @@ urls:
     url: https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-redis-pubsub/
 capabilities:
   - ttl
+authenticationProfiles:
+  - title: "Username and password"
+    description: "Authenticate using username and password."
+    metadata:
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username for Redis host. Defaults to empty. Make sure your Redis server
+          version is 6 or above, and have created ACL rule correctly.
+        example:  "my-username"
+        default: ""
+      - name: redisPassword
+        type: string
+        required: false
+        sensitive: true
+        description: |
+          Password for Redis host. No default. Use secretKeyRef for
+          secret reference
+        example:  "KeFg23!"
+        default: ""
 metadata:
   - name: redisHost
     required: true
     description: |
       Connection-string for the redis host. If "redisType" is "cluster" it can be multiple hosts separated by commas or just a single host
     example: '"redis-master.default.svc.cluster.local:6379"'
-    type: string
-  - name: redisPassword
-    required: true
-    sensitive: true
-    description: |
-      Password for Redis host. No Default. Can be "secretKeyRef" to use a secret reference
-    example: '"KeFg23!"'
-    type: string
-  - name: redisUsername
-    required: false
-    description: Username for Redis host. Defaults to empty. Make sure your redis server version is 6 or above, and have created acl rule correctly.
-    example: "default"
     type: string
   - name: consumerID
     required: false

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -15,22 +15,32 @@ capabilities:
   - transactional
   - etag
   - query
+authenticationProfiles:
+  - title: "Username and password"
+    description: "Authenticate using username and password."
+    metadata:
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username for Redis host. Defaults to empty. Make sure your Redis server
+          version is 6 or above, and have created ACL rule correctly.
+        example:  "my-username"
+        default: ""
+      - name: redisPassword
+        type: string
+        required: false
+        sensitive: true
+        description: |
+          Password for Redis host. No default. Use secretKeyRef for
+          secret reference
+        example:  "KeFg23!"
+        default: ""
 metadata:
   - name: redisHost
     required: true
     description: Connection-string for the redis host
     example: "redis-master.default.svc.cluster.local:6379"
-    type: string
-  - name: redisPassword
-    required: false
-    sensitive: true
-    description: Password for Redis host. No Default. Can be secretKeyRef to use a secret reference
-    example:  "KeFg23!"
-    type: string
-  - name: redisUsername
-    required: false
-    description: Username for Redis host. Defaults to empty. Make sure your redis server version is 6 or above, and have created acl rule correctly.
-    example:  "default"
     type: string
   - name: enableTLS
     required: false


### PR DESCRIPTION
# Description

Some redis components have the auth profile section for username/pwd, and others don't. I've ensured it's on all now.
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
