### PR TITLE
[Bindings][BlobStorage] Update request.go - Log debug instead of warning

### DIFF
--- a/common/component/azure/blobstorage/request.go
+++ b/common/component/azure/blobstorage/request.go
@@ -99,7 +99,7 @@ func SanitizeMetadata(log logger.Logger, metadata map[string]string) map[string]
 
 		if n != len(key) {
 			nks := string(newKey[:n])
-			log.Warnf("metadata key %s contains disallowed characters, sanitized to %s", key, nks)
+			log.Debugf("metadata key %s contains disallowed characters, sanitized to %s", key, nks)
 			key = nks
 		}
 


### PR DESCRIPTION
[Azure-BlobStorage] Log debug instead of warn when metadata has disallowed characters

# Description

Log debug instead of warn when metadata has disallowed characters

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: [#_[4399]_](https://github.com/dapr/docs/issues/4399)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests - not required for this case
* [X] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
