### PR TITLE
Adds conformance tests for AWS Secretes store component

### DIFF
--- a/.github/infrastructure/docker-compose-secrets-manager.yml
+++ b/.github/infrastructure/docker-compose-secrets-manager.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  localstack:
+    container_name: "conformance-aws-secrets-manager"
+    image: localstack/localstack
+    ports:
+      - "127.0.0.1:4566:4566"
+    environment:
+      - DEBUG=1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${PWD}/.github/scripts/docker-compose-init/init-conformance-state-aws-secrets-manager.sh:/etc/localstack/init/ready.d/init-aws.sh"  # ready hook
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.github/scripts/docker-compose-init/init-conformance-state-aws-secrets-manager.sh
+++ b/.github/scripts/docker-compose-init/init-conformance-state-aws-secrets-manager.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+awslocal secretsmanager create-secret \
+    --name conftestsecret \
+    --secret-string "abcd"
+
+awslocal secretsmanager create-secret \
+    --name secondsecret \
+    --secret-string "efgh"

--- a/secretstores/aws/secretmanager/metadata.yaml
+++ b/secretstores/aws/secretmanager/metadata.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../../component-metadata-schema.json
+schemaVersion: v1
+type: secretstores
+name: aws.secretsmanager
+version: v1
+status: beta
+title: "AWS Secrets manager"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-secret-stores/aws-secret-manager/
+builtinAuthenticationProfiles:
+  - name: "aws"
+metadata:
+  - name: endpoint
+    required: false
+    description: |
+      The Secrets manager endpoint. The AWS SDK will generate a default endpoint if not specified. Useful for local testing with AWS LocalStack
+    example: '"http://localhost:4566"'
+    type: string

--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -45,6 +45,7 @@ type SecretManagerMetaData struct {
 	AccessKey    string `json:"accessKey"`
 	SecretKey    string `json:"secretKey"`
 	SessionToken string `json:"sessionToken"`
+	Endpoint     string `json:"endpoint"`
 }
 
 type smSecretStore struct {
@@ -136,7 +137,7 @@ func (s *smSecretStore) BulkGetSecret(ctx context.Context, req secretstores.Bulk
 }
 
 func (s *smSecretStore) getClient(metadata *SecretManagerMetaData) (*secretsmanager.SecretsManager, error) {
-	sess, err := awsAuth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, "")
+	sess, err := awsAuth.GetClient(metadata.AccessKey, metadata.SecretKey, metadata.SessionToken, metadata.Region, metadata.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/config/secretstores/aws/secretsmanager/docker/secretsmanager.yml
+++ b/tests/config/secretstores/aws/secretsmanager/docker/secretsmanager.yml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: awssecretmanager
+spec:
+  type: secretstores.aws.secretmanager
+  version: v1
+  metadata:
+  - name: accessKey
+    value: "test"  # AWS LocalStack placeholder
+  - name: secretKey
+    value: "test"  # AWS LocalStack placeholder
+  - name: region
+    value: "us-east-1" # AWS LocalStack placeholder

--- a/tests/config/secretstores/tests.yml
+++ b/tests/config/secretstores/tests.yml
@@ -5,6 +5,8 @@ components:
     operations: []
   - component: local.file
     operations: []
+  - component: aws.secretsmanager.docker
+    operations: []
   - component: azure.keyvault.certificate
     operations: []
   - component: azure.keyvault.serviceprincipal

--- a/tests/conformance/secretstores/secretstores.go
+++ b/tests/conformance/secretstores/secretstores.go
@@ -58,7 +58,7 @@ func ConformanceTests(t *testing.T, props map[string]string, store secretstores.
 
 	t.Run("ping", func(t *testing.T) {
 		err := secretstores.Ping(context.Background(), store)
-		// TODO: Ideally, all stable components should implenment ping function,
+		// TODO: Ideally, all stable components should implement a ping function,
 		// so will only assert require.NoError(t, err) finally, i.e. when current implementation
 		// implements ping in existing stable components
 		if err != nil {

--- a/tests/conformance/secretstores_test.go
+++ b/tests/conformance/secretstores_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/secretstores"
+	ss_aws "github.com/dapr/components-contrib/secretstores/aws/secretmanager"
 	ss_azure "github.com/dapr/components-contrib/secretstores/azure/keyvault"
 	ss_hashicorp_vault "github.com/dapr/components-contrib/secretstores/hashicorp/vault"
 	ss_kubernetes "github.com/dapr/components-contrib/secretstores/kubernetes"
@@ -71,6 +72,8 @@ func loadSecretStore(name string) secretstores.SecretStore {
 		return ss_local_file.NewLocalSecretStore(testLogger)
 	case "hashicorp.vault":
 		return ss_hashicorp_vault.NewHashiCorpVaultSecretStore(testLogger)
+	case "aws.secretsmanager.docker":
+		return ss_aws.NewSecretManager(testLogger)
 	default:
 		return nil
 	}


### PR DESCRIPTION
# Description

Adds conformance tests for the AWS Secrets manager component, so it can move to beta status

## Issue reference

https://github.com/dapr/components-contrib/issues/3504

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
