### PR TITLE
aws auth: add missing auth methods

### DIFF
--- a/configuration/postgres/metadata.yaml
+++ b/configuration/postgres/metadata.yaml
@@ -65,6 +65,24 @@ builtinAuthenticationProfiles:
         description: |
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+      - name: awsSessionToken
+        type: string
+        sensitive: true
+        description: |
+          AWS session token to use. A session token is only required if you are using temporary security credentials.
+        example: '"TOKEN"'
+      - name: awsIamRoleArn
+        type: string
+        required: true
+        description: |
+          IAM role that has access to AWS Relational Database Service. This is another option to authenticate with AWS aside from the AWS Credentials.
+        example: '"arn:aws:iam::123456789:role/rdsRole"'
+      - name: awsStsSessionName
+        type: string
+        description: |
+          Represents the session name for assuming a role.
+        example: '"MyAppSession"'
+        default: '"PGDefaultSession"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String."

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.37
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.3.10
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.17.3
+	github.com/aws/aws-sdk-go-v2/service/sts v1.31.3
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/camunda/zeebe/clients/go/v8 v8.2.12
 	github.com/cenkalti/backoff/v4 v4.2.1
@@ -186,7 +187,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.23.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.27.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.31.3 // indirect
 	github.com/aws/smithy-go v1.21.0 // indirect
 	github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/state/postgresql/v1/metadata.yaml
+++ b/state/postgresql/v1/metadata.yaml
@@ -72,6 +72,24 @@ builtinAuthenticationProfiles:
         description: |
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+      - name: awsSessionToken
+        type: string
+        sensitive: true
+        description: |
+          AWS session token to use. A session token is only required if you are using temporary security credentials.
+        example: '"TOKEN"'
+      - name: awsIamRoleArn
+        type: string
+        required: true
+        description: |
+          IAM role that has access to AWS Relational Database Service. This is another option to authenticate with AWS aside from the AWS Credentials.
+        example: '"arn:aws:iam::123456789:role/rdsRole"'
+      - name: awsStsSessionName
+        type: string
+        description: |
+          Represents the session name for assuming a role.
+        example: '"MyAppSession"'
+        default: '"PGDefaultSession"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String"

--- a/state/postgresql/v2/metadata.yaml
+++ b/state/postgresql/v2/metadata.yaml
@@ -71,6 +71,24 @@ builtinAuthenticationProfiles:
         description: |
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+      - name: awsSessionToken
+        type: string
+        sensitive: true
+        description: |
+          AWS session token to use. A session token is only required if you are using temporary security credentials.
+        example: '"TOKEN"'
+      - name: awsIamRoleArn
+        type: string
+        required: true
+        description: |
+          IAM role that has access to AWS Relational Database Service. This is another option to authenticate with AWS aside from the AWS Credentials.
+        example: '"arn:aws:iam::123456789:role/rdsRole"'
+      - name: awsStsSessionName
+        type: string
+        description: |
+          Represents the session name for assuming a role.
+        example: '"MyAppSession"'
+        default: '"PGDefaultSession"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String"


### PR DESCRIPTION
# Description

Testing AWS IAM auth with postgres and missing the assume role feature that its documented as part of the aws auth profile

It all started because this error check here is bad https://github.com/dapr/components-contrib/blob/main/common/authentication/aws/aws.go#L133
if there is no error, `errors.Is(err, config.SharedConfigAssumeRoleError{}.Err)` always evaluates to true... because when you do `config.SharedConfigAssumeRoleError{}.Err` then `Err` is nil!

I started fixing that but then looking at the kafka pubsub component https://github.com/dapr/components-contrib/blob/main/common/component/kafka/auth.go#L99 , kafka supports more fields, so it made sense to also support these for postgres.

docs updated here https://github.com/dapr/docs/pull/4429

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
