### PR TITLE
Fixes `subscribeType` metadata field not being respected for Pulsar pub sub

### DIFF
--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -20,25 +20,25 @@ import (
 )
 
 type pulsarMetadata struct {
-	Host                    string                    `mapstructure:"host"`
-	ConsumerID              string                    `mapstructure:"consumerID"`
-	EnableTLS               bool                      `mapstructure:"enableTLS"`
-	DisableBatching         bool                      `mapstructure:"disableBatching"`
-	BatchingMaxPublishDelay time.Duration             `mapstructure:"batchingMaxPublishDelay"`
-	BatchingMaxSize         uint                      `mapstructure:"batchingMaxSize"`
-	BatchingMaxMessages     uint                      `mapstructure:"batchingMaxMessages"`
-	Tenant                  string                    `mapstructure:"tenant"`
-	Namespace               string                    `mapstructure:"namespace"`
-	Persistent              bool                      `mapstructure:"persistent"`
-	RedeliveryDelay         time.Duration             `mapstructure:"redeliveryDelay"`
-	internalTopicSchemas    map[string]schemaMetadata `mapstructure:"-"`
-	PublicKey               string                    `mapstructure:"publicKey"`
-	PrivateKey              string                    `mapstructure:"privateKey"`
-	Keys                    string                    `mapstructure:"keys"`
-	MaxConcurrentHandlers   uint                      `mapstructure:"maxConcurrentHandlers"`
-	ReceiverQueueSize       int                       `mapstructure:"receiverQueueSize"`
-
-	Token                            string `mapstructure:"token"`
+	Host                             string                    `mapstructure:"host"`
+	ConsumerID                       string                    `mapstructure:"consumerID"`
+	EnableTLS                        bool                      `mapstructure:"enableTLS"`
+	DisableBatching                  bool                      `mapstructure:"disableBatching"`
+	BatchingMaxPublishDelay          time.Duration             `mapstructure:"batchingMaxPublishDelay"`
+	BatchingMaxSize                  uint                      `mapstructure:"batchingMaxSize"`
+	BatchingMaxMessages              uint                      `mapstructure:"batchingMaxMessages"`
+	Tenant                           string                    `mapstructure:"tenant"`
+	Namespace                        string                    `mapstructure:"namespace"`
+	Persistent                       bool                      `mapstructure:"persistent"`
+	RedeliveryDelay                  time.Duration             `mapstructure:"redeliveryDelay"`
+	internalTopicSchemas             map[string]schemaMetadata `mapstructure:"-"`
+	PublicKey                        string                    `mapstructure:"publicKey"`
+	PrivateKey                       string                    `mapstructure:"privateKey"`
+	Keys                             string                    `mapstructure:"keys"`
+	MaxConcurrentHandlers            uint                      `mapstructure:"maxConcurrentHandlers"`
+	ReceiverQueueSize                int                       `mapstructure:"receiverQueueSize"`
+	SubscriptionType                 string                    `mapstructure:"subscribeType"`
+	Token                            string                    `mapstructure:"token"`
 	oauth2.ClientCredentialsMetadata `mapstructure:",squash"`
 }
 

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -184,3 +184,12 @@ metadata:
       Controls how many messages can be accumulated by the consumer before it is explicitly called to read messages by Dapr.
     default: '"1000"'
     example: '"1000"'
+  - name: subscribeType
+    type: string
+    description: |
+      Pulsar supports four subscription types:"shared", "exclusive", "failover", "key_shared".
+    default: '"shared"'
+    example: '"exclusive"'
+    url:
+      title: "Pulsar Subscription Types"
+      url: "https://pulsar.apache.org/docs/3.0.x/concepts-messaging/#subscription-types"

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -431,7 +431,7 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 	topic := p.formatTopic(req.Topic)
 
 	subscribeType := p.metadata.SubscriptionType
-	if s, exists := req.Metadata["subscribeType"]; exists {
+	if s, exists := req.Metadata[subscribeTypeKey]; exists {
 		subscribeType = s
 	}
 
@@ -472,6 +472,7 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 		p.logger.Debugf("Could not subscribe to %s, full topic name in pulsar is %s", req.Topic, topic)
 		return err
 	}
+	p.logger.Debugf("Subscribed to %s(%s) with type %s", req.Topic, topic, subscribeType)
 
 	p.wg.Add(2)
 	listenCtx, cancel := context.WithCancel(ctx)

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -430,10 +430,15 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 
 	topic := p.formatTopic(req.Topic)
 
+	subscribeType := p.metadata.SubscriptionType
+	if s, exists := req.Metadata["subscribeType"]; exists {
+		subscribeType = s
+	}
+
 	options := pulsar.ConsumerOptions{
 		Topic:               topic,
 		SubscriptionName:    p.metadata.ConsumerID,
-		Type:                getSubscribeType(p.metadata.SubscriptionType),
+		Type:                getSubscribeType(subscribeType),
 		MessageChannel:      channel,
 		NackRedeliveryDelay: p.metadata.RedeliveryDelay,
 		ReceiverQueueSize:   p.metadata.ReceiverQueueSize,

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -472,7 +472,7 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 		p.logger.Debugf("Could not subscribe to %s, full topic name in pulsar is %s", req.Topic, topic)
 		return err
 	}
-	p.logger.Debugf("Subscribed to %s(%s) with type %s", req.Topic, topic, subscribeType)
+	p.logger.Debugf("Subscribed to '%s'(%s) with type '%s'", req.Topic, topic, subscribeType)
 
 	p.wg.Add(2)
 	listenCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
- Fixes `subscribeType` metadata field not being respected
- Fixes bug not allowing to connect to remote endpoints starting with `pulsar://` or `pulsar+ssl://`

Currently, we have the `subscribeType` configuration field [documented](https://docs.dapr.io/reference/components-reference/supported-pubsub/setup-pulsar/#spec-metadata-fields) but not respected and the same field as subscription metadata is respected, but not documented.

```
var defaultSubscription = &common.Subscription{
		PubsubName: pubsubName,
		Topic:      topicName,
		Route:      "/orders",
		Metadata:   map[string]string{"subscribeType": "key_shared"},
	}
```

This PR uses the value in the configuration as default and overrides with the subscription metadata if one is set.


## Issue reference

https://github.com/dapr/components-contrib/issues/3601

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
