### PR TITLE
fix: initialize the close chan

### DIFF
--- a/common/authentication/aws/x509.go
+++ b/common/authentication/aws/x509.go
@@ -96,6 +96,7 @@ func newX509(ctx context.Context, opts Options, cfg *aws.Config) (*x509, error) 
 			return GetConfig(opts)
 		}(),
 		clients: newClients(),
+		closeCh: make(chan struct{}),
 	}
 
 	if err := auth.getCertPEM(ctx); err != nil {


### PR DESCRIPTION
# Description

oops 😅 

Need this to prevent the nil pointer issue upon component close that I thought that I fixed here: 
https://github.com/dapr/components-contrib/pull/3607

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
