### PR TITLE
fix get aws creds from environment

### DIFF
--- a/common/authentication/aws/aws.go
+++ b/common/authentication/aws/aws.go
@@ -112,13 +112,6 @@ type Provider interface {
 	Close() error
 }
 
-func isX509Auth(m map[string]string) bool {
-	tp, _ := m["trustProfileArn"]
-	ta, _ := m["trustAnchorArn"]
-	ar, _ := m["assumeRoleArn"]
-	return tp != "" && ta != "" && ar != ""
-}
-
 func NewProvider(ctx context.Context, opts Options, cfg *aws.Config) (Provider, error) {
 	if isX509Auth(opts.Properties) {
 		return newX509(ctx, opts, cfg)

--- a/common/authentication/aws/static.go
+++ b/common/authentication/aws/static.go
@@ -38,10 +38,10 @@ type StaticAuth struct {
 	endpoint     *string
 	accessKey    *string
 	secretKey    *string
-	sessionToken *string
+	sessionToken string
 
 	assumeRoleARN *string
-	sessionName   *string
+	sessionName   string
 
 	session *session.Session
 	cfg     *aws.Config
@@ -75,13 +75,13 @@ func newStaticIAM(_ context.Context, opts Options, cfg *aws.Config) (*StaticAuth
 		auth.secretKey = &opts.SecretKey
 	}
 	if opts.SessionToken != "" {
-		auth.sessionToken = &opts.SessionToken
+		auth.sessionToken = opts.SessionToken
 	}
 	if opts.AssumeRoleARN != "" {
 		auth.assumeRoleARN = &opts.AssumeRoleARN
 	}
 	if opts.SessionName != "" {
-		auth.sessionName = &opts.SessionName
+		auth.sessionName = opts.SessionName
 	}
 
 	initialSession, err := auth.createSession()
@@ -245,8 +245,8 @@ func (a *StaticAuth) Kafka(opts KafkaOptions) (*KafkaClients, error) {
 	if a.assumeRoleARN != nil {
 		tokenProvider.awsIamRoleArn = *a.assumeRoleARN
 	}
-	if a.sessionName != nil {
-		tokenProvider.awsStsSessionName = *a.sessionName
+	if a.sessionName != "" {
+		tokenProvider.awsStsSessionName = a.sessionName
 	}
 
 	err := a.clients.kafka.New(a.session, &tokenProvider)
@@ -271,7 +271,7 @@ func (a *StaticAuth) createSession() (*session.Session, error) {
 
 	if a.accessKey != nil && a.secretKey != nil {
 		// session token is an option field
-		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(*a.accessKey, *a.secretKey, *a.sessionToken))
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(*a.accessKey, *a.secretKey, a.sessionToken))
 	}
 
 	if a.endpoint != nil {

--- a/common/authentication/aws/static.go
+++ b/common/authentication/aws/static.go
@@ -50,15 +50,7 @@ type StaticAuth struct {
 
 func newStaticIAM(_ context.Context, opts Options, cfg *aws.Config) (*StaticAuth, error) {
 	auth := &StaticAuth{
-		logger:        opts.Logger,
-		region:        &opts.Region,
-		endpoint:      &opts.Endpoint,
-		accessKey:     &opts.AccessKey,
-		secretKey:     &opts.SecretKey,
-		sessionToken:  &opts.SessionToken,
-		assumeRoleARN: &opts.AssumeRoleARN,
-		sessionName:   &opts.SessionName,
-
+		logger: opts.Logger,
 		cfg: func() *aws.Config {
 			// if nil is passed or it's just a default cfg,
 			// then we use the options to build the aws cfg.
@@ -70,7 +62,29 @@ func newStaticIAM(_ context.Context, opts Options, cfg *aws.Config) (*StaticAuth
 		clients: newClients(),
 	}
 
-	initialSession, err := auth.getTokenClient()
+	if opts.Region != "" {
+		auth.region = &opts.Region
+	}
+	if opts.Endpoint != "" {
+		auth.endpoint = &opts.Endpoint
+	}
+	if opts.AccessKey != "" {
+		auth.accessKey = &opts.AccessKey
+	}
+	if opts.SecretKey != "" {
+		auth.secretKey = &opts.SecretKey
+	}
+	if opts.SessionToken != "" {
+		auth.sessionToken = &opts.SessionToken
+	}
+	if opts.AssumeRoleARN != "" {
+		auth.assumeRoleARN = &opts.AssumeRoleARN
+	}
+	if opts.SessionName != "" {
+		auth.sessionName = &opts.SessionName
+	}
+
+	initialSession, err := auth.createSession()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token client: %v", err)
 	}
@@ -243,7 +257,7 @@ func (a *StaticAuth) Kafka(opts KafkaOptions) (*KafkaClients, error) {
 	return a.clients.kafka, nil
 }
 
-func (a *StaticAuth) getTokenClient() (*session.Session, error) {
+func (a *StaticAuth) createSession() (*session.Session, error) {
 	var awsConfig *aws.Config
 	if a.cfg == nil {
 		awsConfig = aws.NewConfig()
@@ -263,6 +277,8 @@ func (a *StaticAuth) getTokenClient() (*session.Session, error) {
 	if a.endpoint != nil {
 		awsConfig = awsConfig.WithEndpoint(*a.endpoint)
 	}
+
+	// TODO support assume role for all aws components
 
 	awsSession, err := session.NewSessionWithOptions(session.Options{
 		Config:            *awsConfig,

--- a/common/authentication/aws/static_test.go
+++ b/common/authentication/aws/static_test.go
@@ -53,11 +53,17 @@ func TestGetTokenClient(t *testing.T) {
 				endpoint:     aws.String("https://test.endpoint.com"),
 			},
 		},
+		{
+			name: "creds from environment",
+			awsInstance: &StaticAuth{
+				region: aws.String("us-west-2"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session, err := tt.awsInstance.getTokenClient()
+			session, err := tt.awsInstance.createSession()
 			require.NotNil(t, session)
 			require.NoError(t, err)
 			assert.Equal(t, tt.awsInstance.region, session.Config.Region)

--- a/common/authentication/aws/static_test.go
+++ b/common/authentication/aws/static_test.go
@@ -48,7 +48,7 @@ func TestGetTokenClient(t *testing.T) {
 			awsInstance: &StaticAuth{
 				accessKey:    aws.String("testAccessKey"),
 				secretKey:    aws.String("testSecretKey"),
-				sessionToken: aws.String("testSessionToken"),
+				sessionToken: "testSessionToken",
 				region:       aws.String("us-west-2"),
 				endpoint:     aws.String("https://test.endpoint.com"),
 			},

--- a/common/authentication/aws/x509.go
+++ b/common/authentication/aws/x509.go
@@ -41,6 +41,13 @@ import (
 	"github.com/dapr/kit/ptr"
 )
 
+func isX509Auth(m map[string]string) bool {
+	tp := m["trustProfileArn"]
+	ta := m["trustAnchorArn"]
+	ar := m["assumeRoleArn"]
+	return tp != "" && ta != "" && ar != ""
+}
+
 type x509Options struct {
 	TrustProfileArn *string `json:"trustProfileArn" mapstructure:"trustProfileArn"`
 	TrustAnchorArn  *string `json:"trustAnchorArn" mapstructure:"trustAnchorArn"`


### PR DESCRIPTION
# Description

fixes a bug introduced here https://github.com/dapr/components-contrib/pull/3591/files#diff-017233cbc5865ed02ab3eacc4bc99b36ced96fcaf3420176e41d414444e41bc9

previously it was possible to get an aws session without providing access key and secret key, and we would pick the credentials from the environment. But since that PR, specifically because of this
```
func newStaticIAM(_ context.Context, opts Options, cfg *aws.Config) (*StaticAuth, error) {
	auth := &StaticAuth{
		logger:        opts.Logger,
		region:        &opts.Region,
		endpoint:      &opts.Endpoint,
		accessKey:     &opts.AccessKey,
		secretKey:     &opts.SecretKey,
		sessionToken:  &opts.SessionToken,
		assumeRoleARN: &opts.AssumeRoleARN,
		sessionName:   &opts.SessionName,
```
and the later check
```
if a.accessKey != nil && a.secretKey != nil {
		// session token is an option field
		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(*a.accessKey, *a.secretKey, *a.sessionToken))
	}
```

that would always think that access key and secret key are available, despite of them having a value or not

this can cause this error from aws
```
EmptyStaticCreds: static credentials are empty 0xc0003f8600
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
