### PR TITLE
fix: make sure region field is required on other components

### DIFF
--- a/.build-tools/builtin-authentication-profiles.yaml
+++ b/.build-tools/builtin-authentication-profiles.yaml
@@ -5,8 +5,17 @@ aws:
     metadata:
       - name: region
         type: string
-        required: true
+        required: false
         description: |
+          The AWS Region where the AWS resource is deployed to.
+          This will be marked required in Dapr 1.17.
+        example: '"us-east-1"'
+      - name: awsRegion
+        type: string
+        required: false
+        description: |
+          This maintains backwards compatibility with existing fields. 
+          It will be deprecated as of Dapr 1.17. Use 'region' instead.
           The AWS Region where the AWS resource is deployed to.
         example: '"us-east-1"'
       - name: accessKey
@@ -20,11 +29,13 @@ aws:
         sensitive: true
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
       - name: sessionToken
+        type: string
         required: false
         sensitive: true
         description: |
           AWS session token to use. A session token is only required if you are using
           temporary security credentials.
+        example: '"TOKEN"'
   - title: "AWS: Assume IAM Role"
     description: |
       Assume a specific IAM role. Note: This is only supported for Kafka and PostgreSQL.
@@ -41,6 +52,7 @@ aws:
         description: |
           IAM role that has access to AWS resource.
           This is another option to authenticate with MSK and RDS Aurora aside from the AWS Credentials.
+          This will be marked required in Dapr 1.17.
         example: '"arn:aws:iam::123456789:role/mskRole"'
       - name: sessionName
         type: string

--- a/.build-tools/pkg/metadataschema/builtin-authentication-profiles.go
+++ b/.build-tools/pkg/metadataschema/builtin-authentication-profiles.go
@@ -32,25 +32,17 @@ func ParseBuiltinAuthenticationProfile(bi BuiltinAuthenticationProfile, componen
 	for i, profile := range profiles {
 		res[i] = profile
 
-		// convert slice to a slice of pointers to update in place for required -> non-required fields
-		metadataPtr := make([]*Metadata, len(profile.Metadata))
-		for j := range profile.Metadata {
-			metadataPtr[j] = &profile.Metadata[j]
-		}
+		// deep copy the metadata slice to avoid side effects when manually updating some req -> non-req fields to deprecate some fields for kafka/postgres
+		// TODO: rm all of this manipulation in Dapr 1.17!!
+		originalMetadata := profile.Metadata
+		metadataCopy := make([]Metadata, len(originalMetadata))
+		copy(metadataCopy, originalMetadata)
 
 		if componentTitle == "Apache Kafka" || strings.ToLower(componentTitle) == "postgresql" {
-			removeRequiredOnSomeAWSFields(&metadataPtr)
+			removeRequiredOnSomeAWSFields(&metadataCopy)
 		}
 
-		// convert back to value slices for merging
-		updatedMetadata := make([]Metadata, 0, len(metadataPtr))
-		for _, ptr := range metadataPtr {
-			if ptr != nil {
-				updatedMetadata = append(updatedMetadata, *ptr)
-			}
-		}
-
-		merged := mergedMetadata(bi.Metadata, updatedMetadata...)
+		merged := mergedMetadata(bi.Metadata, metadataCopy...)
 
 		// Note: We must apply the removal of deprecated fields after the merge!!
 
@@ -92,12 +84,14 @@ func mergedMetadata(base []Metadata, add ...Metadata) []Metadata {
 // We normally have accessKey, secretKey, and region fields marked required as it is part of the builtin AWS auth profile fields.
 // However, as we rm the aws prefixed ones, we need to then mark the normally required ones as not required only for postgres and kafka.
 // This way we do not break existing users, and transition them to the standardized fields.
-func removeRequiredOnSomeAWSFields(metadata *[]*Metadata) {
+func removeRequiredOnSomeAWSFields(metadata *[]Metadata) {
 	if metadata == nil {
 		return
 	}
 
-	for _, field := range *metadata {
+	for i := range *metadata {
+		field := &(*metadata)[i]
+
 		if field == nil {
 			continue
 		}

--- a/.build-tools/pkg/metadataschema/builtin-authentication-profiles.go
+++ b/.build-tools/pkg/metadataschema/builtin-authentication-profiles.go
@@ -119,6 +119,10 @@ func removeSomeDeprecatedFieldsOnUnrelatedAuthProfiles(metadata []Metadata) []Me
 	filteredMetadata := []Metadata{}
 
 	for _, field := range metadata {
+		// region is required in Assume Role auth profile, so this is needed for now.
+		if field.Name == "region" {
+			field.Required = true
+		}
 		if field.Name == "awsAccessKey" || field.Name == "awsSecretKey" || field.Name == "awsSessionToken" || field.Name == "awsRegion" {
 			continue
 		} else {

--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -29,14 +29,6 @@ builtinAuthenticationProfiles:
         example: '"awsiam"'
         allowedValues:
           - "awsiam"
-      - name: awsRegion
-        type: string
-        required: false
-        description: |
-          This maintains backwards compatibility with existing fields. 
-          It will be deprecated as of Dapr 1.17. Use 'region' instead.
-          The AWS Region where the AWS service is deployed to.
-        example: '"us-east-1"'
       - name: awsAccessKey
         type: string
         required: false

--- a/bindings/postgres/metadata.yaml
+++ b/bindings/postgres/metadata.yaml
@@ -73,14 +73,6 @@ builtinAuthenticationProfiles:
           If both fields are set, then 'secretKey' value will be used.
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
-      - name: awsRegion
-        type: string
-        required: false
-        description: |
-          This maintains backwards compatibility with existing fields. 
-          It will be deprecated as of Dapr 1.17. Use 'region' instead.
-          The AWS Region where the AWS service is deployed to.
-        example: '"us-east-1"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String"

--- a/configuration/postgres/metadata.yaml
+++ b/configuration/postgres/metadata.yaml
@@ -63,14 +63,6 @@ builtinAuthenticationProfiles:
           If both fields are set, then 'secretKey' value will be used.
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
-      - name: awsRegion
-        type: string
-        required: false
-        description: |
-          This maintains backwards compatibility with existing fields. 
-          It will be deprecated as of Dapr 1.17. Use 'region' instead.
-          The AWS Region where the AWS service is deployed to.
-        example: '"us-east-1"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String."

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -23,14 +23,6 @@ builtinAuthenticationProfiles:
         example: '"awsiam"'
         allowedValues:
           - "awsiam"
-      - name: awsRegion
-        type: string
-        required: false
-        description: |
-          This maintains backwards compatibility with existing fields. 
-          It will be deprecated as of Dapr 1.17. Use 'region' instead.
-          The AWS Region where the AWS service is deployed to.
-        example: '"us-east-1"'
       - name: awsAccessKey
         type: string
         required: false

--- a/state/postgresql/v1/metadata.yaml
+++ b/state/postgresql/v1/metadata.yaml
@@ -70,14 +70,6 @@ builtinAuthenticationProfiles:
           If both fields are set, then 'secretKey' value will be used.
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
-      - name: awsRegion
-        type: string
-        required: false
-        description: |
-          This maintains backwards compatibility with existing fields. 
-          It will be deprecated as of Dapr 1.17. Use 'region' instead.
-          The AWS Region where the AWS service is deployed to.
-        example: '"us-east-1"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String"

--- a/state/postgresql/v2/metadata.yaml
+++ b/state/postgresql/v2/metadata.yaml
@@ -69,14 +69,6 @@ builtinAuthenticationProfiles:
           If both fields are set, then 'secretKey' value will be used.
           The secret key associated with the access key.
         example: '"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
-      - name: awsRegion
-        type: string
-        required: false
-        description: |
-          This maintains backwards compatibility with existing fields. 
-          It will be deprecated as of Dapr 1.17. Use 'region' instead.
-          The AWS Region where the AWS service is deployed to.
-        example: '"us-east-1"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a Connection String"


### PR DESCRIPTION
# Description

I realized in looking more at the other component types that my making the metadata fields a pointer then had unintended side effects marking some `region` fields not required when they should be. This PR corrects that and makes a deep copy instead of the pointer to avoid the unintended side effects.

Postgres is still good
```
 {
          "title": "AWS: Access Key ID and Secret Access Key",
          "description": "Authenticate using an Access Key ID and Secret Access Key included in the metadata",
          "metadata": [
            {
              "name": "useAWSIAM",
              "description": "Must be set to `true` to enable the component to retrieve access tokens from AWS IAM.\nThis authentication method only works with AWS Relational Database Service for PostgreSQL databases.",
              "required": true,
              "type": "bool",
              "example": "\"true\""
            },
            {
              "name": "connectionString",
              "description": "The connection string for the PostgreSQL database\nThis must contain the user, which corresponds to the name of the user created inside PostgreSQL that maps to the AWS IAM policy. This connection string should not contain any password. Note that the database name field is denoted by dbname with AWS.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"host=mydb.postgres.database.aws.com user=myapplication port=5432 dbname=dapr_test sslmode=require\"\n"
            },
            {
              "name": "awsAccessKey",
              "description": "Deprecated as of Dapr 1.17. Use 'accessKey' instead if using AWS IAM.\nIf both fields are set, then 'accessKey' value will be used.\nAWS access key associated with an IAM account.",
              "type": "string",
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "awsSecretKey",
              "description": "Deprecated as of Dapr 1.17. Use 'secretKey' instead if using AWS IAM.\nIf both fields are set, then 'secretKey' value will be used.\nThe secret key associated with the access key.",
              "sensitive": true,
              "type": "string",
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "awsRegion",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'region' instead.\nThe AWS Region where the AWS service is deployed to.",
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "accessKey",
              "description": "AWS access key associated with an IAM account",
              "sensitive": true,
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "secretKey",
              "description": "The secret key associated with the access key",
              "sensitive": true,
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "sessionToken",
              "description": "AWS session token to use. A session token is only required if you are using\ntemporary security credentials.",
              "sensitive": true,
              "example": ""
            }
          ]
        },
        {
          "title": "AWS: Assume IAM Role",
          "description": "Assume a specific IAM role. Note: This is only supported for Kafka and PostgreSQL.",
          "metadata": [
            {
              "name": "useAWSIAM",
              "description": "Must be set to `true` to enable the component to retrieve access tokens from AWS IAM.\nThis authentication method only works with AWS Relational Database Service for PostgreSQL databases.",
              "required": true,
              "type": "bool",
              "example": "\"true\""
            },
            {
              "name": "connectionString",
              "description": "The connection string for the PostgreSQL database\nThis must contain the user, which corresponds to the name of the user created inside PostgreSQL that maps to the AWS IAM policy. This connection string should not contain any password. Note that the database name field is denoted by dbname with AWS.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"host=mydb.postgres.database.aws.com user=myapplication port=5432 dbname=dapr_test sslmode=require\"\n"
            },
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "assumeRoleArn",
              "description": "IAM role that has access to AWS resource.\nThis is another option to authenticate with MSK and RDS Aurora aside from the AWS Credentials.",
              "type": "string",
              "example": "\"arn:aws:iam::123456789:role/mskRole\""
            },
            {
              "name": "sessionName",
              "description": "The session name for assuming a role.",
              "type": "string",
              "default": "\"DaprDefaultSession\"",
              "example": "\"MyAppSession\""
            }
          ]
        },
        {
          "title": "AWS: Credentials from Environment Variables",
          "description": "Use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from the environment",
          "metadata": [
            {
              "name": "useAWSIAM",
              "description": "Must be set to `true` to enable the component to retrieve access tokens from AWS IAM.\nThis authentication method only works with AWS Relational Database Service for PostgreSQL databases.",
              "required": true,
              "type": "bool",
              "example": "\"true\""
            },
            {
              "name": "connectionString",
              "description": "The connection string for the PostgreSQL database\nThis must contain the user, which corresponds to the name of the user created inside PostgreSQL that maps to the AWS IAM policy. This connection string should not contain any password. Note that the database name field is denoted by dbname with AWS.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"host=mydb.postgres.database.aws.com user=myapplication port=5432 dbname=dapr_test sslmode=require\"\n"
            }
          ]
        },
        {
          "title": "AWS: IAM Roles Anywhere",
          "description": "Use X.509 certificates to establish trust between AWS and your AWS account and the Dapr cluster using AWS IAM Roles Anywhere.",
          "metadata": [
            {
              "name": "useAWSIAM",
              "description": "Must be set to `true` to enable the component to retrieve access tokens from AWS IAM.\nThis authentication method only works with AWS Relational Database Service for PostgreSQL databases.",
              "required": true,
              "type": "bool",
              "example": "\"true\""
            },
            {
              "name": "connectionString",
              "description": "The connection string for the PostgreSQL database\nThis must contain the user, which corresponds to the name of the user created inside PostgreSQL that maps to the AWS IAM policy. This connection string should not contain any password. Note that the database name field is denoted by dbname with AWS.",
              "required": true,
              "sensitive": true,
              "type": "string",
              "example": "\"host=mydb.postgres.database.aws.com user=myapplication port=5432 dbname=dapr_test sslmode=require\"\n"
            },
            {
              "name": "trustAnchorArn",
              "description": "ARN of the AWS Trust Anchor in the AWS account granting trust to the Dapr Certificate Authority.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:trust-anchor/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "trustProfileArn",
              "description": "ARN of the AWS IAM Profile in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:profile/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "assumeRoleArn",
              "description": "ARN of the AWS IAM role to assume in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:iam:012345678910:role/exampleIAMRoleName"
            }
          ]
        }
      ],
```

Kafka is good too
```
 {
          "title": "AWS: Access Key ID and Secret Access Key",
          "description": "Authenticate using an Access Key ID and Secret Access Key included in the metadata",
          "metadata": [
            {
              "name": "authType",
              "description": "Authentication type.\nThis must be set to \"awsiam\" for this authentication profile.",
              "required": true,
              "type": "string",
              "example": "\"awsiam\"",
              "allowedValues": [
                "awsiam"
              ]
            },
            {
              "name": "awsRegion",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'region' instead.\nThe AWS Region where the AWS service is deployed to.",
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "awsAccessKey",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'accessKey' instead.\nIf both fields are set, then 'accessKey' value will be used.\nAWS access key associated with an IAM account.",
              "type": "string",
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "awsSecretKey",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'secretKey' instead.\nIf both fields are set, then 'secretKey' value will be used.\nThe secret key associated with the access key.",
              "sensitive": true,
              "type": "string",
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "awsSessionToken",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'sessionToken' instead.\nIf both fields are set, then 'sessionToken' value will be used.\nAWS session token to use. A session token is only required if you are using temporary security credentials.",
              "sensitive": true,
              "type": "string",
              "example": "\"TOKEN\""
            },
            {
              "name": "awsIamRoleArn",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'assumeRoleArn' instead.\nIf both fields are set, then 'assumeRoleArn' value will be used.\nIAM role that has access to MSK. This is another option to authenticate with MSK aside from the AWS Credentials.",
              "type": "string",
              "example": "\"arn:aws:iam::123456789:role/mskRole\""
            },
            {
              "name": "awsStsSessionName",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'sessionName' instead.\nIf both fields are set, then 'sessionName' value will be used.\nRepresents the session name for assuming a role.",
              "type": "string",
              "default": "\"DaprDefaultSession\"",
              "example": "\"MyAppSession\""
            },
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "accessKey",
              "description": "AWS access key associated with an IAM account",
              "sensitive": true,
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "secretKey",
              "description": "The secret key associated with the access key",
              "sensitive": true,
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "sessionToken",
              "description": "AWS session token to use. A session token is only required if you are using\ntemporary security credentials.",
              "sensitive": true,
              "example": ""
            }
          ]
        },
        {
          "title": "AWS: Assume IAM Role",
          "description": "Assume a specific IAM role. Note: This is only supported for Kafka and PostgreSQL.",
          "metadata": [
            {
              "name": "authType",
              "description": "Authentication type.\nThis must be set to \"awsiam\" for this authentication profile.",
              "required": true,
              "type": "string",
              "example": "\"awsiam\"",
              "allowedValues": [
                "awsiam"
              ]
            },
            {
              "name": "awsIamRoleArn",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'assumeRoleArn' instead.\nIf both fields are set, then 'assumeRoleArn' value will be used.\nIAM role that has access to MSK. This is another option to authenticate with MSK aside from the AWS Credentials.",
              "type": "string",
              "example": "\"arn:aws:iam::123456789:role/mskRole\""
            },
            {
              "name": "awsStsSessionName",
              "description": "This maintains backwards compatibility with existing fields. \nIt will be deprecated as of Dapr 1.17. Use 'sessionName' instead.\nIf both fields are set, then 'sessionName' value will be used.\nRepresents the session name for assuming a role.",
              "type": "string",
              "default": "\"DaprDefaultSession\"",
              "example": "\"MyAppSession\""
            },
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "assumeRoleArn",
              "description": "IAM role that has access to AWS resource.\nThis is another option to authenticate with MSK and RDS Aurora aside from the AWS Credentials.",
              "type": "string",
              "example": "\"arn:aws:iam::123456789:role/mskRole\""
            },
            {
              "name": "sessionName",
              "description": "The session name for assuming a role.",
              "type": "string",
              "default": "\"DaprDefaultSession\"",
              "example": "\"MyAppSession\""
            }
          ]
        },
        {
          "title": "AWS: Credentials from Environment Variables",
          "description": "Use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from the environment",
          "metadata": [
            {
              "name": "authType",
              "description": "Authentication type.\nThis must be set to \"awsiam\" for this authentication profile.",
              "required": true,
              "type": "string",
              "example": "\"awsiam\"",
              "allowedValues": [
                "awsiam"
              ]
            }
          ]
        },
        {
          "title": "AWS: IAM Roles Anywhere",
          "description": "Use X.509 certificates to establish trust between AWS and your AWS account and the Dapr cluster using AWS IAM Roles Anywhere.",
          "metadata": [
            {
              "name": "authType",
              "description": "Authentication type.\nThis must be set to \"awsiam\" for this authentication profile.",
              "required": true,
              "type": "string",
              "example": "\"awsiam\"",
              "allowedValues": [
                "awsiam"
              ]
            },
            {
              "name": "trustAnchorArn",
              "description": "ARN of the AWS Trust Anchor in the AWS account granting trust to the Dapr Certificate Authority.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:trust-anchor/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "trustProfileArn",
              "description": "ARN of the AWS IAM Profile in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:profile/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "assumeRoleArn",
              "description": "ARN of the AWS IAM role to assume in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:iam:012345678910:role/exampleIAMRoleName"
            }
          ]
        }
      ],
```

dynamodb
```
 {
          "title": "AWS: Access Key ID and Secret Access Key",
          "description": "Authenticate using an Access Key ID and Secret Access Key included in the metadata",
          "metadata": [
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "accessKey",
              "description": "AWS access key associated with an IAM account",
              "required": true,
              "sensitive": true,
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "secretKey",
              "description": "The secret key associated with the access key",
              "required": true,
              "sensitive": true,
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "sessionToken",
              "description": "AWS session token to use. A session token is only required if you are using\ntemporary security credentials.",
              "sensitive": true,
              "example": ""
            }
          ]
        },
        {
          "title": "AWS: Assume IAM Role",
          "description": "Assume a specific IAM role. Note: This is only supported for Kafka and PostgreSQL.",
          "metadata": [
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "assumeRoleArn",
              "description": "IAM role that has access to AWS resource.\nThis is another option to authenticate with MSK and RDS Aurora aside from the AWS Credentials.",
              "type": "string",
              "example": "\"arn:aws:iam::123456789:role/mskRole\""
            },
            {
              "name": "sessionName",
              "description": "The session name for assuming a role.",
              "type": "string",
              "default": "\"DaprDefaultSession\"",
              "example": "\"MyAppSession\""
            }
          ]
        },
        {
          "title": "AWS: Credentials from Environment Variables",
          "description": "Use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from the environment"
        },
        {
          "title": "AWS: IAM Roles Anywhere",
          "description": "Use X.509 certificates to establish trust between AWS and your AWS account and the Dapr cluster using AWS IAM Roles Anywhere.",
          "metadata": [
            {
              "name": "trustAnchorArn",
              "description": "ARN of the AWS Trust Anchor in the AWS account granting trust to the Dapr Certificate Authority.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:trust-anchor/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "trustProfileArn",
              "description": "ARN of the AWS IAM Profile in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:profile/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "assumeRoleArn",
              "description": "ARN of the AWS IAM role to assume in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:iam:012345678910:role/exampleIAMRoleName"
            }
          ]
        }
```


s3
```
{
          "title": "AWS: Access Key ID and Secret Access Key",
          "description": "Authenticate using an Access Key ID and Secret Access Key included in the metadata",
          "metadata": [
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "accessKey",
              "description": "AWS access key associated with an IAM account",
              "required": true,
              "sensitive": true,
              "example": "\"AKIAIOSFODNN7EXAMPLE\""
            },
            {
              "name": "secretKey",
              "description": "The secret key associated with the access key",
              "required": true,
              "sensitive": true,
              "example": "\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
            },
            {
              "name": "sessionToken",
              "description": "AWS session token to use. A session token is only required if you are using\ntemporary security credentials.",
              "sensitive": true,
              "example": ""
            }
          ]
        },
        {
          "title": "AWS: Assume IAM Role",
          "description": "Assume a specific IAM role. Note: This is only supported for Kafka and PostgreSQL.",
          "metadata": [
            {
              "name": "region",
              "description": "The AWS Region where the AWS resource is deployed to.",
              "required": true,
              "type": "string",
              "example": "\"us-east-1\""
            },
            {
              "name": "assumeRoleArn",
              "description": "IAM role that has access to AWS resource.\nThis is another option to authenticate with MSK and RDS Aurora aside from the AWS Credentials.",
              "type": "string",
              "example": "\"arn:aws:iam::123456789:role/mskRole\""
            },
            {
              "name": "sessionName",
              "description": "The session name for assuming a role.",
              "type": "string",
              "default": "\"DaprDefaultSession\"",
              "example": "\"MyAppSession\""
            }
          ]
        },
        {
          "title": "AWS: Credentials from Environment Variables",
          "description": "Use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from the environment"
        },
        {
          "title": "AWS: IAM Roles Anywhere",
          "description": "Use X.509 certificates to establish trust between AWS and your AWS account and the Dapr cluster using AWS IAM Roles Anywhere.",
          "metadata": [
            {
              "name": "trustAnchorArn",
              "description": "ARN of the AWS Trust Anchor in the AWS account granting trust to the Dapr Certificate Authority.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:trust-anchor/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "trustProfileArn",
              "description": "ARN of the AWS IAM Profile in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:rolesanywhere:us-west-1:012345678910:profile/01234568-0123-0123-0123-012345678901"
            },
            {
              "name": "assumeRoleArn",
              "description": "ARN of the AWS IAM role to assume in the trusting AWS account.",
              "required": true,
              "example": "arn:aws:iam:012345678910:role/exampleIAMRoleName"
            }
          ]
        }
      ],
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
