### PR TITLE
Fix Redis EntraId Token Refresh

### DIFF
--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -214,21 +214,21 @@ func ParseClientFromProperties(properties map[string]string, componentType metad
 	// start the token refresh goroutine
 
 	if settings.UseEntraID {
-		StartEntraIDTokenRefreshBackgroundRoutine(c, settings.Username, *tokenExpires, tokenCredential, ctx, logger)
+		StartEntraIDTokenRefreshBackgroundRoutine(c, settings.Username, *tokenExpires, tokenCredential, logger)
 	}
 	return c, &settings, nil
 }
 
-func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username string, nextExpiration time.Time, cred *azcore.TokenCredential, parentCtx context.Context, logger *kitlogger.Logger) {
+func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username string, nextExpiration time.Time, cred *azcore.TokenCredential, logger *kitlogger.Logger) {
 	go func(cred *azcore.TokenCredential, username string, logger *kitlogger.Logger) {
-		ctx, cancel := context.WithCancel(parentCtx)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		backoffConfig := kitretry.DefaultConfig()
 		backoffConfig.MaxRetries = 3
 		backoffConfig.Policy = kitretry.PolicyExponential
 
 		var backoffManager backoff.BackOff
-		const refreshGracePeriod = 2 * time.Minute
+		const refreshGracePeriod = 5 * time.Minute
 		tokenRefreshDuration := time.Until(nextExpiration.Add(-refreshGracePeriod))
 
 		(*logger).Debugf("redis client: starting entraID token refresh loop")


### PR DESCRIPTION
# Description

When authenticating using EntraId Authentication for Azure Cache for Redis, the token needs to be refreshed before the token expires as mentioned here: https://github.com/dapr/components-contrib/issues/3088#issuecomment-1683015805

However, the context being passed to the background routine gets cancelled once the component initialization is done (or timedout for which the default value is 5s) and so auth token is never refreshed once it expires: https://github.com/dapr/dapr/blob/6c488fdf7d2995d074413c875fc2e3fb4134a33b/pkg/runtime/processor/components.go#L215

This PR removes the dependency on initContext so that goroutine keeps running in the background.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3554 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
