### PR TITLE
Update cert tests and build chain to latest

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/components-contrib/build-tools
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/dapr/components-contrib v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/components-contrib
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/datastore v1.15.0

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/components-contrib/tests/certification
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/pubsub v1.43.0
@@ -18,7 +18,7 @@ require (
 	github.com/cloudwego/kitex v0.5.0
 	github.com/cloudwego/kitex-examples v0.1.1
 	github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9
-	github.com/dapr/dapr v1.14.3-0.20240916190634-9bc98db80afa
+	github.com/dapr/dapr v1.15.0-rc.18
 	github.com/dapr/go-sdk v1.10.0-rc-1.0.20240507160435-33180dd89a46
 	github.com/dapr/kit v0.13.1-0.20241127165251-30e2c24840b4
 	github.com/eclipse/paho.mqtt.golang v1.4.3

--- a/tests/e2e/pubsub/jetstream/go.mod
+++ b/tests/e2e/pubsub/jetstream/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/components-contrib/tests/e2e/pubsub/jetstream
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/dapr/components-contrib v1.10.6-0.20230403162214-9ee9d56cb7ea


### PR DESCRIPTION
Updates cert tests to 1.15.0-rc.18 and uses Go 1.23.6
