### PR TITLE
GCP Secret Manager and Storage Bucket Binding implicit authentication support with Workload Identity

### DIFF
--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -104,13 +104,7 @@ func (g *GCPStorage) Init(ctx context.Context, metadata bindings.Metadata) error
 		return err
 	}
 
-	b, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	clientOptions := option.WithCredentialsJSON(b)
-	client, err := storage.NewClient(ctx, clientOptions)
+	client, err := g.getClient(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -119,6 +113,41 @@ func (g *GCPStorage) Init(ctx context.Context, metadata bindings.Metadata) error
 	g.client = client
 
 	return nil
+}
+
+func (g *GCPStorage) getClient(ctx context.Context, m *gcpMetadata) (*storage.Client, error) {
+	var client *storage.Client
+	var err error
+
+	if m.Bucket == "" {
+		return nil, errors.New("missing property `bucket` in metadata")
+	}
+	if m.ProjectID == "" {
+		return nil, errors.New("missing property `project_id` in metadata")
+	}
+
+	// Explicit authentication
+	if m.PrivateKeyID != "" {
+		var b []byte
+		b, err = json.Marshal(m)
+		if err != nil {
+			return nil, err
+		}
+
+		clientOptions := option.WithCredentialsJSON(b)
+		client, err = storage.NewClient(ctx, clientOptions)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Implicit authentication, using GCP Application Default Credentials (ADC)
+		// Credentials search order: https://cloud.google.com/docs/authentication/application-default-credentials#order
+		client, err = storage.NewClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return client, nil
 }
 
 func (g *GCPStorage) parseMetadata(meta bindings.Metadata) (*gcpMetadata, error) {

--- a/bindings/gcp/bucket/bucket_test.go
+++ b/bindings/gcp/bucket/bucket_test.go
@@ -16,6 +16,7 @@ package bucket
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -232,6 +233,41 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, mergedMeta)
 		assert.False(t, mergedMeta.EncodeBase64)
+	})
+}
+
+func TestInit(t *testing.T) {
+	t.Run("Init explicit auth metadata", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{
+			"bucket":    "my_bucket",
+			"projectID": "my_project_id",
+		}
+		gs := GCPStorage{logger: logger.NewLogger("test")}
+		err := gs.Init(context.Background(), m)
+		require.NoError(t, err)
+	})
+
+	t.Run("Init missing bucket from metadata", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{
+			"projectID": "my_project_id",
+		}
+		gs := GCPStorage{logger: logger.NewLogger("test")}
+		err := gs.Init(context.Background(), m)
+		require.Error(t, err)
+		assert.Equal(t, err, errors.New("missing property `bucket` in metadata"))
+	})
+
+	t.Run("Init missing projectID from metadata", func(t *testing.T) {
+		m := bindings.Metadata{}
+		m.Properties = map[string]string{
+			"bucket": "my_bucket",
+		}
+		gs := GCPStorage{logger: logger.NewLogger("test")}
+		err := gs.Init(context.Background(), m)
+		require.Error(t, err)
+		assert.Equal(t, err, errors.New("missing property `project_id` in metadata"))
 	})
 }
 

--- a/bindings/gcp/bucket/bucket_test.go
+++ b/bindings/gcp/bucket/bucket_test.go
@@ -237,17 +237,6 @@ func TestMergeWithRequestMetadata(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	t.Run("Init explicit auth metadata", func(t *testing.T) {
-		m := bindings.Metadata{}
-		m.Properties = map[string]string{
-			"bucket":    "my_bucket",
-			"projectID": "my_project_id",
-		}
-		gs := GCPStorage{logger: logger.NewLogger("test")}
-		err := gs.Init(context.Background(), m)
-		require.NoError(t, err)
-	})
-
 	t.Run("Init missing bucket from metadata", func(t *testing.T) {
 		m := bindings.Metadata{}
 		m.Properties = map[string]string{

--- a/secretstores/gcp/secretmanager/secretmanager_test.go
+++ b/secretstores/gcp/secretmanager/secretmanager_test.go
@@ -134,14 +134,6 @@ func TestInit(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, err, errors.New("missing property `project_id` in metadata"))
 	})
-
-	t.Run("Init implicit auth with no error", func(t *testing.T) {
-		m.Properties = map[string]string{
-			"project_id": "a",
-		}
-		err := sm.Init(ctx, m)
-		require.NoError(t, err)
-	})
 }
 
 func TestGetSecret(t *testing.T) {

--- a/secretstores/gcp/secretmanager/secretmanager_test.go
+++ b/secretstores/gcp/secretmanager/secretmanager_test.go
@@ -76,11 +76,38 @@ func TestInit(t *testing.T) {
 
 	t.Run("Init with missing `type` metadata", func(t *testing.T) {
 		m.Properties = map[string]string{
-			"dummy": "a",
+			"dummy":          "a",
+			"private_key_id": "a",
+			"project_id":     "a",
 		}
 		err := sm.Init(ctx, m)
 		require.Error(t, err)
-		assert.Equal(t, err, errors.New("missing property `type` in metadata"))
+		assert.Equal(t, errors.New("failed to setup secretmanager client: missing property `type` in metadata"), err)
+	})
+
+	t.Run("Init with missing `private_key` metadata", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"dummy":          "a",
+			"private_key_id": "a",
+			"type":           "a",
+			"project_id":     "a",
+		}
+		err := sm.Init(ctx, m)
+		require.Error(t, err)
+		assert.Equal(t, errors.New("failed to setup secretmanager client: missing property `private_key` in metadata"), err)
+	})
+
+	t.Run("Init with missing `client_email` metadata", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"dummy":          "a",
+			"private_key_id": "a",
+			"private_key":    "a",
+			"type":           "a",
+			"project_id":     "a",
+		}
+		err := sm.Init(ctx, m)
+		require.Error(t, err)
+		assert.Equal(t, errors.New("failed to setup secretmanager client: missing property `client_email` in metadata"), err)
 	})
 
 	t.Run("Init with missing `project_id` metadata", func(t *testing.T) {
@@ -90,6 +117,30 @@ func TestInit(t *testing.T) {
 		err := sm.Init(ctx, m)
 		require.Error(t, err)
 		assert.Equal(t, err, errors.New("missing property `project_id` in metadata"))
+	})
+
+	t.Run("Init with missing `project_id` metadata", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"type": "service_account",
+		}
+		err := sm.Init(ctx, m)
+		require.Error(t, err)
+		assert.Equal(t, err, errors.New("missing property `project_id` in metadata"))
+	})
+
+	t.Run("Init with empty metadata", func(t *testing.T) {
+		m.Properties = map[string]string{}
+		err := sm.Init(ctx, m)
+		require.Error(t, err)
+		assert.Equal(t, err, errors.New("missing property `project_id` in metadata"))
+	})
+
+	t.Run("Init implicit auth with no error", func(t *testing.T) {
+		m.Properties = map[string]string{
+			"project_id": "a",
+		}
+		err := sm.Init(ctx, m)
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
# Description

This PR adds support for implicit Workload Identity authentication by using GCP SDK standard ADC order of authentication lookup.
Application Default Credentials (ADS) search order:
https://cloud.google.com/docs/authentication/application-default-credentials#order

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #945 #3651 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
