### PR TITLE
Update metadata for ./bindings/alicloud/dingtalk/webhook

### DIFF
--- a/bindings/alicloud/dingtalk/webhook/metadata.yaml
+++ b/bindings/alicloud/dingtalk/webhook/metadata.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../../../component-metadata-schema.json
+schemaVersion: v1
+type: bindings
+name: dingtalk.webhook
+version: v1
+status: alpha
+title: "Alibaba Cloud DingTalk"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-bindings/alicloud-dingtalk/
+binding:
+  output: true
+  input: true
+  operations:
+    - name: create
+      description: "Send a message using DingTalk Webhook"
+    - name: get
+      description: "Retrieve a message using DingTalk Webhook"
+metadata:
+  - name: id
+    type: string
+    required: true
+    description: "Unique identifier for the DingTalk Webhook"
+    example: "test_webhook_id"
+  - name: url
+    type: string
+    required: true
+    description: "DingTalk's Webhook URL"
+    example: "https://oapi.dingtalk.com/robot/send?access_token=******"
+  - name: secret
+    type: string
+    required: false
+    sensitive: true
+    description: "The secret of DingTalk's Webhook"
+    example: "****************"
+  - name: direction
+    type: string
+    required: false
+    description: "The direction of the binding"
+    example: "input, output"


### PR DESCRIPTION
This PR updates the metadata.yaml file for the ./bindings/alicloud/dingtalk/webhook component.

https://docs.dapr.io/reference/components-reference/supported-bindings/alicloud-dingtalk/