### PR TITLE
Add Azure spiffe oidc auth profile

### DIFF
--- a/common/authentication/aws/x509.go
+++ b/common/authentication/aws/x509.go
@@ -143,7 +143,7 @@ func (a *x509) Close() error {
 
 func (a *x509) getCertPEM(ctx context.Context) error {
 	// retrieve svid from spiffe context
-	svid, ok := spiffecontext.From(ctx)
+	svid, ok := spiffecontext.X509From(ctx)
 	if !ok {
 		return errors.New("no SVID found in context")
 	}

--- a/common/authentication/aws/x509_test.go
+++ b/common/authentication/aws/x509_test.go
@@ -117,7 +117,7 @@ func TestGetX509Client(t *testing.T) {
 			require.NoError(t, err)
 
 			// inject the SVID source into the context
-			ctx = spiffecontext.With(ctx, s)
+			ctx = spiffecontext.WithX509(ctx, s.X509SVIDSource())
 			session, err := mockAWS.createOrRefreshSession(ctx)
 
 			require.NoError(t, err)

--- a/common/authentication/azure/spiffe.go
+++ b/common/authentication/azure/spiffe.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2025 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/common/authentication/azure/spiffe.go
+++ b/common/authentication/azure/spiffe.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	//nolint:gosec
 	AzureADTokenExchangeAudience = "api://AzureADTokenExchange"
 )
 
@@ -56,7 +57,7 @@ func (c SpiffeWorkloadIdentityConfig) GetTokenCredential() (azcore.TokenCredenti
 	tokenProvider := func(ctx context.Context) (string, error) {
 		tknSource, ok := spiffecontext.JWTFrom(ctx)
 		if !ok {
-			return "", fmt.Errorf("failed to get JWT SVID source from context")
+			return "", errors.New("failed to get JWT SVID source from context")
 		}
 		jwt, err := tknSource.FetchJWTSVID(ctx, jwtsvid.Params{
 			Audience: AzureADTokenExchangeAudience,

--- a/common/authentication/azure/spiffe.go
+++ b/common/authentication/azure/spiffe.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+
+	spiffecontext "github.com/dapr/kit/crypto/spiffe/context"
+)
+
+const (
+	AzureADTokenExchangeAudience = "api://AzureADTokenExchange"
+)
+
+// SpiffeWorkloadIdentityConfig provides the options to get a bearer authorizer using SPIFFE-based workload identity.
+type SpiffeWorkloadIdentityConfig struct {
+	TenantID   string
+	ClientID   string
+	AzureCloud *cloud.Configuration
+}
+
+// GetTokenCredential returns the azcore.TokenCredential object using a SPIFFE JWT token.
+func (c SpiffeWorkloadIdentityConfig) GetTokenCredential() (azcore.TokenCredential, error) {
+	if c.TenantID == "" || c.ClientID == "" {
+		return nil, errors.New("parameters clientId and tenantId must be present for SPIFFE workload identity")
+	}
+
+	var opts *azidentity.ClientAssertionCredentialOptions
+	if c.AzureCloud != nil {
+		opts = &azidentity.ClientAssertionCredentialOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: *c.AzureCloud,
+			},
+		}
+	}
+
+	// Create a token provider function that retrieves the JWT from SPIFFE context
+	tokenProvider := func(ctx context.Context) (string, error) {
+		tknSource, ok := spiffecontext.JWTFrom(ctx)
+		if !ok {
+			return "", fmt.Errorf("failed to get JWT SVID source from context")
+		}
+		jwt, err := tknSource.FetchJWTSVID(ctx, jwtsvid.Params{
+			Audience: AzureADTokenExchangeAudience,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to get JWT SVID: %w", err)
+		}
+		return jwt.Marshal(), nil
+	}
+
+	return azidentity.NewClientAssertionCredential(c.TenantID, c.ClientID, tokenProvider, opts)
+}
+
+// GetSpiffeWorkloadIdentity creates a config object from the available SPIFFE workload identity credentials.
+// An error is returned if required credentials are not available.
+func (s EnvironmentSettings) GetSpiffeWorkloadIdentity() (config SpiffeWorkloadIdentityConfig, err error) {
+	azureCloud, err := s.GetAzureEnvironment()
+	if err != nil {
+		return config, err
+	}
+
+	config.ClientID, _ = s.GetEnvironment("ClientID")
+	config.TenantID, _ = s.GetEnvironment("TenantID")
+
+	if config.ClientID == "" || config.TenantID == "" {
+		return config, errors.New("parameters clientId and tenantId must be present for SPIFFE workload identity")
+	}
+
+	config.AzureCloud = azureCloud
+
+	return config, nil
+}

--- a/common/component/azure/blobstorage/client.go
+++ b/common/component/azure/blobstorage/client.go
@@ -161,7 +161,6 @@ func (opts *ContainerClientOpts) InitContainerClient(azEnvSettings azauth.Enviro
 		if err != nil {
 			return nil, fmt.Errorf("cannot init blob storage container client with shared key: %w", err)
 		}
-
 	// Use Azure AD as fallback
 	default:
 		credential, tokenErr := azEnvSettings.GetTokenCredential()

--- a/state/azure/blobstorage/v2/metadata.yaml
+++ b/state/azure/blobstorage/v2/metadata.yaml
@@ -19,6 +19,23 @@ builtinAuthenticationProfiles:
         sensitive: false
         description: "The storage account name"
         example: '"mystorageaccount"'
+  - name: "azuread.spiffe"
+    metadata:
+      - name: accountName
+        required: true
+        sensitive: false
+        description: "The storage account name"
+        example: '"mystorageaccount"'
+      - name: tenantId
+        required: true
+        sensitive: false
+        description: "The Azure AD tenant ID"
+        example: '"00000000-0000-0000-0000-000000000000"'
+      - name: clientId
+        required: true
+        sensitive: false
+        description: "The Azure AD client ID (application ID)"
+        example: '"00000000-0000-0000-0000-000000000000"'
 authenticationProfiles:
   - title: "Connection string"
     description: "Authenticate using a connection string."

--- a/tests/e2e/pubsub/jetstream/go.sum
+++ b/tests/e2e/pubsub/jetstream/go.sum
@@ -4,24 +4,8 @@ github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.14.0 h1:dEopBSOSjB5f
 github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.14.0/go.mod h1:qDSbb0fgIfFNjZrNTPtS5MOMScAGyQtn1KlSvoOdqYw=
 github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
 github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
-<<<<<<< HEAD
 github.com/dapr/kit v0.15.3-0.20250717140748-8b780b4d81c5 h1:Q26gmPxs6WnnBYoudOlznPHsmrbTawcYEpHg4VoB7v8=
 github.com/dapr/kit v0.15.3-0.20250717140748-8b780b4d81c5/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
-||||||| parent of 513e3f5f (fix lint)
-<<<<<<< HEAD
-github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69 h1:I1Uoy3fn906AZZdG8+n8fHitgY7Wn9c+smz4WQdOy1Q=
-github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
-||||||| parent of e56079b0 (go mod tidy)
-github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d h1:v+kZn9ami23xBsruyZmKErIOSlCdW9pR8wfHUg5+jys=
-github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
-=======
-github.com/dapr/kit v0.15.3-0.20250522135818-baea6263991d h1:8/Qhy5T6mb49KipoHnWQaG+uQ5Cjo9/tRaL8MFojG+g=
-github.com/dapr/kit v0.15.3-0.20250522135818-baea6263991d/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
->>>>>>> e56079b0 (go mod tidy)
-=======
-github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69 h1:I1Uoy3fn906AZZdG8+n8fHitgY7Wn9c+smz4WQdOy1Q=
-github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
->>>>>>> 513e3f5f (fix lint)
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/tests/e2e/pubsub/jetstream/go.sum
+++ b/tests/e2e/pubsub/jetstream/go.sum
@@ -4,8 +4,24 @@ github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.14.0 h1:dEopBSOSjB5f
 github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.14.0/go.mod h1:qDSbb0fgIfFNjZrNTPtS5MOMScAGyQtn1KlSvoOdqYw=
 github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
 github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
+<<<<<<< HEAD
 github.com/dapr/kit v0.15.3-0.20250717140748-8b780b4d81c5 h1:Q26gmPxs6WnnBYoudOlznPHsmrbTawcYEpHg4VoB7v8=
 github.com/dapr/kit v0.15.3-0.20250717140748-8b780b4d81c5/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
+||||||| parent of 513e3f5f (fix lint)
+<<<<<<< HEAD
+github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69 h1:I1Uoy3fn906AZZdG8+n8fHitgY7Wn9c+smz4WQdOy1Q=
+github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
+||||||| parent of e56079b0 (go mod tidy)
+github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d h1:v+kZn9ami23xBsruyZmKErIOSlCdW9pR8wfHUg5+jys=
+github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
+=======
+github.com/dapr/kit v0.15.3-0.20250522135818-baea6263991d h1:8/Qhy5T6mb49KipoHnWQaG+uQ5Cjo9/tRaL8MFojG+g=
+github.com/dapr/kit v0.15.3-0.20250522135818-baea6263991d/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
+>>>>>>> e56079b0 (go mod tidy)
+=======
+github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69 h1:I1Uoy3fn906AZZdG8+n8fHitgY7Wn9c+smz4WQdOy1Q=
+github.com/dapr/kit v0.15.3-0.20250616160611-598b032bce69/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
+>>>>>>> 513e3f5f (fix lint)
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
Signed-off-by: Jonathan Collinge <jonathancollinge@live.com>

# Description
Adds a new Azure SPIFFE OIDC authentication profile. This allows Azure users to create federated credentials for Azure AD (EntraID) Applications that directly target the SPIFFE ID of the Dapr App. This allows users to natively integrate their Dapr SPIFFE IDs into their IAM and achieve cross cloud federation without needing to host the application on the same provider and leverage the native IAM providers. For instance Dapr deployment running on AWS could access resources on Azure without needing to use secrets via a federated app credential.

This PR builds on
- https://github.com/dapr/dapr/pull/8662
- https://github.com/dapr/kit/pull/118

## Steps to reproduce
```
# Check out the required PRs

# Update go mods to use local builds

# Build local binaries from dapr/dapr for your arch/os
export DAPR_REGISTRY=docker.io/<your_docker_hub_account>
export DAPR_TAG=dev
TARGET_ARCH=arm64 GOOS=linux GOARCH=arm64 make build-linux
TARGET_ARCH=arm64 GOOS=linux GOARCH=arm64 make docker-build
TARGET_ARCH=arm64 GOOS=linux GOARCH=arm64 make docker-push

# Create KinD cluster
kind create cluster --name dapr

# Create Azure resources
az group create $GROUP
az storage account create --name $ACCOUNT_NAME --resource-group $GROUP --location $LOCATION --sku Standard_LRS
az storage container create --account-name $ACCOUNT_NAME -n $CONTAINER_NAME

# Create TLS certs for your public domain

# Use the helper below to generate a jwt.key and jwks.json and then create the dapr trust bundle in dapr-system namespace

# Deploy Dapr
TARGET_ARCH=arm64 GOOS=linux GOARCH=arm64 ADDITIONAL_HELM_SET=dapr_sentry.jwt.enabled=true,dapr_sentry.jwt.audiences=["api://AzureADTokenExchange"],dapr_sentry.jwt.issuer=https://$DOMAIN,dapr_sentry.oidc.httpPort=9082,dapr_sentry.oidc.tlsCertFile=/var/run/secrets/dapr.io/oidc/tls.crt,dapr_sentry.oidc.tlsKeyFile=/var/run/secrets/dapr.io/oidc/tls.key,global.extraVolumes.sentry[0].name=oidc,global.extraVolumes.sentry[0].secret.secretName=$TLS_SECRET,global.extraVolumeMounts.sentry[0].name=oidc,global.extraVolumeMounts.sentry[0].mountPath=/var/run/secrets/dapr.io/oidc,global.extraVolumeMounts.sentry[0].readOnly=true
 make docker-deploy-k8s

# Expose OIDC server to the internet via server, ingress or tunnel

# Configure Azure AD (EntraID)

cat > creds.json <<EOF
{ 
  "name": "DaprSpiffe", 
  "issuer": "https://$DOMAIN", 
  "subject": spiffe://public/ns/default/app1",
  "audiences": ["api://AzureADTokenExchange"], 
  "description": "App1 Dapr App Access" 
}
EOF

az ad app create --display-name spiffeapp --enable-access-token-issuance --enable-id-token-issuance
az ad sp create --id $APP_ID
az role assignment create --assignee-object-id $APP_ID --assignee-principal-type ServicePrincipal --role "Storage Blob Data Owner" --scope "/subscriptions/$SUBSCRIPTION/resourceGroups/$GROUP/providers/Microsoft.Storage/storageAccounts/$ACCOUNT_NAME"
az ad app federated-credential create --id $APP_ID --parameters creds.json
CLIENT_ID=$(az ad app show --id $APP_ID --query appId --output tsv)
TENANT_ID=$(az account show --query tenantId --output tsv)

# Creata a Dapr component

cat > azureblob.yaml <<EOF
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: azureblob
spec:
  type: state.azure.blobstorage
  version: v2
  metadata:
  - name: accountName
    value: $ACCOUNT_NAME
  - name: containerName
    value: $CONTAINER_NAME
  - name: clientId
    value: $CLIENT_ID
  - name: tenantId
    value:  $TENANT_ID
EOF


# Deploy a Dapr app with app id app1 in the default namespace that uses the azure blob component
```


## Helper to create jwt.key and jwks.json

```
package main

import (
	"crypto"
	"crypto/ecdsa"
	"crypto/rand"
	"crypto/rsa"
	"crypto/x509"
	"encoding/base64"
	"encoding/json"
	"encoding/pem"
	"errors"
	"fmt"
	"os"
	"reflect"

	"github.com/lestrrat-go/jwx/v2/jwk"
)

func main() {
	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
	//privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
	if err != nil {
		panic(fmt.Sprintf("Failed to generate key: %v", err))
	}

	// Create jwt.key (PEM format)
	keyPKCS8, err := x509.MarshalPKCS8PrivateKey(privateKey)
	if err != nil {
		panic(fmt.Sprintf("Failed to marshal private key: %v", err))
	}

	keyPEM := pem.EncodeToMemory(&pem.Block{
		Type:  "PRIVATE KEY",
		Bytes: keyPKCS8,
	})

	// Create JWKS with the same key
	key, err := jwk.FromRaw(privateKey.Public())
	if err != nil {
		panic(fmt.Sprintf("Failed to create JWK: %v", err))
	}

	// Set necessary attributes
	if err := key.Set(jwk.KeyIDKey, "dapr-sentry-jwt"); err != nil {
		panic(fmt.Sprintf("Failed to set key ID: %v", err))
	}
	if err := key.Set(jwk.AlgorithmKey, "ES256"); err != nil {
		panic(fmt.Sprintf("Failed to set algorithm: %v", err))
	}
	if err := key.Set(jwk.KeyUsageKey, "sig"); err != nil {
		panic(fmt.Sprintf("Failed to set key usage: %v", err))
	}

	// Create a key set with this key
	keySet := jwk.NewSet()
	keySet.AddKey(key)

	// Marshal the JWKS to JSON
	jwksBytes, err := json.MarshalIndent(keySet, "", "  ")
	if err != nil {
		panic(fmt.Sprintf("Failed to marshal JWKS: %v", err))
	}

	// Validate the key pair
	if err := verifyJWKS(jwksBytes, privateKey); err != nil {
		panic(fmt.Sprintf("Key validation failed: %v", err))
	} else {
		fmt.Println("✅ Keys validated successfully! They match and should work with Dapr.")
	}

	// Write files
	if err := os.WriteFile("jwt.key", keyPEM, 0600); err != nil {
		panic(fmt.Sprintf("Failed to write jwt.key: %v", err))
	}

	if err := os.WriteFile("jwks.json", jwksBytes, 0644); err != nil {
		panic(fmt.Sprintf("Failed to write jwks.json: %v", err))
	}

	// Print base64 versions for Kubernetes
	fmt.Println("\n📋 Base64 encoded jwt.key (for Kubernetes):")
	fmt.Println(base64.StdEncoding.EncodeToString(keyPEM))
	fmt.Println("\n📋 Base64 encoded jwks.json (for Kubernetes):")
	fmt.Println(base64.StdEncoding.EncodeToString(jwksBytes))

	fmt.Println("\n✅ Files created successfully:")
	fmt.Println("   - jwt.key")
	fmt.Println("   - jwks.json")

	fmt.Println("\n🔄 Update your Kubernetes secret with:")
	fmt.Println("kubectl create secret generic dapr-trust-bundle \\\n" +
		"  --namespace dapr-system \\\n" +
		"  --from-file=jwt.key=jwt.key \\\n" +
		"  --from-file=jwks.json=jwks.json \\\n" +
		"  --dry-run=client -o yaml | kubectl apply -f -")
}

// verifyJWKS verifies that the JWKS is valid and contains a corresponding
// public key for the provided signing key.
func verifyJWKS(jwksBytes []byte, signingKey crypto.Signer) error {
	if signingKey == nil {
		// If no signing key is provided but JWKS exists, we can't verify the match
		return errors.New("can't verify JWKS without signing key")
	}

	// Parse the JWKS
	keySet, err := jwk.Parse(jwksBytes)
	if err != nil {
		return fmt.Errorf("failed to parse JWKS: %w", err)
	}

	// Make sure the JWKS has at least one key
	if keySet.Len() == 0 {
		return errors.New("JWKS doesn't contain any keys")
	}

	// Convert signing key to JWK
	privateJWK, err := jwk.FromRaw(signingKey)
	if err != nil {
		return fmt.Errorf("failed to convert signing key to JWK: %w", err)
	}

	// Get the public key part
	publicJWK, err := privateJWK.PublicKey()
	if err != nil {
		return fmt.Errorf("failed to extract public key from JWT signing key: %w", err)
	}

	// Get the key ID if it exists on the signing key
	var signingKeyID string
	if kid, ok := publicJWK.Get(jwk.KeyIDKey); ok {
		if s, ok := kid.(string); ok {
			signingKeyID = s
		}
	}

	// Verify that the public key is in the JWKS
	found := false
	matchAttempted := false

	for i := 0; i < keySet.Len(); i++ {
		key, _ := keySet.Key(i)

		// If both keys have key IDs, check if they match first (faster path)
		if signingKeyID != "" {
			if kid, ok := key.Get(jwk.KeyIDKey); ok {
				if s, ok := kid.(string); ok && s == signingKeyID {
					found = true
					break
				}
			}
		}

		// If key ID check wasn't successful, compare the key contents
		matchAttempted = true

		// First, ensure we're comparing public keys
		keyPublic, err := key.PublicKey()
		if err != nil {
			continue
		}

		// Check if the key has a valid "use" field (if present)
		if use, ok := keyPublic.Get(jwk.KeyUsageKey); ok {
			if s, ok := use.(string); ok && s != "sig" {
				// Skip keys not meant for signature verification
				continue
			}
		}

		// Get raw representations of both keys to compare
		var pubRaw interface{}
		if err = keyPublic.Raw(&pubRaw); err != nil {
			continue
		}

		var signerPubRaw interface{}
		if err = publicJWK.Raw(&signerPubRaw); err != nil {
			continue
		}

		// Type-specific comparisons for different key types
		switch pubKey := pubRaw.(type) {
		case *ecdsa.PublicKey:
			if signerPubKey, ok := signerPubRaw.(*ecdsa.PublicKey); ok {
				// For ECDSA, compare the curve, X and Y values
				if pubKey.Curve == signerPubKey.Curve &&
					pubKey.X.Cmp(signerPubKey.X) == 0 &&
					pubKey.Y.Cmp(signerPubKey.Y) == 0 {
					found = true
				}
			}
		default:
			// For other key types, try direct comparison
			if reflect.TypeOf(pubRaw) == reflect.TypeOf(signerPubRaw) {
				// If keys are the same type and same value, they are equal
				if reflect.DeepEqual(pubRaw, signerPubRaw) {
					found = true
				}
			}
		}

		if found {
			break
		}
	}

	if !found {
		if !matchAttempted {
			return fmt.Errorf("JWKS doesn't contain a key with matching key ID '%s'", signingKeyID)
		}
		return errors.New("JWKS doesn't contain a matching public key for the JWT signing key")
	}

	return nil
}
```



## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
