### PR TITLE
Updates dapr/kit to main

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb // indirect
+	github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae // indirect
+	github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/.build-tools/go.sum
+++ b/.build-tools/go.sum
@@ -1,6 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae h1:qAnZKghhJ3bhX2Q/RiOgm2rdy8B+9uoEqGuwjGfad70=
-github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
+github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d h1:v+kZn9ami23xBsruyZmKErIOSlCdW9pR8wfHUg5+jys=
+github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/.build-tools/go.sum
+++ b/.build-tools/go.sum
@@ -1,6 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb h1:ahLO7pMmX6HAuT6/RxYWBY4AN2fXQJcYlU1msY6Kt7U=
-github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
+github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae h1:qAnZKghhJ3bhX2Q/RiOgm2rdy8B+9uoEqGuwjGfad70=
+github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -40,7 +40,7 @@ import (
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
 	"github.com/dapr/kit/ptr"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 const (
@@ -455,11 +455,11 @@ func (metadata s3Metadata) mergeWithRequestMetadata(req *bindings.InvokeRequest)
 	merged := metadata
 
 	if val, ok := req.Metadata[metadataDecodeBase64]; ok && val != "" {
-		merged.DecodeBase64 = utils.IsTruthy(val)
+		merged.DecodeBase64 = kitstrings.IsTruthy(val)
 	}
 
 	if val, ok := req.Metadata[metadataEncodeBase64]; ok && val != "" {
-		merged.EncodeBase64 = utils.IsTruthy(val)
+		merged.EncodeBase64 = kitstrings.IsTruthy(val)
 	}
 
 	if val, ok := req.Metadata[metadataFilePath]; ok && val != "" {

--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -37,7 +37,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
-	"github.com/dapr/kit/utils"
+	"github.com/dapr/kit/strings"
 )
 
 const (
@@ -325,11 +325,11 @@ func (metadata gcpMetadata) mergeWithRequestMetadata(req *bindings.InvokeRequest
 	merged := metadata
 
 	if val, ok := req.Metadata[metadataDecodeBase64]; ok && val != "" {
-		merged.DecodeBase64 = utils.IsTruthy(val)
+		merged.DecodeBase64 = strings.IsTruthy(val)
 	}
 
 	if val, ok := req.Metadata[metadataEncodeBase64]; ok && val != "" {
-		merged.EncodeBase64 = utils.IsTruthy(val)
+		merged.EncodeBase64 = strings.IsTruthy(val)
 	}
 	if val, ok := req.Metadata[metadataSignTTL]; ok && val != "" {
 		merged.SignTTL = val

--- a/bindings/http/http.go
+++ b/bindings/http/http.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 const (
@@ -137,7 +137,7 @@ func (h *HTTPSource) Init(_ context.Context, meta bindings.Metadata) error {
 	}
 
 	if val := meta.Properties["errorIfNot2XX"]; val != "" {
-		h.errorIfNot2XX = utils.IsTruthy(val)
+		h.errorIfNot2XX = kitstrings.IsTruthy(val)
 	} else {
 		// Default behavior
 		h.errorIfNot2XX = true
@@ -252,7 +252,7 @@ func (h *HTTPSource) Invoke(parentCtx context.Context, req *bindings.InvokeReque
 		u = strings.TrimRight(u, "/") + "/" + strings.TrimLeft(req.Metadata["path"], "/")
 	}
 	if req.Metadata["errorIfNot2XX"] != "" {
-		errorIfNot2XX = utils.IsTruthy(req.Metadata["errorIfNot2XX"])
+		errorIfNot2XX = kitstrings.IsTruthy(req.Metadata["errorIfNot2XX"])
 	}
 
 	var body io.Reader

--- a/bindings/rabbitmq/rabbitmq.go
+++ b/bindings/rabbitmq/rabbitmq.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
-	"github.com/dapr/kit/utils"
+	"github.com/dapr/kit/strings"
 )
 
 const (
@@ -313,7 +313,7 @@ func (r *RabbitMQ) parseMetadata(meta bindings.Metadata) error {
 	}
 
 	if val, ok := meta.Properties[externalSasl]; ok && val != "" {
-		m.ExternalSasl = utils.IsTruthy(val)
+		m.ExternalSasl = strings.IsTruthy(val)
 	}
 
 	if val, ok := meta.Properties[caCert]; ok && val != "" {
@@ -336,7 +336,7 @@ func (r *RabbitMQ) parseMetadata(meta bindings.Metadata) error {
 	}
 
 	if val, ok := meta.Properties[externalSasl]; ok && val != "" {
-		m.ExternalSasl = utils.IsTruthy(val)
+		m.ExternalSasl = strings.IsTruthy(val)
 	}
 
 	ttl, ok, err := metadata.TryGetTTL(meta.Properties)

--- a/common/authentication/aws/x509_test.go
+++ b/common/authentication/aws/x509_test.go
@@ -92,9 +92,11 @@ func TestGetX509Client(t *testing.T) {
 			var fetches atomic.Int32
 			s := spiffe.New(spiffe.Options{
 				Log: logger.NewLogger("test"),
-				RequestSVIDFn: func(context.Context, []byte) ([]*cryptoX509.Certificate, error) {
+				RequestSVIDFn: func(context.Context, []byte) (*spiffe.SVIDResponse, error) {
 					fetches.Add(1)
-					return respCert, respErr
+					return &spiffe.SVIDResponse{
+						X509Certificates: respCert,
+					}, respErr
 				},
 			})
 

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/cohesion-org/deepseek-go v1.2.0
 	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/dancannon/gorethink v4.0.0+incompatible
-	github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb
+	github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae
 	github.com/didip/tollbooth/v7 v7.0.1
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/fasthttp-contrib/sessions v0.0.0-20160905201309-74f6ac73d5d5

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/cohesion-org/deepseek-go v1.2.0
 	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/dancannon/gorethink v4.0.0+incompatible
-	github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae
+	github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d
 	github.com/didip/tollbooth/v7 v7.0.1
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/fasthttp-contrib/sessions v0.0.0-20160905201309-74f6ac73d5d5

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae h1:qAnZKghhJ3bhX2Q/RiOgm2rdy8B+9uoEqGuwjGfad70=
-github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
+github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d h1:v+kZn9ami23xBsruyZmKErIOSlCdW9pR8wfHUg5+jys=
+github.com/dapr/kit v0.15.3-0.20250516121556-bc7dc566c45d/go.mod h1:6w2Pr38zOAtBn+ld/jknwI4kgMfwanCIcFVnPykdPZQ=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb h1:ahLO7pMmX6HAuT6/RxYWBY4AN2fXQJcYlU1msY6Kt7U=
-github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
+github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae h1:qAnZKghhJ3bhX2Q/RiOgm2rdy8B+9uoEqGuwjGfad70=
+github.com/dapr/kit v0.15.3-0.20250423142915-e3d4a8f1b4ae/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	kitmd "github.com/dapr/kit/metadata"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 const (
@@ -253,10 +253,10 @@ func GetMetadataInfoFromStructType(t reflect.Type, metadataMap *MetadataMap, com
 		}
 
 		// If there's a mdignore tag and that's truthy, the field should be ignored by the metadata analyzer
-		mdField.Ignored = utils.IsTruthy(currentField.Tag.Get("mdignore"))
+		mdField.Ignored = kitstrings.IsTruthy(currentField.Tag.Get("mdignore"))
 
 		// If there's a "mddeprecated" tag, the field may be deprecated
-		mdField.Deprecated = utils.IsTruthy(currentField.Tag.Get("mddeprecated"))
+		mdField.Deprecated = kitstrings.IsTruthy(currentField.Tag.Get("mddeprecated"))
 
 		// If there's a "mdaliases" tag, the field contains aliases
 		// The value is a comma-separated string

--- a/middleware/http/oauth2/oauth2_middleware.go
+++ b/middleware/http/oauth2/oauth2_middleware.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dapr/components-contrib/middleware"
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 // Metadata is the oAuth middleware config.
@@ -70,7 +70,7 @@ func (m *Middleware) GetHandler(ctx context.Context, metadata middleware.Metadat
 		return nil, err
 	}
 
-	forceHTTPS := utils.IsTruthy(meta.ForceHTTPS)
+	forceHTTPS := kitstrings.IsTruthy(meta.ForceHTTPS)
 	conf := &oauth2.Config{
 		ClientID:     meta.ClientID,
 		ClientSecret: meta.ClientSecret,

--- a/middleware/http/opa/middleware.go
+++ b/middleware/http/opa/middleware.go
@@ -36,7 +36,7 @@ import (
 	"github.com/dapr/components-contrib/middleware"
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 type Status int
@@ -145,7 +145,7 @@ func (m *Middleware) evalRequest(w http.ResponseWriter, r *http.Request, meta *m
 	}
 
 	var body string
-	if utils.IsTruthy(meta.ReadBody) {
+	if kitstrings.IsTruthy(meta.ReadBody) {
 		buf, _ := io.ReadAll(r.Body)
 		body = string(buf)
 

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/ptr"
-	"github.com/dapr/kit/utils"
+	"github.com/dapr/kit/strings"
 )
 
 // AzureEventHubs allows sending/receiving Azure Event Hubs events.
@@ -129,7 +129,7 @@ func (aeh *AzureEventHubs) Subscribe(ctx context.Context, req pubsub.SubscribeRe
 	}
 
 	// Check if requireAllProperties is set and is truthy
-	getAllProperties := utils.IsTruthy(req.Metadata["requireAllProperties"])
+	getAllProperties := strings.IsTruthy(req.Metadata["requireAllProperties"])
 	if !getAllProperties {
 		getAllProperties = aeh.GetAllMessageProperties()
 	}
@@ -158,7 +158,7 @@ func (aeh *AzureEventHubs) BulkSubscribe(ctx context.Context, req pubsub.Subscri
 	}
 
 	// Check if requireAllProperties is set and is truthy
-	getAllProperties := utils.IsTruthy(req.Metadata["requireAllProperties"])
+	getAllProperties := strings.IsTruthy(req.Metadata["requireAllProperties"])
 	if !getAllProperties {
 		getAllProperties = aeh.GetAllMessageProperties()
 	}

--- a/pubsub/azure/servicebus/topics/servicebus.go
+++ b/pubsub/azure/servicebus/topics/servicebus.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/utils"
+	"github.com/dapr/kit/strings"
 )
 
 const (
@@ -85,7 +85,7 @@ func (a *azureServiceBus) Subscribe(subscribeCtx context.Context, req pubsub.Sub
 		return errors.New("component is closed")
 	}
 
-	requireSessions := utils.IsTruthy(req.Metadata[impl.RequireSessionsMetadataKey])
+	requireSessions := strings.IsTruthy(req.Metadata[impl.RequireSessionsMetadataKey])
 	sessionIdleTimeout := time.Duration(commonutils.GetElemOrDefaultFromMap(req.Metadata, impl.SessionIdleTimeoutMetadataKey, impl.DefaultSesssionIdleTimeoutInSec)) * time.Second
 	maxConcurrentSessions := commonutils.GetElemOrDefaultFromMap(req.Metadata, impl.MaxConcurrentSessionsMetadataKey, impl.DefaultMaxConcurrentSessions)
 
@@ -116,7 +116,7 @@ func (a *azureServiceBus) BulkSubscribe(subscribeCtx context.Context, req pubsub
 		return errors.New("component is closed")
 	}
 
-	requireSessions := utils.IsTruthy(req.Metadata[impl.RequireSessionsMetadataKey])
+	requireSessions := strings.IsTruthy(req.Metadata[impl.RequireSessionsMetadataKey])
 	sessionIdleTimeout := time.Duration(commonutils.GetElemOrDefaultFromMap(req.Metadata, impl.SessionIdleTimeoutMetadataKey, impl.DefaultSesssionIdleTimeoutInSec)) * time.Second
 	maxConcurrentSessions := commonutils.GetElemOrDefaultFromMap(req.Metadata, impl.MaxConcurrentSessionsMetadataKey, impl.DefaultMaxConcurrentSessions)
 

--- a/pubsub/mqtt3/mqtt.go
+++ b/pubsub/mqtt3/mqtt.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 const (
@@ -139,7 +139,7 @@ func (m *mqttPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 	if topic == "" {
 		return errors.New("topic name is empty")
 	}
-	unsubscribeOnClose := utils.IsTruthy(req.Metadata[unsubscribeOnCloseKey])
+	unsubscribeOnClose := kitstrings.IsTruthy(req.Metadata[unsubscribeOnCloseKey])
 
 	m.subscribingLock.Lock()
 	defer m.subscribingLock.Unlock()

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 const (
@@ -435,7 +435,7 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 	}
 
 	// Applying x-single-active-consumer if defined at subscription level
-	if val := req.Metadata[reqMetadataSingleActiveConsumerKey]; utils.IsTruthy(val) {
+	if val := req.Metadata[reqMetadataSingleActiveConsumerKey]; kitstrings.IsTruthy(val) {
 		args[argSingleActiveConsumer] = true
 	}
 

--- a/pubsub/rocketmq/rocketmq.go
+++ b/pubsub/rocketmq/rocketmq.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 type daprQueueSelector struct {
@@ -185,7 +185,7 @@ func (r *rocketMQ) setUpConsumer() (mq.PushConsumer, error) {
 		opts = append(opts, mqc.WithConsumeTimestamp(r.metadata.ConsumeTimestamp))
 	}
 	if r.metadata.ConsumeOrderly != "" {
-		if utils.IsTruthy(r.metadata.ConsumeOrderly) {
+		if kitstrings.IsTruthy(r.metadata.ConsumeOrderly) {
 			opts = append(opts, mqc.WithConsumerOrder(true))
 			// in orderly message mode, if no value is set of MessageBatchMaxSize, the recommended value [1] is used
 			if r.metadata.ConsumeMessageBatchMaxSize <= 0 {
@@ -205,7 +205,7 @@ func (r *rocketMQ) setUpConsumer() (mq.PushConsumer, error) {
 		opts = append(opts, mqc.WithMaxReconsumeTimes(r.metadata.MaxReconsumeTimes))
 	}
 	if r.metadata.AutoCommit != "" {
-		opts = append(opts, mqc.WithAutoCommit(utils.IsTruthy(r.metadata.AutoCommit)))
+		opts = append(opts, mqc.WithAutoCommit(kitstrings.IsTruthy(r.metadata.AutoCommit)))
 	}
 	if r.metadata.ConsumeTimeout > 0 {
 		opts = append(opts, mqc.WithConsumeTimeout(time.Duration(r.metadata.ConsumeTimeout)*time.Minute))
@@ -386,7 +386,7 @@ func (r *rocketMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, h
 	}
 
 	var cb func(ctx context.Context, msgs ...*primitive.MessageExt) (mqc.ConsumeResult, error)
-	if utils.IsTruthy(r.metadata.ConsumeOrderly) {
+	if kitstrings.IsTruthy(r.metadata.ConsumeOrderly) {
 		cb = r.consumeMessageOrderly(req.Topic, selector, handler)
 	} else {
 		cb = r.consumeMessageConcurrently(req.Topic, selector, handler)

--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -32,7 +32,7 @@ import (
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
 	"github.com/dapr/kit/ptr"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 // Etcd is a state store implementation for Etcd.
@@ -109,7 +109,7 @@ func (e *Etcd) ParseClientFromConfig(etcdConfig *etcdConfig) (*clientv3.Client, 
 	}
 
 	var tlsConfig *tls.Config
-	if utils.IsTruthy(etcdConfig.TLSEnable) {
+	if kitstrings.IsTruthy(etcdConfig.TLSEnable) {
 		if etcdConfig.Cert != "" && etcdConfig.Key != "" && etcdConfig.CA != "" {
 			var err error
 			tlsConfig, err = NewTLSConfig(etcdConfig.Cert, etcdConfig.Key, etcdConfig.CA)

--- a/state/rethinkdb/rethinkdb_test.go
+++ b/state/rethinkdb/rethinkdb_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/utils"
+	"github.com/dapr/kit/strings"
 )
 
 // go test -timeout 30s github.com/dapr/components-contrib/state/rethinkdb -count 1 -run ^TestGetRethinkDBMetadata$.
@@ -229,7 +229,7 @@ func testGetTestObj(t *testing.T, resp *state.GetResponse) *testObj {
 }
 
 func isLiveTest() bool {
-	return utils.IsTruthy(os.Getenv("RUN_LIVE_RETHINKDB_TEST"))
+	return strings.IsTruthy(os.Getenv("RUN_LIVE_RETHINKDB_TEST"))
 }
 
 func getTestMetadata() map[string]string {

--- a/tests/utils/configupdater/postgres/postgres.go
+++ b/tests/utils/configupdater/postgres/postgres.go
@@ -15,7 +15,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/tests/utils/configupdater"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/utils"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 type ConfigUpdater struct {
@@ -92,8 +92,8 @@ func (r *ConfigUpdater) Init(props map[string]string) error {
 
 	md := pgauth.PostgresAuthMetadata{
 		ConnectionString: connString,
-		UseAzureAD:       utils.IsTruthy(useAzureAd),
-		UseAWSIAM:        utils.IsTruthy(useAwsIam),
+		UseAzureAD:       kitstrings.IsTruthy(useAzureAd),
+		UseAWSIAM:        kitstrings.IsTruthy(useAwsIam),
 	}
 	err := md.InitWithMetadata(props, pgauth.InitWithMetadataOpts{AzureADEnabled: true, AWSIAMEnabled: true})
 	if err != nil {


### PR DESCRIPTION
Certification tests will fail until we also update dapr/dapr to use kit@main.

We should merge this PR as is- failing certification tests. Then update dapr/dapr, then come back to updating the go.mod for certification tests here.

This is happening because of the removal of the `dapr/kit/utils` package, in favor of proper package naming.