### PR TITLE
Update metadata.yaml for azure eventhubs binding

### DIFF
--- a/bindings/azure/eventhubs/metadata.yaml
+++ b/bindings/azure/eventhubs/metadata.yaml
@@ -162,8 +162,9 @@ metadata:
       Storage container name.
     example: '"myeventhubstoragecontainer"'
   - name: getAllMessageProperties
+    type: bool
     required: false
-    default: "false"
+    default: false
     example: "false"
     binding:
       input: true


### PR DESCRIPTION
getAllMessageProperties omitted type, therefore it's treated as a string. We should prefer explicit types over ambiguous coercion rules.

# Description

The property omitted a type hint when bool is the intended usage, therefore it would be treated as string.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
