### PR TITLE
Fixed Kafka PubSub intermittently dropping messages while retrying

### DIFF
--- a/common/component/kafka/consumer.go
+++ b/common/component/kafka/consumer.go
@@ -33,29 +33,6 @@ type consumer struct {
 	mutex sync.Mutex
 }
 
-func notifyRecover(consumer *consumer, message *sarama.ConsumerMessage, session sarama.ConsumerGroupSession, b backoff.BackOff) error {
-	for {
-		if err := retry.NotifyRecover(func() error {
-			return consumer.doCallback(session, message)
-		}, b, func(err error, d time.Duration) {
-			consumer.k.logger.Warnf("Error processing Kafka message: %s/%d/%d [key=%s]. Error: %v. Retrying...", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
-		}, func() {
-			consumer.k.logger.Infof("Successfully processed Kafka message after it previously failed: %s/%d/%d [key=%s]", message.Topic, message.Partition, message.Offset, asBase64String(message.Key))
-		}); err != nil {
-			// If the retry policy got interrupted, it could mean that either
-			// the policy has reached its maximum number of attempts or the context has been cancelled.
-			// There is a weird edge case where the error returned is a 'context canceled' error but the session.Context is not done.
-			// This is a workaround to handle that edge case and reprocess the current message.
-			if err == context.Canceled && session.Context().Err() == nil {
-				consumer.k.logger.Warnf("Error processing Kafka message: %s/%d/%d [key=%s]. The error returned is 'context canceled' but the session context is not done. Retrying...")
-				continue
-			}
-			return err
-		}
-		return nil
-	}
-}
-
 func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	b := consumer.k.backOffConfig.NewBackOffWithContext(session.Context())
 	isBulkSubscribe := consumer.k.checkBulkSubscribe(claim.Topic())
@@ -107,7 +84,13 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 				}
 
 				if consumer.k.consumeRetryEnabled {
-					if err := notifyRecover(consumer, message, session, b); err != nil {
+					if err := retry.NotifyRecover(func() error {
+						return consumer.doCallback(session, message)
+					}, b, func(err error, d time.Duration) {
+						consumer.k.logger.Warnf("Error processing Kafka message: %s/%d/%d [key=%s]. Error: %v. Retrying...", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
+					}, func() {
+						consumer.k.logger.Infof("Successfully processed Kafka message after it previously failed: %s/%d/%d [key=%s]", message.Topic, message.Partition, message.Offset, asBase64String(message.Key))
+					}); err != nil {
 						consumer.k.logger.Errorf("Too many failed attempts at processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
 						if errors.Is(session.Context().Err(), context.Canceled) {
 							// If the context is canceled, we should not attempt to consume any more messages. Exiting the loop.

--- a/common/component/kafka/consumer_test.go
+++ b/common/component/kafka/consumer_test.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/retry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// Mock implementations
+type mockConsumerGroupSession struct {
+	mock.Mock
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (m *mockConsumerGroupSession) Claims() map[string][]int32 {
+	args := m.Called()
+	return args.Get(0).(map[string][]int32)
+}
+
+func (m *mockConsumerGroupSession) MemberID() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *mockConsumerGroupSession) GenerationID() int32 {
+	args := m.Called()
+	return int32(args.Int(0))
+}
+
+func (m *mockConsumerGroupSession) MarkOffset(topic string, partition int32, offset int64, metadata string) {
+	m.Called(topic, partition, offset, metadata)
+}
+
+func (m *mockConsumerGroupSession) ResetOffset(topic string, partition int32, offset int64, metadata string) {
+	m.Called(topic, partition, offset, metadata)
+}
+
+func (m *mockConsumerGroupSession) MarkMessage(msg *sarama.ConsumerMessage, metadata string) {
+	m.Called(msg, metadata)
+}
+
+func (m *mockConsumerGroupSession) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockConsumerGroupSession) Commit() {
+	m.Called()
+}
+
+type mockConsumerGroupClaim struct {
+	mock.Mock
+	messages chan *sarama.ConsumerMessage
+	topic    string
+}
+
+func (m *mockConsumerGroupClaim) Topic() string {
+	return m.topic
+}
+
+func (m *mockConsumerGroupClaim) Partition() int32 {
+	args := m.Called()
+	return int32(args.Int(0))
+}
+
+func (m *mockConsumerGroupClaim) InitialOffset() int64 {
+	args := m.Called()
+	return int64(args.Int(0))
+}
+
+func (m *mockConsumerGroupClaim) HighWaterMarkOffset() int64 {
+	args := m.Called()
+	return int64(args.Int(0))
+}
+
+func (m *mockConsumerGroupClaim) Messages() <-chan *sarama.ConsumerMessage {
+	return m.messages
+}
+
+func Test_ConsumeClaim(t *testing.T) {
+	t.Run("single message", func(t *testing.T) {
+		t.Run("no retry", func(t *testing.T) {
+			// Setup
+			k := &Kafka{
+				logger:              logger.NewLogger("test"),
+				consumeRetryEnabled: false,
+				subscribeTopics:     make(map[string]SubscriptionHandlerConfig),
+			}
+			consumer := &consumer{
+				k:     k,
+				mutex: sync.Mutex{},
+			}
+
+			t.Run("successfully consume message", func(t *testing.T) {
+				topic := "test-topic-success"
+				msg := &sarama.ConsumerMessage{
+					Topic:     topic,
+					Partition: 0,
+					Offset:    1,
+					Key:       []byte("test-key"),
+					Value:     []byte("test-value"),
+					Headers:   nil,
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
+				mockSession.On("MarkMessage", msg, "").Return()
+
+				mockClaim := &mockConsumerGroupClaim{
+					messages: make(chan *sarama.ConsumerMessage, 1),
+					topic:    topic,
+				}
+
+				wg := sync.WaitGroup{}
+				wg.Add(1)
+
+				k.subscribeTopics[topic] = SubscriptionHandlerConfig{
+					Handler: func(ctx context.Context, event *NewEvent) error {
+						assert.Equal(t, topic, event.Topic)
+						assert.Equal(t, "test-value", string(event.Data))
+						wg.Done()
+						return nil
+					},
+				}
+
+				// Send message and cancel context
+				mockClaim.messages <- msg
+				go func() {
+					wg.Wait()
+					cancel()
+				}()
+
+				// Test
+				err := consumer.ConsumeClaim(mockSession, mockClaim)
+				assert.NoError(t, err)
+				mockSession.AssertExpectations(t)
+			})
+
+			t.Run("failed to consume message", func(t *testing.T) {
+				topic := "test-topic-failure"
+				msg := &sarama.ConsumerMessage{
+					Topic:     topic,
+					Partition: 0,
+					Offset:    1,
+					Key:       []byte("test-key"),
+					Value:     []byte("test-value"),
+					Headers:   nil,
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
+
+				mockClaim := &mockConsumerGroupClaim{
+					messages: make(chan *sarama.ConsumerMessage, 1),
+					topic:    topic,
+				}
+
+				wg := sync.WaitGroup{}
+				wg.Add(1)
+
+				k.subscribeTopics[topic] = SubscriptionHandlerConfig{
+					Handler: func(ctx context.Context, event *NewEvent) error {
+						wg.Done()
+						return errors.New("test error")
+					},
+				}
+
+				// Send message and cancel context
+				mockClaim.messages <- msg
+				go func() {
+					wg.Wait()
+					cancel()
+				}()
+
+				// Test
+				err := consumer.ConsumeClaim(mockSession, mockClaim)
+				assert.Nil(t, err) // The error isn't returned by this method
+				mockSession.AssertNotCalled(t, "MarkMessage", msg, "")
+			})
+		})
+
+		t.Run("retry", func(t *testing.T) {
+			// Setup
+			k := &Kafka{
+				logger:              logger.NewLogger("test"),
+				consumeRetryEnabled: true,
+				backOffConfig: retry.Config{
+					Policy:     retry.PolicyConstant,
+					MaxRetries: 0,
+				},
+				subscribeTopics: make(map[string]SubscriptionHandlerConfig),
+			}
+			consumer := &consumer{
+				k:     k,
+				mutex: sync.Mutex{},
+			}
+
+			t.Run("successfully consume message", func(t *testing.T) {
+				topic := "test-topic-success"
+				msg := &sarama.ConsumerMessage{
+					Topic:     topic,
+					Partition: 0,
+					Offset:    1,
+					Key:       []byte("test-key"),
+					Value:     []byte("test-value"),
+					Headers:   nil,
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
+				mockSession.On("MarkMessage", msg, "").Return()
+
+				mockClaim := &mockConsumerGroupClaim{
+					messages: make(chan *sarama.ConsumerMessage, 1),
+					topic:    topic,
+				}
+
+				wg := sync.WaitGroup{}
+				wg.Add(1)
+
+				k.subscribeTopics[topic] = SubscriptionHandlerConfig{
+					Handler: func(ctx context.Context, event *NewEvent) error {
+						assert.Equal(t, topic, event.Topic)
+						assert.Equal(t, "test-value", string(event.Data))
+						wg.Done()
+						return nil
+					},
+				}
+
+				// Send message and cancel context
+				mockClaim.messages <- msg
+				go func() {
+					wg.Wait()
+					cancel()
+				}()
+
+				// Test
+				err := consumer.ConsumeClaim(mockSession, mockClaim)
+				assert.NoError(t, err)
+				mockSession.AssertExpectations(t)
+			})
+
+			t.Run("failed to consume message", func(t *testing.T) {
+				topic := "test-topic-failure"
+				msg := &sarama.ConsumerMessage{
+					Topic:     topic,
+					Partition: 0,
+					Offset:    1,
+					Key:       []byte("test-key"),
+					Value:     []byte("test-value"),
+					Headers:   nil,
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
+
+				mockClaim := &mockConsumerGroupClaim{
+					messages: make(chan *sarama.ConsumerMessage, 1),
+					topic:    topic,
+				}
+
+				wg := sync.WaitGroup{}
+				wg.Add(1)
+
+				k.subscribeTopics[topic] = SubscriptionHandlerConfig{
+					Handler: func(ctx context.Context, event *NewEvent) error {
+						wg.Done()
+						return errors.New("test error")
+					},
+				}
+
+				// Send message and cancel context
+				mockClaim.messages <- msg
+				go func() {
+					wg.Wait()
+					cancel()
+				}()
+
+				// Test
+				err := consumer.ConsumeClaim(mockSession, mockClaim)
+				assert.NoError(t, err)
+				mockSession.AssertNotCalled(t, "MarkMessage", msg, "")
+			})
+
+			t.Run("exits on context cancel", func(t *testing.T) {
+				topic := "test-topic-cancel"
+				msg := &sarama.ConsumerMessage{
+					Topic:     topic,
+					Partition: 0,
+					Offset:    1,
+					Key:       []byte("test-key"),
+					Value:     []byte("test-value"),
+					Headers:   nil,
+				}
+
+				msg2 := &sarama.ConsumerMessage{
+					Topic:     topic,
+					Partition: 0,
+					Offset:    2,
+					Key:       []byte("test-key"),
+					Value:     []byte("test-value-2"),
+					Headers:   nil,
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
+
+				mockClaim := &mockConsumerGroupClaim{
+					messages: make(chan *sarama.ConsumerMessage, 2),
+					topic:    topic,
+				}
+
+				k.subscribeTopics[topic] = SubscriptionHandlerConfig{
+					Handler: func(ctx context.Context, event *NewEvent) error {
+						// This must never be test-value-2
+						assert.Equal(t, "test-value", string(event.Data))
+
+						return context.Canceled
+					},
+				}
+
+				// Send multiple messages to make sure there are more than one message in the channel.
+				mockClaim.messages <- msg
+				mockClaim.messages <- msg2
+
+				go func() {
+					// Let it run for a bit before canceling.
+					time.Sleep(50 * time.Millisecond)
+					cancel()
+				}()
+
+				// Test
+				err := consumer.ConsumeClaim(mockSession, mockClaim)
+				assert.NoError(t, err)
+				mockSession.AssertNotCalled(t, "MarkMessage", msg, "")
+			})
+		})
+	})
+}

--- a/common/component/kafka/consumer_test.go
+++ b/common/component/kafka/consumer_test.go
@@ -21,10 +21,12 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
-	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/retry"
 )
 
 // Mock implementations
@@ -46,6 +48,7 @@ func (m *mockConsumerGroupSession) MemberID() string {
 
 func (m *mockConsumerGroupSession) GenerationID() int32 {
 	args := m.Called()
+	//nolint:gosec // Ignoring integer overflow in test code
 	return int32(args.Int(0))
 }
 
@@ -81,6 +84,7 @@ func (m *mockConsumerGroupClaim) Topic() string {
 
 func (m *mockConsumerGroupClaim) Partition() int32 {
 	args := m.Called()
+	//nolint:gosec // Ignoring integer overflow in test code
 	return int32(args.Int(0))
 }
 
@@ -123,7 +127,7 @@ func Test_ConsumeClaim(t *testing.T) {
 					Headers:   nil,
 				}
 
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
 				mockSession.On("MarkMessage", msg, "").Return()
 
@@ -153,7 +157,7 @@ func Test_ConsumeClaim(t *testing.T) {
 
 				// Test
 				err := consumer.ConsumeClaim(mockSession, mockClaim)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				mockSession.AssertExpectations(t)
 			})
 
@@ -168,7 +172,7 @@ func Test_ConsumeClaim(t *testing.T) {
 					Headers:   nil,
 				}
 
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
 
 				mockClaim := &mockConsumerGroupClaim{
@@ -195,7 +199,7 @@ func Test_ConsumeClaim(t *testing.T) {
 
 				// Test
 				err := consumer.ConsumeClaim(mockSession, mockClaim)
-				assert.Nil(t, err) // The error isn't returned by this method
+				require.NoError(t, err)
 				mockSession.AssertNotCalled(t, "MarkMessage", msg, "")
 			})
 		})
@@ -227,7 +231,7 @@ func Test_ConsumeClaim(t *testing.T) {
 					Headers:   nil,
 				}
 
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
 				mockSession.On("MarkMessage", msg, "").Return()
 
@@ -257,7 +261,7 @@ func Test_ConsumeClaim(t *testing.T) {
 
 				// Test
 				err := consumer.ConsumeClaim(mockSession, mockClaim)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				mockSession.AssertExpectations(t)
 			})
 
@@ -272,7 +276,7 @@ func Test_ConsumeClaim(t *testing.T) {
 					Headers:   nil,
 				}
 
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
 
 				mockClaim := &mockConsumerGroupClaim{
@@ -299,7 +303,7 @@ func Test_ConsumeClaim(t *testing.T) {
 
 				// Test
 				err := consumer.ConsumeClaim(mockSession, mockClaim)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				mockSession.AssertNotCalled(t, "MarkMessage", msg, "")
 			})
 
@@ -323,7 +327,7 @@ func Test_ConsumeClaim(t *testing.T) {
 					Headers:   nil,
 				}
 
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				mockSession := &mockConsumerGroupSession{ctx: ctx, cancel: cancel}
 
 				mockClaim := &mockConsumerGroupClaim{
@@ -352,7 +356,7 @@ func Test_ConsumeClaim(t *testing.T) {
 
 				// Test
 				err := consumer.ConsumeClaim(mockSession, mockClaim)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				mockSession.AssertNotCalled(t, "MarkMessage", msg, "")
 			})
 		})

--- a/common/component/kafka/consumer_test.go
+++ b/common/component/kafka/consumer_test.go
@@ -335,8 +335,8 @@ func Test_ConsumeClaim(t *testing.T) {
 					Handler: func(ctx context.Context, event *NewEvent) error {
 						// This must never be test-value-2
 						assert.Equal(t, "test-value", string(event.Data))
-
-						return context.Canceled
+						cancel()
+						return ctx.Err()
 					},
 				}
 


### PR DESCRIPTION
# Description

This prevents the Kafka PubSub components from intermittently dropping message during the retry cycle when it coincides with the consumers rebalancing or any other event requiring re-initialization of the consumer.

The detailed description of the error is in the issue referenced below.

This also reverts some of the changes from #3610. That PR was trying to resolve the same issue, but wasn't successful. This has been confirmed by the author (@passuied).

## Issue reference

Please reference the issue this PR will close: #3849

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo
  * This is a bug fix and doesn't need documentation update. 
