### PR TITLE
update connection string handling

### DIFF
--- a/common/component/azure/servicebus/metadata.go
+++ b/common/component/azure/servicebus/metadata.go
@@ -16,6 +16,7 @@ package servicebus
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	sbadmin "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
@@ -186,6 +187,17 @@ func ParseMetadata(md map[string]string, logger logger.Logger, mode byte) (m *Me
 	if m.MaxRetriableErrorsPerSec < 0 {
 		err = errors.New("must not be negative")
 		return m, err
+	}
+
+	if strings.Contains(strings.ToLower(m.ConnectionString), "usedevelopmentemulator=true") {
+		if !m.DisableEntityManagement {
+			logger.Warn(
+				"UseDevelopmentEmulator=true detected in connection string. " +
+					"Azure emulator does not support topic management APIs. " +
+					"Dapr will skip admin operations. " +
+					"To suppress this warning, explicitly set disableEntityManagement: true.")
+		}
+		m.DisableEntityManagement = true
 	}
 
 	/* Nullable configuration settings - defaults will be set by the server. */


### PR DESCRIPTION
# Description


The emulator does not support the Service Bus Management APIs (over HTTPS), which causes Dapr to fail during topic or subscription creation. With this change:

- `disableEntityManagement` is set to `true` automatically
- A helpful warning is logged to guide users
- Prevents confusing `EOF` or `connection refused` errors during topic checks

This allows developers to test pub/sub functionality locally with fewer manual steps and less confusion.

## Issue reference

Please reference the issue this PR will close: #3674  
(https://github.com/dapr/components-contrib/issues/3674)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
