### PR TITLE
Implement ability to exclude metadata items from being converted to/from headers

### DIFF
--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -372,3 +372,10 @@ metadata:
       - "range"
       - "sticky"
       - "roundrobin"
+  - name: headerFromToMetadataExcludedKeysRegex
+    type: string
+    required: false
+    description: |
+      A regular expression to exclude keys from being converted to/from headers from/to metadata to avoid unwanted downstream side effects.
+    example: '"^rawPayload|valueSchemaType$"'
+    default: '""'

--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -372,7 +372,7 @@ metadata:
       - "range"
       - "sticky"
       - "roundrobin"
-  - name: headerFromToMetadataExcludedKeysRegex
+  - name: excludeHeaderMetaRegex
     type: string
     required: false
     description: |

--- a/common/component/kafka/consumer.go
+++ b/common/component/kafka/consumer.go
@@ -230,7 +230,7 @@ func GetEventMetadata(message *sarama.ConsumerMessage, kafka *Kafka) map[string]
 		metadata[partitionMetadataKey] = strconv.FormatInt(int64(message.Partition), 10)
 		for _, header := range message.Headers {
 			// skip headers that are excluded from metadata
-			if kafka.headerFromToMetadataExcludedKeysRegex != nil && kafka.headerFromToMetadataExcludedKeysRegex.MatchString(string(header.Key)) {
+			if kafka.excludeHeaderMetaRegex != nil && kafka.excludeHeaderMetaRegex.MatchString(string(header.Key)) {
 				kafka.logger.Debugf("Skipping header %v that is excluded from metadata", string(header.Key))
 				continue
 			}

--- a/common/component/kafka/consumer.go
+++ b/common/component/kafka/consumer.go
@@ -231,6 +231,7 @@ func GetEventMetadata(message *sarama.ConsumerMessage, kafka *Kafka) map[string]
 		for _, header := range message.Headers {
 			// skip headers that are excluded from metadata
 			if kafka.headerFromToMetadataExcludedKeysRegex != nil && kafka.headerFromToMetadataExcludedKeysRegex.MatchString(string(header.Key)) {
+				kafka.logger.Debugf("Skipping header %v that is excluded from metadata", string(header.Key))
 				continue
 			}
 			if kafka.escapeHeaders {

--- a/common/component/kafka/consumer.go
+++ b/common/component/kafka/consumer.go
@@ -145,7 +145,7 @@ func (consumer *consumer) doBulkCallback(session sarama.ConsumerGroupSession,
 
 	for i, message := range messages {
 		if message != nil {
-			metadata := GetEventMetadata(message, consumer.k.escapeHeaders)
+			metadata := GetEventMetadata(message, consumer.k)
 			handlerConfig, err := consumer.k.GetTopicHandlerConfig(message.Topic)
 			if err != nil {
 				return err
@@ -205,7 +205,7 @@ func (consumer *consumer) doCallback(session sarama.ConsumerGroupSession, messag
 		Topic: message.Topic,
 		Data:  messageVal,
 	}
-	event.Metadata = GetEventMetadata(message, consumer.k.escapeHeaders)
+	event.Metadata = GetEventMetadata(message, consumer.k)
 
 	err = handlerConfig.Handler(session.Context(), &event)
 	if err == nil {
@@ -214,11 +214,11 @@ func (consumer *consumer) doCallback(session sarama.ConsumerGroupSession, messag
 	return err
 }
 
-func GetEventMetadata(message *sarama.ConsumerMessage, escapeHeaders bool) map[string]string {
+func GetEventMetadata(message *sarama.ConsumerMessage, kafka *Kafka) map[string]string {
 	if message != nil {
 		metadata := make(map[string]string, len(message.Headers)+5)
 		if message.Key != nil {
-			if escapeHeaders {
+			if kafka.escapeHeaders {
 				metadata[keyMetadataKey] = url.QueryEscape(string(message.Key))
 			} else {
 				metadata[keyMetadataKey] = string(message.Key)
@@ -229,7 +229,11 @@ func GetEventMetadata(message *sarama.ConsumerMessage, escapeHeaders bool) map[s
 		metadata[timestampMetadataKey] = strconv.FormatInt(message.Timestamp.UnixMilli(), 10)
 		metadata[partitionMetadataKey] = strconv.FormatInt(int64(message.Partition), 10)
 		for _, header := range message.Headers {
-			if escapeHeaders {
+			// skip headers that are excluded from metadata
+			if kafka.headerFromToMetadataExcludedKeysRegex != nil && kafka.headerFromToMetadataExcludedKeysRegex.MatchString(string(header.Key)) {
+				continue
+			}
+			if kafka.escapeHeaders {
 				metadata[string(header.Key)] = url.QueryEscape(string(header.Value))
 			} else {
 				metadata[string(header.Key)] = string(header.Value)

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -83,7 +83,7 @@ type Kafka struct {
 	consumeRetryEnabled        bool
 	consumeRetryInterval       time.Duration
 
-	headerFromToMetadataExcludedKeysRegex *regexp.Regexp
+	excludeHeaderMetaRegex *regexp.Regexp
 }
 
 type SchemaType int
@@ -259,8 +259,8 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 		return errors.New("component is closed")
 	}
 
-	if meta.HeaderFromToMetadataExcludedKeysRegex != "" {
-		k.headerFromToMetadataExcludedKeysRegex = regexp.MustCompile(meta.HeaderFromToMetadataExcludedKeysRegex)
+	if meta.ExcludeHeaderMetaRegex != "" {
+		k.excludeHeaderMetaRegex = regexp.MustCompile(meta.ExcludeHeaderMetaRegex)
 	}
 
 	k.logger.Debug("Kafka message bus initialization complete")

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -81,6 +82,8 @@ type Kafka struct {
 	DefaultConsumeRetryEnabled bool
 	consumeRetryEnabled        bool
 	consumeRetryInterval       time.Duration
+
+	headerFromToMetadataExcludedKeysRegex *regexp.Regexp
 }
 
 type SchemaType int
@@ -254,6 +257,10 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 	}
 	if clients.consumerGroup == nil {
 		return errors.New("component is closed")
+	}
+
+	if meta.HeaderFromToMetadataExcludedKeysRegex != "" {
+		k.headerFromToMetadataExcludedKeysRegex = regexp.MustCompile(meta.HeaderFromToMetadataExcludedKeysRegex)
 	}
 
 	k.logger.Debug("Kafka message bus initialization complete")

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -116,6 +116,9 @@ type KafkaMetadata struct {
 	SchemaRegistryAPISecret     string        `mapstructure:"schemaRegistryAPISecret"`
 	SchemaCachingEnabled        bool          `mapstructure:"schemaCachingEnabled"`
 	SchemaLatestVersionCacheTTL time.Duration `mapstructure:"schemaLatestVersionCacheTTL"`
+
+	// header to metadata excluded keys regex
+	HeaderFromToMetadataExcludedKeysRegex string `mapstructure:"headerFromToMetadataExcludedKeysRegex"`
 }
 
 // upgradeMetadata updates metadata properties based on deprecated usage.
@@ -168,6 +171,7 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		SchemaCachingEnabled:                         true,
 		SchemaLatestVersionCacheTTL:                  5 * time.Minute,
 		EscapeHeaders:                                false,
+		HeaderFromToMetadataExcludedKeysRegex:        "",
 	}
 
 	err := metadata.DecodeMetadata(meta, &m)
@@ -345,6 +349,10 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 
 	if m.ClientConnectionKeepAliveInterval < 0 {
 		m.ClientConnectionKeepAliveInterval = defaultClientConnectionKeepAliveInterval
+	}
+
+	if val, ok := meta["headerFromToMetadataExcludedKeysRegex"]; ok && val != "" {
+		m.HeaderFromToMetadataExcludedKeysRegex = val
 	}
 
 	return &m, nil

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -117,8 +117,8 @@ type KafkaMetadata struct {
 	SchemaCachingEnabled        bool          `mapstructure:"schemaCachingEnabled"`
 	SchemaLatestVersionCacheTTL time.Duration `mapstructure:"schemaLatestVersionCacheTTL"`
 
-	// header to metadata excluded keys regex
-	HeaderFromToMetadataExcludedKeysRegex string `mapstructure:"headerFromToMetadataExcludedKeysRegex"`
+	// header from/to metadata excluded keys regex
+	ExcludeHeaderMetaRegex string `mapstructure:"excludeHeaderMetaRegex"`
 }
 
 // upgradeMetadata updates metadata properties based on deprecated usage.
@@ -171,7 +171,7 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		SchemaCachingEnabled:                         true,
 		SchemaLatestVersionCacheTTL:                  5 * time.Minute,
 		EscapeHeaders:                                false,
-		HeaderFromToMetadataExcludedKeysRegex:        "",
+		ExcludeHeaderMetaRegex:                       "",
 	}
 
 	err := metadata.DecodeMetadata(meta, &m)
@@ -351,8 +351,8 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		m.ClientConnectionKeepAliveInterval = defaultClientConnectionKeepAliveInterval
 	}
 
-	if val, ok := meta["headerFromToMetadataExcludedKeysRegex"]; ok && val != "" {
-		m.HeaderFromToMetadataExcludedKeysRegex = val
+	if val, ok := meta["excludeHeaderMetaRegex"]; ok && val != "" {
+		m.ExcludeHeaderMetaRegex = val
 	}
 
 	return &m, nil

--- a/common/component/kafka/metadata_test.go
+++ b/common/component/kafka/metadata_test.go
@@ -516,6 +516,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: false,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Len(t, act, 5)
@@ -536,6 +537,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: false,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Len(t, act, 7)
@@ -554,6 +556,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: false,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Len(t, act, 4)
@@ -566,6 +569,7 @@ func TestGetEventMetadata(t *testing.T) {
 	t.Run("null message", func(t *testing.T) {
 		k := Kafka{
 			escapeHeaders: false,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(nil, &k)
 		require.Nil(t, act)
@@ -580,6 +584,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: true,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Equal(t, escapedKeyValue, act[keyMetadataKey])
@@ -593,6 +598,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: false,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Equal(t, keyValue, act[keyMetadataKey])
@@ -611,6 +617,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: true,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Len(t, act, 6)
@@ -629,6 +636,7 @@ func TestGetEventMetadata(t *testing.T) {
 		}
 		k := Kafka{
 			escapeHeaders: false,
+			logger:        logger.NewLogger("kafka_test"),
 		}
 		act := GetEventMetadata(&m, &k)
 		require.Len(t, act, 6)
@@ -643,6 +651,7 @@ func TestGetEventMetadata(t *testing.T) {
 		k := Kafka{
 			escapeHeaders:                         false,
 			headerFromToMetadataExcludedKeysRegex: regexp.MustCompile("^valueSchemaType$"),
+			logger:                                logger.NewLogger("kafka_test"),
 		}
 		m := sarama.ConsumerMessage{
 			Headers: headers, Timestamp: ts, Key: []byte("MyKey"), Value: []byte("MyValue"), Partition: 0, Offset: 123, Topic: "TestTopic",
@@ -661,6 +670,7 @@ func TestGetEventMetadata(t *testing.T) {
 		k := Kafka{
 			escapeHeaders:                         false,
 			headerFromToMetadataExcludedKeysRegex: regexp.MustCompile("^valueSchemaType|rawPayload$"),
+			logger:                                logger.NewLogger("kafka_test"),
 		}
 		m := sarama.ConsumerMessage{
 			Headers: headers, Timestamp: ts, Key: []byte("MyKey"), Value: []byte("MyValue"), Partition: 0, Offset: 123, Topic: "TestTopic",

--- a/common/component/kafka/metadata_test.go
+++ b/common/component/kafka/metadata_test.go
@@ -649,9 +649,9 @@ func TestGetEventMetadata(t *testing.T) {
 			{Key: []byte("rawPayload"), Value: []byte("true")},
 		}
 		k := Kafka{
-			escapeHeaders:                         false,
-			headerFromToMetadataExcludedKeysRegex: regexp.MustCompile("^valueSchemaType$"),
-			logger:                                logger.NewLogger("kafka_test"),
+			escapeHeaders:          false,
+			excludeHeaderMetaRegex: regexp.MustCompile("^valueSchemaType$"),
+			logger:                 logger.NewLogger("kafka_test"),
 		}
 		m := sarama.ConsumerMessage{
 			Headers: headers, Timestamp: ts, Key: []byte("MyKey"), Value: []byte("MyValue"), Partition: 0, Offset: 123, Topic: "TestTopic",
@@ -668,9 +668,9 @@ func TestGetEventMetadata(t *testing.T) {
 			{Key: []byte("rawPayload"), Value: []byte("true")},
 		}
 		k := Kafka{
-			escapeHeaders:                         false,
-			headerFromToMetadataExcludedKeysRegex: regexp.MustCompile("^valueSchemaType|rawPayload$"),
-			logger:                                logger.NewLogger("kafka_test"),
+			escapeHeaders:          false,
+			excludeHeaderMetaRegex: regexp.MustCompile("^valueSchemaType|rawPayload$"),
+			logger:                 logger.NewLogger("kafka_test"),
 		}
 		m := sarama.ConsumerMessage{
 			Headers: headers, Timestamp: ts, Key: []byte("MyKey"), Value: []byte("MyValue"), Partition: 0, Offset: 123, Topic: "TestTopic",

--- a/common/component/kafka/producer.go
+++ b/common/component/kafka/producer.go
@@ -78,6 +78,11 @@ func (k *Kafka) Publish(_ context.Context, topic string, data []byte, metadata m
 		if msg.Headers == nil {
 			msg.Headers = make([]sarama.RecordHeader, 0, len(metadata))
 		}
+		// skip metadata that is excluded from headers
+		if k.headerFromToMetadataExcludedKeysRegex != nil && k.headerFromToMetadataExcludedKeysRegex.MatchString(name) {
+			k.logger.Debugf("Skipping metadata %v that is excluded from headers", name)
+			continue
+		}
 		msg.Headers = append(msg.Headers, sarama.RecordHeader{
 			Key:   []byte(name),
 			Value: []byte(value),
@@ -140,6 +145,11 @@ func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.Bu
 
 			if msg.Headers == nil {
 				msg.Headers = make([]sarama.RecordHeader, 0, len(metadata))
+			}
+			// skip metadata that is excluded from headers
+			if k.headerFromToMetadataExcludedKeysRegex != nil && k.headerFromToMetadataExcludedKeysRegex.MatchString(name) {
+				k.logger.Debugf("Skipping metadata %v that is excluded from headers", name)
+				continue
 			}
 			msg.Headers = append(msg.Headers, sarama.RecordHeader{
 				Key:   []byte(name),

--- a/common/component/kafka/producer.go
+++ b/common/component/kafka/producer.go
@@ -79,7 +79,7 @@ func (k *Kafka) Publish(_ context.Context, topic string, data []byte, metadata m
 			msg.Headers = make([]sarama.RecordHeader, 0, len(metadata))
 		}
 		// skip metadata that is excluded from headers
-		if k.headerFromToMetadataExcludedKeysRegex != nil && k.headerFromToMetadataExcludedKeysRegex.MatchString(name) {
+		if k.excludeHeaderMetaRegex != nil && k.excludeHeaderMetaRegex.MatchString(name) {
 			k.logger.Debugf("Skipping metadata %v that is excluded from headers", name)
 			continue
 		}
@@ -147,7 +147,7 @@ func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.Bu
 				msg.Headers = make([]sarama.RecordHeader, 0, len(metadata))
 			}
 			// skip metadata that is excluded from headers
-			if k.headerFromToMetadataExcludedKeysRegex != nil && k.headerFromToMetadataExcludedKeysRegex.MatchString(name) {
+			if k.excludeHeaderMetaRegex != nil && k.excludeHeaderMetaRegex.MatchString(name) {
 				k.logger.Debugf("Skipping metadata %v that is excluded from headers", name)
 				continue
 			}

--- a/common/component/kafka/producer_test.go
+++ b/common/component/kafka/producer_test.go
@@ -111,7 +111,7 @@ func TestPublish(t *testing.T) {
 		}
 		messageAsserter := createMessageAsserter(t, sarama.StringEncoder("key"), metadataOut)
 		k := arrangeKafkaWithAssertions(t, messageAsserter)
-		k.headerFromToMetadataExcludedKeysRegex = regexp.MustCompile("^b|c$")
+		k.excludeHeaderMetaRegex = regexp.MustCompile("^b|c$")
 
 		// act
 		err := k.Publish(ctx, "a", []byte("a"), metadataIn)
@@ -235,7 +235,7 @@ func TestBulkPublish(t *testing.T) {
 			createMessageAsserter(t, nil, map[string]string{"common": "common"}),
 		}
 		k := arrangeKafkaWithAssertions(t, messageAsserters...)
-		k.headerFromToMetadataExcludedKeysRegex = regexp.MustCompile("^b|c$")
+		k.excludeHeaderMetaRegex = regexp.MustCompile("^b|c$")
 
 		// act
 		_, err := k.BulkPublish(ctx, "a", entries, metadata)

--- a/common/component/kafka/producer_test.go
+++ b/common/component/kafka/producer_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/IBM/sarama"
@@ -94,6 +95,30 @@ func TestPublish(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 	})
+
+	t.Run("produce message with excluded headers", func(t *testing.T) {
+		// arrange
+		metadataIn := map[string]string{
+			"a":     "a",
+			"b":     "bVal",
+			"c":     "cVal",
+			"__key": "key",
+		}
+
+		metadataOut := map[string]string{
+			"a":     "a",
+			"__key": "key",
+		}
+		messageAsserter := createMessageAsserter(t, sarama.StringEncoder("key"), metadataOut)
+		k := arrangeKafkaWithAssertions(t, messageAsserter)
+		k.headerFromToMetadataExcludedKeysRegex = regexp.MustCompile("^b|c$")
+
+		// act
+		err := k.Publish(ctx, "a", []byte("a"), metadataIn)
+
+		// assert
+		require.NoError(t, err)
+	})
 }
 
 func TestBulkPublish(t *testing.T) {
@@ -181,6 +206,36 @@ func TestBulkPublish(t *testing.T) {
 			createMessageAsserter(t, nil, map[string]string{"c": "c", "common": "common"}),
 		}
 		k := arrangeKafkaWithAssertions(t, messageAsserters...)
+
+		// act
+		_, err := k.BulkPublish(ctx, "a", entries, metadata)
+
+		// assert
+		require.NoError(t, err)
+	})
+
+	t.Run("bulk produce messages with excluded headers", func(t *testing.T) {
+		// arrange
+		entries := []pubsub.BulkMessageEntry{
+			{
+				EntryId:     "0",
+				Event:       []byte("a"),
+				ContentType: "a",
+				Metadata:    map[string]string{"__key": "key", "a": "a", "b": "b", "c": "c"},
+			},
+			{
+				EntryId:     "0",
+				Event:       []byte("a"),
+				ContentType: "a",
+				Metadata:    map[string]string{"c": "c"},
+			},
+		}
+		messageAsserters := []saramamocks.MessageChecker{
+			createMessageAsserter(t, sarama.StringEncoder("key"), map[string]string{"__key": "key", "common": "common", "a": "a"}),
+			createMessageAsserter(t, nil, map[string]string{"common": "common"}),
+		}
+		k := arrangeKafkaWithAssertions(t, messageAsserters...)
+		k.headerFromToMetadataExcludedKeysRegex = regexp.MustCompile("^b|c$")
 
 		// act
 		_, err := k.BulkPublish(ctx, "a", entries, metadata)

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -363,3 +363,10 @@ metadata:
         - "range"
         - "sticky"
         - "roundrobin"
+    - name: headerFromToMetadataExcludedKeysRegex
+      type: string
+      required: false
+      description: |
+        A regular expression to exclude keys from being converted to/from headers from/to metadata to avoid unwanted downstream side effects.
+      example: '"^rawPayload|valueSchemaType$"'
+      default: '""'

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -363,7 +363,7 @@ metadata:
         - "range"
         - "sticky"
         - "roundrobin"
-    - name: headerFromToMetadataExcludedKeysRegex
+    - name: excludeHeaderMetaRegex
       type: string
       required: false
       description: |


### PR DESCRIPTION
# Description

Implement ability to exclude metadata items from being added as headers when publishing, and similarly from being converted from headers to metadata when consuming messages.

Forwarding certain metadata as headers has some unwanted downstream side effects.

## Issue reference

#3858

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#4701
