### PR TITLE
fix(defaults): mv description defaults to actually show as comp defaults

### DIFF
--- a/bindings/zeebe/command/metadata.yaml
+++ b/bindings/zeebe/command/metadata.yaml
@@ -49,6 +49,7 @@ metadata:
     description: Sets how often keep alive messages should be sent to the gateway. Defaults to 45 seconds
     example: "45s"
     type: duration
+    default: "45s"
   - name: usePlainTextConnection	
     required: false
     description: Whether to use a plain text connection or not

--- a/bindings/zeebe/command/metadata.yaml
+++ b/bindings/zeebe/command/metadata.yaml
@@ -46,7 +46,7 @@ metadata:
     type: string
   - name: gatewayKeepAlive
     required: false
-    description: Sets how often keep alive messages should be sent to the gateway. Defaults to 45 seconds
+    description: Sets how often keep alive messages should be sent to the gateway.
     example: "45s"
     type: duration
     default: "45s"

--- a/bindings/zeebe/jobworker/metadata.yaml
+++ b/bindings/zeebe/jobworker/metadata.yaml
@@ -23,6 +23,7 @@ metadata:
     description: Sets how often keep alive messages should be sent to the gateway. Defaults to 45 seconds
     example: "45s"
     type: duration
+    default: "45s"
   - name: usePlainTextConnection	
     required: false
     description: Whether to use a plain text connection or not
@@ -48,6 +49,7 @@ metadata:
     description: The request will be completed when at least one job is activated or after the requestTimeout. If the requestTimeout = 0, a default timeout is used. If the requestTimeout < 0, long polling is disabled and the request is completed immediately, even when no job is activated. Defaults to 10 seconds
     example: "30s"
     type: duration
+    default: "10s"
   - name: jobType
     required: true
     description: the job type, as defined in the BPMN process (e.g. <zeebe:taskDefinition type=\"fetch-products\" />)
@@ -58,21 +60,25 @@ metadata:
     description: Set the maximum number of jobs which will be activated for this worker at the same time. Defaults to 32
     example: "32"
     type: number
+    default: "32"
   - name: concurrency
     required: false
     description: The maximum number of concurrent spawned goroutines to complete jobs. Defaults to 4
     example: "4"
+    default: "4"
     type: number
   - name: pollInterval
     required: false
     description: Set the maximal interval between polling for new jobs. Defaults to 100 milliseconds
     example: "100ms"
     type: duration
+    default: "100ms"
   - name: pollThreshold
     required: false
     description: Set the threshold of buffered activated jobs before polling for new jobs, i.e. threshold * maxJobsActive. Defaults to 0.3
     example: "0.3"
     type: number
+    default: "0.3"
   - name: fetchVariables
     required: false
     description: A list of variables to fetch as the job variables; if empty, all visible variables at the time of activation for the scope of the job will be returned

--- a/bindings/zeebe/jobworker/metadata.yaml
+++ b/bindings/zeebe/jobworker/metadata.yaml
@@ -20,7 +20,7 @@ metadata:
     type: string
   - name: gatewayKeepAlive
     required: false
-    description: Sets how often keep alive messages should be sent to the gateway. Defaults to 45 seconds
+    description: Sets how often keep alive messages should be sent to the gateway.
     example: "45s"
     type: duration
     default: "45s"
@@ -41,7 +41,7 @@ metadata:
     type: string
   - name: workerTimeout
     required: false
-    description: A job returned after this call will not be activated by another call until the timeout has been reached; defaults to 5 minutes
+    description: A job returned after this call will not be activated by another call until the timeout has been reached.
     example: "5m"
     type: duration
   - name: requestTimeout
@@ -57,25 +57,25 @@ metadata:
     type: string
   - name: maxJobsActive
     required: false
-    description: Set the maximum number of jobs which will be activated for this worker at the same time. Defaults to 32
+    description: Set the maximum number of jobs which will be activated for this worker at the same time.
     example: "32"
     type: number
     default: "32"
   - name: concurrency
     required: false
-    description: The maximum number of concurrent spawned goroutines to complete jobs. Defaults to 4
+    description: The maximum number of concurrent spawned goroutines to complete jobs.
     example: "4"
     default: "4"
     type: number
   - name: pollInterval
     required: false
-    description: Set the maximal interval between polling for new jobs. Defaults to 100 milliseconds
+    description: Set the maximal interval between polling for new jobs.
     example: "100ms"
     type: duration
     default: "100ms"
   - name: pollThreshold
     required: false
-    description: Set the threshold of buffered activated jobs before polling for new jobs, i.e. threshold * maxJobsActive. Defaults to 0.3
+    description: Set the threshold of buffered activated jobs before polling for new jobs, i.e. threshold * maxJobsActive.
     example: "0.3"
     type: number
     default: "0.3"

--- a/conversation/anthropic/metadata.yaml
+++ b/conversation/anthropic/metadata.yaml
@@ -24,9 +24,10 @@ metadata:
   - name: model
     required: false
     description: |
-      The Anthropic LLM to use. Defaults to claude-3-5-sonnet-20240620
+      The Anthropic LLM to use.
     type: string
     example: 'claude-3-5-sonnet-20240620'
+    default: 'claude-3-5-sonnet-20240620'
   - name: cacheTTL
     required: false
     description: |

--- a/conversation/googleai/metadata.yaml
+++ b/conversation/googleai/metadata.yaml
@@ -24,9 +24,10 @@ metadata:
   - name: model
     required: false
     description: |
-      The GoogleAI LLM to use. Defaults to gemini-1.5-flash
+      The GoogleAI LLM to use.
     type: string
     example: 'gemini-2.0-flash'
+    default: 'gemini-2.0-flash'
   - name: cacheTTL
     required: false
     description: |

--- a/conversation/huggingface/metadata.yaml
+++ b/conversation/huggingface/metadata.yaml
@@ -24,9 +24,10 @@ metadata:
   - name: model
     required: false
     description: |
-      The Huggingface model to use. Uses OpenAI-compatible API. Defaults to deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
+      The Huggingface model to use. Uses OpenAI-compatible API.
     type: string
     example: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B'
+    default: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B'
   - name: endpoint
     required: false
     description: |

--- a/conversation/mistral/metadata.yaml
+++ b/conversation/mistral/metadata.yaml
@@ -24,9 +24,10 @@ metadata:
   - name: model
     required: false
     description: |
-      The Mistral LLM to use. Defaults to open-mistral-7b
+      The Mistral LLM to use.
     type: string
     example: 'open-mistral-7b'
+    default: 'open-mistral-7b'
   - name: cacheTTL
     required: false
     description: |

--- a/conversation/ollama/metadata.yaml
+++ b/conversation/ollama/metadata.yaml
@@ -12,9 +12,10 @@ metadata:
   - name: model
     required: false
     description: |
-      The Ollama LLM to use. Defaults to llama3.2:latest
+      The Ollama LLM to use.
     type: string
     example: 'llama3.2:latest'
+    default: 'llama3.2:latest'
   - name: cacheTTL
     required: false
     description: |

--- a/conversation/openai/metadata.yaml
+++ b/conversation/openai/metadata.yaml
@@ -24,9 +24,10 @@ metadata:
   - name: model
     required: false
     description: |
-      The OpenAI LLM to use. Defaults to gpt-4o
+      The OpenAI LLM to use.
     type: string
     example: 'gpt-4-turbo'
+    default: 'gpt-4o'
   - name: endpoint
     required: false
     description: |

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -46,9 +46,10 @@ metadata:
   - name: enableTLS
     required: false
     description: |
-      If the Redis instance supports TLS, can be configured to be enabled or disabled. Defaults to "false".
+      If the Redis instance supports TLS, can be configured to be enabled or disabled.
     example: "false"
     type: bool
+    default: "false"
   - name: clientCert
     required: false
     description: Client certificate for Redis host. No Default. Can be secretKeyRef to use a secret reference
@@ -62,38 +63,44 @@ metadata:
   - name: redeliverInterval
     required: false
     description: |
-      The interval between checking for pending messages to redelivery. Defaults to "60s". "0" disables redelivery.
+      The interval between checking for pending messages to redelivery. "0" disables redelivery.
     example: "30s"
+    default: "60s"
     type: duration
   - name: processingTimeout
     required: false
     description: |
-      The amount time a message must be pending before attempting to redeliver it. Defaults to "15s". "0" disables redelivery.
+      The amount time a message must be pending before attempting to redeliver it. "0" disables redelivery.
     example: "30s"
     type: duration
+    default: "15s"
   - name: queueDepth
     required: false
     description: |
-      The size of the message queue for processing. Defaults to "100".
+      The size of the message queue for processing.
     example: "1000"
+    default: "100"
     type: number
   - name: concurrency
     required: false
     description: |
-      The number of concurrent workers that are processing messages. Defaults to "10".
+      The number of concurrent workers that are processing messages.
     example: "15"
+    default: "10"
     type: number
   - name: redisType
     required: false
     description: |
-      The type of redis. There are two valid values, one is "node" for single node mode, the other is "cluster" for redis cluster mode. Defaults to "node".
+      The type of redis. There are two valid values, one is "node" for single node mode, the other is "cluster" for redis cluster mode.
     example: "cluster"
     type: string
+    default: "node"
   - name: redisDB
     required: false
     description: |
-      Database selected after connecting to redis. If "redisType" is "cluster" this option is ignored. Defaults to "0".
+      Database selected after connecting to redis. If "redisType" is "cluster" this option is ignored.
     example: "0"
+    default: "0"
     type: number
   - name: redisMaxRetries
     required: false
@@ -103,26 +110,30 @@ metadata:
   - name: redisMinRetryInterval
     required: false
     description: |
-      Minimum backoff for redis commands between each retry. Default is "8ms"; "-1" disables backoff.
+      Minimum backoff for redis commands between each retry. "-1" disables backoff.
     example: "8ms"
+    default: "8ms"
     type: duration
   - name: redisMaxRetryInterval
     required: false
     description: |
-      Maximum backoff for redis commands between each retry. Default is "512ms";"-1" disables backoff.
+      Maximum backoff for redis commands between each retry. "-1" disables backoff.
     example: "5s"
+    default: "512ms"
     type: duration
   - name: dialTimeout
     required: false
     description: |
-      Dial timeout for establishing new connections. Defaults to "5s".
+      Dial timeout for establishing new connections.
     example: "5s"
+    default: "5s"
     type: duration
   - name: readTimeout
     required: false
     description: |
-      Timeout for socket reads. If reached, redis commands will fail with a timeout instead of blocking. Defaults to "3s", "-1" for no timeout.
+      Timeout for socket reads. If reached, redis commands will fail with a timeout instead of blocking. "-1" for no timeout.
     example: "3s"
+    default: "3"
     type: duration
   - name: writeTimeout
     required: false
@@ -147,26 +158,30 @@ metadata:
   - name: minIdleConns
     required: false
     description: |
-      Minimum number of idle connections to keep open in order to avoid the performance degradation associated with creating new connections. Defaults to "0".
+      Minimum number of idle connections to keep open in order to avoid the performance degradation associated with creating new connections.
     example: "2"
+    default: "0"
     type: number
   - name: idleCheckFrequency
     required: false
     description: |
-      Frequency of idle checks made by idle connections reaper. Default is "1m". "-1" disables idle connections reaper.
+      Frequency of idle checks made by idle connections reaper. "-1" disables idle connections reaper.
     example: "-1"
+    default: "1m"
     type: duration
   - name: idleTimeout
     required: false
     description: |
-      Amount of time after which the client closes idle connections. Should be less than server's timeout. Default is "5m". "-1" disables idle timeout check.
+      Amount of time after which the client closes idle connections. Should be less than server's timeout. "-1" disables idle timeout check.
     example: "10m"
+    default: "5m"
     type: duration
   - name: failover
     required: false
     description: |
-      Property to enabled failover configuration. Needs sentinelMasterName to be set. Defaults to "false"
+      Property to enabled failover configuration. Needs sentinelMasterName to be set.
     example: "false"
+    default: "false"
     type: bool
   - name: sentinelMasterName
     required: false

--- a/secretstores/hashicorp/vault/metadata.yaml
+++ b/secretstores/hashicorp/vault/metadata.yaml
@@ -12,9 +12,10 @@ metadata:
   - name: vaultAddr
     required: false
     description: |
-      The address of the Vault server. Defaults to "https://127.0.0.1:8200"
+      The address of the Vault server.
     example: "https://127.0.0.1:8200"
     type: string
+    default: "https://127.0.0.1:8200"
   - name: caPem
     required: false
     description: |
@@ -34,8 +35,9 @@ metadata:
     type: string
   - name: skipVerify
     required: false
-    description: Skip TLS verification. Defaults to false
+    description: Skip TLS verification.
     example: "true"
+    default: "false"
     type: string
   - name: tlsServerName
     required: false
@@ -55,8 +57,9 @@ metadata:
   - name: vaultKVPrefix
     required: false
     description: |
-      The prefix in vault. Defaults to "dapr"
+      The prefix in vault.
     example: "myprefix"
+    default: "dapr"
     type: string
   - name: vaultKVUsePrefix
     required: false
@@ -66,12 +69,14 @@ metadata:
   - name: enginePath
     required: false
     description: |
-      The engine path in vault. Defaults to "secret"
+      The engine path in vault.
     example: "kv"
     type: string
+    default: "secret"
   - name: vaultValueType
     required: false
     description: |
-      Vault value type. map means to parse the value into map[string]string, text means to use the value as a string. "map" sets the multipleKeyValuesPerSecret behavior. text makes Vault behave as a secret store with name/value semantics. Defaults to "map"
+      Vault value type. map means to parse the value into map[string]string, text means to use the value as a string. "map" sets the multipleKeyValuesPerSecret behavior. text makes Vault behave as a secret store with name/value semantics.
     example: "map"
+    default: "map"
     type: string

--- a/state/azure/tablestorage/metadata.yaml
+++ b/state/azure/tablestorage/metadata.yaml
@@ -34,8 +34,9 @@ metadata:
     type: string
     example: '"table"'
   - name: cosmosDbMode
-    description: "If enabled, connects to Cosmos DB Table API instead of Azure Tables (Storage Accounts). Defaults to `false`."
+    description: "If enabled, connects to Cosmos DB Table API instead of Azure Tables (Storage Accounts).
     example: '"false"'
+    default: "false"
     type: bool
     default: 'false'
   - name: serviceURL
@@ -43,7 +44,7 @@ metadata:
     example: '"https://mystorageaccount.table.core.windows.net/"'
     type: string
   - name: skipCreateTable
-    description: "Skips the check for and, if necessary, creation of the specified storage table. This is useful when using active directory authentication with minimal privileges. Defaults to `false`."
+    description: "Skips the check for and, if necessary, creation of the specified storage table. This is useful when using active directory authentication with minimal privileges.
     example: '"true"'
     type: bool
     default: 'false'


### PR DESCRIPTION
# Description

If folks look at the metadata bundle for values such as defaults, then currently there are some differences between what we define as defaults in the component metadata field description vs it's actual default value. This PR corrects that. In addition, it is redundant and err prone to list defaults in descriptions when there is a default field. I've corrected this as well.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
