### PR TITLE
add conversation components to component metadata schema and bundle

### DIFF
--- a/.build-tools/component-folders.yaml
+++ b/.build-tools/component-folders.yaml
@@ -9,6 +9,7 @@ componentFolders:
   - secretstores
   - state
   - workflows
+  - conversation
 
 excludeFolders:
   - bindings/alicloud

--- a/.build-tools/pkg/metadataschema/schema.go
+++ b/.build-tools/pkg/metadataschema/schema.go
@@ -20,7 +20,7 @@ type ComponentMetadata struct {
 	// Version of the component metadata schema.
 	SchemaVersion string `json:"schemaVersion" yaml:"schemaVersion" jsonschema:"enum=v1"`
 	// Component type, of one of the allowed values.
-	Type string `json:"type" yaml:"type" jsonschema:"enum=bindings,enum=state,enum=secretstores,enum=pubsub,enum=workflows,enum=configuration,enum=lock,enum=middleware,enum=crypto"`
+	Type string `json:"type" yaml:"type" jsonschema:"enum=bindings,enum=state,enum=secretstores,enum=pubsub,enum=workflows,enum=configuration,enum=lock,enum=middleware,enum=crypto,enum=conversation"`
 	// Name of the component (without the inital type, e.g. "http" instead of "bindings.http").
 	Name string `json:"name" yaml:"name"`
 	// Version of the component, with the leading "v", e.g. "v1".

--- a/component-metadata-schema.json
+++ b/component-metadata-schema.json
@@ -213,7 +213,8 @@
         "configuration",
         "lock",
         "middleware",
-        "crypto"
+        "crypto",
+        "conversation"
       ],
       "description": "Component type, of one of the allowed values."
     },

--- a/conversation/deepseek/metadata.yaml
+++ b/conversation/deepseek/metadata.yaml
@@ -25,5 +25,5 @@ metadata:
     required: false
     description: |
       Max tokens for each request
-    type: int
-    example: 2048
+    type: number
+    example: "2048"

--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -168,7 +168,8 @@ func (t ComponentType) IsValid() bool {
 		SecretStoreType, PubSubType,
 		LockStoreType, ConfigurationStoreType,
 		MiddlewareType, CryptoType,
-		NameResolutionType, WorkflowType:
+		NameResolutionType, WorkflowType,
+		ConversationType:
 		return true
 	default:
 		return false


### PR DESCRIPTION
# Description

_Please explain the changes you've made_

opening https://github.com/dapr/components-contrib/pull/3705 again

we really need this merged... otherwise the metadata schema does not contain the conversation components

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
