### PR TITLE
fix default value in azure eventhubs binding metadata.yaml

### DIFF
--- a/bindings/azure/eventhubs/metadata.yaml
+++ b/bindings/azure/eventhubs/metadata.yaml
@@ -164,7 +164,7 @@ metadata:
   - name: getAllMessageProperties
     type: bool
     required: false
-    default: false
+    default: "false"
     example: "false"
     binding:
       input: true


### PR DESCRIPTION
# Description

`make bundle-component-metadata` fails because of this

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
