### PR TITLE
Allow to use environment variable for key if present

### DIFF
--- a/conversation/anthropic/anthropic.go
+++ b/conversation/anthropic/anthropic.go
@@ -16,6 +16,7 @@ package anthropic
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	"github.com/dapr/components-contrib/conversation"
@@ -53,6 +54,13 @@ func (a *Anthropic) Init(ctx context.Context, meta conversation.Metadata) error 
 	model := defaultModel
 	if m.Model != "" {
 		model = m.Model
+	}
+
+	if m.Key == "" {
+		envKey, ok := os.LookupEnv("ANTHROPIC_API_KEY")
+		if ok {
+			m.Key = envKey
+		}
 	}
 
 	llm, err := anthropic.New(

--- a/conversation/aws/bedrock/bedrock.go
+++ b/conversation/aws/bedrock/bedrock.go
@@ -16,6 +16,7 @@ package bedrock
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	awsAuth "github.com/dapr/components-contrib/common/authentication/aws"
@@ -59,6 +60,25 @@ func (b *AWSBedrock) Init(ctx context.Context, meta conversation.Metadata) error
 	err := kmeta.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return err
+	}
+
+	if m.Region == "" {
+		region, ok := os.LookupEnv("AWS_REGION")
+		if ok {
+			m.Region = region
+		}
+	}
+	if m.AccessKey == "" {
+		accessKey, ok := os.LookupEnv("AWS_ACCESS_KEY_ID")
+		if ok {
+			m.AccessKey = accessKey
+		}
+	}
+	if m.SecretKey == "" {
+		secretKey, ok := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
+		if ok {
+			m.SecretKey = secretKey
+		}
 	}
 
 	awsConfig, err := awsAuth.GetConfigV2(m.AccessKey, m.SecretKey, m.SessionToken, m.Region, m.Endpoint)

--- a/conversation/deepseek/deepseek.go
+++ b/conversation/deepseek/deepseek.go
@@ -17,6 +17,7 @@ package deepseek
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	"github.com/dapr/components-contrib/conversation"
@@ -57,6 +58,13 @@ func (d *Deepseek) Init(ctx context.Context, meta conversation.Metadata) error {
 	model := defaultModel
 	if md.Model != "" {
 		model = md.Model
+	}
+
+	if md.Key == "" {
+		envKey, ok := os.LookupEnv("DEEPSEEK_API_KEY")
+		if ok {
+			md.Key = envKey
+		}
 	}
 
 	options := []openai.Option{

--- a/conversation/googleai/googleai.go
+++ b/conversation/googleai/googleai.go
@@ -16,6 +16,7 @@ package googleai
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	"github.com/dapr/components-contrib/conversation"
@@ -53,6 +54,22 @@ func (g *GoogleAI) Init(ctx context.Context, meta conversation.Metadata) error {
 	model := defaultModel
 	if md.Model != "" {
 		model = md.Model
+	}
+
+	if md.Key == "" {
+		envKey, ok := os.LookupEnv("GOOGLE_API_KEY")
+		if ok {
+			md.Key = envKey
+		} else {
+			envKey, ok = os.LookupEnv("GEMINI_API_KEY")
+			if ok {
+				md.Key = envKey
+			} else {
+				if envKey, ok := os.LookupEnv("GOOGLE_AI_API_KEY"); ok {
+					md.Key = envKey
+				}
+			}
+		}
 	}
 
 	opts := []googleai.Option{

--- a/conversation/huggingface/huggingface.go
+++ b/conversation/huggingface/huggingface.go
@@ -16,6 +16,7 @@ package huggingface
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"strings"
 
@@ -63,6 +64,13 @@ func (h *Huggingface) Init(ctx context.Context, meta conversation.Metadata) erro
 	endpoint := strings.Replace(defaultEndpoint, "{{model}}", model, 1)
 	if m.Endpoint != "" {
 		endpoint = m.Endpoint
+	}
+
+	if m.Key == "" {
+		envKey, ok := os.LookupEnv("HUGGINGFACE_API_KEY")
+		if ok {
+			m.Key = envKey
+		}
 	}
 
 	// Create options for OpenAI client using HuggingFace's OpenAI-compatible API

--- a/conversation/mistral/mistral.go
+++ b/conversation/mistral/mistral.go
@@ -16,6 +16,7 @@ package mistral
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	"github.com/dapr/components-contrib/conversation"
@@ -54,6 +55,13 @@ func (m *Mistral) Init(ctx context.Context, meta conversation.Metadata) error {
 	model := defaultModel
 	if md.Model != "" {
 		model = md.Model
+	}
+
+	if md.Key == "" {
+		envKey, ok := os.LookupEnv("MISTRAL_API_KEY")
+		if ok {
+			md.Key = envKey
+		}
 	}
 
 	llm, err := mistral.New(

--- a/conversation/openai/openai.go
+++ b/conversation/openai/openai.go
@@ -16,6 +16,7 @@ package openai
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	"github.com/dapr/components-contrib/conversation"
@@ -54,6 +55,14 @@ func (o *OpenAI) Init(ctx context.Context, meta conversation.Metadata) error {
 	if md.Model != "" {
 		model = md.Model
 	}
+
+	if md.Key == "" {
+		envKey, ok := os.LookupEnv("OPENAI_API_KEY")
+		if ok {
+			md.Key = envKey
+		}
+	}
+
 	// Create options for OpenAI client
 	options := []openai.Option{
 		openai.WithModel(model),


### PR DESCRIPTION
# Description

While developing applications, it is useful to be able to quickly use the API Keys that are present on the environment, and also specially on quickstarts. This adds an option to provide some credentials for conversation API via environment variables if not already provided.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
