### PR TITLE
Add Path Filter Support to OAuth2 and Client Credentials Middlewares

### DIFF
--- a/middleware/http/oauth2/oauth2_middleware_test.go
+++ b/middleware/http/oauth2/oauth2_middleware_test.go
@@ -61,3 +61,48 @@ func TestOAuth2CreatesAuthorizationHeaderWhenInSessionState(t *testing.T) {
 
 	assert.Equal(t, "Bearer abcd", r.Header.Get("someHeader"))
 }
+
+func TestOAuth2CreatesAuthorizationHeaderGetNativeMetadata(t *testing.T) {
+	var metadata middleware.Metadata
+	metadata.Properties = map[string]string{
+		"clientID":       "testId",
+		"clientSecret":   "testSecret",
+		"scopes":         "ascope",
+		"authURL":        "https://idp:9999",
+		"tokenURL":       "https://idp:9999",
+		"redirectUrl":    "https://localhost:9999",
+		"authHeaderName": "someHeader",
+	}
+
+	log := logger.NewLogger("oauth2.test")
+	oauth2Middleware, _ := NewOAuth2Middleware(log).(*Middleware)
+
+	tc := []struct {
+		name       string
+		pathFilter string
+		wantErr    bool
+	}{
+		{name: "empty pathFilter", pathFilter: "", wantErr: false},
+		{name: "wildcard pathFilter", pathFilter: ".*", wantErr: false},
+		{name: "api path pathFilter", pathFilter: "/api/v1/users", wantErr: false},
+		{name: "debug endpoint pathFilter", pathFilter: "^/debug/?$", wantErr: false},
+		{name: "user id pathFilter", pathFilter: "^/user/[0-9]+$", wantErr: false},
+		{name: "invalid wildcard pathFilter", pathFilter: "*invalid", wantErr: true},
+		{name: "unclosed parenthesis pathFilter", pathFilter: "invalid(", wantErr: true},
+		{name: "unopened parenthesis pathFilter", pathFilter: "invalid)", wantErr: true},
+		{name: "duplicate unclosed parenthesis pathFilter", pathFilter: "invalid(", wantErr: true},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata.Properties["pathFilter"] = tt.pathFilter
+			nativeMetadata, err := oauth2Middleware.getNativeMetadata(metadata)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, nativeMetadata.pathFilterRegex)
+			}
+		})
+	}
+}

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -43,6 +44,9 @@ type oAuth2ClientCredentialsMiddlewareMetadata struct {
 	HeaderName          string `json:"headerName" mapstructure:"headerName"`
 	EndpointParamsQuery string `json:"endpointParamsQuery,omitempty" mapstructure:"endpointParamsQuery"`
 	AuthStyle           int    `json:"authStyle" mapstructure:"authStyle"`
+	PathFilter          string `json:"pathFilter" mapstructure:"pathFilter"`
+
+	pathFilterRegex *regexp.Regexp
 }
 
 // TokenProviderInterface provides a common interface to Mock the Token retrieval in unit tests.
@@ -69,7 +73,7 @@ type Middleware struct {
 	tokenProvider TokenProviderInterface
 }
 
-// GetHandler retruns the HTTP handler provided by the middleware.
+// GetHandler returns the HTTP handler provided by the middleware.
 func (m *Middleware) GetHandler(_ context.Context, metadata middleware.Metadata) (func(next http.Handler) http.Handler, error) {
 	meta, err := m.getNativeMetadata(metadata)
 	if err != nil {
@@ -98,26 +102,37 @@ func (m *Middleware) GetHandler(_ context.Context, metadata middleware.Metadata)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var headerValue string
 
-			// Check if valid token is in the cache
-			cachedToken, found := m.tokenCache.Get(cacheKey)
-			if !found {
-				m.log.Debugf("Cached token not found, try get one")
-
-				token, err := m.tokenProvider.GetToken(r.Context(), conf)
-				if err != nil {
-					m.log.Errorf("Error acquiring token: %s", err)
+			if meta.pathFilterRegex != nil {
+				matched := meta.pathFilterRegex.MatchString(r.URL.Path)
+				if !matched {
+					m.log.Debugf("PathFilter %s didn't match %s! Skipping!", meta.PathFilter, r.URL.Path)
+					next.ServeHTTP(w, r)
 					return
 				}
-
-				tokenExpirationDuration := time.Until(token.Expiry)
-				m.log.Debugf("Token expires at %s (%s from now)", token.Expiry, tokenExpirationDuration)
-
-				headerValue = token.Type() + " " + token.AccessToken
-				m.tokenCache.Set(cacheKey, headerValue, tokenExpirationDuration)
-			} else {
-				m.log.Debugf("Cached token found for key %s", cacheKey)
-				headerValue = cachedToken.(string)
 			}
+
+			// Check if valid token is in the cache
+			cachedToken, found := m.tokenCache.Get(cacheKey)
+			if found {
+				m.log.Infof("Cached token found for key %s", cacheKey)
+				headerValue = cachedToken.(string)
+				r.Header.Add(meta.HeaderName, headerValue)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			m.log.Infof("Cached token not found, try get one")
+			token, err := m.tokenProvider.GetToken(r.Context(), conf)
+			if err != nil {
+				m.log.Errorf("Error acquiring token: %s", err)
+				return
+			}
+
+			tokenExpirationDuration := time.Until(token.Expiry)
+			m.log.Infof("Token expires at %s (%s from now)", token.Expiry, tokenExpirationDuration)
+
+			headerValue = token.Type() + " " + token.AccessToken
+			m.tokenCache.Set(cacheKey, headerValue, tokenExpirationDuration)
 
 			r.Header.Add(meta.HeaderName, headerValue)
 			next.ServeHTTP(w, r)
@@ -141,6 +156,14 @@ func (m *Middleware) getNativeMetadata(metadata middleware.Metadata) (*oAuth2Cli
 	m.checkMetadataValueExists(&errorString, &middlewareMetadata.ClientSecret, "clientSecret")
 	m.checkMetadataValueExists(&errorString, &middlewareMetadata.Scopes, "scopes")
 	m.checkMetadataValueExists(&errorString, &middlewareMetadata.TokenURL, "tokenURL")
+
+	if middlewareMetadata.PathFilter != "" {
+		rx, err := regexp.Compile(middlewareMetadata.PathFilter)
+		if err != nil {
+			errorString += fmt.Sprintf("Parameter 'pathFilter' is not a valid regex: %s. ", err)
+		}
+		middlewareMetadata.pathFilterRegex = rx
+	}
 
 	// Value-check AuthStyle
 	if middlewareMetadata.AuthStyle < 0 || middlewareMetadata.AuthStyle > 2 {

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_benchmark_test.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_benchmark_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth2clientcredentials
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dapr/components-contrib/middleware"
+	mock "github.com/dapr/components-contrib/middleware/http/oauth2clientcredentials/mocks"
+	"github.com/dapr/kit/logger"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func BenchmarkTestOAuth2ClientCredentialsGetHandler(b *testing.B) {
+	mockCtrl := gomock.NewController(b)
+	defer mockCtrl.Finish()
+	mockTokenProvider := mock.NewMockTokenProviderInterface(mockCtrl)
+	gomock.InOrder(
+		mockTokenProvider.
+			EXPECT().
+			GetToken(gomock.Any()).
+			Return(&oauth2.Token{
+				AccessToken: "abcd",
+				TokenType:   "Bearer",
+				Expiry:      time.Now().Add(1 * time.Minute),
+			}, nil).
+			Times(1),
+	)
+
+	var metadata middleware.Metadata
+	metadata.Properties = map[string]string{
+		"clientID":     "testId",
+		"clientSecret": "testSecret",
+		"scopes":       "ascope",
+		"tokenURL":     "https://localhost:9999",
+		"headerName":   "authorization",
+		"authStyle":    "1",
+	}
+
+	log := logger.NewLogger("oauth2clientcredentials.test")
+	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
+	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(b.Context(), metadata)
+	require.NoError(b, err)
+
+	for i := 0; i < b.N; i++ {
+		url := fmt.Sprintf("http://dapr.io/api/v1/users/%d", i)
+		r := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		handler(http.HandlerFunc(mockedRequestHandler)).ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkTestOAuth2ClientCredentialsGetHandlerWithPathFilter(b *testing.B) {
+	mockCtrl := gomock.NewController(b)
+	defer mockCtrl.Finish()
+	mockTokenProvider := mock.NewMockTokenProviderInterface(mockCtrl)
+	gomock.InOrder(
+		mockTokenProvider.
+			EXPECT().
+			GetToken(gomock.Any()).
+			Return(&oauth2.Token{
+				AccessToken: "abcd",
+				TokenType:   "Bearer",
+				Expiry:      time.Now().Add(1 * time.Minute),
+			}, nil).
+			Times(1),
+	)
+
+	var metadata middleware.Metadata
+	metadata.Properties = map[string]string{
+		"clientID":     "testId",
+		"clientSecret": "testSecret",
+		"scopes":       "ascope",
+		"tokenURL":     "https://localhost:9999",
+		"headerName":   "authorization",
+		"authStyle":    "1",
+		"pathFilter":   "/api/v1/users/.*",
+	}
+
+	log := logger.NewLogger("oauth2clientcredentials.test")
+	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
+	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(b.Context(), metadata)
+	require.NoError(b, err)
+
+	for i := 0; i < b.N; i++ {
+		url := fmt.Sprintf("http://dapr.io/api/v1/users/%d", i)
+		r := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		handler(http.HandlerFunc(mockedRequestHandler)).ServeHTTP(w, r)
+	}
+}

--- a/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
+++ b/middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	oauth2 "golang.org/x/oauth2"
 
+	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/middleware"
 	mock "github.com/dapr/components-contrib/middleware/http/oauth2clientcredentials/mocks"
 	"github.com/dapr/kit/logger"
@@ -198,4 +199,103 @@ func TestOAuth2ClientCredentialsCache(t *testing.T) {
 
 	// Assertion
 	assert.Equal(t, "MAC def", r.Header.Get("someHeader"))
+}
+
+func TestOAuth2ClientCredentialsPathFilterGetNativeMetadata(t *testing.T) {
+	log := logger.NewLogger("oauth2clientcredentials.test")
+	m, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
+
+	baseMiddlewareMetadata := middleware.Metadata{
+		Base: metadata.Base{
+			Properties: map[string]string{
+				"clientID":     "testId",
+				"clientSecret": "testSecret",
+				"scopes":       "ascope",
+				"tokenURL":     "https://localhost:9999",
+				"headerName":   "someHeader",
+				"authStyle":    "1",
+			},
+		},
+	}
+
+	tc := []struct {
+		name       string
+		pathFilter string
+		wantErr    bool
+	}{
+		{name: "empty pathFilter", pathFilter: "", wantErr: false},
+		{name: "wildcard pathFilter", pathFilter: ".*", wantErr: false},
+		{name: "api path pathFilter", pathFilter: "/api/v1/users", wantErr: false},
+		{name: "debug endpoint pathFilter", pathFilter: "^/debug/?$", wantErr: false},
+		{name: "user id pathFilter", pathFilter: "^/user/[0-9]+$", wantErr: false},
+		{name: "invalid wildcard pathFilter", pathFilter: "*invalid", wantErr: true},
+		{name: "unclosed parenthesis pathFilter", pathFilter: "invalid(", wantErr: true},
+		{name: "unopened parenthesis pathFilter", pathFilter: "invalid)", wantErr: true},
+		{name: "duplicate unclosed parenthesis pathFilter", pathFilter: "invalid(", wantErr: true},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			baseMiddlewareMetadata.Properties["pathFilter"] = tt.pathFilter
+			_, err := m.getNativeMetadata(baseMiddlewareMetadata)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOAuth2ClientCredentialsPathFilterGetHandler(t *testing.T) {
+	// Setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Mock mockTokenProvider
+	mockTokenProvider := mock.NewMockTokenProviderInterface(mockCtrl)
+
+	gomock.InOrder(
+		// First call returning abc and Bearer, expires within 1 second
+		mockTokenProvider.
+			EXPECT().
+			GetToken(gomock.Any()).
+			Return(&oauth2.Token{
+				AccessToken: "abcd",
+				TokenType:   "Bearer",
+				Expiry:      time.Now().In(time.UTC).Add(1 * time.Second),
+			}, nil).
+			Times(1),
+	)
+
+	var metadata middleware.Metadata
+	metadata.Properties = map[string]string{
+		"clientID":     "testId",
+		"clientSecret": "testSecret",
+		"scopes":       "ascope",
+		"tokenURL":     "https://localhost:9999",
+		"headerName":   "authorization",
+		"authStyle":    "1",
+		"pathFilter":   "/api/v1/users/.*",
+	}
+
+	log := logger.NewLogger("oauth2clientcredentials.test")
+	oauth2clientcredentialsMiddleware, _ := NewOAuth2ClientCredentialsMiddleware(log).(*Middleware)
+	oauth2clientcredentialsMiddleware.SetTokenProvider(mockTokenProvider)
+	handler, err := oauth2clientcredentialsMiddleware.GetHandler(t.Context(), metadata)
+	require.NoError(t, err)
+
+	// pathFilter should match
+	r := httptest.NewRequest(http.MethodGet, "http://dapr.io/api/v1/users/123", nil)
+	w := httptest.NewRecorder()
+	handler(http.HandlerFunc(mockedRequestHandler)).ServeHTTP(w, r)
+
+	assert.Equal(t, "Bearer abcd", r.Header.Get("authorization"))
+
+	// pathFilter should not match
+	r = httptest.NewRequest(http.MethodGet, "http://dapr.io/api/v1/tokens/123", nil)
+	w = httptest.NewRecorder()
+	handler(http.HandlerFunc(mockedRequestHandler)).ServeHTTP(w, r)
+
+	assert.Equal(t, "", r.Header.Get("authorization"))
 }


### PR DESCRIPTION
# Description

This pull request introduces a new `pathFilter` feature to the OAuth2 and OAuth2 Client Credentials middleware, allowing users to specify regex-based path filtering. The changes include updates to the middleware logic, metadata handling, and the addition of unit and benchmark tests to validate the functionality.

### Path Filter Feature Implementation:

* **OAuth2 Middleware:**
  - Added `pathFilter` and its compiled regex (`pathFilterRegex`) to the `oAuth2MiddlewareMetadata` struct  
    [`oauth2_middleware.go` L46–48](middleware/http/oauth2/oauth2_middleware.go#L46-L48)
  - Integrated `pathFilterRegex` validation in the request handling pipeline to skip middleware logic for non-matching paths  
    [`oauth2_middleware.go` L91–99](middleware/http/oauth2/oauth2_middleware.go#L91-L99)
  - Updated `getNativeMetadata` to compile the `pathFilter` regex and handle invalid regex errors  
    [`oauth2_middleware.go` L169–177](middleware/http/oauth2/oauth2_middleware.go#L169-L177)

* **OAuth2 Client Credentials Middleware:**
  - Added `pathFilter` and `pathFilterRegex` to the `oAuth2ClientCredentialsMiddlewareMetadata` struct  
    [`oauth2clientcredentials_middleware.go` L47–49](middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go#L47-L49)
  - Incorporated `pathFilterRegex` validation in the middleware request handler  
    [`oauth2clientcredentials_middleware.go` L105–120](middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go#L105-L120)
  - Enhanced `getNativeMetadata` to compile and validate the `pathFilter` regex  
    [`oauth2clientcredentials_middleware.go` L160–167](middleware/http/oauth2clientcredentials/oauth2clientcredentials_middleware.go#L160-L167)



### Benchmark Comparison

| Benchmark                                               | Parallelism | Time per op (ns) | Allocated bytes | Allocs per op |
|---------------------------------------------------------|-------------|------------------|------------------|----------------|
| `...WithPathFilter`                                     | 10          | 23139            | 7071             | 40             |
| `...WithoutPathFilter`                                  | 10          | 23256            | 6955             | 40             |
| `...WithPathFilter`                                     | 1000        | 24672            | 7024             | 40             |
| `...WithoutPathFilter`                                  | 1000        | 21861            | 7085             | 40             |

** Adding a pre-compiled regex-based path filter has negligible impact on performance and allocations. **


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

https://github.com/dapr/components-contrib/issues/3898

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: WIP
