### PR TITLE
fix: Fix kafka consumer shutdown

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -22,6 +22,8 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 )
 
+var ErrGracefulShutdown = errors.New("pubsub shutdown")
+
 // PubSub is the interface for message buses.
 type PubSub interface {
 	metadata.ComponentWithMetadata


### PR DESCRIPTION
# Description

### Problem
When running Dapr with `dapr.io/block-shutdown-duration`, Kafka subscriptions are stopped before the graceful shutdown starts. This prevents Kafka from triggering a rebalance, which only occurs when the consumer group is properly closed. As a result, messages are not consumed by other members of the consumer group until the session timeout expires, leading to message processing delays during application shutdown.
### Solution
This PR modifies the Kafka component's shutdown behavior to ensure proper consumer group closure during graceful shutdown:
1. **Enhanced Context Handling**: Added logic to detect when the subscription context is canceled due to shutdown (using ) `pubsub.ErrGracefulShutdown`
2. **Graceful Consumer Group Closure**: When shutdown is detected, the consumer group is explicitly closed to trigger an immediate Kafka rebalance, allowing other consumers in the group to take over message processing without waiting for session timeout
3. **Improved Logging**: Added debug logging to better track the shutdown process and consumer group closure

### Changes
- Modified `Subscribe` method in to handle shutdown-specific context cancellation `subscriber.go`
- Added post-action logic to close consumer group when shutdown is detected
- Enhanced error handling and logging for better observability during shutdown

### Testing
The changes maintain backward compatibility and only affect the shutdown path when `dapr.io/block-shutdown-duration` is used.



## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3887

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
