### PR TITLE
ci: sync release branch workflow

### DIFF
--- a/.github/workflows/sync-release-branch.yaml.yml
+++ b/.github/workflows/sync-release-branch.yaml.yml
@@ -1,0 +1,44 @@
+
+# ------------------------------------------------------------
+# Copyright 2025 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+name: Sync release branch to main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release-*
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing release branch to main
+    outputs:
+      pr_number: ${{ steps.create_pr.outputs.pr_number }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - name: Create sync PR from release branch to main
+      id: create_pr
+      uses: tretuna/sync-branches@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+        FROM_BRANCH: ${{ github.ref_name }}
+        TO_BRANCH: main

--- a/.github/workflows/sync-release-branch.yaml.yml
+++ b/.github/workflows/sync-release-branch.yaml.yml
@@ -1,4 +1,3 @@
-
 # ------------------------------------------------------------
 # Copyright 2025 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the synchronization of release branches to the `main` branch. The workflow is triggered by either a manual dispatch or a push to any `release-*` branch.

### New GitHub Actions Workflow:

* [`.github/workflows/sync-release-branch.yaml.yml`](diffhunk://#diff-0678707cf92d7c29b2ff25f01375383bc62990f98f7cf146feeb0e6e8a619b4bR1-R44): Added a new workflow named "Sync release branch to main" to automate the creation of pull requests for syncing changes from release branches to the `main` branch. It includes steps for checking out the repository, setting up Node.js, and using the `tretuna/sync-branches` action to create the pull request.