### PR TITLE
fixed the kubernetes secret component for cryptography

### DIFF
--- a/crypto/kubernetes/secrets/component.go
+++ b/crypto/kubernetes/secrets/component.go
@@ -123,7 +123,7 @@ func (k *kubeSecretsCrypto) retrieveKeyFromSecret(parentCtx context.Context, key
 // parseKeyString returns the secret name, key, and optional namespace from the key parameter.
 // If the key parameter doesn't contain a namespace, returns the default one.
 func (k *kubeSecretsCrypto) parseKeyString(param string) (namespace string, secret string, key string, err error) {
-	parts := strings.Split(key, "/")
+	parts := strings.Split(param, "/")
 	switch len(parts) {
 	case 3:
 		namespace = parts[0]


### PR DESCRIPTION
# Description

Bug in the kubernetes secret component for cyptography prevented it from being utilised in any fashion. This is now fixed.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3840

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
