### PR TITLE
fix: pin macos-14

### DIFF
--- a/.github/workflows/components-contrib-all.yml
+++ b/.github/workflows/components-contrib-all.yml
@@ -68,19 +68,20 @@ jobs:
       GOLANGCI_LINT_VER: "v1.64.6"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # TODO: @nelson-parente Upgrade macos latest once dns is fixed.
+        os: [ubuntu-latest, windows-latest, macos-14]
         target_arch: [arm, amd64]
         include:
           - os: ubuntu-latest
             target_os: linux
           - os: windows-latest
             target_os: windows
-          - os: macOS-latest
+          - os: macos-14
             target_os: darwin
         exclude:
           - os: windows-latest
             target_arch: arm
-          - os: macOS-latest
+          - os: macos-14
             target_arch: arm
     steps:
       - name: Set default payload repo and ref


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to address an issue with the macOS runner. Specifically, it replaces `macOS-latest` with `macos-14` in the job matrix, with a note to upgrade once DNS issues are resolved.

Platform matrix update:

* Updated the `os` matrix in `.github/workflows/components-contrib-all.yml` to use `macos-14` instead of `macOS-latest` for all relevant jobs, and adjusted the corresponding `include` and `exclude` entries. Added a TODO comment referencing the DNS issue.