### PR TITLE
fix: wasm timing issue with strict sandbox

### DIFF
--- a/common/wasm/wasm_test.go
+++ b/common/wasm/wasm_test.go
@@ -180,7 +180,7 @@ func TestNewModuleConfig(t *testing.T) {
 			// lower bound. In any case, the important part is that we aren't
 			// actually sleeping 50ms, which is what wasm thinks is happening.
 			minDuration: 0,
-			maxDuration: 1 * time.Millisecond,
+			maxDuration: 10 * time.Millisecond,
 		},
 	}
 
@@ -219,9 +219,7 @@ func TestNewModuleConfig(t *testing.T) {
 				require.NotEqual(t, deterministicOut, out.String())
 			}
 			require.GreaterOrEqual(t, duration, tc.minDuration)
-			// Add 0.1ms buffer to account for the extra time we spend in Go.
-			allowed := tc.maxDuration + 100*time.Microsecond
-			require.LessOrEqual(t, duration, allowed)
+			require.LessOrEqual(t, duration, tc.maxDuration)
 		})
 	}
 }


### PR DESCRIPTION
The test is failing ([source](https://github.com/dapr/components-contrib/actions/runs/17108414770/job/48523298942?pr=3924)) because the wasm code is taking a bit longer to run, 1ms is not enough sometimes.

I adjusted the `maxDuration` to 10ms. It's plenty of time to run it, but as long as it's lower than 50 we are testing that the `time.Sleep` is not actually happening, so 10 is enough