### PR TITLE
Fix certification pubsub errors

### DIFF
--- a/pubsub/aws/snssqs/subscription_mgmt.go
+++ b/pubsub/aws/snssqs/subscription_mgmt.go
@@ -118,7 +118,11 @@ func (sm *SubscriptionManager) queueConsumerController(queueConsumerCbk func(con
 
 			sm.lock.Unlock()
 		case <-sm.closeCh:
-			return
+			if sm.topicsHandlers.Size() == 0 {
+				return
+			} else {
+				sm.logger.Info("Shutdown initiated, waiting for all subscriptions to be cleaned up")
+			}
 		}
 	}
 }

--- a/tests/certification/bindings/zeebe/command/create_instance_test.go
+++ b/tests/certification/bindings/zeebe/command/create_instance_test.go
@@ -290,6 +290,7 @@ func TestCreateInstanceOperation(t *testing.T) {
 	flow.New(t, "Test create instance operation (async)").
 		Step(dockercompose.Run("zeebe", zeebe_test.DockerComposeYaml)).
 		Step("Waiting for Zeebe Readiness...", retry.Do(time.Second*3, 10, zeebe_test.CheckZeebeConnection)).
+		Step(app.Run("workerApp", fmt.Sprintf(":%d", appPort), workers(0))).
 		Step(sidecar.Run(zeebe_test.SidecarName,
 			append(componentRuntimeOptions(),
 				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
@@ -298,7 +299,6 @@ func TestCreateInstanceOperation(t *testing.T) {
 				embedded.WithResourcesPath("components/standard"),
 			)...,
 		)).
-		Step(app.Run("workerApp", fmt.Sprintf(":%d", appPort), workers(0))).
 		Step("Waiting for the component to start", flow.Sleep(10*time.Second)).
 		Step("Deploy process in version 1", deployVersion1).
 		Step("Deploy process in version 2", deployVersion2).
@@ -314,6 +314,7 @@ func TestCreateInstanceOperation(t *testing.T) {
 	flow.New(t, "Test create instance operation (sync)").
 		Step(dockercompose.Run("zeebe", zeebe_test.DockerComposeYaml)).
 		Step("Waiting for Zeebe Readiness...", retry.Do(time.Second*3, 10, zeebe_test.CheckZeebeConnection)).
+		Step(app.Run("workerApp", fmt.Sprintf(":%d", appPort), workers(20*time.Second))).
 		Step(sidecar.Run(zeebe_test.SidecarName,
 			append(componentRuntimeOptions(),
 				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
@@ -322,7 +323,6 @@ func TestCreateInstanceOperation(t *testing.T) {
 				embedded.WithResourcesPath("components/syncProcessCreation"),
 			)...,
 		)).
-		Step(app.Run("workerApp", fmt.Sprintf(":%d", appPort), workers(20*time.Second))).
 		Step("Waiting for the component to start", flow.Sleep(10*time.Second)).
 		Step("Deploy process in version 1", deployVersion1).
 		Step("Deploy process in version 2", deployVersion2).


### PR DESCRIPTION
In certification tests, wait for sidecar to be healthy before continuing with the test.

Also added a small improvement in AWS SQS/SNS to wait for subscriptions to be unsubscribed on close before stopping the subscriber loop, otherwise the stopped sidecars were not really unsubscribing and stopping the consuming loop.