### PR TITLE
add contentType metadata support for GCP bucket operations

### DIFF
--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -42,13 +42,14 @@ import (
 )
 
 const (
-	objectURLBase        = "https://storage.googleapis.com/%s/%s"
-	metadataDecodeBase64 = "decodeBase64"
-	metadataEncodeBase64 = "encodeBase64"
-	metadataSignTTL      = "signTTL"
-
-	metadataKey = "key"
-	maxResults  = 1000
+	objectURLBase           = "https://storage.googleapis.com/%s/%s"
+	metadataDecodeBase64    = "decodeBase64"
+	metadataEncodeBase64    = "encodeBase64"
+	metadataSignTTL         = "signTTL"
+	metadataContentType     = "contentType"
+	metadataContentEncoding = "contentEncoding"
+	metadataKey             = "key"
+	maxResults              = 1000
 
 	metadataKeyBC    = "name"
 	signOperation    = "sign"
@@ -77,6 +78,7 @@ type gcpMetadata struct {
 	TokenURI            string `json:"token_uri" mapstructure:"tokenURI" mdignore:"true" mapstructurealiases:"token_uri"`
 	AuthProviderCertURL string `json:"auth_provider_x509_cert_url" mapstructure:"authProviderX509CertURL" mdignore:"true" mapstructurealiases:"auth_provider_x509_cert_url"`
 	ClientCertURL       string `json:"client_x509_cert_url" mapstructure:"clientX509CertURL" mdignore:"true" mapstructurealiases:"client_x509_cert_url"`
+	ContentType         string `json:"contentType,omitempty" mapstructure:"contentType"`
 
 	Bucket       string `json:"bucket" mapstructure:"bucket"`
 	DecodeBase64 bool   `json:"decodeBase64,string" mapstructure:"decodeBase64"`
@@ -233,6 +235,12 @@ func (g *GCPStorage) create(ctx context.Context, req *bindings.InvokeRequest) (*
 	}
 
 	h := g.client.Bucket(g.metadata.Bucket).Object(name).NewWriter(ctx)
+
+	// Set content type if provided
+	if metadata.ContentType != "" {
+		h.ContentType = metadata.ContentType
+	}
+
 	// Cannot do `defer h.Close()` as Close() will flush the bytes and need to have error handling.
 	if _, err = io.Copy(h, r); err != nil {
 		cerr := h.Close()
@@ -378,9 +386,15 @@ func (metadata gcpMetadata) mergeWithRequestMetadata(req *bindings.InvokeRequest
 	if val, ok := req.Metadata[metadataEncodeBase64]; ok && val != "" {
 		merged.EncodeBase64 = strings.IsTruthy(val)
 	}
+
 	if val, ok := req.Metadata[metadataSignTTL]; ok && val != "" {
 		merged.SignTTL = val
 	}
+
+	if val, ok := req.Metadata[metadataContentType]; ok && val != "" {
+		merged.ContentType = val
+	}
+
 	return merged, nil
 }
 

--- a/bindings/gcp/bucket/bucket.go
+++ b/bindings/gcp/bucket/bucket.go
@@ -42,14 +42,14 @@ import (
 )
 
 const (
-	objectURLBase           = "https://storage.googleapis.com/%s/%s"
-	metadataDecodeBase64    = "decodeBase64"
-	metadataEncodeBase64    = "encodeBase64"
-	metadataSignTTL         = "signTTL"
-	metadataContentType     = "contentType"
-	metadataContentEncoding = "contentEncoding"
-	metadataKey             = "key"
-	maxResults              = 1000
+	objectURLBase        = "https://storage.googleapis.com/%s/%s"
+	metadataDecodeBase64 = "decodeBase64"
+	metadataEncodeBase64 = "encodeBase64"
+	metadataSignTTL      = "signTTL"
+
+	metadataContentType = "contentType"
+	metadataKey         = "key"
+	maxResults          = 1000
 
 	metadataKeyBC    = "name"
 	signOperation    = "sign"

--- a/bindings/gcp/bucket/metadata.yaml
+++ b/bindings/gcp/bucket/metadata.yaml
@@ -45,3 +45,11 @@ metadata:
       Configuration to encode base64 file content before return the content. 
       (In case of saving a file with binary content).
     example: '"true, false"'
+  - name: contentType
+    type: string
+    required: false
+    description: |
+      The MIME type of the object being stored. If not specified, GCS will attempt to 
+      auto-detect the type, which may default to application/octet-stream or text/plain.
+      Common values include text/csv, application/json, image/png, etc.
+    example: '"text/csv", "application/json"'


### PR DESCRIPTION
# Description

Allows sending `contentType` metadata to gcs

## Issue reference

PR will close: #3997

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/4846

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
