### PR TITLE
Fix aws secrets manager yaml

### DIFF
--- a/secretstores/aws/secretmanager/secretmanager.go
+++ b/secretstores/aws/secretmanager/secretmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/kit/logger"
+	kitmd "github.com/dapr/kit/metadata"
 )
 
 const (
@@ -177,17 +178,11 @@ func (s *smSecretStore) BulkGetSecret(ctx context.Context, req secretstores.Bulk
 }
 
 func (s *smSecretStore) getSecretManagerMetadata(spec secretstores.Metadata) (*SecretManagerMetaData, error) {
-	b, err := json.Marshal(spec.Properties)
-	if err != nil {
-		return nil, err
-	}
-
 	var meta SecretManagerMetaData
-	err = json.Unmarshal(b, &meta)
+	err := kitmd.DecodeMetadata(spec.Properties, &meta)
 	if err != nil {
 		return nil, err
 	}
-
 	return &meta, nil
 }
 

--- a/secretstores/aws/secretmanager/secretmanager_test.go
+++ b/secretstores/aws/secretmanager/secretmanager_test.go
@@ -499,3 +499,23 @@ func TestGetFeatures(t *testing.T) {
 		assert.Empty(t, f)
 	})
 }
+
+func TestGetSecretManagerMetadata(t *testing.T) {
+	s := &smSecretStore{
+		logger: logger.NewLogger("test"),
+	}
+
+	t.Run("parse multipleKeyValuesPerSecret as string", func(t *testing.T) {
+		metadata := secretstores.Metadata{}
+		metadata.Properties = map[string]string{
+			"region":                     "us-east-1",
+			"accessKey":                  "test",
+			"secretKey":                  "test",
+			"multipleKeyValuesPerSecret": "true",
+		}
+
+		meta, err := s.getSecretManagerMetadata(metadata)
+		require.NoError(t, err)
+		assert.True(t, meta.MultipleKeyValuesPerSecret)
+	})
+}


### PR DESCRIPTION
# Description

Replaced the JSON marshal/unmarshal approach in `getSecretManagerMetadata` with `kitmd.DecodeMetadata` to properly handle string-to-boolean conversion for the `multipleKeyValuesPerSecret` field.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #4045

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
