### PR TITLE
Adds Global TTL Configuration for DynamoDB State Store

### DIFF
--- a/state/aws/dynamodb/dynamodb.go
+++ b/state/aws/dynamodb/dynamodb.go
@@ -493,26 +493,7 @@ func (d *StateStore) Multi(ctx context.Context, request *state.TransactionalStat
 			if err != nil {
 				return fmt.Errorf("dynamodb error: failed to marshal value for key %s: %w", req.Key, err)
 			}
-			ttl, err := d.parseTTL(&req)
-			if err != nil {
-				return fmt.Errorf("dynamodb error: failed to parse ttlInSeconds: %w", err)
-			}
-			twi.Put = &types.Put{
-				TableName: ptr.Of(d.table),
-				Item: map[string]types.AttributeValue{
-					d.partitionKey: &types.AttributeValueMemberS{
-						Value: req.Key,
-					},
-					"value": &types.AttributeValueMemberS{
-						Value: value,
-					},
-				},
-			}
-			if ttl != nil {
-				twi.Put.Item[d.ttlAttributeName] = &types.AttributeValueMemberN{
-					Value: strconv.FormatInt(*ttl, 10),
-				}
-			}
+			twi.Put = pd.ToPut()
 
 		case state.DeleteRequest:
 			twi.Delete = &types.Delete{

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -1008,3 +1008,200 @@ func TestMultiTx(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestParseTTLWithDefault(t *testing.T) {
+	t.Run("Use explicit TTL from request metadata", func(t *testing.T) {
+		defaultTTL := 600
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key: "test-key",
+			Metadata: map[string]string{
+				"ttlInSeconds": "300",
+			},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		require.NotNil(t, ttl)
+
+		// Should use explicit value (300), not default (600)
+		expectedTime := time.Now().Unix() + 300
+		assert.InDelta(t, expectedTime, *ttl, 2) // Allow 2 second tolerance
+	})
+
+	t.Run("Use default TTL when no explicit TTL in request", func(t *testing.T) {
+		defaultTTL := 600
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key:      "test-key",
+			Metadata: map[string]string{},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		require.NotNil(t, ttl)
+
+		// Should use default value (600)
+		expectedTime := time.Now().Unix() + 600
+		assert.InDelta(t, expectedTime, *ttl, 2) // Allow 2 second tolerance
+	})
+
+	t.Run("No TTL when no default and no explicit TTL", func(t *testing.T) {
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     nil, // No default configured
+		}
+
+		req := &state.SetRequest{
+			Key:      "test-key",
+			Metadata: map[string]string{},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		assert.Nil(t, ttl)
+	})
+
+	t.Run("No TTL when ttlAttributeName is not set", func(t *testing.T) {
+		defaultTTL := 600
+		s := StateStore{
+			ttlAttributeName: "", // TTL not enabled in component
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key: "test-key",
+			Metadata: map[string]string{
+				"ttlInSeconds": "300",
+			},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		assert.Nil(t, ttl) // Should return nil when TTL not enabled
+	})
+
+	t.Run("Explicit TTL with value -1 means no expiration", func(t *testing.T) {
+		defaultTTL := 600
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key: "test-key",
+			Metadata: map[string]string{
+				"ttlInSeconds": "-1",
+			},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		// -1 means never expire
+		assert.Nil(t, ttl)
+	})
+
+	t.Run("Default TTL with large value", func(t *testing.T) {
+		defaultTTL := 86400 // 24 hours
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key:      "test-key",
+			Metadata: map[string]string{},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		require.NotNil(t, ttl)
+
+		expectedTime := time.Now().Unix() + 86400
+		assert.InDelta(t, expectedTime, *ttl, 2)
+	})
+
+	t.Run("Error on invalid TTL value", func(t *testing.T) {
+		defaultTTL := 600
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key: "test-key",
+			Metadata: map[string]string{
+				"ttlInSeconds": "invalid",
+			},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.Error(t, err)
+		assert.Nil(t, ttl)
+		assert.Contains(t, err.Error(), "invalid syntax")
+	})
+
+	t.Run("Explicit TTL with value 0 means no expiration", func(t *testing.T) {
+		defaultTTL := 1200
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key: "test-key",
+			Metadata: map[string]string{
+				"ttlInSeconds": "0",
+			},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		// 0 means never expire, overriding default
+		assert.Nil(t, ttl)
+	})
+
+	t.Run("Default TTL with value 0 means no expiration", func(t *testing.T) {
+		defaultTTL := 0
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key:      "test-key",
+			Metadata: map[string]string{},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		// Default of 0 means never expire
+		assert.Nil(t, ttl)
+	})
+
+	t.Run("Default TTL with negative value means no expiration", func(t *testing.T) {
+		defaultTTL := -1
+		s := StateStore{
+			ttlAttributeName: "expiresAt",
+			ttlInSeconds:     &defaultTTL,
+		}
+
+		req := &state.SetRequest{
+			Key:      "test-key",
+			Metadata: map[string]string{},
+		}
+
+		ttl, err := s.parseTTL(req)
+		require.NoError(t, err)
+		// Default of -1 means never expire
+		assert.Nil(t, ttl)
+	})
+}

--- a/state/aws/dynamodb/dynamodb_test.go
+++ b/state/aws/dynamodb/dynamodb_test.go
@@ -635,15 +635,15 @@ func TestSet(t *testing.T) {
 	t.Run("Successfully set item with ttl = -1", func(t *testing.T) {
 		mockedDB := &awsMock.DynamoDBClient{
 			PutItemFn: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
-				assert.Len(t, params.Item, 4)
+				// Negative TTL value means "no expiration", so TTL attribute should not be present
+				_, hasTTL := params.Item["testAttributeName"]
+				assert.False(t, hasTTL)
 
 				result := DynamoDBItem{}
 				require.NoError(t, attributevalue.UnmarshalMap(params.Item, &result))
 
 				assert.Equal(t, "someKey", result.Key)
 				assert.JSONEq(t, "{\"Value\":\"someValue\"}", result.Value)
-				assert.Greater(t, result.TestAttributeName, time.Now().Unix()-2)
-				assert.Less(t, result.TestAttributeName, time.Now().Unix())
 
 				return &dynamodb.PutItemOutput{
 					Attributes: map[string]types.AttributeValue{
@@ -1027,7 +1027,6 @@ func TestParseTTLWithDefault(t *testing.T) {
 		ttl, err := s.parseTTL(req)
 		require.NoError(t, err)
 		require.NotNil(t, ttl)
-
 		// Should use explicit value (300), not default (600)
 		expectedTime := time.Now().Unix() + 300
 		assert.InDelta(t, expectedTime, *ttl, 2) // Allow 2 second tolerance
@@ -1048,7 +1047,6 @@ func TestParseTTLWithDefault(t *testing.T) {
 		ttl, err := s.parseTTL(req)
 		require.NoError(t, err)
 		require.NotNil(t, ttl)
-
 		// Should use default value (600)
 		expectedTime := time.Now().Unix() + 600
 		assert.InDelta(t, expectedTime, *ttl, 2) // Allow 2 second tolerance

--- a/state/aws/dynamodb/metadata.yaml
+++ b/state/aws/dynamodb/metadata.yaml
@@ -36,6 +36,13 @@ metadata:
       The table attribute name which should be used for TTL.
     example: '"expiresAt"'
     type: string
+  - name: ttlInSeconds
+    required: false
+    description: |
+      Allows specifying a Time-to-live (TTL) in seconds that will be applied to every state store request unless TTL is explicitly defined via the request metadata. If set to zero or less, no default TTL is applied, and items will only expire if a TTL is explicitly provided in the request metadata with ttlAttributeName set.
+    example: "600"
+    default: "0"
+    type: number
   - name: partitionKey
     required: false
     description: |
@@ -46,4 +53,3 @@ metadata:
       url: https://docs.dapr.io/reference/components-reference/supported-state-stores/setup-dynamodb/#partition-keys
     example: '"ContractID"'
     type: string
- 

--- a/tests/certification/state/aws/dynamodb/dynamodb_test.go
+++ b/tests/certification/state/aws/dynamodb/dynamodb_test.go
@@ -118,8 +118,17 @@ func TestAWSDynamoDBStorage(t *testing.T) {
 			// Test	with TTL long enough for value to exist
 			test(metaTTL, stateValue)
 
-			// Test with expired TTL; value must not exist
-			test(metaExpiredTTL, "")
+			// Test with TTL = -1; value must still exist (no expiration) and have no ttlExpireTime
+			err = client.SaveState(ctx, statestore, stateKey, []byte(stateValue), metaExpiredTTL)
+			require.NoError(t, err)
+
+			item, err := client.GetState(ctx, statestore, stateKey, nil)
+			require.NoError(t, err)
+			assert.Equal(t, stateValue, string(item.Value))
+			assert.NotContains(t, item.Metadata, "ttlExpireTime")
+
+			err = client.DeleteState(ctx, statestore, stateKey, nil)
+			require.NoError(t, err)
 
 			return nil
 		}


### PR DESCRIPTION
# Description

Adds a way to globally configure the state TTL for dynamo (inspired by #1059).

The defined default TTL will only be used if the state request does not explicitly specify a TTL itself.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/4911
