### PR TITLE
Fixing an intermittent avro decoding issue on union types

### DIFF
--- a/common/component/kafka/kafka_test.go
+++ b/common/component/kafka/kafka_test.go
@@ -220,7 +220,8 @@ func TestDeserializeValue(t *testing.T) {
 		datum, _, err := codecCard2.NativeFromBinary([]byte{0x02, 0x06})
 		require.NoError(t, err)
 
-		// Prior to bug fix, the datum would be returned as a ["null", 3]!
+		// Prior to bug fix, the datum would be returned as a {"null", 3} but should return '{"long":3}'!
+		require.Nil(t, datum.(map[string]any)["null"])
 		require.Equal(t, int64(3), datum.(map[string]any)["long"])
 
 		// As a result, next call to TextualFromNative would fail with "Cannot encode textual union: cannot encode textual null: expected: Go nil; received: int64"


### PR DESCRIPTION
# Description

Fixing intermittent avro decoding issue on union types due to underlying goavro library issue due to shared state mutation.
[x] Created unit test to reproduce the issue
[ ] Upgraded goavro library following merging [PR](https://github.com/linkedin/goavro/pull/298)

## Issue reference

#4067

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / N/A

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
