### PR TITLE
chore: Propagate message metadata in pubsub

### DIFF
--- a/pubsub/in-memory/in-memory.go
+++ b/pubsub/in-memory/in-memory.go
@@ -64,7 +64,7 @@ func (a *bus) Publish(_ context.Context, req *pubsub.PublishRequest) error {
 		return errors.New("component is closed")
 	}
 
-	a.bus.Publish(req.Topic, req.Data)
+	a.bus.Publish(req.Topic, req.Data, req.Metadata)
 
 	return nil
 }
@@ -75,9 +75,9 @@ func (a *bus) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handle
 	}
 
 	// For this component we allow built-in retries because it is backed by memory
-	retryHandler := func(data []byte) {
+	retryHandler := func(data []byte, md map[string]string) {
 		for range 10 {
-			handleErr := handler(ctx, &pubsub.NewMessage{Data: data, Topic: req.Topic, Metadata: req.Metadata})
+			handleErr := handler(ctx, &pubsub.NewMessage{Data: data, Topic: req.Topic, Metadata: md})
 			if handleErr == nil {
 				break
 			}

--- a/pubsub/in-memory/in-memory_test.go
+++ b/pubsub/in-memory/in-memory_test.go
@@ -102,8 +102,39 @@ func TestRetry(t *testing.T) {
 	assert.Equal(t, 5, i)
 }
 
+func TestMessageMetadataPropagation(t *testing.T) {
+	bus := New(logger.NewLogger("test"))
+	bus.Init(t.Context(), pubsub.Metadata{})
+
+	ch := make(chan []byte)
+	metadataCh := make(chan map[string]string)
+	bus.Subscribe(t.Context(), pubsub.SubscribeRequest{Topic: "demo"}, func(ctx context.Context, msg *pubsub.NewMessage) error {
+		return publishWithMetadata(ch, metadataCh, msg)
+	})
+
+	bus.Publish(t.Context(), &pubsub.PublishRequest{Data: []byte("ABCD"), Metadata: map[string]string{
+		"test": "test",
+	}, Topic: "demo"})
+
+	assert.Equal(t, "ABCD", string(<-ch))
+	assert.Equal(t, map[string]string{
+		"test": "test",
+	}, <-metadataCh)
+}
+
 func publish(ch chan []byte, msg *pubsub.NewMessage) error {
 	go func() { ch <- msg.Data }()
+
+	return nil
+}
+
+func publishWithMetadata(ch chan []byte, mdCh chan map[string]string, msg *pubsub.NewMessage) error {
+	err := publish(ch, msg)
+	if err != nil {
+		return err
+	}
+
+	go func() { mdCh <- msg.Metadata }()
 
 	return nil
 }


### PR DESCRIPTION
# Description
When a message is published using inmemory-pubsub the metadata is propagate alongside the content of the message

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
