### PR TITLE
fix(test): correct mysql cert test failure check

### DIFF
--- a/tests/certification/state/mysql/mysql_test.go
+++ b/tests/certification/state/mysql/mysql_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -273,8 +274,7 @@ func TestMySQL(t *testing.T) {
 			// Should fail
 			err = component.Ping(t.Context())
 			require.Error(t, err)
-			assert.Equal(t, "driver: bad connection", err.Error())
-
+			assert.True(t, strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "bad connection"))
 			return nil
 		}
 	}


### PR DESCRIPTION
# Description

MySQL cert test fails 100% of the time due to an assertion on a string matching that is incorrect now.
https://github.com/dapr/components-contrib/issues/4180

I'm seeing it again here https://github.com/dapr/components-contrib/pull/4184

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
