### PR TITLE
bug: Mysql regression

### DIFF
--- a/bindings/mysql/mysql.go
+++ b/bindings/mysql/mysql.go
@@ -64,7 +64,11 @@ const (
 	respRowsAffectedKey = "rows-affected"
 	respEndTimeKey      = "end-time"
 	respDurationKey     = "duration"
+
+	jsonType = "JSON"
 )
+
+var rawByteType = reflect.TypeOf(&sql.RawBytes{})
 
 // Mysql represents MySQL output bindings.
 type Mysql struct {
@@ -330,6 +334,10 @@ func (m *Mysql) jsonify(rows *sql.Rows) ([]byte, error) {
 func prepareValues(columnTypes []*sql.ColumnType) []any {
 	types := make([]reflect.Type, len(columnTypes))
 	for i, tp := range columnTypes {
+		if tp.DatabaseTypeName() == jsonType {
+			types[i] = rawByteType
+			continue
+		}
 		types[i] = tp.ScanType()
 	}
 


### PR DESCRIPTION
# Description
New version of mysql driver does not return automatically RawBytes for JSON columns, this is a breaking change for dapr mysql binding. This PR fixes the problem by enforcing RawBytes for JSON columns.

[MySql driver PR](https://github.com/go-sql-driver/mysql/pull/1424)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
