### PR TITLE
chore: Sftp binding check for error message

### DIFF
--- a/bindings/sftp/client.go
+++ b/bindings/sftp/client.go
@@ -312,5 +312,7 @@ func isDirNotExistError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, sftpClient.ErrSSHFxNoSuchFile)
+
+	return errors.Is(err, sftpClient.ErrSSHFxNoSuchFile) ||
+		strings.Contains(strings.ToLower(err.Error()), "file does not exist")
 }


### PR DESCRIPTION
# Description

Check for error string containing `"file does not exist"` as some sftp does not return the expected error

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
