### PR TITLE
fix(nr): update to actually match docs on aws auth support

### DIFF
--- a/nameresolution/aws/cloudmap/cloudmap_test.go
+++ b/nameresolution/aws/cloudmap/cloudmap_test.go
@@ -374,3 +374,40 @@ func TestResolve(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertConfigurationToStringMap(t *testing.T) {
+	t.Run("nil configuration", func(t *testing.T) {
+		got := convertConfigurationToStringMap(nil)
+		assert.Nil(t, got)
+	})
+
+	t.Run("map string to string", func(t *testing.T) {
+		in := map[string]string{
+			"region": "us-west-2",
+			"foo":    "bar",
+		}
+		got := convertConfigurationToStringMap(in)
+		assert.Equal(t, len(in), len(got))
+		for k, v := range in {
+			assert.Equal(t, v, got[k])
+		}
+	})
+
+	t.Run("map string to any with mixed types", func(t *testing.T) {
+		in := map[string]any{
+			"string": "value",
+			"int":    42,
+			"bool":   true,
+		}
+		got := convertConfigurationToStringMap(in)
+		assert.Equal(t, len(in), len(got))
+		assert.Equal(t, "value", got["string"])
+		assert.Equal(t, "42", got["int"])
+		assert.Equal(t, "true", got["bool"])
+	})
+
+	t.Run("unsupported type returns nil", func(t *testing.T) {
+		got := convertConfigurationToStringMap([]string{"not", "a", "map"})
+		assert.Nil(t, got)
+	})
+}


### PR DESCRIPTION
# Description

Was checking everything for my 1.17 endgame task for component registration across runtime and metadata bundle and saw this one said it supports all aws auth profiles when in fact it did not. I went ahead and made the minor change to reflect the docs and support all auth profile types.
https://docs.dapr.io/reference/components-reference/supported-name-resolution/nr-awscloudmap/


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
