### PR TITLE
Fix kafka certification flaky test

### DIFF
--- a/tests/certification/bindings/kafka/components/consumer1/kafka.yaml
+++ b/tests/certification/bindings/kafka/components/consumer1/kafka.yaml
@@ -24,3 +24,5 @@ spec:
     value: 50ms
   - name: backOffDuration
     value: 50ms
+  - name: clientConnectionTopicMetadataRefreshInterval
+    value: 15s

--- a/tests/certification/bindings/kafka/components/consumer2/kafka.yaml
+++ b/tests/certification/bindings/kafka/components/consumer2/kafka.yaml
@@ -24,3 +24,5 @@ spec:
     value: 50ms
   - name: backOffDuration
     value: 50ms
+  - name: clientConnectionTopicMetadataRefreshInterval
+    value: 15s

--- a/tests/certification/bindings/kafka/components/sasl-password/kafka-binding.yaml
+++ b/tests/certification/bindings/kafka/components/sasl-password/kafka-binding.yaml
@@ -24,3 +24,5 @@ spec:
     value: admin-secret
   - name: disableTls
     value: "true"
+  - name: clientConnectionTopicMetadataRefreshInterval
+    value: 15s

--- a/tests/certification/pubsub/kafka/components/consumer1/kafka.yaml
+++ b/tests/certification/pubsub/kafka/components/consumer1/kafka.yaml
@@ -16,3 +16,5 @@ spec:
     value: oldest
   - name: backOffDuration
     value: 50ms
+  - name: clientConnectionTopicMetadataRefreshInterval
+    value: 15s

--- a/tests/certification/pubsub/kafka/components/consumer2/kafka.yaml
+++ b/tests/certification/pubsub/kafka/components/consumer2/kafka.yaml
@@ -17,3 +17,5 @@ spec:
     value: oldest
   - name: backOffDuration
     value: 50ms
+  - name: clientConnectionTopicMetadataRefreshInterval
+    value: 15s

--- a/tests/certification/pubsub/kafka/components/consumerAvro/kafka.yaml
+++ b/tests/certification/pubsub/kafka/components/consumerAvro/kafka.yaml
@@ -17,5 +17,7 @@ spec:
     value: oldest
   - name: backOffDuration
     value: 50ms
+  - name: clientConnectionTopicMetadataRefreshInterval
+    value: 15s
   - name: schemaRegistryURL
     value: http://localhost:8081


### PR DESCRIPTION
The `pubsub.kafka certification` has been failing recently.
Here is a recent failed run: https://github.com/dapr/components-contrib/actions/runs/22064373148/job/63752298533

I've rerun the CI step for this PR 5 times and are all green, this is the latest: https://github.com/dapr/components-contrib/actions/runs/22138271750/job/64006659930?pr=4225
<img width="286" height="420" alt="image" src="https://github.com/user-attachments/assets/8fb83cdb-402f-4597-acf7-0c23c17a67af" />

