### PR TITLE
feat: warn when multiple redis stream trim strategies are specified

### DIFF
--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -227,7 +227,10 @@ metadata:
     type: string
   - name: maxLenApprox
     required: false
-    description: Maximum number of items inside a stream. The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited.
+    description: |
+      Maximum number of items inside a stream. The old entries are automatically evicted when the specified length is reached,
+      so that the stream is left at a constant size. Defaults to unlimited.
+      Cannot be used together with streamTTL; only one stream trimming strategy can be active at a time.
     example: "10000"
     type: number
   - name: streamTTL
@@ -237,6 +240,7 @@ metadata:
       This is an approximate value, as it's implemented using Redis stream's MINID trimming with the '~' modifier.
       The actual retention may include slightly more entries than strictly defined by the TTL,
       as Redis optimizes the trimming operation for efficiency by potentially keeping some additional entries.
+      Cannot be used together with maxLenApprox; only one stream trimming strategy can be active at a time.
     example: "30d"
     type: duration
 

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -85,6 +85,10 @@ func (r *redisStreams) Init(ctx context.Context, metadata pubsub.Metadata) error
 	if _, err = r.client.PingResult(ctx); err != nil {
 		return fmt.Errorf("redis streams: error connecting to redis at %s: %s", r.clientSettings.Host, err)
 	}
+
+	if r.clientSettings.MaxLenApprox > 0 && r.clientSettings.StreamTTL > 0 {
+		r.logger.Warn("redis streams: maxLenApprox and streamTTL cannot be used together; only one stream trimming strategy can be active at a time.")
+	}
 	r.queue = make(chan redisMessageWrapper, int(r.clientSettings.QueueDepth)) //nolint:gosec
 
 	for range r.clientSettings.Concurrency {


### PR DESCRIPTION
# Description

This is a bug/feature that I encountered while working with Dapr's Redis pubsub component. Redis supports **either** MAXLEN or MINID for [XADD](https://redis.io/docs/latest/commands/xadd/) and [XTRIM](https://redis.io/docs/latest/commands/xtrim/)

The `go-redis` client quietly chooses MAXLEN when both are specified: 
- [go-redis v8](https://github.com/redis/go-redis/blob/v8.11.5/commands.go#L1749-L1764)
- [go-redis v9](https://github.com/redis/go-redis/blob/v9.18.0/stream_commands.go#L106-L118)

Dapr let's me declare both in the `pubsub.redis` component

```yaml
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: pubsub
spec:
  type: pubsub.redis
  version: v1
  metadata:
    ...
    - name: maxLenApprox
      value: "100000"
    - name: streamTTL
      value: "10s"
```

and `streamTTL` is ignored. I think the warning log and/or a docs update would be helpful.

## Issue reference

None -- can open if appropriate.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5061
