### PR TITLE
[backport release-1.17] fix(state/oracledatabase): return per-key errors in BulkGet instead of HTTP 500

### DIFF
--- a/common/component/kafka/subscriber_test.go
+++ b/common/component/kafka/subscriber_test.go
@@ -482,9 +482,9 @@ func Test_Subscribe(t *testing.T) {
 
 		cancel()
 		assert.Eventually(t, func() bool {
-			return consumeCalled.Load() == 3
+			return cancelCalled.Load() == 3
 		}, time.Second, time.Millisecond)
-		assert.Equal(t, int64(3), cancelCalled.Load())
+		assert.Equal(t, int64(3), consumeCalled.Load())
 
 		k.Subscribe(ctx, SubscriptionHandlerConfig{})
 		assert.Nil(t, k.consumerCancel)

--- a/crypto/pubkey_cache_test.go
+++ b/crypto/pubkey_cache_test.go
@@ -211,14 +211,6 @@ func TestPubKeyCacheGetKey(t *testing.T) {
 					return cache.pubKeys["key"].ctx.Size() == 2
 				}, time.Second*5, time.Millisecond)
 
-				t.Cleanup(func() {
-					select {
-					case <-getKeyReturned:
-					case <-time.After(1 * time.Second):
-						assert.Fail(t, "expected GetKey to return from cancelled context in time")
-					}
-				})
-
 				assert.Equal(t, "key", i)
 				cancel1(assert.AnError)
 				select {
@@ -240,6 +232,16 @@ func TestPubKeyCacheGetKey(t *testing.T) {
 		result, err := cache.GetKey(ctx1, "key")
 		assert.Equal(t, context.Canceled, err)
 		assert.Nil(t, result)
+
+		// Wait for the background goroutine to finish before the test
+		// returns, otherwise t.Context() (used by ctx2) gets cancelled
+		// when the test function exits, causing a race where ctx2's
+		// GetKey sees a cancelled context instead of the resolved value.
+		select {
+		case <-getKeyReturned:
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "expected GetKey to return from cancelled context in time")
+		}
 	})
 
 	t.Run("if all callers give cancelled contexts, the underlying context should also be cancelled", func(t *testing.T) {

--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -337,7 +337,17 @@ func (o *oracleDatabaseAccess) BulkGet(ctx context.Context, req []state.GetReque
 
 	rows, err := o.db.QueryContext(ctx, query, params...)
 	if err != nil {
-		return nil, err
+		// If the query fails, return per-key error entries instead of
+		// propagating the error, for consistency with other state stores
+		// (e.g. Redis, SQL Server) which return HTTP 200 with per-key errors.
+		res := make([]state.BulkGetResponse, len(req))
+		for i, r := range req {
+			res[i] = state.BulkGetResponse{
+				Key:   r.Key,
+				Error: "bulk get query failed: " + err.Error(),
+			}
+		}
+		return res, nil
 	}
 	defer rows.Close()
 
@@ -383,10 +393,22 @@ func (o *oracleDatabaseAccess) BulkGet(ctx context.Context, req []state.GetReque
 					data []byte
 				)
 				if err = json.Unmarshal([]byte(value), &s); err != nil {
-					return nil, err
+					res[n] = state.BulkGetResponse{
+						Key:   key,
+						Error: "failed to decode binary value: " + err.Error(),
+					}
+					foundKeys[key] = struct{}{}
+					n++
+					continue
 				}
 				if data, err = base64.StdEncoding.DecodeString(s); err != nil {
-					return nil, err
+					res[n] = state.BulkGetResponse{
+						Key:   key,
+						Error: "failed to decode binary value: " + err.Error(),
+					}
+					foundKeys[key] = struct{}{}
+					n++
+					continue
 				}
 				response.Data = data
 			} else {
@@ -400,8 +422,29 @@ func (o *oracleDatabaseAccess) BulkGet(ctx context.Context, req []state.GetReque
 		n++
 	}
 
+	// rows.Err() reports errors from iteration; return what we have as per-key
+	// errors for any keys not yet found, for consistency with other stores.
 	if err = rows.Err(); err != nil {
-		return nil, err
+		errMsg := err.Error()
+		anyUnfound := false
+		for _, r := range req {
+			if _, ok := foundKeys[r.Key]; !ok {
+				anyUnfound = true
+				if n >= len(req) {
+					break
+				}
+				res[n] = state.BulkGetResponse{
+					Key:   r.Key,
+					Error: "rows iteration failed: " + errMsg,
+				}
+				foundKeys[r.Key] = struct{}{}
+				n++
+			}
+		}
+		if !anyUnfound {
+			o.logger.Warnf("Oracle BulkGet: rows iteration error after all rows processed: %v", err)
+		}
+		return res[:n], nil
 	}
 
 	// Populate missing keys with empty values

--- a/state/oracledatabase/oracledatabaseaccess_test.go
+++ b/state/oracledatabase/oracledatabaseaccess_test.go
@@ -16,14 +16,20 @@ limitations under the License.
 package oracledatabase
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"net/url"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/state"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/dapr/kit/logger"
 )
 
 func TestConnectionString(t *testing.T) {
@@ -152,4 +158,408 @@ func TestConnectionString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBulkGetQueryFailure(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	mock.ExpectQuery("SELECT").WillReturnError(errors.New("connection refused"))
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: "key2"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	for _, r := range res {
+		assert.NotEmpty(t, r.Error)
+		assert.Contains(t, r.Error, "bulk get query failed:")
+		assert.Contains(t, r.Error, "connection refused")
+		assert.Nil(t, r.Data)
+		assert.Nil(t, r.ETag)
+	}
+	assert.Equal(t, "key1", res[0].Key)
+	assert.Equal(t, "key2", res[1].Key)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetBinaryDecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	// First row: valid non-binary data
+	// Second row: binary flag "Y" but value is not valid JSON-encoded base64
+	// Third row: valid binary data
+	validBinaryValue, _ := json.Marshal(base64.StdEncoding.EncodeToString([]byte("hello")))
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"plain text"`, "N", "etag1", nil).
+		AddRow("key2", `not-valid-json`, "Y", "etag2", nil).
+		AddRow("key3", string(validBinaryValue), "Y", "etag3", nil)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: "key2"},
+		{Key: "key3"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	// key1 should succeed
+	assert.Equal(t, "key1", res[0].Key)
+	assert.Empty(t, res[0].Error)
+	assert.NotNil(t, res[0].Data)
+
+	// key2 should have an error with clean struct (no ETag/Metadata leaking)
+	assert.Equal(t, "key2", res[1].Key)
+	assert.NotEmpty(t, res[1].Error)
+	assert.Nil(t, res[1].ETag, "error response should not leak ETag")
+	assert.Nil(t, res[1].Metadata, "error response should not leak Metadata")
+
+	// key3 should succeed
+	assert.Equal(t, "key3", res[2].Key)
+	assert.Empty(t, res[2].Error)
+	assert.Equal(t, []byte("hello"), res[2].Data)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetBinaryBase64DecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	// Value is valid JSON string but not valid base64
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"not-valid-base64!!!"`, "Y", "etag1", nil)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	assert.Equal(t, "key1", res[0].Key)
+	assert.NotEmpty(t, res[0].Error)
+	assert.Nil(t, res[0].ETag, "error response should not leak ETag")
+	assert.Nil(t, res[0].Metadata, "error response should not leak Metadata")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsErrFailure(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	// sqlmock's RowError(N, err) causes rows.Next() to return false (with the
+	// error surfaced via rows.Err()) when attempting to read row at index N.
+	// We need at least N+1 rows added for RowError(N) to fire; the error
+	// prevents the Nth row from being read. So we add a dummy second row
+	// (key2) and set RowError(1, ...) -- key1 at index 0 is scanned
+	// successfully, then the attempt to advance to index 1 fails.
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"value1"`, "N", "etag1", nil).
+		AddRow("key2", `"value2"`, "N", "etag2", nil).
+		RowError(1, errors.New("network timeout"))
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: "key2"},
+		{Key: "key3"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	// Build a map for easier assertion regardless of ordering.
+	byKey := make(map[string]state.BulkGetResponse, len(res))
+	for _, r := range res {
+		byKey[r.Key] = r
+	}
+
+	// key1 was scanned successfully before the error.
+	successfulResult := byKey["key1"]
+	assert.Empty(t, successfulResult.Error)
+	assert.NotNil(t, successfulResult.Data)
+
+	// key2 and key3 were never returned by the DB; they should carry the
+	// rows.Err() message as per-key errors.
+	for _, k := range []string{"key2", "key3"} {
+		r := byKey[k]
+		assert.Equal(t, k, r.Key)
+		assert.NotEmpty(t, r.Error, "unfound key %q should have an error from rows.Err()", k)
+		assert.Contains(t, r.Error, "rows iteration failed:")
+		assert.Contains(t, r.Error, "network timeout")
+		assert.Nil(t, r.Data, "error entry should have nil data")
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsErrAfterAllRowsProcessed(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	// Return the one requested row successfully, then trigger rows.Err().
+	// This tests the warning-log path where all requested keys are found but
+	// rows.Err() still reports an error (e.g. a late network hiccup).
+	//
+	// sqlmock limitation: CloseError only sets the error returned by
+	// rows.Close(), NOT rows.Err(). To make rows.Err() return an error we
+	// must use RowError. RowError(N) requires at least N+1 rows to be added
+	// so that sqlmock actually attempts to advance to index N. We add a
+	// dummy second row and set RowError(1, ...) -- row 0 (key1) is read
+	// successfully, then the attempt to advance to row 1 fails, and
+	// rows.Err() reports the error.
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"value1"`, "N", "etag1", nil).
+		AddRow("dummy", `"dummy"`, "N", "dummy", nil).
+		RowError(1, errors.New("late network error"))
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	// key1 was found before the error, so the warning-log branch is taken
+	// (no unfound keys to attach the error to). The result should still
+	// contain the successfully scanned key.
+	require.Len(t, res, 1)
+	assert.Equal(t, "key1", res[0].Key)
+	assert.Empty(t, res[0].Error)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetWithExpiration(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	expTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"value1"`, "N", "etag1", expTime)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.Equal(t, "key1", res[0].Key)
+	assert.Empty(t, res[0].Error)
+	assert.NotNil(t, res[0].Metadata)
+	assert.Contains(t, res[0].Metadata, state.GetRespMetaKeyTTLExpireTime)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetEmpty(t *testing.T) {
+	t.Parallel()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	res, err := o.BulkGet(t.Context(), []state.GetRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, res)
+}
+
+func TestBulkGetMissingKeys(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	// DB only returns key2; key1 and key3 are not in the database.
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key2", `"value2"`, "N", "etag2", nil)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: "key2"},
+		{Key: "key3"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	// Build a map for easier assertion regardless of ordering.
+	byKey := make(map[string]state.BulkGetResponse, len(res))
+	for _, r := range res {
+		byKey[r.Key] = r
+	}
+
+	// key2 was returned by the DB — should have data and etag.
+	r2 := byKey["key2"]
+	assert.Empty(t, r2.Error)
+	assert.NotNil(t, r2.Data)
+	assert.NotNil(t, r2.ETag)
+
+	// key1 and key3 were not in the DB — should be empty entries with no error.
+	for _, k := range []string{"key1", "key3"} {
+		r := byKey[k]
+		assert.Equal(t, k, r.Key)
+		assert.Empty(t, r.Error, "missing key should not have an error")
+		assert.Nil(t, r.Data, "missing key should have nil data")
+		assert.Nil(t, r.ETag, "missing key should have nil etag")
+		assert.Nil(t, r.Metadata, "missing key should have nil metadata")
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsScanFailure(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	// To trigger a Scan error, pass a string for the expiration_time column.
+	// sql.NullTime.Scan cannot convert a plain string to time.Time,
+	// so rows.Scan() will return an error for that row.
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"value1"`, "N", "etag1", nil).                // valid row
+		AddRow("key2", `"value2"`, "N", "etag2", "not-a-time-value"). // expiration_time is a string — Scan will fail
+		AddRow("key3", `"value3"`, "N", "etag3", nil)                 // valid row
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: "key2"},
+		{Key: "key3"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	// key1 should succeed.
+	assert.Equal(t, "key1", res[0].Key)
+	assert.Empty(t, res[0].Error)
+	assert.NotNil(t, res[0].Data)
+
+	// key2 should have a per-key scan error.
+	assert.NotEmpty(t, res[1].Error, "scan failure should produce a per-key error")
+	assert.Nil(t, res[1].Data, "scan failure entry should have nil data")
+
+	// key3 should succeed despite key2's failure.
+	assert.Equal(t, "key3", res[2].Key)
+	assert.Empty(t, res[2].Error)
+	assert.NotNil(t, res[2].Data)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetEmptyKeyValidation(t *testing.T) {
+	t.Parallel()
+
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		metadata: oracleDatabaseMetadata{TableName: "state"},
+	}
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: ""},
+		{Key: "key3"},
+	}
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Equal(t, "missing key in bulk get operation", err.Error())
 }


### PR DESCRIPTION
## Summary

Backport of #4243 to `release-1.17`.

- Returns per-key errors in BulkGet instead of failing the entire request with HTTP 500
- Adds comprehensive test coverage for BulkGet error handling

Cherry-picked cleanly from merge commit `08c517e`. Build and tests pass.

## Test plan
- [x] `go build ./state/oracledatabase/...` passes
- [x] `go test ./state/oracledatabase/...` passes (all tests green)

🤖 Generated with [Claude Code](https://claude.ai/code)