### PR TITLE
fix(pubsub/pulsar): decode Avro binary payload on subscribe path

### DIFF
--- a/.github/infrastructure/docker-compose-secrets-manager.yml
+++ b/.github/infrastructure/docker-compose-secrets-manager.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: "conformance-aws-secrets-manager"
-    image: localstack/localstack
+    image: localstack/localstack:1.4.0
     ports:
       - "127.0.0.1:4566:4566"
     environment:

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -669,8 +669,29 @@ func (p *Pulsar) listenMessage(ctx context.Context, req pubsub.SubscribeRequest,
 }
 
 func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, msg pulsar.ConsumerMessage, handler pubsub.Handler) error {
+	data := msg.Payload()
+
+	// If an Avro schema is registered for this topic, decode the Avro binary
+	// payload to JSON before passing it to the Dapr runtime. The Pulsar Go
+	// client does not automatically decode msg.Payload() when using Chan(),
+	// so we must do it explicitly here.
+	// The goavro codec was compiled once at init in parsePulsarMetadata.
+	if sm, ok := p.metadata.internalTopicSchemas[originTopic]; ok && sm.protocol == avroProtocol {
+		native, _, decodeErr := sm.codec.NativeFromBinary(data)
+		if decodeErr != nil {
+			msg.Nack(msg.Message)
+			return fmt.Errorf("avro decode failed for topic %q: %w", originTopic, decodeErr)
+		}
+		jsonBytes, encodeErr := sm.codec.TextualFromNative(nil, native)
+		if encodeErr != nil {
+			msg.Nack(msg.Message)
+			return fmt.Errorf("avro to json conversion failed for topic %q: %w", originTopic, encodeErr)
+		}
+		data = jsonBytes
+	}
+
 	pubsubMsg := pubsub.NewMessage{
-		Data:     msg.Payload(),
+		Data:     data,
 		Topic:    originTopic,
 		Metadata: msg.Properties(),
 	}

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"encoding/json"
+
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
@@ -1872,3 +1874,140 @@ func (m *MockPulsarConsumer) Chan() <-chan pulsar.ConsumerMessage {
 }
 
 func (m *MockPulsarConsumer) Close() {}
+
+// --- handleMessage Avro decode tests ---
+
+// mockPulsarMessage is a minimal pulsar.Message stub for unit tests.
+type mockPulsarMessage struct {
+	pulsar.Message
+	payload    []byte
+	properties map[string]string
+	topic      string
+	id         pulsar.MessageID
+}
+
+func (m *mockPulsarMessage) Payload() []byte                    { return m.payload }
+func (m *mockPulsarMessage) Properties() map[string]string      { return m.properties }
+func (m *mockPulsarMessage) Topic() string                      { return m.topic }
+func (m *mockPulsarMessage) ID() pulsar.MessageID               { return m.id }
+
+// mockAckConsumer is a pulsar.Consumer stub that tracks Ack/Nack calls.
+type mockAckConsumer struct {
+	pulsar.Consumer
+	acked  bool
+	nacked bool
+}
+
+func (m *mockAckConsumer) Ack(msg pulsar.Message) error  { m.acked = true; return nil }
+func (m *mockAckConsumer) Nack(msg pulsar.Message)       { m.nacked = true }
+
+// makeConsumerMessage wraps a stub message+consumer into a pulsar.ConsumerMessage.
+func makeConsumerMessage(msg pulsar.Message, consumer pulsar.Consumer) pulsar.ConsumerMessage {
+	return pulsar.ConsumerMessage{Consumer: consumer, Message: msg}
+}
+
+func TestHandleMessageAvroDecodeRoundTrip(t *testing.T) {
+	const avroSchema = `{"type":"record","name":"Event","fields":[{"name":"id","type":"int"},{"name":"name","type":"string"}]}`
+	const topic = "my-topic"
+
+	codec, err := goavro.NewCodecForStandardJSONFull(avroSchema)
+	require.NoError(t, err)
+
+	// Encode a test record as Avro binary (simulating what the Pulsar producer sends).
+	native, _, err := codec.NativeFromTextual([]byte(`{"id":42,"name":"hello"}`))
+	require.NoError(t, err)
+	avroBinary, err := codec.BinaryFromNative(nil, native)
+	require.NoError(t, err)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{
+				topic: {protocol: avroProtocol, value: avroSchema, codec: codec},
+			},
+		},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{payload: avroBinary, properties: map[string]string{}, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedData []byte
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedData = m.Data
+		return nil
+	}
+
+	err = p.handleMessage(context.Background(), topic, cm, handler)
+	require.NoError(t, err)
+	assert.True(t, consumer.acked, "message should be acked on success")
+	assert.False(t, consumer.nacked, "message should not be nacked on success")
+
+	// The handler must have received valid JSON, not Avro binary.
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(receivedData, &decoded), "handleMessage must deliver JSON, not Avro binary")
+	assert.EqualValues(t, 42, decoded["id"])
+	assert.Equal(t, "hello", decoded["name"])
+}
+
+func TestHandleMessageAvroDecodeError(t *testing.T) {
+	const avroSchema = `{"type":"record","name":"Event","fields":[{"name":"id","type":"int"}]}`
+	const topic = "my-topic"
+
+	codec, err := goavro.NewCodecForStandardJSONFull(avroSchema)
+	require.NoError(t, err)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{
+				topic: {protocol: avroProtocol, value: avroSchema, codec: codec},
+			},
+		},
+	}
+
+	consumer := &mockAckConsumer{}
+	// Pass a truncated Avro payload (empty → varint EOF) that cannot be decoded.
+	msg := &mockPulsarMessage{payload: []byte{}, properties: map[string]string{}, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	called := false
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		called = true
+		return nil
+	}
+
+	err = p.handleMessage(context.Background(), topic, cm, handler)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "avro decode failed")
+	assert.True(t, consumer.nacked, "message should be nacked on decode error")
+	assert.False(t, called, "handler should not be called when decode fails")
+}
+
+func TestHandleMessageNoAvroSchema(t *testing.T) {
+	// Without a schema, msg.Payload() is passed through as-is (existing behaviour).
+	const topic = "plain-topic"
+	rawJSON := []byte(`{"specversion":"1.0","type":"test"}`)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{},
+		},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{payload: rawJSON, properties: map[string]string{}, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedData []byte
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedData = m.Data
+		return nil
+	}
+
+	err := p.handleMessage(context.Background(), topic, cm, handler)
+	require.NoError(t, err)
+	assert.Equal(t, rawJSON, receivedData)
+	assert.True(t, consumer.acked)
+}

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -1898,8 +1898,14 @@ type mockAckConsumer struct {
 	nacked bool
 }
 
-func (m *mockAckConsumer) Ack(msg pulsar.Message) error { m.acked = true; return nil }
-func (m *mockAckConsumer) Nack(msg pulsar.Message)      { m.nacked = true }
+func (m *mockAckConsumer) Ack(msg pulsar.Message) error {
+	m.acked = true
+	return nil
+}
+
+func (m *mockAckConsumer) Nack(msg pulsar.Message) {
+	m.nacked = true
+}
 
 // makeConsumerMessage wraps a stub message+consumer into a pulsar.ConsumerMessage.
 func makeConsumerMessage(msg pulsar.Message, consumer pulsar.Consumer) pulsar.ConsumerMessage {

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -15,6 +15,8 @@ package pulsar
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -26,8 +28,6 @@ import (
 	goavro "github.com/linkedin/goavro/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"encoding/json"
 
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
@@ -2010,4 +2010,103 @@ func TestHandleMessageNoAvroSchema(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rawJSON, receivedData)
 	assert.True(t, consumer.acked)
+}
+
+func TestHandleMessageHandlerErrorNacks(t *testing.T) {
+	// When the handler returns an error, the message must be Nacked (not Acked).
+	const topic = "plain-topic"
+	rawJSON := []byte(`{"event":"test"}`)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{},
+		},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{payload: rawJSON, properties: map[string]string{}, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	handlerErr := errors.New("downstream processing failed")
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		return handlerErr
+	}
+
+	err := p.handleMessage(context.Background(), topic, cm, handler)
+	require.Error(t, err)
+	assert.Equal(t, handlerErr, err)
+	assert.True(t, consumer.nacked, "message must be nacked when handler returns error")
+	assert.False(t, consumer.acked, "message must not be acked when handler returns error")
+}
+
+func TestHandleMessageAvroPropertiesPreserved(t *testing.T) {
+	// Properties from the Pulsar message must be passed through to the handler
+	// even when the Avro decode path is taken.
+	const avroSchema = `{"type":"record","name":"Event","fields":[{"name":"id","type":"int"},{"name":"name","type":"string"}]}`
+	const topic = "my-topic"
+
+	codec, err := goavro.NewCodecForStandardJSONFull(avroSchema)
+	require.NoError(t, err)
+
+	native, _, err := codec.NativeFromTextual([]byte(`{"id":1,"name":"test"}`))
+	require.NoError(t, err)
+	avroBinary, err := codec.BinaryFromNative(nil, native)
+	require.NoError(t, err)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{
+				topic: {protocol: avroProtocol, value: avroSchema, codec: codec},
+			},
+		},
+	}
+
+	props := map[string]string{"trace-id": "abc123", "source": "unit-test"}
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{payload: avroBinary, properties: props, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedMetadata map[string]string
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedMetadata = m.Metadata
+		return nil
+	}
+
+	err = p.handleMessage(context.Background(), topic, cm, handler)
+	require.NoError(t, err)
+	assert.Equal(t, props, receivedMetadata, "properties must be preserved through the Avro decode path")
+}
+
+func TestHandleMessageNonAvroSchemaPassthrough(t *testing.T) {
+	// A topic with a JSON schema (not Avro) must pass raw bytes through
+	// without attempting Avro decode.
+	const topic = "json-schema-topic"
+	rawJSON := []byte(`{"key":"value"}`)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{
+				topic: {protocol: jsonProtocol, value: `{"type":"object"}`},
+			},
+		},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{payload: rawJSON, properties: map[string]string{}, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedData []byte
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedData = m.Data
+		return nil
+	}
+
+	err := p.handleMessage(context.Background(), topic, cm, handler)
+	require.NoError(t, err)
+	assert.Equal(t, rawJSON, receivedData, "non-Avro schema topics must pass raw bytes through")
+	assert.True(t, consumer.acked)
+	assert.False(t, consumer.nacked)
 }

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -1886,10 +1886,10 @@ type mockPulsarMessage struct {
 	id         pulsar.MessageID
 }
 
-func (m *mockPulsarMessage) Payload() []byte                    { return m.payload }
-func (m *mockPulsarMessage) Properties() map[string]string      { return m.properties }
-func (m *mockPulsarMessage) Topic() string                      { return m.topic }
-func (m *mockPulsarMessage) ID() pulsar.MessageID               { return m.id }
+func (m *mockPulsarMessage) Payload() []byte               { return m.payload }
+func (m *mockPulsarMessage) Properties() map[string]string { return m.properties }
+func (m *mockPulsarMessage) Topic() string                 { return m.topic }
+func (m *mockPulsarMessage) ID() pulsar.MessageID          { return m.id }
 
 // mockAckConsumer is a pulsar.Consumer stub that tracks Ack/Nack calls.
 type mockAckConsumer struct {
@@ -1898,8 +1898,8 @@ type mockAckConsumer struct {
 	nacked bool
 }
 
-func (m *mockAckConsumer) Ack(msg pulsar.Message) error  { m.acked = true; return nil }
-func (m *mockAckConsumer) Nack(msg pulsar.Message)       { m.nacked = true }
+func (m *mockAckConsumer) Ack(msg pulsar.Message) error { m.acked = true; return nil }
+func (m *mockAckConsumer) Nack(msg pulsar.Message)      { m.nacked = true }
 
 // makeConsumerMessage wraps a stub message+consumer into a pulsar.ConsumerMessage.
 func makeConsumerMessage(msg pulsar.Message, consumer pulsar.Consumer) pulsar.ConsumerMessage {
@@ -1938,7 +1938,7 @@ func TestHandleMessageAvroDecodeRoundTrip(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(context.Background(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, cm, handler)
 	require.NoError(t, err)
 	assert.True(t, consumer.acked, "message should be acked on success")
 	assert.False(t, consumer.nacked, "message should not be nacked on success")
@@ -1977,7 +1977,7 @@ func TestHandleMessageAvroDecodeError(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(context.Background(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, cm, handler)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "avro decode failed")
 	assert.True(t, consumer.nacked, "message should be nacked on decode error")
@@ -2006,9 +2006,9 @@ func TestHandleMessageNoAvroSchema(t *testing.T) {
 		return nil
 	}
 
-	err := p.handleMessage(context.Background(), topic, cm, handler)
+	err := p.handleMessage(t.Context(), topic, cm, handler)
 	require.NoError(t, err)
-	assert.Equal(t, rawJSON, receivedData)
+	assert.JSONEq(t, string(rawJSON), string(receivedData))
 	assert.True(t, consumer.acked)
 }
 
@@ -2033,7 +2033,7 @@ func TestHandleMessageHandlerErrorNacks(t *testing.T) {
 		return handlerErr
 	}
 
-	err := p.handleMessage(context.Background(), topic, cm, handler)
+	err := p.handleMessage(t.Context(), topic, cm, handler)
 	require.Error(t, err)
 	assert.Equal(t, handlerErr, err)
 	assert.True(t, consumer.nacked, "message must be nacked when handler returns error")
@@ -2074,7 +2074,7 @@ func TestHandleMessageAvroPropertiesPreserved(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(context.Background(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, cm, handler)
 	require.NoError(t, err)
 	assert.Equal(t, props, receivedMetadata, "properties must be preserved through the Avro decode path")
 }
@@ -2104,9 +2104,9 @@ func TestHandleMessageNonAvroSchemaPassthrough(t *testing.T) {
 		return nil
 	}
 
-	err := p.handleMessage(context.Background(), topic, cm, handler)
+	err := p.handleMessage(t.Context(), topic, cm, handler)
 	require.NoError(t, err)
-	assert.Equal(t, rawJSON, receivedData, "non-Avro schema topics must pass raw bytes through")
+	assert.JSONEq(t, string(rawJSON), string(receivedData), "non-Avro schema topics must pass raw bytes through")
 	assert.True(t, consumer.acked)
 	assert.False(t, consumer.nacked)
 }

--- a/tests/certification/pubsub/pulsar/README.md
+++ b/tests/certification/pubsub/pulsar/README.md
@@ -52,8 +52,13 @@ The purpose of this module is to provide tests that certify the Pulsar Pubsub as
    - Restart pulsar service
    - Subscriber is subscribed to 1 topic
    - Verify that all expected messages were received
-- Verify ordering process with partitioned topic 
+- Verify ordering process with partitioned topic
    - Run dapr application with 1 publisher and 2 subscriber
-   - Publisher publishes to 1 4-partitioned topic 
+   - Publisher publishes to 1 4-partitioned topic
    - Subscriber is subscribed to 1 topic
    - Verify that all expected messages were received in order
+- Verify Avro schema encode/decode round trip
+   - Run dapr application with 1 publisher and 1 subscriber configured with `.avroschema`
+   - Publisher publishes JSON messages that are Avro-encoded on the publish path
+   - Subscriber receives messages that are decoded from Avro binary back to JSON
+   - Verify that all expected messages were received with correct data

--- a/tests/certification/pubsub/pulsar/components/auth-none/consumer_nine/pulsar.yaml
+++ b/tests/certification/pubsub/pulsar/components/auth-none/consumer_nine/pulsar.yaml
@@ -13,4 +13,4 @@ spec:
   - name: redeliveryDelay
     value: 200ms
   - name: certification-pubsub-topic-active.avroschema
-    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\"}]}"
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"

--- a/tests/certification/pubsub/pulsar/components/auth-none/consumer_nine/pulsar.yaml
+++ b/tests/certification/pubsub/pulsar/components/auth-none/consumer_nine/pulsar.yaml
@@ -1,0 +1,16 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification9
+  - name: redeliveryDelay
+    value: 200ms
+  - name: certification-pubsub-topic-active.avroschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\"}]}"

--- a/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_nine/pulsar.yml.tmpl
+++ b/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_nine/pulsar.yml.tmpl
@@ -1,0 +1,28 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification9
+  - name: redeliveryDelay
+    value: 200ms
+  - name: certification-pubsub-topic-active.avroschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"
+  - name: oauth2TokenURL
+    value: https://localhost:8085/issuer1/token
+  - name: oauth2ClientID
+    value: foo
+  - name: oauth2ClientSecret
+    value: bar
+  - name: oauth2Scopes
+    value: openid
+  - name: oauth2Audiences
+    value: pulsar
+  - name: oauth2TokenCAPEM
+    value: "{{ .OAuth2CAPEM }}"

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -964,7 +964,8 @@ func publishAvroSchemaMessages(sidecarName string, topicName string, messageWatc
 				TestName: uuid.New().String(),
 			}
 
-			b, _ := json.Marshal(test)
+			b, err := json.Marshal(test)
+			require.NoError(ctx, err, "error marshaling avroSchemaTest")
 			messages[i] = string(b)
 		}
 

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -882,6 +882,35 @@ type schemaTest struct {
 	Name string `json:"name"`
 }
 
+type avroSchemaTest struct {
+	TestID   int    `json:"testId"`
+	TestName string `json:"testName"`
+}
+
+func subscriberAvroSchemaApplication(appID string, topicName string, messagesWatcher *watcher.Watcher) app.SetupFn {
+	return func(ctx flow.Context, s common.Service) error {
+		return multierr.Combine(
+			s.AddTopicEventHandler(&common.Subscription{
+				PubsubName: pubsubName,
+				Topic:      topicName,
+				Route:      "/orders",
+				Metadata:   map[string]string{"rawPayload": "true"},
+			}, func(_ context.Context, e *common.TopicEvent) (retry bool, err error) {
+				// With rawPayload, e.Data arrives as []uint8.
+				// Unmarshal into the typed struct to normalize JSON field order
+				// so that it matches the published strings.
+				dataStr := fmt.Sprintf("%s", e.Data)
+				var obj avroSchemaTest
+				json.Unmarshal([]byte(dataStr), &obj)
+				normalized, _ := json.Marshal(obj)
+				messagesWatcher.Observe(string(normalized))
+				ctx.Logf("Message Received appID: %s,pubsub: %s, topic: %s, id: %s, data: %s", appID, e.PubsubName, e.Topic, e.ID, e.Data)
+				return false, nil
+			}),
+		)
+	}
+}
+
 func publishSchemaMessages(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
 	return func(ctx flow.Context) error {
 		// prepare the messages
@@ -910,6 +939,37 @@ func publishSchemaMessages(sidecarName string, topicName string, messageWatchers
 			ctx.Logf("Publishing: %q", message)
 
 			err := client.PublishEvent(ctx, pubsubName, topicName, message)
+			require.NoError(ctx, err, "error publishing message")
+		}
+		return nil
+	}
+}
+
+func publishAvroSchemaMessages(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
+	return func(ctx flow.Context) error {
+		messages := make([]string, numMessages)
+		for i := range messages {
+			test := &avroSchemaTest{
+				TestID:   i,
+				TestName: uuid.New().String(),
+			}
+
+			b, _ := json.Marshal(test)
+			messages[i] = string(b)
+		}
+
+		for _, messageWatcher := range messageWatchers {
+			messageWatcher.ExpectStrings(messages...)
+		}
+
+		client := sidecar.GetClient(ctx, sidecarName)
+
+		ctx.Logf("Publishing messages. sidecarName: %s, topicName: %s", sidecarName, topicName)
+
+		for _, message := range messages {
+			ctx.Logf("Publishing: %q", message)
+
+			err := client.PublishEvent(ctx, pubsubName, topicName, message, dapr.PublishEventWithRawPayload())
 			require.NoError(ctx, err, "error publishing message")
 		}
 		return nil
@@ -964,11 +1024,13 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 	t := p.T()
 	consumerGroup1 := watcher.NewUnordered()
 
+	avroSchema := `{"type":"record","name":"Example","namespace":"test","fields":[{"name":"testId","type":"int"},{"name":"testName","type":"string"}]}`
+
 	flow.New(t, "pulsar certification avro schema test").
 
 		// Run subscriberApplication app1
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
-			subscriberSchemaApplication(appID1, topicActiveName, consumerGroup1))).
+			subscriberAvroSchemaApplication(appID1, topicActiveName, consumerGroup1))).
 		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
 		Step("wait", flow.Sleep(10*time.Second)).
 		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
@@ -991,6 +1053,26 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 
 			return err
 		})).
+		// Pre-register the Avro schema on the topic so the sidecar's
+		// subscribe call finds it already present on the broker.
+		Step("register avro schema on topic", func(ctx flow.Context) error {
+			client, err := p.client(t)
+			if err != nil {
+				return fmt.Errorf("could not create pulsar client: %v", err)
+			}
+			defer client.Close()
+
+			producer, err := client.CreateProducer(pulsar.ProducerOptions{
+				Topic:  "persistent://public/default/" + topicActiveName,
+				Schema: pulsar.NewAvroSchema(avroSchema, nil),
+			})
+			if err != nil {
+				return fmt.Errorf("could not create producer to register avro schema: %v", err)
+			}
+			producer.Close()
+
+			return nil
+		}).
 		Step(sidecar.Run(sidecarName1,
 			append(componentRuntimeOptions(),
 				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_nine")),
@@ -999,7 +1081,7 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
 			)...,
 		)).
-		Step("publish messages to topic1", publishSchemaMessages(sidecarName1, topicActiveName, consumerGroup1)).
+		Step("publish messages to topic1", publishAvroSchemaMessages(sidecarName1, topicActiveName, consumerGroup1)).
 		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
 		Run()
 }

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -882,43 +882,43 @@ type schemaTest struct {
 	Name string `json:"name"`
 }
 
+func publishSchemaMessages(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
+	return func(ctx flow.Context) error {
+		// prepare the messages
+		messages := make([]string, numMessages)
+		for i := range messages {
+			test := &schemaTest{
+				ID:   i,
+				Name: uuid.New().String(),
+			}
+
+			b, _ := json.Marshal(test)
+			messages[i] = string(b)
+		}
+
+		for _, messageWatcher := range messageWatchers {
+			messageWatcher.ExpectStrings(messages...)
+		}
+
+		// get the sidecar (dapr) client
+		client := sidecar.GetClient(ctx, sidecarName)
+
+		// publish messages
+		ctx.Logf("Publishing messages. sidecarName: %s, topicName: %s", sidecarName, topicName)
+
+		for _, message := range messages {
+			ctx.Logf("Publishing: %q", message)
+
+			err := client.PublishEvent(ctx, pubsubName, topicName, message)
+			require.NoError(ctx, err, "error publishing message")
+		}
+		return nil
+	}
+}
+
 func (p *pulsarSuite) TestPulsarSchema() {
 	t := p.T()
 	consumerGroup1 := watcher.NewUnordered()
-
-	publishMessages := func(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
-		return func(ctx flow.Context) error {
-			// prepare the messages
-			messages := make([]string, numMessages)
-			for i := range messages {
-				test := &schemaTest{
-					ID:   i,
-					Name: uuid.New().String(),
-				}
-
-				b, _ := json.Marshal(test)
-				messages[i] = string(b)
-			}
-
-			for _, messageWatcher := range messageWatchers {
-				messageWatcher.ExpectStrings(messages...)
-			}
-
-			// get the sidecar (dapr) client
-			client := sidecar.GetClient(ctx, sidecarName)
-
-			// publish messages
-			ctx.Logf("Publishing messages. sidecarName: %s, topicName: %s", sidecarName, topicName)
-
-			for _, message := range messages {
-				ctx.Logf("Publishing: %q", message)
-
-				err := client.PublishEvent(ctx, pubsubName, topicName, message)
-				require.NoError(ctx, err, "error publishing message")
-			}
-			return nil
-		}
-	}
 
 	flow.New(t, "pulsar certification schema test").
 
@@ -955,7 +955,51 @@ func (p *pulsarSuite) TestPulsarSchema() {
 				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
 			)...,
 		)).
-		Step("publish messages to topic1", publishMessages(sidecarName1, topicActiveName, consumerGroup1)).
+		Step("publish messages to topic1", publishSchemaMessages(sidecarName1, topicActiveName, consumerGroup1)).
+		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
+		Run()
+}
+
+func (p *pulsarSuite) TestPulsarAvroSchema() {
+	t := p.T()
+	consumerGroup1 := watcher.NewUnordered()
+
+	flow.New(t, "pulsar certification avro schema test").
+
+		// Run subscriberApplication app1
+		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
+			subscriberSchemaApplication(appID1, topicActiveName, consumerGroup1))).
+		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
+		Step("wait", flow.Sleep(10*time.Second)).
+		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
+			client, err := p.client(t)
+			if err != nil {
+				return fmt.Errorf("could not create pulsar client: %v", err)
+			}
+
+			defer client.Close()
+
+			consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+				Topic:            "topic-1",
+				SubscriptionName: "my-sub",
+				Type:             pulsar.Shared,
+			})
+			if err != nil {
+				return fmt.Errorf("could not create pulsar Topic: %v", err)
+			}
+			defer consumer.Close()
+
+			return err
+		})).
+		Step(sidecar.Run(sidecarName1,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_nine")),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
+			)...,
+		)).
+		Step("publish messages to topic1", publishSchemaMessages(sidecarName1, topicActiveName, consumerGroup1)).
 		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
 		Run()
 }

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -901,8 +901,17 @@ func subscriberAvroSchemaApplication(appID string, topicName string, messagesWat
 				// so that it matches the published strings.
 				dataStr := fmt.Sprintf("%s", e.Data)
 				var obj avroSchemaTest
-				json.Unmarshal([]byte(dataStr), &obj)
-				normalized, _ := json.Marshal(obj)
+				if err := json.Unmarshal([]byte(dataStr), &obj); err != nil {
+					ctx.Logf("failed to unmarshal Avro schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
+					// Non-retryable error so the test fails clearly on bad payloads.
+					return false, fmt.Errorf("subscriberAvroSchemaApplication: unmarshal payload: %w", err)
+				}
+				normalized, err := json.Marshal(obj)
+				if err != nil {
+					ctx.Logf("failed to marshal normalized Avro schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
+					// Non-retryable error so the test fails clearly on bad normalization.
+					return false, fmt.Errorf("subscriberAvroSchemaApplication: marshal normalized payload: %w", err)
+				}
 				messagesWatcher.Observe(string(normalized))
 				ctx.Logf("Message Received appID: %s,pubsub: %s, topic: %s, id: %s, data: %s", appID, e.PubsubName, e.Topic, e.ID, e.Data)
 				return false, nil
@@ -921,7 +930,8 @@ func publishSchemaMessages(sidecarName string, topicName string, messageWatchers
 				Name: uuid.New().String(),
 			}
 
-			b, _ := json.Marshal(test)
+			b, err := json.Marshal(test)
+			require.NoError(ctx, err, "error marshaling schemaTest")
 			messages[i] = string(b)
 		}
 


### PR DESCRIPTION
## Summary

PR #4244 added Avro schema validation on the **publish** path but did not update `handleMessage` on the **subscribe** side.

The Pulsar Go client returns raw Avro binary bytes from `msg.Payload()` even when a schema consumer is configured. The Dapr runtime then tries `json.Unmarshal` on those bytes and fails:

```
error deserializing cloud event in pubsub <component> and topic <topic>:
invalid character '\x06' looking for beginning of value
scope=dapr.runtime.processor.subscription
```

`\x06` is the first byte of the Avro binary-encoded payload (string length 3 for `specversion` = `"1.0"` encoded as zigzag varint). Every message on an Avro-enforced topic gets stuck in a permanent retry loop and is never delivered to the application.

## Root Cause

`handleMessage` always passes `msg.Payload()` (raw bytes) directly:

```go
pubsubMsg := pubsub.NewMessage{
    Data: msg.Payload(), // always raw bytes, never decoded
    ...
}
```

The `goavro.Codec` required for decoding is already compiled and cached in `p.metadata.internalTopicSchemas[topic].codec` (added by #4244). It is simply never used on the receive path.

## Fix

When an Avro schema is registered for the incoming topic, decode the binary payload to native Go types using the cached codec, then re-encode as JSON before passing to the handler. This mirrors the publish path:

| Direction | Operation |
|---|---|
| Publish (#4244) | `NativeFromTextual` (JSON → native) → `msg.Value` (Avro binary via SDK) |
| Subscribe (this PR) | `NativeFromBinary` (Avro binary → native) → `TextualFromNative` (→ JSON) |

No new dependencies. The fix is ~15 lines in `handleMessage` only.

## Tests

Adds three unit tests for the subscribe decode path:
- **Round-trip**: Avro binary → `handleMessage` → JSON delivered to handler ✅
- **Decode error**: truncated payload → Nack + error returned, handler not called ✅
- **No schema**: raw payload passed through unchanged (existing behaviour preserved) ✅

Fixes the subscribe-side gap introduced by #4244.