### PR TITLE
fix(conversation): nil pointer dereference in langchaingokit LLM logger

### DIFF
--- a/conversation/anthropic/anthropic.go
+++ b/conversation/anthropic/anthropic.go
@@ -36,6 +36,7 @@ type Anthropic struct {
 func NewAnthropic(logger logger.Logger) conversation.Conversation {
 	a := &Anthropic{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return a

--- a/conversation/aws/bedrock/bedrock.go
+++ b/conversation/aws/bedrock/bedrock.go
@@ -57,6 +57,7 @@ type AWSBedrockMetadata struct {
 func NewAWSBedrock(logger logger.Logger) conversation.Conversation {
 	b := &AWSBedrock{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return b

--- a/conversation/deepseek/deepseek.go
+++ b/conversation/deepseek/deepseek.go
@@ -43,6 +43,7 @@ const (
 func NewDeepseek(logger logger.Logger) conversation.Conversation {
 	o := &Deepseek{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return o

--- a/conversation/googleai/googleai.go
+++ b/conversation/googleai/googleai.go
@@ -36,6 +36,7 @@ type GoogleAI struct {
 func NewGoogleAI(logger logger.Logger) conversation.Conversation {
 	g := &GoogleAI{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return g

--- a/conversation/huggingface/huggingface.go
+++ b/conversation/huggingface/huggingface.go
@@ -37,6 +37,7 @@ type Huggingface struct {
 func NewHuggingface(logger logger.Logger) conversation.Conversation {
 	h := &Huggingface{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return h

--- a/conversation/langchaingokit/model.go
+++ b/conversation/langchaingokit/model.go
@@ -32,6 +32,12 @@ type LLM struct {
 	logger logger.Logger
 }
 
+func New(logger logger.Logger) LLM {
+	return LLM{
+		logger: logger,
+	}
+}
+
 func (a *LLM) Converse(ctx context.Context, r *conversation.Request) (res *conversation.Response, err error) {
 	opts := getOptionsFromRequest(r, a.logger)
 

--- a/conversation/langchaingokit/translate_test.go
+++ b/conversation/langchaingokit/translate_test.go
@@ -17,11 +17,14 @@ package langchaingokit
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
 
 	"github.com/dapr/components-contrib/conversation"
+	"github.com/dapr/kit/logger"
 )
 
 func TestExtractInt64FromGenInfo(t *testing.T) {
@@ -272,6 +275,116 @@ func TestExtractUsageFromLangchainGenerationInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := extractUsageFromLangchainGenerationInfo(tt.genInfo)
 			tt.validate(t, result, err)
+		})
+	}
+}
+
+func TestGetOptionsFromRequest(t *testing.T) {
+	log := logger.NewLogger("test")
+
+	toolChoice := "auto"
+	tools := []llms.Tool{
+		{
+			Type: "function",
+			Function: &llms.FunctionDefinition{
+				Name:        "test_func",
+				Description: "a test function",
+			},
+		},
+	}
+	ttl := 5 * time.Minute
+
+	tests := map[string]struct {
+		request      *conversation.Request
+		existingOpts []llms.CallOption
+		validate     func(t *testing.T, r *conversation.Request, opts []llms.CallOption)
+	}{
+		"invalid ResponseFormatAsJSONSchema logs warning and continues": {
+			request: &conversation.Request{
+				ResponseFormatAsJSONSchema: map[string]any{
+					"description": "missing type field",
+				},
+			},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.NotNil(t, opts)
+			},
+		},
+		"valid ResponseFormatAsJSONSchema adds structured output option": {
+			request: &conversation.Request{
+				ResponseFormatAsJSONSchema: map[string]any{
+					"type": "object",
+					"name": "test_schema",
+					"properties": map[string]any{
+						"name": map[string]any{
+							"type": "string",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.NotEmpty(t, opts)
+			},
+		},
+		"temperature sets option": {
+			request: &conversation.Request{
+				Temperature: 0.7,
+			},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.NotEmpty(t, opts)
+			},
+		},
+		"zero temperature sets no option": {
+			request: &conversation.Request{},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.Empty(t, opts)
+			},
+		},
+		"tools and tool choice set options": {
+			request: &conversation.Request{
+				Tools:      &tools,
+				ToolChoice: &toolChoice,
+			},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.Len(t, opts, 2)
+			},
+		},
+		"metadata sets option": {
+			request: &conversation.Request{
+				Metadata: map[string]string{
+					"key": "value",
+				},
+			},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.NotEmpty(t, opts)
+			},
+		},
+		"prompt cache retention adds to metadata": {
+			request: &conversation.Request{
+				PromptCacheRetention: &ttl,
+			},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.NotEmpty(t, opts)
+				assert.NotNil(t, r.Metadata)
+				assert.Equal(t, "5m0s", r.Metadata["prompt_cache_retention"])
+			},
+		},
+		"existing options are preserved": {
+			request: &conversation.Request{
+				Temperature: 0.5,
+			},
+			existingOpts: []llms.CallOption{llms.WithMaxTokens(100)},
+			validate: func(t *testing.T, r *conversation.Request, opts []llms.CallOption) {
+				assert.Len(t, opts, 2)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				opts := getOptionsFromRequest(tt.request, log, tt.existingOpts...)
+				tt.validate(t, tt.request, opts)
+			})
 		})
 	}
 }

--- a/conversation/mistral/mistral.go
+++ b/conversation/mistral/mistral.go
@@ -38,6 +38,7 @@ type Mistral struct {
 func NewMistral(logger logger.Logger) conversation.Conversation {
 	m := &Mistral{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return m

--- a/conversation/ollama/ollama.go
+++ b/conversation/ollama/ollama.go
@@ -40,6 +40,7 @@ const (
 func NewOllama(logger logger.Logger) conversation.Conversation {
 	o := &Ollama{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return o

--- a/conversation/openai/openai.go
+++ b/conversation/openai/openai.go
@@ -39,6 +39,7 @@ type OpenAI struct {
 func NewOpenAI(logger logger.Logger) conversation.Conversation {
 	o := &OpenAI{
 		logger: logger,
+		LLM:    langchaingokit.New(logger),
 	}
 
 	return o


### PR DESCRIPTION
The embedded langchaingokit.LLM struct had an unexported logger field that was never initialized by any conversation component, causing a panic when ResponseFormatAsJSONSchema was set and structured output conversion failed. Add a `New()` constructor to langchaingokit.LLM and use it in all conversation component constructors.