### PR TITLE
Fix MongoDB state store to implement KeysLiker

### DIFF
--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -412,9 +412,14 @@ func getFilterTTL() bson.D {
 	// Since MongoDB doesn't delete the document immediately when the TTL value
 	// is reached, we need to filter out the documents with TTL value less than
 	// the current time.
+	// Use $ifNull so that documents missing the _ttl field entirely are treated
+	// the same as documents with _ttl explicitly set to null.
 	return bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$or", Value: bson.A{
-			bson.D{{Key: "$eq", Value: bson.A{"$_ttl", primitive.Null{}}}},
+			bson.D{{Key: "$eq", Value: bson.A{
+				bson.D{{Key: "$ifNull", Value: bson.A{"$_ttl", primitive.Null{}}}},
+				primitive.Null{},
+			}}},
 			bson.D{{Key: "$gte", Value: bson.A{"$_ttl", "$$NOW"}}},
 		}},
 	}}}

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -121,6 +121,7 @@ func NewMongoDB(logger logger.Logger) state.Store {
 			state.FeatureTransactional,
 			state.FeatureQueryAPI,
 			state.FeatureTTL,
+			state.FeatureKeysLike,
 		},
 		logger: logger,
 	}
@@ -717,7 +718,7 @@ func (m *MongoDB) Close() error {
 	return m.client.Disconnect(ctx)
 }
 
-func (m *MongoDB) KeysLike(ctx context.Context, req state.KeysLikeRequest) (*state.KeysLikeResponse, error) {
+func (m *MongoDB) KeysLike(ctx context.Context, req *state.KeysLikeRequest) (*state.KeysLikeResponse, error) {
 	if len(req.Pattern) == 0 {
 		return nil, state.ErrKeysLikeEmptyPattern
 	}

--- a/state/mongodb/mongodb.go
+++ b/state/mongodb/mongodb.go
@@ -777,9 +777,9 @@ func (m *MongoDB) KeysLike(ctx context.Context, req *state.KeysLikeRequest) (*st
 
 	//nolint:gosec
 	if pageSize > 0 && uint32(len(recs)) > pageSize {
-		next := recs[pageSize].Key // first NOT returned
-		resp.ContinuationToken = &next
 		recs = recs[:pageSize]
+		next := recs[pageSize-1].Key // last returned; next query resumes with _id > this
+		resp.ContinuationToken = &next
 	}
 
 	for _, r := range recs {

--- a/state/mongodb/mongodb_test.go
+++ b/state/mongodb/mongodb_test.go
@@ -293,9 +293,11 @@ func TestGetMongoDBMetadata(t *testing.T) {
 	})
 }
 
+// Compile-time assertion that MongoDB implements KeysLiker.
+var _ state.KeysLiker = (*MongoDB)(nil)
+
 func TestKeysLiker(t *testing.T) {
 	s := NewMongoDB(logger.NewLogger("test"))
-	var _ state.KeysLiker = s.(*MongoDB)
 	assert.True(t, state.FeatureKeysLike.IsPresent(s.Features()), "MongoDB should advertise FeatureKeysLike")
 }
 

--- a/state/mongodb/mongodb_test.go
+++ b/state/mongodb/mongodb_test.go
@@ -293,6 +293,77 @@ func TestGetMongoDBMetadata(t *testing.T) {
 	})
 }
 
+func TestKeysLiker(t *testing.T) {
+	s := NewMongoDB(logger.NewLogger("test"))
+	var _ state.KeysLiker = s.(*MongoDB)
+	assert.True(t, state.FeatureKeysLike.IsPresent(s.Features()), "MongoDB should advertise FeatureKeysLike")
+}
+
+func TestLikeToRegex(t *testing.T) {
+	tests := map[string]struct {
+		pattern string
+		match   []string
+		noMatch []string
+	}{
+		"wildcard all": {
+			pattern: "%",
+			match:   []string{"abc", "x", ""},
+		},
+		"prefix": {
+			pattern: "abc%",
+			match:   []string{"abc", "abcdef"},
+			noMatch: []string{"xabc", "ab"},
+		},
+		"suffix": {
+			pattern: "%xyz",
+			match:   []string{"xyz", "abcxyz"},
+			noMatch: []string{"xyza"},
+		},
+		"contains": {
+			pattern: "%mid%",
+			match:   []string{"mid", "xxmidyy"},
+			noMatch: []string{"abc"},
+		},
+		"single char wildcard": {
+			pattern: "a_c",
+			match:   []string{"abc", "axc"},
+			noMatch: []string{"ac", "abbc"},
+		},
+		"escaped percent": {
+			pattern: `\%lit`,
+			match:   []string{"%lit"},
+			noMatch: []string{"xxlit"},
+		},
+		"escaped underscore": {
+			pattern: `a\_b`,
+			match:   []string{"a_b"},
+			noMatch: []string{"axb"},
+		},
+		"pipe chars": {
+			pattern: "a||b||%||meta",
+			match:   []string{"a||b||xyz||meta"},
+			noMatch: []string{"a|b|c|meta"},
+		},
+		"workflow pattern": {
+			pattern: `app||dapr.internal.ns.app.workflow||%||metadata`,
+			match:   []string{"app||dapr.internal.ns.app.workflow||inst1||metadata"},
+			noMatch: []string{"app||dapr.internal.ns.app.workflow||inst1||history"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			re, err := likeToRegex(tc.pattern)
+			require.NoError(t, err)
+			for _, s := range tc.match {
+				assert.True(t, re.MatchString(s), "expected %q to match pattern %q", s, tc.pattern)
+			}
+			for _, s := range tc.noMatch {
+				assert.False(t, re.MatchString(s), "expected %q to NOT match pattern %q", s, tc.pattern)
+			}
+		})
+	}
+}
+
 func TestGoroutineLeak(t *testing.T) {
 	defer goleak.VerifyNone(t)
 

--- a/tests/certification/state/mongodb/mongodb_test.go
+++ b/tests/certification/state/mongodb/mongodb_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dapr/go-sdk/client"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/state"
 	stateMongoDB "github.com/dapr/components-contrib/state/mongodb"
@@ -21,9 +23,9 @@ import (
 	"github.com/dapr/components-contrib/tests/certification/flow/sidecar"
 	stateLoader "github.com/dapr/dapr/pkg/components/state"
 	daprTesting "github.com/dapr/dapr/pkg/testing"
+	"github.com/dapr/go-sdk/client"
 	"github.com/dapr/kit/logger"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/dapr/kit/ptr"
 )
 
 const (
@@ -148,6 +150,85 @@ func TestMongoDB(t *testing.T) {
 		}
 	}
 
+	keysLikeTest := func(sidecarName string) func(ctx flow.Context) error {
+		return func(ctx flow.Context) error {
+			cl, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017/?directConnection=true"))
+			require.NoError(t, err)
+			defer cl.Disconnect(ctx)
+
+			coll := cl.Database("admin").Collection("daprCollection")
+
+			// Clean up any existing test keys first.
+			_, err = coll.DeleteMany(ctx, bson.M{
+				"_id": bson.M{"$regex": "^" + sidecarName + `\|\|keyslike-`},
+			})
+			require.NoError(t, err)
+
+			// Insert test documents using the same key format Dapr uses.
+			testKeys := []string{
+				sidecarName + "||keyslike-workflow||instance1||metadata",
+				sidecarName + "||keyslike-workflow||instance2||metadata",
+				sidecarName + "||keyslike-workflow||instance3||metadata",
+				sidecarName + "||keyslike-other||instance4||metadata",
+			}
+			for _, key := range testKeys {
+				_, err = coll.InsertOne(ctx, bson.M{
+					"_id":   key,
+					"value": "test",
+				})
+				require.NoError(t, err)
+			}
+
+			// Use the state store's KeysLike method directly.
+			store, ok := state.Store(stateStore).(state.KeysLiker)
+			require.True(t, ok, "MongoDB must implement KeysLiker interface")
+
+			// Query for workflow keys only.
+			resp, err := store.KeysLike(ctx, &state.KeysLikeRequest{
+				Pattern: sidecarName + "||keyslike-workflow||%||metadata",
+			})
+			require.NoError(t, err)
+			require.Len(t, resp.Keys, 3)
+			assert.ElementsMatch(t, []string{
+				sidecarName + "||keyslike-workflow||instance1||metadata",
+				sidecarName + "||keyslike-workflow||instance2||metadata",
+				sidecarName + "||keyslike-workflow||instance3||metadata",
+			}, resp.Keys)
+
+			// Test pagination.
+			resp, err = store.KeysLike(ctx, &state.KeysLikeRequest{
+				Pattern:  sidecarName + "||keyslike-workflow||%||metadata",
+				PageSize: ptr.Of(2),
+			})
+			require.NoError(t, err)
+			require.Len(t, resp.Keys, 2)
+			require.NotNil(t, resp.ContinuationToken)
+
+			resp2, err := store.KeysLike(ctx, &state.KeysLikeRequest{
+				Pattern:           sidecarName + "||keyslike-workflow||%||metadata",
+				ContinuationToken: resp.ContinuationToken,
+			})
+			require.NoError(t, err)
+			require.Len(t, resp2.Keys, 1)
+			assert.Nil(t, resp2.ContinuationToken)
+
+			allKeys := append(resp.Keys, resp2.Keys...)
+			assert.ElementsMatch(t, []string{
+				sidecarName + "||keyslike-workflow||instance1||metadata",
+				sidecarName + "||keyslike-workflow||instance2||metadata",
+				sidecarName + "||keyslike-workflow||instance3||metadata",
+			}, allKeys)
+
+			// Clean up.
+			_, err = coll.DeleteMany(ctx, bson.M{
+				"_id": bson.M{"$regex": "^" + sidecarName + `\|\|keyslike-`},
+			})
+			require.NoError(t, err)
+
+			return nil
+		}
+	}
+
 	flow.New(t, "Connecting MongoDB And Verifying majority of the tests for a replica set here").
 		Step(dockercompose.Run("mongodb", dockerComposeClusterYAML)).
 		Step("Waiting for component to start...", flow.Sleep(20*time.Second)).
@@ -160,6 +241,7 @@ func TestMongoDB(t *testing.T) {
 		Step("Waiting for component to load...", flow.Sleep(10*time.Second)).
 		Step("Run basic test", basicTest).
 		Step("Run time to live test", timeToLiveTest(sidecarNamePrefix+"dockerClusterDefault")).
+		Step("Run KeysLike test", keysLikeTest(sidecarNamePrefix+"dockerClusterDefault")).
 		Step("Interrupt network",
 			network.InterruptNetwork(5*time.Second, nil, nil, "27017:27017")).
 		// Component should recover at this point.

--- a/tests/certification/state/mongodb/mongodb_test.go
+++ b/tests/certification/state/mongodb/mongodb_test.go
@@ -198,7 +198,7 @@ func TestMongoDB(t *testing.T) {
 			// Test pagination.
 			resp, err = store.KeysLike(ctx, &state.KeysLikeRequest{
 				Pattern:  sidecarName + "||keyslike-workflow||%||metadata",
-				PageSize: ptr.Of(2),
+				PageSize: ptr.Of(uint32(2)),
 			})
 			require.NoError(t, err)
 			require.Len(t, resp.Keys, 2)

--- a/tests/certification/state/mongodb/mongodb_test.go
+++ b/tests/certification/state/mongodb/mongodb_test.go
@@ -152,7 +152,7 @@ func TestMongoDB(t *testing.T) {
 
 	keysLikeTest := func(sidecarName string) func(ctx flow.Context) error {
 		return func(ctx flow.Context) error {
-			cl, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017/?directConnection=true"))
+			cl, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
 			require.NoError(t, err)
 			defer cl.Disconnect(ctx)
 

--- a/tests/certification/state/mongodb/mongodb_test.go
+++ b/tests/certification/state/mongodb/mongodb_test.go
@@ -152,7 +152,7 @@ func TestMongoDB(t *testing.T) {
 
 	keysLikeTest := func(sidecarName string) func(ctx flow.Context) error {
 		return func(ctx flow.Context) error {
-			cl, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
+			cl, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017/?directConnection=true"))
 			require.NoError(t, err)
 			defer cl.Disconnect(ctx)
 

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -15,7 +15,7 @@ components:
       # This component requires etags to be numeric
       badEtag: "9999999"
   - component: mongodb
-    operations: [ "transaction", "etag", "first-write", "query", "ttl", "actorStateStore" ]
+    operations: [ "transaction", "etag", "first-write", "query", "ttl", "actorStateStore", "keyslike" ]
   - component: memcached
     operations: [ "ttl" ]
   - component: azure.cosmosdb


### PR DESCRIPTION
MongoDB implemented the KeysLike() method but had two issues preventing it from satisfying the state.KeysLiker interface: the FeatureKeysLike capability was not advertised, and the method signature took a value receiver (KeysLikeRequest) instead of a pointer (*KeysLikeRequest).

This prevented `dapr workflow list` from working with MongoDB as the actor state store via the gRPC path.