### PR TITLE
feat(bindings): add fromTemp metadata to localstorage

### DIFF
--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -57,6 +57,7 @@ type LocalStorage struct {
 // Metadata defines the metadata.
 type Metadata struct {
 	RootPath string `json:"rootPath"`
+	FromTemp bool   `json:"fromTemp"`
 }
 
 type createResponse struct {
@@ -89,6 +90,10 @@ func (ls *LocalStorage) parseMetadata(meta bindings.Metadata) (*Metadata, error)
 	err := kitmd.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
+	}
+
+	if m.FromTemp {
+		m.RootPath = filepath.Join(os.TempDir(), m.RootPath)
 	}
 
 	m.RootPath, err = validateRootPath(m.RootPath)

--- a/bindings/localstorage/localstorage_test.go
+++ b/bindings/localstorage/localstorage_test.go
@@ -37,8 +37,21 @@ func TestParseMetadata(t *testing.T) {
 	meta, err := localStorage.parseMetadata(m)
 	require.NoError(t, err)
 	assert.Equal(t, path, meta.RootPath)
-}
 
+	m.Properties = map[string]string{
+		"rootPath": "myapp_data",
+		"fromTemp": "true",
+	}
+	metaTemp, err := localStorage.parseMetadata(m)
+	require.NoError(t, err)
+
+	realTempDir, err := filepath.EvalSymlinks(os.TempDir())
+	require.NoError(t, err)
+	expectedTempPath := filepath.Join(realTempDir, "myapp_data")
+
+	assert.Equal(t, expectedTempPath, metaTemp.RootPath)
+	assert.True(t, metaTemp.FromTemp)
+}
 func TestValidateRootPath(t *testing.T) {
 	// Get the current working directory
 	cwd, err := os.Getwd()

--- a/bindings/localstorage/metadata.yaml
+++ b/bindings/localstorage/metadata.yaml
@@ -23,3 +23,8 @@ metadata:
     required: true
     description: "The file name to write"
     example: "data.txt"
+  - name: fromTemp
+    description: "If true, resolves rootPath from the system-wide temporary directory."
+    type: bool
+    required: false
+    default: "false"


### PR DESCRIPTION
## Description

This PR adds the `fromTemp` boolean metadata to the `localstorage` binding component to allow resolving the `rootPath` from the system-wide temporary directory using `os.TempDir()`. This ensures true cross-platform compatibility.

This addresses the need for using system temp directories in development scenarios without hardcoding OS-specific paths (like `/tmp` or `C:\Windows\Temp`). Downward compatibility is strictly maintained (defaults to `false`). Unit tests and `metadata.yaml` have been updated accordingly.

Fixes #3158
