### PR TITLE
feat(bindings/smtp): support email attachments via JSON payload

### DIFF
--- a/bindings/smtp/smtp.go
+++ b/bindings/smtp/smtp.go
@@ -16,8 +16,11 @@ package smtp
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"strconv"
 	"strings"
@@ -56,6 +59,19 @@ type Metadata struct {
 	EmailBCC      string `mapstructure:"emailBCC"`
 	Subject       string `mapstructure:"subject"`
 	Priority      int    `mapstructure:"priority"`
+}
+
+// emailAttachment maps the attachment payload.
+type emailAttachment struct {
+	ContentType string `json:"content-type,omitempty"`
+	FileName    string `json:"filename"`
+	Data        string `json:"data"` // Base64 encoded file content
+}
+
+// emailPayload maps the new JSON payload structure supporting attachments.
+type emailPayload struct {
+	Body        string            `json:"body"`
+	Attachments []emailAttachment `json:"attachments"`
 }
 
 // NewSMTP returns a new smtp binding instance.
@@ -111,15 +127,41 @@ func (s *Mailer) Invoke(_ context.Context, req *bindings.InvokeRequest) (*bindin
 	msg.SetHeader("Subject", metadata.Subject)
 	msg.SetHeader("X-priority", strconv.Itoa(metadata.Priority))
 
-	body, err := strconv.Unquote(string(req.Data))
-
-	if err != nil {
-		// When data arrives over gRPC it's not quoted. Unquoting the original data will result in an error.
-		// Instead of unquoting it we'll just use the raw string as that one's already in the right format.
-
-		msg.SetBody("text/html", string(req.Data))
+	var rawData []byte
+	if unquoted, err := strconv.Unquote(string(req.Data)); err == nil {
+		rawData = []byte(unquoted)
 	} else {
-		msg.SetBody("text/html", body)
+		rawData = req.Data
+	}
+
+	var payload emailPayload
+	err = json.Unmarshal(rawData, &payload)
+
+	if err == nil && (len(payload.Attachments) > 0 || payload.Body != "") {
+		msg.SetBody("text/html", payload.Body)
+
+		for _, att := range payload.Attachments {
+			decodedData, decodeErr := base64.StdEncoding.DecodeString(att.Data)
+			if decodeErr != nil {
+				return nil, fmt.Errorf("smtp binding error: failed to decode base64 attachment %s: %w", att.FileName, decodeErr)
+			}
+
+			settings := []gomail.FileSetting{
+				gomail.SetCopyFunc(func(w io.Writer) error {
+					_, writeErr := w.Write(decodedData)
+					return writeErr
+				}),
+			}
+			if att.ContentType != "" {
+				settings = append(settings, gomail.SetHeader(map[string][]string{
+					"Content-Type": {att.ContentType},
+				}))
+			}
+
+			msg.Attach(att.FileName, settings...)
+		}
+	} else {
+		msg.SetBody("text/html", string(rawData))
 	}
 
 	// Send message

--- a/bindings/smtp/smtp_test.go
+++ b/bindings/smtp/smtp_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package smtp
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -319,5 +320,68 @@ func TestMergeWithRequestMetadata_invalidPriorityNotNumber(t *testing.T) {
 
 		assert.NotNil(t, mergedMeta)
 		require.Error(t, err)
+	})
+}
+
+func TestInvokeWithAttachments(t *testing.T) {
+	logger := logger.NewLogger("test")
+	m := bindings.Metadata{}
+	m.Properties = map[string]string{
+		"host":      "127.0.0.1",
+		"port":      "2525",
+		"user":      "user@dapr.io",
+		"password":  "pass",
+		"emailFrom": "from@dapr.io",
+		"emailTo":   "to@dapr.io",
+		"subject":   "Test attachments",
+	}
+
+	s := NewSMTP(logger).(*Mailer)
+	err := s.Init(context.Background(), m)
+	require.NoError(t, err)
+
+	t.Run("Valid JSON payload with invalid base64 attachment", func(t *testing.T) {
+		req := &bindings.InvokeRequest{
+			Data: []byte(`{
+                "body": "<h1>Hello</h1>",
+                "attachments": [
+                    {
+                        "filename": "test.txt",
+                        "data": "!!!invalid_base64!!!",
+                        "content-type": "text/plain"
+                    }
+                ]
+            }`),
+		}
+		_, err := s.Invoke(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode base64 attachment test.txt")
+	})
+
+	t.Run("Valid JSON payload with valid base64 attachment", func(t *testing.T) {
+		req := &bindings.InvokeRequest{
+			Data: []byte(`{
+                "body": "<h1>Hello</h1>",
+                "attachments": [
+                    {
+                        "filename": "test.txt",
+                        "data": "SGVsbG8gV29ybGQ=", 
+                        "content-type": "text/plain"
+                    }
+                ]
+            }`),
+		}
+		_, err := s.Invoke(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sending email failed")
+	})
+
+	t.Run("Fallback to raw text body if JSON parsing fails", func(t *testing.T) {
+		req := &bindings.InvokeRequest{
+			Data: []byte(`Just a plain text body, not JSON`),
+		}
+		_, err := s.Invoke(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sending email failed")
 	})
 }


### PR DESCRIPTION
## Description
Resolves #1062

This PR adds support for sending email attachments using the SMTP output binding. It parses the incoming JSON payload for an `attachments` array and constructs the multipart MIME message utilizing the existing `gomail` dependency, avoiding any new third-party libraries.

**Changes:**
- Introduced `emailPayload` and `emailAttachment` structs to parse the JSON request.
- Decodes base64-encoded attachment data and attaches it to the message using `gomail.SetCopyFunc`.
- Maintains 100% backward compatibility. If JSON parsing fails (e.g., standard text/HTML payload), it falls back to setting the raw data directly to the body.
- Added unit tests covering successful JSON parsing, base64 decoding errors, and the plain-text fallback scenario.

## Checklist
- [x] Code compiles correctly.
- [x] Created/updated tests.
- [x] DCO signed off.