### PR TITLE
Bulk file transfer operations to AWS S3 binding

### DIFF
--- a/bindings/aws/s3/metadata.yaml
+++ b/bindings/aws/s3/metadata.yaml
@@ -19,6 +19,12 @@ binding:
       description: "Delete blob"
     - name: list
       description: "List blob"
+    - name: bulkGet
+      description: "Download multiple blobs in parallel"
+    - name: bulkCreate
+      description: "Upload multiple blobs in parallel"
+    - name: bulkDelete
+      description: "Delete multiple blobs in batch"
 capabilities: []
 builtinAuthenticationProfiles:
   - name: "aws"

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -538,7 +538,7 @@ func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bind
 			defer func() { <-sem }()
 
 			resp, gerr := s.s3Client.GetObject(ctx, &s3.GetObjectInput{
-				Bucket: ptr.Of(s.metadata.Bucket),
+				Bucket: ptr.Of(metadata.Bucket),
 				Key:    ptr.Of(it.Key),
 			})
 			if gerr != nil {
@@ -706,7 +706,7 @@ func (s *AWSS3) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*b
 }
 
 func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
-	_, err := s.metadata.mergeWithRequestMetadata(req)
+	metadata, err := s.metadata.mergeWithRequestMetadata(req)
 	if err != nil {
 		return nil, fmt.Errorf("s3 binding error: error merging metadata: %w", err)
 	}
@@ -751,7 +751,7 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 
 		var output *s3.DeleteObjectsOutput
 		output, err = s.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-			Bucket: ptr.Of(s.metadata.Bucket),
+			Bucket: ptr.Of(metadata.Bucket),
 			Delete: &s3types.Delete{
 				Objects: objects,
 				Quiet:   ptr.Of(false),

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -142,7 +142,7 @@ type bulkDeletePayload struct {
 
 type bulkItemResult struct {
 	Key      string `json:"key"`
-	Data     []byte `json:"data,omitempty"`
+	Data     string `json:"data,omitempty"`
 	Location string `json:"location,omitempty"`
 	Error    string `json:"error,omitempty"`
 }
@@ -291,22 +291,11 @@ func (s *AWSS3) create(ctx context.Context, req *bindings.InvokeRequest) (*bindi
 		return nil, fmt.Errorf("s3 binding error: uploading failed: %w", err)
 	}
 
-	// location/path construction
-	var location string
-	if uploadOut != nil && uploadOut.Location != nil && *uploadOut.Location != "" {
-		location = *uploadOut.Location
-	} else if s.metadata.Endpoint != "" {
-		ep := strings.TrimRight(s.metadata.Endpoint, "/")
-		location = fmt.Sprintf("%s/%s/%s", ep, metadata.Bucket, key)
-	} else {
-		if s.metadata.ForcePathStyle {
-			location = fmt.Sprintf("https://s3.amazonaws.com/%s/%s", metadata.Bucket, key)
-		} else {
-			location = fmt.Sprintf("https://%s.s3.amazonaws.com/%s", metadata.Bucket, key)
-		}
+	var uploadLocation *string
+	if uploadOut != nil {
+		uploadLocation = uploadOut.Location
 	}
-
-	resultLocation := location
+	resultLocation := s.buildLocation(uploadLocation, metadata.Bucket, key)
 	var versionID *string
 	if uploadOut != nil {
 		versionID = uploadOut.VersionID
@@ -492,6 +481,21 @@ func resolveConcurrency(c *int) (int, error) {
 	return *c, nil
 }
 
+// buildLocation constructs the object URL from the upload output or falls back to endpoint/bucket/key conventions.
+func (s *AWSS3) buildLocation(uploadLocation *string, bucket, key string) string {
+	if uploadLocation != nil && *uploadLocation != "" {
+		return *uploadLocation
+	}
+	if s.metadata.Endpoint != "" {
+		ep := strings.TrimRight(s.metadata.Endpoint, "/")
+		return fmt.Sprintf("%s/%s/%s", ep, bucket, key)
+	}
+	if s.metadata.ForcePathStyle {
+		return fmt.Sprintf("https://s3.amazonaws.com/%s/%s", bucket, key)
+	}
+	return fmt.Sprintf("https://%s.s3.amazonaws.com/%s", bucket, key)
+}
+
 func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	metadata, err := s.metadata.mergeWithRequestMetadata(req)
 	if err != nil {
@@ -532,7 +536,12 @@ func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bind
 				Key:    ptr.Of(it.Key),
 			})
 			if gerr != nil {
-				results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+				var apiErr smithy.APIError
+				if errors.As(gerr, &apiErr) && apiErr.ErrorCode() == "NoSuchKey" {
+					results[idx] = bulkItemResult{Key: it.Key, Error: "object not found"}
+				} else {
+					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+				}
 				return
 			}
 			defer resp.Body.Close()
@@ -549,8 +558,12 @@ func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bind
 				var w io.Writer = f
 				if metadata.EncodeBase64 {
 					encoder := b64.NewEncoder(b64.StdEncoding, f)
-					defer encoder.Close()
 					w = encoder
+					defer func() {
+						if cerr := encoder.Close(); cerr != nil && results[idx].Error == "" {
+							results[idx].Error = cerr.Error()
+						}
+					}()
 				}
 
 				if _, gerr = io.Copy(w, resp.Body); gerr != nil {
@@ -569,7 +582,10 @@ func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bind
 					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
 					return
 				}
-				encoder.Close()
+				if gerr = encoder.Close(); gerr != nil {
+					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+					return
+				}
 			} else {
 				if _, gerr = io.Copy(&buf, resp.Body); gerr != nil {
 					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
@@ -577,7 +593,7 @@ func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bind
 				}
 			}
 
-			results[idx] = bulkItemResult{Key: it.Key, Data: buf.Bytes()}
+			results[idx] = bulkItemResult{Key: it.Key, Data: buf.String()}
 		}(i, item)
 	}
 	wg.Wait()
@@ -660,21 +676,11 @@ func (s *AWSS3) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*b
 				return
 			}
 
-			var location string
-			if uploadOut != nil && uploadOut.Location != nil && *uploadOut.Location != "" {
-				location = *uploadOut.Location
-			} else if s.metadata.Endpoint != "" {
-				ep := strings.TrimRight(s.metadata.Endpoint, "/")
-				location = fmt.Sprintf("%s/%s/%s", ep, metadata.Bucket, it.Key)
-			} else {
-				if s.metadata.ForcePathStyle {
-					location = fmt.Sprintf("https://s3.amazonaws.com/%s/%s", metadata.Bucket, it.Key)
-				} else {
-					location = fmt.Sprintf("https://%s.s3.amazonaws.com/%s", metadata.Bucket, it.Key)
-				}
+			var uploadLocation *string
+			if uploadOut != nil {
+				uploadLocation = uploadOut.Location
 			}
-
-			results[idx] = bulkItemResult{Key: it.Key, Location: location}
+			results[idx] = bulkItemResult{Key: it.Key, Location: s.buildLocation(uploadLocation, metadata.Bucket, it.Key)}
 		}(i, item)
 	}
 	wg.Wait()
@@ -700,6 +706,12 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 	// Initialize all results as success
 	for i, key := range payload.Keys {
 		results[i] = bulkItemResult{Key: key}
+	}
+
+	// Build a key→index map for O(1) lookups when mapping S3 errors
+	keyIndex := make(map[string]int, len(payload.Keys))
+	for i, key := range payload.Keys {
+		keyIndex[key] = i
 	}
 
 	// Process in batches of 1000 (S3 DeleteObjects limit)
@@ -730,19 +742,16 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 			continue
 		}
 
-		// Map individual errors from S3 response
+		// Map individual errors from S3 response using the key→index map
 		if output != nil {
 			for _, s3err := range output.Errors {
 				if s3err.Key != nil {
-					for i := batchStart; i < batchEnd; i++ {
-						if results[i].Key == *s3err.Key {
-							msg := "unknown error"
-							if s3err.Message != nil {
-								msg = *s3err.Message
-							}
-							results[i].Error = msg
-							break
+					if idx, ok := keyIndex[*s3err.Key]; ok {
+						msg := "unknown error"
+						if s3err.Message != nil {
+							msg = *s3err.Message
 						}
+						results[idx].Error = msg
 					}
 				}
 			}

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -703,24 +703,29 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 	}
 
 	results := make([]bulkItemResult, len(payload.Keys))
-	// Initialize all results as success
+	// Initialize results and validate keys; track valid keys for batching Build
+	// a key->indices map to handle duplicates correctly
+	keyIndices := make(map[string][]int, len(payload.Keys))
+	validKeys := make([]string, 0, len(payload.Keys))
 	for i, key := range payload.Keys {
 		results[i] = bulkItemResult{Key: key}
-	}
-
-	// Build a key→index map for O(1) lookups when mapping S3 errors
-	keyIndex := make(map[string]int, len(payload.Keys))
-	for i, key := range payload.Keys {
-		keyIndex[key] = i
-	}
-
-	// Process in batches of 1000 (S3 DeleteObjects limit)
-	for batchStart := 0; batchStart < len(payload.Keys); batchStart += maxDeleteBatchSize {
-		batchEnd := batchStart + maxDeleteBatchSize
-		if batchEnd > len(payload.Keys) {
-			batchEnd = len(payload.Keys)
+		if strings.TrimSpace(key) == "" {
+			results[i].Error = "key is required"
+			continue
 		}
-		batch := payload.Keys[batchStart:batchEnd]
+		if _, exists := keyIndices[key]; !exists {
+			validKeys = append(validKeys, key)
+		}
+		keyIndices[key] = append(keyIndices[key], i)
+	}
+
+	// Process valid keys in batches of 1000 (S3 DeleteObjects limit)
+	for batchStart := 0; batchStart < len(validKeys); batchStart += maxDeleteBatchSize {
+		batchEnd := batchStart + maxDeleteBatchSize
+		if batchEnd > len(validKeys) {
+			batchEnd = len(validKeys)
+		}
+		batch := validKeys[batchStart:batchEnd]
 
 		objects := make([]s3types.ObjectIdentifier, len(batch))
 		for i, key := range batch {
@@ -736,21 +741,23 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 		})
 		if err != nil {
 			// If the entire batch call failed, mark all keys in this batch as failed
-			for i := batchStart; i < batchEnd; i++ {
-				results[i].Error = err.Error()
+			for _, key := range batch {
+				for _, idx := range keyIndices[key] {
+					results[idx].Error = err.Error()
+				}
 			}
 			continue
 		}
 
-		// Map individual errors from S3 response using the key→index map
+		// Map individual errors from S3 response to all matching indices
 		if output != nil {
 			for _, s3err := range output.Errors {
 				if s3err.Key != nil {
-					if idx, ok := keyIndex[*s3err.Key]; ok {
-						msg := "unknown error"
-						if s3err.Message != nil {
-							msg = *s3err.Message
-						}
+					msg := "unknown error"
+					if s3err.Message != nil {
+						msg = *s3err.Message
+					}
+					for _, idx := range keyIndices[*s3err.Key] {
 						results[idx].Error = msg
 					}
 				}

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -14,6 +14,7 @@ limitations under the License.
 package s3
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	b64 "encoding/base64"
@@ -25,10 +26,12 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/google/uuid"
 
@@ -57,8 +60,13 @@ const (
 	metatadataContentType = "Content-Type"
 	metadataKey           = "key"
 
-	defaultMaxResults = 1000
-	presignOperation  = "presign"
+	defaultMaxResults      = 1000
+	presignOperation       = "presign"
+	bulkGetOperation       = "bulkGet"
+	bulkCreateOperation    = "bulkCreate"
+	bulkDeleteOperation    = "bulkDelete"
+	defaultBulkConcurrency = 10
+	maxDeleteBatchSize     = 1000
 )
 
 // AWSS3 is a binding for an AWS S3 storage bucket.
@@ -104,6 +112,39 @@ type listPayload struct {
 	Prefix     string `json:"prefix"`
 	MaxResults int32  `json:"maxResults"`
 	Delimiter  string `json:"delimiter"`
+}
+
+type bulkGetItem struct {
+	Key      string  `json:"key"`
+	FilePath *string `json:"filePath,omitempty"`
+}
+
+type bulkGetPayload struct {
+	Items       []bulkGetItem `json:"items"`
+	Concurrency *int          `json:"concurrency,omitempty"`
+}
+
+type bulkCreateItem struct {
+	Key         string  `json:"key"`
+	Data        *string `json:"data,omitempty"`
+	ContentType *string `json:"contentType,omitempty"`
+	FilePath    *string `json:"filePath,omitempty"`
+}
+
+type bulkCreatePayload struct {
+	Items       []bulkCreateItem `json:"items"`
+	Concurrency *int             `json:"concurrency,omitempty"`
+}
+
+type bulkDeletePayload struct {
+	Keys []string `json:"keys"`
+}
+
+type bulkItemResult struct {
+	Key      string `json:"key"`
+	Data     []byte `json:"data,omitempty"`
+	Location string `json:"location,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 // NewAWSS3 returns a new AWSS3 instance.
@@ -174,6 +215,9 @@ func (s *AWSS3) Operations() []bindings.OperationKind {
 		bindings.DeleteOperation,
 		bindings.ListOperation,
 		presignOperation,
+		bulkGetOperation,
+		bulkCreateOperation,
+		bulkDeleteOperation,
 	}
 }
 
@@ -436,6 +480,283 @@ func (s *AWSS3) list(ctx context.Context, req *bindings.InvokeRequest) (*binding
 	}, nil
 }
 
+// resolveConcurrency validates and resolves the concurrency pointer.
+// Returns defaultBulkConcurrency if nil, or an error if the value is <= 0.
+func resolveConcurrency(c *int) (int, error) {
+	if c == nil {
+		return defaultBulkConcurrency, nil
+	}
+	if *c <= 0 {
+		return 0, fmt.Errorf("s3 binding error: concurrency must be greater than 0, got %d", *c)
+	}
+	return *c, nil
+}
+
+func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	metadata, err := s.metadata.mergeWithRequestMetadata(req)
+	if err != nil {
+		return nil, fmt.Errorf("s3 binding error: error merging metadata: %w", err)
+	}
+
+	var payload bulkGetPayload
+	if err = json.Unmarshal(req.Data, &payload); err != nil {
+		return nil, fmt.Errorf("s3 binding error: invalid bulkGet payload: %w", err)
+	}
+	if len(payload.Items) == 0 {
+		return nil, errors.New("s3 binding error: bulkGet requires at least one item")
+	}
+
+	concurrency, err := resolveConcurrency(payload.Concurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]bulkItemResult, len(payload.Items))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for i, item := range payload.Items {
+		if item.Key == "" {
+			results[i] = bulkItemResult{Key: "", Error: "key is required"}
+			continue
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, it bulkGetItem) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			resp, gerr := s.s3Client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: ptr.Of(s.metadata.Bucket),
+				Key:    ptr.Of(it.Key),
+			})
+			if gerr != nil {
+				results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+				return
+			}
+			defer resp.Body.Close()
+
+			// If filePath is specified, stream directly to file
+			if it.FilePath != nil {
+				f, ferr := os.Create(*it.FilePath)
+				if ferr != nil {
+					results[idx] = bulkItemResult{Key: it.Key, Error: ferr.Error()}
+					return
+				}
+				defer f.Close()
+
+				var w io.Writer = f
+				if metadata.EncodeBase64 {
+					encoder := b64.NewEncoder(b64.StdEncoding, f)
+					defer encoder.Close()
+					w = encoder
+				}
+
+				if _, gerr = io.Copy(w, resp.Body); gerr != nil {
+					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+					return
+				}
+				results[idx] = bulkItemResult{Key: it.Key}
+				return
+			}
+
+			// No filePath: stream into buffer with optional base64 encoding
+			var buf bytes.Buffer
+			if metadata.EncodeBase64 {
+				encoder := b64.NewEncoder(b64.StdEncoding, &buf)
+				if _, gerr = io.Copy(encoder, resp.Body); gerr != nil {
+					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+					return
+				}
+				encoder.Close()
+			} else {
+				if _, gerr = io.Copy(&buf, resp.Body); gerr != nil {
+					results[idx] = bulkItemResult{Key: it.Key, Error: gerr.Error()}
+					return
+				}
+			}
+
+			results[idx] = bulkItemResult{Key: it.Key, Data: buf.Bytes()}
+		}(i, item)
+	}
+	wg.Wait()
+
+	jsonResponse, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("s3 binding error: error marshalling bulkGet response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{Data: jsonResponse}, nil
+}
+
+func (s *AWSS3) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	metadata, err := s.metadata.mergeWithRequestMetadata(req)
+	if err != nil {
+		return nil, fmt.Errorf("s3 binding error: error merging metadata: %w", err)
+	}
+
+	var payload bulkCreatePayload
+	if err = json.Unmarshal(req.Data, &payload); err != nil {
+		return nil, fmt.Errorf("s3 binding error: invalid bulkCreate payload: %w", err)
+	}
+	if len(payload.Items) == 0 {
+		return nil, errors.New("s3 binding error: bulkCreate requires at least one item")
+	}
+
+	concurrency, err := resolveConcurrency(payload.Concurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]bulkItemResult, len(payload.Items))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for i, item := range payload.Items {
+		if item.Key == "" {
+			results[i] = bulkItemResult{Key: "", Error: "key is required"}
+			continue
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, it bulkCreateItem) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			var r io.Reader
+			if it.FilePath != nil {
+				f, ferr := os.Open(*it.FilePath)
+				if ferr != nil {
+					results[idx] = bulkItemResult{Key: it.Key, Error: ferr.Error()}
+					return
+				}
+				defer f.Close()
+				r = f
+			} else if it.Data != nil {
+				r = strings.NewReader(*it.Data)
+			} else {
+				results[idx] = bulkItemResult{Key: it.Key, Error: "either data or filePath is required"}
+				return
+			}
+
+			if metadata.DecodeBase64 {
+				r = b64.NewDecoder(b64.StdEncoding, r)
+			}
+
+			uploadIn := &transfermanager.UploadObjectInput{
+				Bucket: ptr.Of(metadata.Bucket),
+				Key:    ptr.Of(it.Key),
+				Body:   r,
+			}
+			if it.ContentType != nil {
+				uploadIn.ContentType = it.ContentType
+			}
+
+			uploadOut, uerr := s.tmClient.UploadObject(ctx, uploadIn)
+			if uerr != nil {
+				results[idx] = bulkItemResult{Key: it.Key, Error: uerr.Error()}
+				return
+			}
+
+			var location string
+			if uploadOut != nil && uploadOut.Location != nil && *uploadOut.Location != "" {
+				location = *uploadOut.Location
+			} else if s.metadata.Endpoint != "" {
+				ep := strings.TrimRight(s.metadata.Endpoint, "/")
+				location = fmt.Sprintf("%s/%s/%s", ep, metadata.Bucket, it.Key)
+			} else {
+				if s.metadata.ForcePathStyle {
+					location = fmt.Sprintf("https://s3.amazonaws.com/%s/%s", metadata.Bucket, it.Key)
+				} else {
+					location = fmt.Sprintf("https://%s.s3.amazonaws.com/%s", metadata.Bucket, it.Key)
+				}
+			}
+
+			results[idx] = bulkItemResult{Key: it.Key, Location: location}
+		}(i, item)
+	}
+	wg.Wait()
+
+	jsonResponse, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("s3 binding error: error marshalling bulkCreate response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{Data: jsonResponse}, nil
+}
+
+func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	var payload bulkDeletePayload
+	if err := json.Unmarshal(req.Data, &payload); err != nil {
+		return nil, fmt.Errorf("s3 binding error: invalid bulkDelete payload: %w", err)
+	}
+	if len(payload.Keys) == 0 {
+		return nil, errors.New("s3 binding error: bulkDelete requires at least one key")
+	}
+
+	results := make([]bulkItemResult, len(payload.Keys))
+	// Initialize all results as success
+	for i, key := range payload.Keys {
+		results[i] = bulkItemResult{Key: key}
+	}
+
+	// Process in batches of 1000 (S3 DeleteObjects limit)
+	for batchStart := 0; batchStart < len(payload.Keys); batchStart += maxDeleteBatchSize {
+		batchEnd := batchStart + maxDeleteBatchSize
+		if batchEnd > len(payload.Keys) {
+			batchEnd = len(payload.Keys)
+		}
+		batch := payload.Keys[batchStart:batchEnd]
+
+		objects := make([]s3types.ObjectIdentifier, len(batch))
+		for i, key := range batch {
+			objects[i] = s3types.ObjectIdentifier{Key: ptr.Of(key)}
+		}
+
+		output, err := s.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: ptr.Of(s.metadata.Bucket),
+			Delete: &s3types.Delete{
+				Objects: objects,
+				Quiet:   ptr.Of(false),
+			},
+		})
+		if err != nil {
+			// If the entire batch call failed, mark all keys in this batch as failed
+			for i := batchStart; i < batchEnd; i++ {
+				results[i].Error = err.Error()
+			}
+			continue
+		}
+
+		// Map individual errors from S3 response
+		if output != nil {
+			for _, s3err := range output.Errors {
+				if s3err.Key != nil {
+					for i := batchStart; i < batchEnd; i++ {
+						if results[i].Key == *s3err.Key {
+							msg := "unknown error"
+							if s3err.Message != nil {
+								msg = *s3err.Message
+							}
+							results[i].Error = msg
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	jsonResponse, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("s3 binding error: error marshalling bulkDelete response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{Data: jsonResponse}, nil
+}
+
 func (s *AWSS3) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	switch req.Operation {
 	case bindings.CreateOperation:
@@ -448,6 +769,12 @@ func (s *AWSS3) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindi
 		return s.list(ctx, req)
 	case presignOperation:
 		return s.presign(ctx, req)
+	case bulkGetOperation:
+		return s.bulkGet(ctx, req)
+	case bulkCreateOperation:
+		return s.bulkCreate(ctx, req)
+	case bulkDeleteOperation:
+		return s.bulkDelete(ctx, req)
 	default:
 		return nil, fmt.Errorf("s3 binding error: unsupported operation %s", req.Operation)
 	}

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -526,7 +526,13 @@ func (s *AWSS3) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bind
 		}
 
 		wg.Add(1)
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			results[i] = bulkItemResult{Key: item.Key, Error: ctx.Err().Error()}
+			wg.Done()
+			continue
+		}
 		go func(idx int, it bulkGetItem) {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -636,7 +642,13 @@ func (s *AWSS3) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*b
 		}
 
 		wg.Add(1)
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			results[i] = bulkItemResult{Key: item.Key, Error: ctx.Err().Error()}
+			wg.Done()
+			continue
+		}
 		go func(idx int, it bulkCreateItem) {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -694,6 +706,11 @@ func (s *AWSS3) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*b
 }
 
 func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	_, err := s.metadata.mergeWithRequestMetadata(req)
+	if err != nil {
+		return nil, fmt.Errorf("s3 binding error: error merging metadata: %w", err)
+	}
+
 	var payload bulkDeletePayload
 	if err := json.Unmarshal(req.Data, &payload); err != nil {
 		return nil, fmt.Errorf("s3 binding error: invalid bulkDelete payload: %w", err)

--- a/bindings/aws/s3/s3.go
+++ b/bindings/aws/s3/s3.go
@@ -712,7 +712,7 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 	}
 
 	var payload bulkDeletePayload
-	if err := json.Unmarshal(req.Data, &payload); err != nil {
+	if err = json.Unmarshal(req.Data, &payload); err != nil {
 		return nil, fmt.Errorf("s3 binding error: invalid bulkDelete payload: %w", err)
 	}
 	if len(payload.Keys) == 0 {
@@ -749,7 +749,8 @@ func (s *AWSS3) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*b
 			objects[i] = s3types.ObjectIdentifier{Key: ptr.Of(key)}
 		}
 
-		output, err := s.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		var output *s3.DeleteObjectsOutput
+		output, err = s.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 			Bucket: ptr.Of(s.metadata.Bucket),
 			Delete: &s3types.Delete{
 				Objects: objects,

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -556,6 +556,26 @@ func TestBulkDeleteValidation(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires at least one key")
 	})
+
+	t.Run("empty key in list returns per-item error", func(t *testing.T) {
+		srv := fakeS3Server(t)
+		defer srv.Close()
+		s := newTestAWSS3(t, srv.URL)
+
+		payload, _ := json.Marshal(bulkDeletePayload{Keys: []string{"valid.txt", "", "  "}})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		resp, err := s.bulkDelete(t.Context(), &r)
+		require.NoError(t, err)
+		var results []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &results))
+		require.Len(t, results, 3)
+		assert.Empty(t, results[0].Error, "valid key should succeed")
+		assert.Equal(t, "key is required", results[1].Error)
+		assert.Equal(t, "key is required", results[2].Error)
+	})
 }
 
 func TestBulkPayloadParsing(t *testing.T) {

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 // fakeS3Server creates an httptest server that implements minimal S3 GET/PUT/POST/DELETE.
-// Objects are stored in memory keyed by path. Returns the server and a cleanup function.
+// Objects are stored in memory keyed by path.
 func fakeS3Server(t *testing.T) *httptest.Server {
 	t.Helper()
 	var mu sync.RWMutex
@@ -732,7 +732,7 @@ func TestBulkItemResultJSON(t *testing.T) {
 	})
 
 	t.Run("includes data when present", func(t *testing.T) {
-		r := bulkItemResult{Key: "test.txt", Data: []byte("hello")}
+		r := bulkItemResult{Key: "test.txt", Data: "hello"}
 		data, err := json.Marshal(r)
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `"data"`)
@@ -845,7 +845,7 @@ func TestBulkCreateAndGetRoundTrip(t *testing.T) {
 		}
 		for _, r := range getResults {
 			assert.Empty(t, r.Error)
-			assert.Equal(t, expected[r.Key], string(r.Data))
+			assert.Equal(t, expected[r.Key], r.Data)
 		}
 	})
 }
@@ -883,7 +883,7 @@ func TestBulkGetEncodeBase64(t *testing.T) {
 		assert.Empty(t, results[0].Error)
 
 		// Verify the data is valid base64 and decodes to original
-		decoded, err := b64.StdEncoding.DecodeString(string(results[0].Data))
+		decoded, err := b64.StdEncoding.DecodeString(results[0].Data)
 		require.NoError(t, err)
 		assert.Equal(t, "binary content here", string(decoded))
 	})
@@ -902,7 +902,7 @@ func TestBulkGetEncodeBase64(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Data, &results))
 		require.Len(t, results, 1)
 		assert.Empty(t, results[0].Error)
-		assert.Equal(t, "binary content here", string(results[0].Data))
+		assert.Equal(t, "binary content here", results[0].Data)
 	})
 }
 
@@ -940,7 +940,7 @@ func TestBulkCreateDecodeBase64(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Data, &results))
 	require.Len(t, results, 1)
 	assert.Empty(t, results[0].Error)
-	assert.Equal(t, originalContent, string(results[0].Data))
+	assert.Equal(t, originalContent, results[0].Data)
 }
 
 func TestBulkCreateDecodeBase64ThenGetEncodeBase64(t *testing.T) {
@@ -979,7 +979,7 @@ func TestBulkCreateDecodeBase64ThenGetEncodeBase64(t *testing.T) {
 	assert.Empty(t, results[0].Error)
 
 	// The returned data should be base64 of the original content
-	assert.Equal(t, b64Content, string(results[0].Data))
+	assert.Equal(t, b64Content, results[0].Data)
 }
 
 func TestBulkGetToFile(t *testing.T) {
@@ -1018,7 +1018,7 @@ func TestBulkGetToFile(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Data, &results))
 		require.Len(t, results, 1)
 		assert.Empty(t, results[0].Error)
-		assert.Nil(t, results[0].Data, "data should be nil when writing to file")
+		assert.Empty(t, results[0].Data, "data should be empty when writing to file")
 
 		// Verify file contents
 		fileBytes, err := os.ReadFile(outPath)
@@ -1095,7 +1095,7 @@ func TestBulkCreateFromFile(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Data, &getResults))
 		require.Len(t, getResults, 1)
 		assert.Empty(t, getResults[0].Error)
-		assert.Equal(t, "uploaded from file", string(getResults[0].Data))
+		assert.Equal(t, "uploaded from file", getResults[0].Data)
 	})
 
 	t.Run("upload from filePath with decodeBase64", func(t *testing.T) {
@@ -1134,7 +1134,7 @@ func TestBulkCreateFromFile(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Data, &getResults))
 		require.Len(t, getResults, 1)
 		assert.Empty(t, getResults[0].Error)
-		assert.Equal(t, original, string(getResults[0].Data))
+		assert.Equal(t, original, getResults[0].Data)
 	})
 }
 
@@ -1175,10 +1175,10 @@ func TestBulkGetPartialFailure(t *testing.T) {
 	for _, r := range results {
 		if r.Key == "exists.txt" {
 			assert.Empty(t, r.Error)
-			assert.Equal(t, "I exist", string(r.Data))
+			assert.Equal(t, "I exist", r.Data)
 		} else {
 			assert.NotEmpty(t, r.Error, "non-existent key should have an error")
-			assert.Nil(t, r.Data)
+			assert.Empty(t, r.Data)
 		}
 	}
 }

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -140,8 +140,8 @@ func fakeS3Server(t *testing.T) *httptest.Server {
 func newTestAWSS3(t *testing.T, endpoint string) *AWSS3 {
 	t.Helper()
 	cfg := aws.Config{
-		Region:      "us-east-1",
-		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
+		Region:       "us-east-1",
+		Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
 		BaseEndpoint: &endpoint,
 	}
 	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
@@ -1063,7 +1063,7 @@ func TestBulkCreateFromFile(t *testing.T) {
 	t.Run("upload from filePath", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		srcPath := filepath.Join(tmpDir, "upload.txt")
-		require.NoError(t, os.WriteFile(srcPath, []byte("uploaded from file"), 0o644))
+		require.NoError(t, os.WriteFile(srcPath, []byte("uploaded from file"), 0o600))
 
 		createPayload, _ := json.Marshal(bulkCreatePayload{
 			Items: []bulkCreateItem{
@@ -1102,7 +1102,7 @@ func TestBulkCreateFromFile(t *testing.T) {
 		tmpDir := t.TempDir()
 		srcPath := filepath.Join(tmpDir, "upload-b64.txt")
 		original := "base64 file content"
-		require.NoError(t, os.WriteFile(srcPath, []byte(b64.StdEncoding.EncodeToString([]byte(original))), 0o644))
+		require.NoError(t, os.WriteFile(srcPath, []byte(b64.StdEncoding.EncodeToString([]byte(original))), 0o600))
 
 		createPayload, _ := json.Marshal(bulkCreatePayload{
 			Items: []bulkCreateItem{

--- a/bindings/aws/s3/s3_test.go
+++ b/bindings/aws/s3/s3_test.go
@@ -14,17 +14,147 @@ limitations under the License.
 package s3
 
 import (
+	b64 "encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
 )
+
+// fakeS3Server creates an httptest server that implements minimal S3 GET/PUT/POST/DELETE.
+// Objects are stored in memory keyed by path. Returns the server and a cleanup function.
+func fakeS3Server(t *testing.T) *httptest.Server {
+	t.Helper()
+	var mu sync.RWMutex
+	objects := make(map[string][]byte)
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Path // e.g. "/bucket/key"
+
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			objects[key] = body
+			mu.Unlock()
+			w.Header().Set("Location", r.URL.String())
+			w.WriteHeader(http.StatusOK)
+
+		case http.MethodGet:
+			mu.RLock()
+			data, ok := objects[key]
+			mu.RUnlock()
+			if !ok {
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(http.StatusNotFound)
+				//nolint:errcheck
+				w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			//nolint:errcheck
+			w.Write(data)
+
+		case http.MethodDelete:
+			mu.Lock()
+			delete(objects, key)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+
+		case http.MethodPost:
+			// Handle DeleteObjects (batch delete) - path ends with ?delete
+			if strings.Contains(r.URL.RawQuery, "delete") {
+				// Parse the request body to find keys and actually delete them
+				body, _ := io.ReadAll(r.Body)
+				bodyStr := string(body)
+				mu.Lock()
+				// Extract keys from XML like <Key>foo</Key>
+				for {
+					start := strings.Index(bodyStr, "<Key>")
+					if start == -1 {
+						break
+					}
+					end := strings.Index(bodyStr[start:], "</Key>")
+					if end == -1 {
+						break
+					}
+					delKey := bodyStr[start+5 : start+end]
+					// The key in the store includes the bucket prefix
+					delete(objects, "/test/"+delKey)
+					bodyStr = bodyStr[start+end+6:]
+				}
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(http.StatusOK)
+				//nolint:errcheck
+				w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>`))
+				return
+			}
+			// Handle multipart upload initiation
+			if strings.Contains(r.URL.RawQuery, "uploads") {
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(http.StatusOK)
+				//nolint:errcheck
+				w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>test</Bucket><Key>` + key + `</Key><UploadId>fake-upload-id</UploadId></InitiateMultipartUploadResult>`))
+				return
+			}
+			// Handle multipart upload completion
+			if strings.Contains(r.URL.RawQuery, "uploadId") {
+				// For complete multipart, read the body (it's the part list XML)
+				// but we already stored data via PUT for each part
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(http.StatusOK)
+				//nolint:errcheck
+				w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult><Location>` + r.URL.String() + `</Location><Bucket>test</Bucket><Key>` + key + `</Key></CompleteMultipartUploadResult>`))
+				return
+			}
+			http.Error(w, "unsupported POST", http.StatusBadRequest)
+
+		default:
+			http.Error(w, "unsupported method", http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+// newTestAWSS3 creates an AWSS3 instance pointed at the given fake server endpoint.
+func newTestAWSS3(t *testing.T, endpoint string) *AWSS3 {
+	t.Helper()
+	cfg := aws.Config{
+		Region:      "us-east-1",
+		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
+		BaseEndpoint: &endpoint,
+	}
+	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+	return &AWSS3{
+		metadata:  &s3Metadata{Bucket: "test", ForcePathStyle: true, Endpoint: endpoint},
+		s3Client:  s3Client,
+		tmClient:  transfermanager.New(s3Client),
+		presigner: s3.NewPresignClient(s3Client),
+		logger:    logger.NewLogger("s3-test"),
+	}
+}
 
 func TestParseMetadata(t *testing.T) {
 	t.Run("Has correct metadata", func(t *testing.T) {
@@ -266,4 +396,901 @@ func TestForcePathStylePresignURL(t *testing.T) {
 		require.Contains(t, presigned.URL, "/"+bucket+"/"+key)
 		require.Equal(t, "https://s3."+region+".amazonaws.com/"+bucket+"/"+key, presigned.URL[:len("https://s3."+region+".amazonaws.com/"+bucket+"/"+key)])
 	})
+}
+
+func TestOperationsIncludesBulk(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	ops := s.Operations()
+
+	opNames := make(map[bindings.OperationKind]bool)
+	for _, op := range ops {
+		opNames[op] = true
+	}
+
+	assert.True(t, opNames[bulkGetOperation], "should include bulkGet")
+	assert.True(t, opNames[bulkCreateOperation], "should include bulkCreate")
+	assert.True(t, opNames[bulkDeleteOperation], "should include bulkDelete")
+}
+
+func TestBulkGetValidation(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	s.metadata = &s3Metadata{Bucket: "test"}
+
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data:     []byte("not-json"),
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid bulkGet payload")
+	})
+
+	t.Run("empty items", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkGetPayload{Items: []bulkGetItem{}})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires at least one item")
+	})
+
+	t.Run("nil items", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkGetPayload{})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires at least one item")
+	})
+
+	t.Run("concurrency zero is error", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkGetPayload{
+			Items:       []bulkGetItem{{Key: "a"}},
+			Concurrency: ptr.Of(0),
+		})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "concurrency must be greater than 0")
+	})
+
+	t.Run("negative concurrency is error", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkGetPayload{
+			Items:       []bulkGetItem{{Key: "a"}},
+			Concurrency: ptr.Of(-1),
+		})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "concurrency must be greater than 0")
+	})
+
+	t.Run("empty key in item returns per-item error", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{{Key: ""}},
+		})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		resp, err := s.bulkGet(t.Context(), &r)
+		require.NoError(t, err)
+		var results []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &results))
+		require.Len(t, results, 1)
+		assert.Equal(t, "key is required", results[0].Error)
+	})
+}
+
+func TestBulkCreateValidation(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	s.metadata = &s3Metadata{Bucket: "test"}
+
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data:     []byte("{bad}"),
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid bulkCreate payload")
+	})
+
+	t.Run("empty items", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkCreatePayload{Items: []bulkCreateItem{}})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires at least one item")
+	})
+
+	t.Run("concurrency zero is error", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkCreatePayload{
+			Items:       []bulkCreateItem{{Key: "a", Data: ptr.Of("x")}},
+			Concurrency: ptr.Of(0),
+		})
+		r := bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "concurrency must be greater than 0")
+	})
+}
+
+func TestBulkDeleteValidation(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	s.metadata = &s3Metadata{Bucket: "test"}
+
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data:     []byte("bad"),
+			Metadata: map[string]string{},
+		}
+		_, err := s.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid bulkDelete payload")
+	})
+
+	t.Run("empty keys", func(t *testing.T) {
+		payload, _ := json.Marshal(bulkDeletePayload{Keys: []string{}})
+		r := bindings.InvokeRequest{
+			Data: payload,
+		}
+		_, err := s.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires at least one key")
+	})
+}
+
+func TestBulkPayloadParsing(t *testing.T) {
+	t.Run("bulkGet payload with concurrency and filePath", func(t *testing.T) {
+		raw := `{"items":[{"key":"a.txt"},{"key":"b.txt","filePath":"/tmp/b.txt"}],"concurrency":5}`
+		var p bulkGetPayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		require.Len(t, p.Items, 2)
+		assert.Equal(t, "a.txt", p.Items[0].Key)
+		assert.Nil(t, p.Items[0].FilePath)
+		assert.Equal(t, "b.txt", p.Items[1].Key)
+		require.NotNil(t, p.Items[1].FilePath)
+		assert.Equal(t, "/tmp/b.txt", *p.Items[1].FilePath)
+		require.NotNil(t, p.Concurrency)
+		assert.Equal(t, 5, *p.Concurrency)
+	})
+
+	t.Run("bulkGet payload without concurrency is nil", func(t *testing.T) {
+		raw := `{"items":[{"key":"a.txt"}]}`
+		var p bulkGetPayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Nil(t, p.Concurrency)
+	})
+
+	t.Run("bulkCreate payload with pointers", func(t *testing.T) {
+		raw := `{"items":[{"key":"f1.txt","data":"hello"},{"key":"f2.txt","filePath":"/tmp/f2.txt","contentType":"text/plain"}],"concurrency":3}`
+		var p bulkCreatePayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Len(t, p.Items, 2)
+		assert.Equal(t, "f1.txt", p.Items[0].Key)
+		require.NotNil(t, p.Items[0].Data)
+		assert.Equal(t, "hello", *p.Items[0].Data)
+		assert.Nil(t, p.Items[0].FilePath)
+		assert.Nil(t, p.Items[0].ContentType)
+		assert.Equal(t, "f2.txt", p.Items[1].Key)
+		require.NotNil(t, p.Items[1].FilePath)
+		assert.Equal(t, "/tmp/f2.txt", *p.Items[1].FilePath)
+		require.NotNil(t, p.Items[1].ContentType)
+		assert.Equal(t, "text/plain", *p.Items[1].ContentType)
+		require.NotNil(t, p.Concurrency)
+		assert.Equal(t, 3, *p.Concurrency)
+	})
+
+	t.Run("bulkCreate item with neither data nor filePath", func(t *testing.T) {
+		raw := `{"items":[{"key":"f1.txt"}]}`
+		var p bulkCreatePayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Nil(t, p.Items[0].Data)
+		assert.Nil(t, p.Items[0].FilePath)
+	})
+
+	t.Run("bulkDelete payload", func(t *testing.T) {
+		raw := `{"keys":["x.txt","y.txt"]}`
+		var p bulkDeletePayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"x.txt", "y.txt"}, p.Keys)
+	})
+}
+
+func TestBulkCreateMissingKey(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	s.metadata = &s3Metadata{Bucket: "test"}
+
+	// Test the validation path with only the empty-key item.
+	payload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "", Data: ptr.Of("data1")},
+		},
+	})
+	r := bindings.InvokeRequest{
+		Data:     payload,
+		Metadata: map[string]string{},
+	}
+	resp, err := s.bulkCreate(t.Context(), &r)
+	require.NoError(t, err)
+
+	var results []bulkItemResult
+	err = json.Unmarshal(resp.Data, &results)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "key is required", results[0].Error)
+}
+
+func TestBulkCreateMissingDataAndFilePath(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	s.metadata = &s3Metadata{Bucket: "test"}
+
+	// Item with key but neither data nor filePath
+	payload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "test.txt"},
+		},
+	})
+	r := bindings.InvokeRequest{
+		Data:     payload,
+		Metadata: map[string]string{},
+	}
+	resp, err := s.bulkCreate(t.Context(), &r)
+	require.NoError(t, err)
+
+	var results []bulkItemResult
+	err = json.Unmarshal(resp.Data, &results)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "either data or filePath is required", results[0].Error)
+}
+
+func TestResolveConcurrency(t *testing.T) {
+	t.Run("nil returns default", func(t *testing.T) {
+		c, err := resolveConcurrency(nil)
+		require.NoError(t, err)
+		assert.Equal(t, defaultBulkConcurrency, c)
+	})
+
+	t.Run("positive value is returned", func(t *testing.T) {
+		c, err := resolveConcurrency(ptr.Of(25))
+		require.NoError(t, err)
+		assert.Equal(t, 25, c)
+	})
+
+	t.Run("zero is error", func(t *testing.T) {
+		_, err := resolveConcurrency(ptr.Of(0))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "concurrency must be greater than 0")
+	})
+
+	t.Run("negative is error", func(t *testing.T) {
+		_, err := resolveConcurrency(ptr.Of(-5))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "concurrency must be greater than 0")
+	})
+}
+
+func TestBulkDeleteChunking(t *testing.T) {
+	// Verify the chunking logic by checking that maxDeleteBatchSize is 1000
+	assert.Equal(t, 1000, maxDeleteBatchSize)
+
+	// Verify that bulkDeletePayload can hold more than 1000 keys
+	keys := make([]string, 2500)
+	for i := range keys {
+		keys[i] = "key" + string(rune('0'+i%10))
+	}
+	p := bulkDeletePayload{Keys: keys}
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var parsed bulkDeletePayload
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Len(t, parsed.Keys, 2500)
+}
+
+func TestBulkItemResultJSON(t *testing.T) {
+	t.Run("omits empty fields", func(t *testing.T) {
+		r := bulkItemResult{Key: "test.txt"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "data")
+		assert.NotContains(t, string(data), "location")
+		assert.NotContains(t, string(data), "error")
+		assert.Contains(t, string(data), `"key":"test.txt"`)
+	})
+
+	t.Run("includes error when present", func(t *testing.T) {
+		r := bulkItemResult{Key: "test.txt", Error: "not found"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"error":"not found"`)
+	})
+
+	t.Run("includes data when present", func(t *testing.T) {
+		r := bulkItemResult{Key: "test.txt", Data: []byte("hello")}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"data"`)
+	})
+
+	t.Run("includes location when present", func(t *testing.T) {
+		r := bulkItemResult{Key: "test.txt", Location: "https://bucket.s3.amazonaws.com/test.txt"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"location"`)
+	})
+}
+
+func TestInvokeRoutesBulkOperations(t *testing.T) {
+	s := NewAWSS3(logger.NewLogger("s3")).(*AWSS3)
+	s.metadata = &s3Metadata{Bucket: "test"}
+
+	// Use empty/invalid payloads to trigger validation errors (not "unsupported operation")
+	// which proves the operation was routed to the correct handler.
+	t.Run("bulkGet routes correctly", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Operation: bulkGetOperation,
+			Data:      []byte(`{"items":[]}`),
+			Metadata:  map[string]string{},
+		}
+		_, err := s.Invoke(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bulkGet requires at least one item")
+	})
+
+	t.Run("bulkCreate routes correctly", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Operation: bulkCreateOperation,
+			Data:      []byte(`{"items":[]}`),
+			Metadata:  map[string]string{},
+		}
+		_, err := s.Invoke(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bulkCreate requires at least one item")
+	})
+
+	t.Run("bulkDelete routes correctly", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Operation: bulkDeleteOperation,
+			Data:      []byte(`{"keys":[]}`),
+			Metadata:  map[string]string{},
+		}
+		_, err := s.Invoke(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bulkDelete requires at least one key")
+	})
+
+	t.Run("unknown operation returns error", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Operation: "nonexistent",
+			Data:      []byte(`{}`),
+			Metadata:  map[string]string{},
+		}
+		_, err := s.Invoke(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported operation")
+	})
+}
+
+func TestBulkCreateAndGetRoundTrip(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	t.Run("raw data round-trip", func(t *testing.T) {
+		// Create two objects
+		payload, _ := json.Marshal(bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{Key: "hello.txt", Data: ptr.Of("hello world")},
+				{Key: "foo.txt", Data: ptr.Of("foo bar baz")},
+			},
+		})
+		resp, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+			Data:     payload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+		var createResults []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &createResults))
+		require.Len(t, createResults, 2)
+		for _, r := range createResults {
+			assert.Empty(t, r.Error)
+			assert.NotEmpty(t, r.Location)
+		}
+
+		// Get them back
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{
+				{Key: "hello.txt"},
+				{Key: "foo.txt"},
+			},
+		})
+		resp, err = s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+		var getResults []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &getResults))
+		require.Len(t, getResults, 2)
+
+		expected := map[string]string{
+			"hello.txt": "hello world",
+			"foo.txt":   "foo bar baz",
+		}
+		for _, r := range getResults {
+			assert.Empty(t, r.Error)
+			assert.Equal(t, expected[r.Key], string(r.Data))
+		}
+	})
+}
+
+func TestBulkGetEncodeBase64(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	// Upload raw data
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "binary.bin", Data: ptr.Of("binary content here")},
+		},
+	})
+	_, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	t.Run("encodeBase64 returns base64 encoded data", func(t *testing.T) {
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{{Key: "binary.bin"}},
+		})
+		resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{"encodeBase64": "true"},
+		})
+		require.NoError(t, err)
+
+		var results []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &results))
+		require.Len(t, results, 1)
+		assert.Empty(t, results[0].Error)
+
+		// Verify the data is valid base64 and decodes to original
+		decoded, err := b64.StdEncoding.DecodeString(string(results[0].Data))
+		require.NoError(t, err)
+		assert.Equal(t, "binary content here", string(decoded))
+	})
+
+	t.Run("without encodeBase64 returns raw data", func(t *testing.T) {
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{{Key: "binary.bin"}},
+		})
+		resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		var results []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &results))
+		require.Len(t, results, 1)
+		assert.Empty(t, results[0].Error)
+		assert.Equal(t, "binary content here", string(results[0].Data))
+	})
+}
+
+func TestBulkCreateDecodeBase64(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	originalContent := "hello base64 world"
+	b64Content := b64.StdEncoding.EncodeToString([]byte(originalContent))
+
+	// Upload with decodeBase64 = true (data is base64, should be decoded before storing)
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "decoded.txt", Data: ptr.Of(b64Content)},
+		},
+	})
+	_, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{"decodeBase64": "true"},
+	})
+	require.NoError(t, err)
+
+	// Get back raw - should be the decoded original content
+	getPayload, _ := json.Marshal(bulkGetPayload{
+		Items: []bulkGetItem{{Key: "decoded.txt"}},
+	})
+	resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+		Data:     getPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	var results []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &results))
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Error)
+	assert.Equal(t, originalContent, string(results[0].Data))
+}
+
+func TestBulkCreateDecodeBase64ThenGetEncodeBase64(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	originalContent := "round trip base64"
+	b64Content := b64.StdEncoding.EncodeToString([]byte(originalContent))
+
+	// Upload: base64 data → decode before store
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "roundtrip.txt", Data: ptr.Of(b64Content)},
+		},
+	})
+	_, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{"decodeBase64": "true"},
+	})
+	require.NoError(t, err)
+
+	// Get: encode back to base64
+	getPayload, _ := json.Marshal(bulkGetPayload{
+		Items: []bulkGetItem{{Key: "roundtrip.txt"}},
+	})
+	resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+		Data:     getPayload,
+		Metadata: map[string]string{"encodeBase64": "true"},
+	})
+	require.NoError(t, err)
+
+	var results []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &results))
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Error)
+
+	// The returned data should be base64 of the original content
+	assert.Equal(t, b64Content, string(results[0].Data))
+}
+
+func TestBulkGetToFile(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	// Upload some content
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "download-me.txt", Data: ptr.Of("file content for download")},
+		},
+	})
+	_, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	t.Run("stream to file raw", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outPath := filepath.Join(tmpDir, "out.txt")
+
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{
+				{Key: "download-me.txt", FilePath: ptr.Of(outPath)},
+			},
+		})
+		resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		var results []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &results))
+		require.Len(t, results, 1)
+		assert.Empty(t, results[0].Error)
+		assert.Nil(t, results[0].Data, "data should be nil when writing to file")
+
+		// Verify file contents
+		fileBytes, err := os.ReadFile(outPath)
+		require.NoError(t, err)
+		assert.Equal(t, "file content for download", string(fileBytes))
+	})
+
+	t.Run("stream to file with encodeBase64", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outPath := filepath.Join(tmpDir, "out-b64.txt")
+
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{
+				{Key: "download-me.txt", FilePath: ptr.Of(outPath)},
+			},
+		})
+		resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{"encodeBase64": "true"},
+		})
+		require.NoError(t, err)
+
+		var results []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &results))
+		require.Len(t, results, 1)
+		assert.Empty(t, results[0].Error)
+
+		// Verify file contains base64-encoded content
+		fileBytes, err := os.ReadFile(outPath)
+		require.NoError(t, err)
+		decoded, err := b64.StdEncoding.DecodeString(string(fileBytes))
+		require.NoError(t, err)
+		assert.Equal(t, "file content for download", string(decoded))
+	})
+}
+
+func TestBulkCreateFromFile(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	t.Run("upload from filePath", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcPath := filepath.Join(tmpDir, "upload.txt")
+		require.NoError(t, os.WriteFile(srcPath, []byte("uploaded from file"), 0o644))
+
+		createPayload, _ := json.Marshal(bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{Key: "from-file.txt", FilePath: ptr.Of(srcPath)},
+			},
+		})
+		resp, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+			Data:     createPayload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		var createResults []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &createResults))
+		require.Len(t, createResults, 1)
+		assert.Empty(t, createResults[0].Error)
+
+		// Verify by getting it back
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{{Key: "from-file.txt"}},
+		})
+		resp, err = s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		var getResults []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &getResults))
+		require.Len(t, getResults, 1)
+		assert.Empty(t, getResults[0].Error)
+		assert.Equal(t, "uploaded from file", string(getResults[0].Data))
+	})
+
+	t.Run("upload from filePath with decodeBase64", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcPath := filepath.Join(tmpDir, "upload-b64.txt")
+		original := "base64 file content"
+		require.NoError(t, os.WriteFile(srcPath, []byte(b64.StdEncoding.EncodeToString([]byte(original))), 0o644))
+
+		createPayload, _ := json.Marshal(bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{Key: "from-b64-file.txt", FilePath: ptr.Of(srcPath)},
+			},
+		})
+		resp, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+			Data:     createPayload,
+			Metadata: map[string]string{"decodeBase64": "true"},
+		})
+		require.NoError(t, err)
+
+		var createResults []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &createResults))
+		require.Len(t, createResults, 1)
+		assert.Empty(t, createResults[0].Error)
+
+		// Verify by getting raw - should be decoded content
+		getPayload, _ := json.Marshal(bulkGetPayload{
+			Items: []bulkGetItem{{Key: "from-b64-file.txt"}},
+		})
+		resp, err = s.bulkGet(t.Context(), &bindings.InvokeRequest{
+			Data:     getPayload,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		var getResults []bulkItemResult
+		require.NoError(t, json.Unmarshal(resp.Data, &getResults))
+		require.Len(t, getResults, 1)
+		assert.Empty(t, getResults[0].Error)
+		assert.Equal(t, original, string(getResults[0].Data))
+	})
+}
+
+func TestBulkGetPartialFailure(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	// Upload one object
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "exists.txt", Data: ptr.Of("I exist")},
+		},
+	})
+	_, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	// Get one that exists and one that doesn't
+	getPayload, _ := json.Marshal(bulkGetPayload{
+		Items: []bulkGetItem{
+			{Key: "exists.txt"},
+			{Key: "nope.txt"},
+		},
+	})
+	resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+		Data:     getPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	var results []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &results))
+	require.Len(t, results, 2)
+
+	for _, r := range results {
+		if r.Key == "exists.txt" {
+			assert.Empty(t, r.Error)
+			assert.Equal(t, "I exist", string(r.Data))
+		} else {
+			assert.NotEmpty(t, r.Error, "non-existent key should have an error")
+			assert.Nil(t, r.Data)
+		}
+	}
+}
+
+func TestBulkDeleteRoundTrip(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	// Create objects
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items: []bulkCreateItem{
+			{Key: "del-a.txt", Data: ptr.Of("a")},
+			{Key: "del-b.txt", Data: ptr.Of("b")},
+		},
+	})
+	_, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	// Verify they exist
+	getPayload, _ := json.Marshal(bulkGetPayload{
+		Items: []bulkGetItem{{Key: "del-a.txt"}, {Key: "del-b.txt"}},
+	})
+	resp, err := s.bulkGet(t.Context(), &bindings.InvokeRequest{
+		Data:     getPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+	var getResults []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &getResults))
+	for _, r := range getResults {
+		assert.Empty(t, r.Error)
+	}
+
+	// Bulk delete
+	deletePayload, _ := json.Marshal(bulkDeletePayload{
+		Keys: []string{"del-a.txt", "del-b.txt"},
+	})
+	resp, err = s.bulkDelete(t.Context(), &bindings.InvokeRequest{
+		Data:     deletePayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+	var deleteResults []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &deleteResults))
+	require.Len(t, deleteResults, 2)
+	for _, r := range deleteResults {
+		assert.Empty(t, r.Error)
+	}
+
+	// Verify they're gone
+	resp, err = s.bulkGet(t.Context(), &bindings.InvokeRequest{
+		Data:     getPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Data, &getResults))
+	for _, r := range getResults {
+		assert.NotEmpty(t, r.Error, "deleted key %s should have error", r.Key)
+	}
+}
+
+func TestBulkMultipleConcurrency(t *testing.T) {
+	srv := fakeS3Server(t)
+	defer srv.Close()
+	s := newTestAWSS3(t, srv.URL)
+
+	// Create 20 objects with concurrency=3
+	items := make([]bulkCreateItem, 20)
+	for i := range items {
+		key := "concurrent-" + string(rune('a'+i)) + ".txt"
+		data := "data-" + string(rune('a'+i))
+		items[i] = bulkCreateItem{Key: key, Data: ptr.Of(data)}
+	}
+	createPayload, _ := json.Marshal(bulkCreatePayload{
+		Items:       items,
+		Concurrency: ptr.Of(3),
+	})
+	resp, err := s.bulkCreate(t.Context(), &bindings.InvokeRequest{
+		Data:     createPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+	var createResults []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &createResults))
+	require.Len(t, createResults, 20)
+	for _, r := range createResults {
+		assert.Empty(t, r.Error, "key %s should succeed", r.Key)
+	}
+
+	// Get all 20 with concurrency=5
+	getItems := make([]bulkGetItem, 20)
+	for i := range getItems {
+		getItems[i] = bulkGetItem{Key: items[i].Key}
+	}
+	getPayload, _ := json.Marshal(bulkGetPayload{
+		Items:       getItems,
+		Concurrency: ptr.Of(5),
+	})
+	resp, err = s.bulkGet(t.Context(), &bindings.InvokeRequest{
+		Data:     getPayload,
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+	var getResults []bulkItemResult
+	require.NoError(t, json.Unmarshal(resp.Data, &getResults))
+	require.Len(t, getResults, 20)
+	for _, r := range getResults {
+		assert.Empty(t, r.Error, "key %s should succeed", r.Key)
+		assert.NotEmpty(t, r.Data)
+	}
 }

--- a/tests/certification/bindings/aws/s3/s3_test.go
+++ b/tests/certification/bindings/aws/s3/s3_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -423,19 +424,41 @@ func S3SBulkOperations(t *testing.T) {
 		}
 		defer client.Close()
 
+		// Use UUID prefix to avoid key collisions in shared buckets
+		prefix := uuid.New().String() + "/"
+		keyA := prefix + "bulk-a.txt"
+		keyB := prefix + "bulk-b.txt"
+		keyC := prefix + "bulk-c.txt"
+		allKeys := []string{keyA, keyB, keyC}
+
+		// Ensure cleanup even on failure
+		defer func() {
+			bulkDeleteData, _ := json.Marshal(map[string]interface{}{
+				"keys": allKeys,
+			})
+			deleteReq := &daprsdk.InvokeBindingRequest{
+				Name:      bindingsMetadataName,
+				Operation: "bulkDelete",
+				Data:      bulkDeleteData,
+				Metadata:  map[string]string{},
+			}
+			// Best-effort cleanup; ignore errors
+			_, _ = client.InvokeBinding(ctx, deleteReq)
+		}()
+
 		// Bulk create 3 objects
-		bulkCreateData := `{
-			"items": [
-				{"key": "bulk-a.txt", "data": "content-a"},
-				{"key": "bulk-b.txt", "data": "content-b"},
-				{"key": "bulk-c.txt", "data": "content-c"}
-			],
-			"concurrency": 2
-		}`
+		bulkCreateData, _ := json.Marshal(map[string]interface{}{
+			"items": []map[string]string{
+				{"key": keyA, "data": "content-a"},
+				{"key": keyB, "data": "content-b"},
+				{"key": keyC, "data": "content-c"},
+			},
+			"concurrency": 2,
+		})
 		createReq := &daprsdk.InvokeBindingRequest{
 			Name:      bindingsMetadataName,
 			Operation: "bulkCreate",
-			Data:      []byte(bulkCreateData),
+			Data:      bulkCreateData,
 			Metadata:  map[string]string{},
 		}
 		createOut, invokeErr := client.InvokeBinding(ctx, createReq)
@@ -454,18 +477,18 @@ func S3SBulkOperations(t *testing.T) {
 		}
 
 		// Bulk get the 3 objects
-		bulkGetData := `{
-			"items": [
-				{"key": "bulk-a.txt"},
-				{"key": "bulk-b.txt"},
-				{"key": "bulk-c.txt"}
-			],
-			"concurrency": 2
-		}`
+		bulkGetData, _ := json.Marshal(map[string]interface{}{
+			"items": []map[string]string{
+				{"key": keyA},
+				{"key": keyB},
+				{"key": keyC},
+			},
+			"concurrency": 2,
+		})
 		getReq := &daprsdk.InvokeBindingRequest{
 			Name:      bindingsMetadataName,
 			Operation: "bulkGet",
-			Data:      []byte(bulkGetData),
+			Data:      bulkGetData,
 			Metadata:  map[string]string{},
 		}
 		getOut, invokeErr := client.InvokeBinding(ctx, getReq)
@@ -473,32 +496,32 @@ func S3SBulkOperations(t *testing.T) {
 
 		var getResults []struct {
 			Key   string `json:"key"`
-			Data  []byte `json:"data,omitempty"`
+			Data  string `json:"data,omitempty"`
 			Error string `json:"error,omitempty"`
 		}
 		require.NoError(t, json.Unmarshal(getOut.Data, &getResults))
 		require.Len(t, getResults, 3)
 		expectedContent := map[string]string{
-			"bulk-a.txt": "content-a",
-			"bulk-b.txt": "content-b",
-			"bulk-c.txt": "content-c",
+			keyA: "content-a",
+			keyB: "content-b",
+			keyC: "content-c",
 		}
 		for _, r := range getResults {
 			assert.Empty(t, r.Error, "expected no error for key %s", r.Key)
-			assert.Equal(t, expectedContent[r.Key], string(r.Data), "content mismatch for key %s", r.Key)
+			assert.Equal(t, expectedContent[r.Key], r.Data, "content mismatch for key %s", r.Key)
 		}
 
 		// Bulk get with a non-existent key (partial failure)
-		bulkGetMixedData := `{
-			"items": [
-				{"key": "bulk-a.txt"},
-				{"key": "does-not-exist.txt"}
-			]
-		}`
+		bulkGetMixedData, _ := json.Marshal(map[string]interface{}{
+			"items": []map[string]string{
+				{"key": keyA},
+				{"key": prefix + "does-not-exist.txt"},
+			},
+		})
 		getMixedReq := &daprsdk.InvokeBindingRequest{
 			Name:      bindingsMetadataName,
 			Operation: "bulkGet",
-			Data:      []byte(bulkGetMixedData),
+			Data:      bulkGetMixedData,
 			Metadata:  map[string]string{},
 		}
 		getMixedOut, invokeErr := client.InvokeBinding(ctx, getMixedReq)
@@ -506,29 +529,29 @@ func S3SBulkOperations(t *testing.T) {
 
 		var mixedResults []struct {
 			Key   string `json:"key"`
-			Data  []byte `json:"data,omitempty"`
+			Data  string `json:"data,omitempty"`
 			Error string `json:"error,omitempty"`
 		}
 		require.NoError(t, json.Unmarshal(getMixedOut.Data, &mixedResults))
 		require.Len(t, mixedResults, 2)
 		// Find results by key
 		for _, r := range mixedResults {
-			if r.Key == "bulk-a.txt" {
+			if r.Key == keyA {
 				assert.Empty(t, r.Error)
-				assert.Equal(t, "content-a", string(r.Data))
+				assert.Equal(t, "content-a", r.Data)
 			} else {
 				assert.NotEmpty(t, r.Error, "expected error for non-existent key")
 			}
 		}
 
 		// Bulk delete all 3 objects
-		bulkDeleteData := `{
-			"keys": ["bulk-a.txt", "bulk-b.txt", "bulk-c.txt"]
-		}`
+		bulkDeleteData, _ := json.Marshal(map[string]interface{}{
+			"keys": allKeys,
+		})
 		deleteReq := &daprsdk.InvokeBindingRequest{
 			Name:      bindingsMetadataName,
 			Operation: "bulkDelete",
-			Data:      []byte(bulkDeleteData),
+			Data:      bulkDeleteData,
 			Metadata:  map[string]string{},
 		}
 		deleteOut, invokeErr := client.InvokeBinding(ctx, deleteReq)
@@ -545,7 +568,7 @@ func S3SBulkOperations(t *testing.T) {
 		}
 
 		// Confirm deletion by trying to get them individually
-		for _, key := range []string{"bulk-a.txt", "bulk-b.txt", "bulk-c.txt"} {
+		for _, key := range allKeys {
 			_, getErr := getObjectRequest(ctx, client, key, false)
 			assert.Error(t, getErr)
 			assert.Contains(t, getErr.Error(), objNotFound)

--- a/tests/certification/bindings/aws/s3/s3_test.go
+++ b/tests/certification/bindings/aws/s3/s3_test.go
@@ -68,6 +68,10 @@ func TestAWSS3CertificationTests(t *testing.T) {
 	t.Run("S3SBase64", func(t *testing.T) {
 		S3SBase64(t)
 	})
+
+	t.Run("S3SBulkOperations", func(t *testing.T) {
+		S3SBulkOperations(t)
+	})
 }
 
 // createObjectRequest is used to make a common binding request for create operation.
@@ -401,6 +405,165 @@ func S3SBase64(t *testing.T) {
 			)...,
 		)).
 		Step("Create blob from file get  encode base64", testCreateFromFileGetEncodeBase64()).
+		Run()
+}
+
+// Verify bulk operations (bulkCreate, bulkGet, bulkDelete).
+func S3SBulkOperations(t *testing.T) {
+	ports, err := dapr_testing.GetFreePorts(2)
+	require.NoError(t, err)
+
+	currentGRPCPort := ports[0]
+	currentHTTPPort := ports[1]
+
+	testBulkCreateGetDelete := func(ctx flow.Context) error {
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// Bulk create 3 objects
+		bulkCreateData := `{
+			"items": [
+				{"key": "bulk-a.txt", "data": "content-a"},
+				{"key": "bulk-b.txt", "data": "content-b"},
+				{"key": "bulk-c.txt", "data": "content-c"}
+			],
+			"concurrency": 2
+		}`
+		createReq := &daprsdk.InvokeBindingRequest{
+			Name:      bindingsMetadataName,
+			Operation: "bulkCreate",
+			Data:      []byte(bulkCreateData),
+			Metadata:  map[string]string{},
+		}
+		createOut, invokeErr := client.InvokeBinding(ctx, createReq)
+		require.NoError(t, invokeErr)
+
+		var createResults []struct {
+			Key      string `json:"key"`
+			Location string `json:"location,omitempty"`
+			Error    string `json:"error,omitempty"`
+		}
+		require.NoError(t, json.Unmarshal(createOut.Data, &createResults))
+		require.Len(t, createResults, 3)
+		for _, r := range createResults {
+			assert.Empty(t, r.Error, "expected no error for key %s", r.Key)
+			assert.NotEmpty(t, r.Location, "expected location for key %s", r.Key)
+		}
+
+		// Bulk get the 3 objects
+		bulkGetData := `{
+			"items": [
+				{"key": "bulk-a.txt"},
+				{"key": "bulk-b.txt"},
+				{"key": "bulk-c.txt"}
+			],
+			"concurrency": 2
+		}`
+		getReq := &daprsdk.InvokeBindingRequest{
+			Name:      bindingsMetadataName,
+			Operation: "bulkGet",
+			Data:      []byte(bulkGetData),
+			Metadata:  map[string]string{},
+		}
+		getOut, invokeErr := client.InvokeBinding(ctx, getReq)
+		require.NoError(t, invokeErr)
+
+		var getResults []struct {
+			Key   string `json:"key"`
+			Data  []byte `json:"data,omitempty"`
+			Error string `json:"error,omitempty"`
+		}
+		require.NoError(t, json.Unmarshal(getOut.Data, &getResults))
+		require.Len(t, getResults, 3)
+		expectedContent := map[string]string{
+			"bulk-a.txt": "content-a",
+			"bulk-b.txt": "content-b",
+			"bulk-c.txt": "content-c",
+		}
+		for _, r := range getResults {
+			assert.Empty(t, r.Error, "expected no error for key %s", r.Key)
+			assert.Equal(t, expectedContent[r.Key], string(r.Data), "content mismatch for key %s", r.Key)
+		}
+
+		// Bulk get with a non-existent key (partial failure)
+		bulkGetMixedData := `{
+			"items": [
+				{"key": "bulk-a.txt"},
+				{"key": "does-not-exist.txt"}
+			]
+		}`
+		getMixedReq := &daprsdk.InvokeBindingRequest{
+			Name:      bindingsMetadataName,
+			Operation: "bulkGet",
+			Data:      []byte(bulkGetMixedData),
+			Metadata:  map[string]string{},
+		}
+		getMixedOut, invokeErr := client.InvokeBinding(ctx, getMixedReq)
+		require.NoError(t, invokeErr)
+
+		var mixedResults []struct {
+			Key   string `json:"key"`
+			Data  []byte `json:"data,omitempty"`
+			Error string `json:"error,omitempty"`
+		}
+		require.NoError(t, json.Unmarshal(getMixedOut.Data, &mixedResults))
+		require.Len(t, mixedResults, 2)
+		// Find results by key
+		for _, r := range mixedResults {
+			if r.Key == "bulk-a.txt" {
+				assert.Empty(t, r.Error)
+				assert.Equal(t, "content-a", string(r.Data))
+			} else {
+				assert.NotEmpty(t, r.Error, "expected error for non-existent key")
+			}
+		}
+
+		// Bulk delete all 3 objects
+		bulkDeleteData := `{
+			"keys": ["bulk-a.txt", "bulk-b.txt", "bulk-c.txt"]
+		}`
+		deleteReq := &daprsdk.InvokeBindingRequest{
+			Name:      bindingsMetadataName,
+			Operation: "bulkDelete",
+			Data:      []byte(bulkDeleteData),
+			Metadata:  map[string]string{},
+		}
+		deleteOut, invokeErr := client.InvokeBinding(ctx, deleteReq)
+		require.NoError(t, invokeErr)
+
+		var deleteResults []struct {
+			Key   string `json:"key"`
+			Error string `json:"error,omitempty"`
+		}
+		require.NoError(t, json.Unmarshal(deleteOut.Data, &deleteResults))
+		require.Len(t, deleteResults, 3)
+		for _, r := range deleteResults {
+			assert.Empty(t, r.Error, "expected no error for key %s", r.Key)
+		}
+
+		// Confirm deletion by trying to get them individually
+		for _, key := range []string{"bulk-a.txt", "bulk-b.txt", "bulk-c.txt"} {
+			_, getErr := getObjectRequest(ctx, client, key, false)
+			assert.Error(t, getErr)
+			assert.Contains(t, getErr.Error(), objNotFound)
+		}
+
+		return nil
+	}
+
+	flow.New(t, "AWS S3 binding bulk operations").
+		Step(sidecar.Run(sidecarName,
+			append(componentRuntimeOptions(),
+				embedded.WithoutApp(),
+				embedded.WithComponentsPath("./components/basic"),
+				embedded.WithDaprGRPCPort(strconv.Itoa(currentGRPCPort)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(currentHTTPPort)),
+			)...,
+		)).
+		Step("BulkCreate/BulkGet/BulkDelete S3 Objects", testBulkCreateGetDelete).
 		Run()
 }
 


### PR DESCRIPTION
Add bulkGet, bulkCreate, and bulkDelete operations to enable parallel file transfers, addressing the performance gap when transferring 100+ large files.

- bulkGet: parallel downloads with optional filePath for streaming directly to disk (avoids loading large files into memory)
- bulkCreate: parallel uploads from inline data or filePath, using the existing transfer manager for multipart uploads
- bulkDelete: batch deletes using the S3 DeleteObjects API with automatic chunking at the 1000-key limit
- Bounded concurrency via configurable pointer field (default 10)
- Streaming base64 encode/decode throughout
- Per-item error reporting for partial success semantics

Fixes #3873 