### PR TITLE
Azure Blob Storage binding: add bulk operations

### DIFF
--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -323,25 +323,33 @@ func (a *AzureBlobStorage) get(ctx context.Context, req *bindings.InvokeRequest)
 	}, nil
 }
 
-func (a *AzureBlobStorage) getToFile(ctx context.Context, blockBlobClient *blockblob.Client, filePath string) (*bindings.InvokeResponse, error) {
-	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
-		return nil, fmt.Errorf("error creating directory for %q: %w", filePath, err)
+// downloadBlobToFile downloads a blob directly to a local file, creating parent
+// directories as needed. On error, any partially-written file is removed.
+func downloadBlobToFile(ctx context.Context, blockBlobClient *blockblob.Client, filePath string) error {
+	if mkdirErr := os.MkdirAll(filepath.Dir(filePath), 0o755); mkdirErr != nil {
+		return fmt.Errorf("error creating directory for %q: %w", filePath, mkdirErr)
 	}
 
-	f, err := os.Create(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("error creating file %q: %w", filePath, err)
+	f, createErr := os.Create(filePath)
+	if createErr != nil {
+		return fmt.Errorf("error creating file %q: %w", filePath, createErr)
 	}
 	defer f.Close()
 
-	_, err = blockBlobClient.DownloadFile(ctx, f, nil)
-	if err != nil {
-		// Clean up partial file on error.
+	if _, dlErr := blockBlobClient.DownloadFile(ctx, f, nil); dlErr != nil {
 		os.Remove(filePath)
-		if bloberror.HasCode(err, bloberror.BlobNotFound) {
-			return nil, errors.New("blob not found")
+		if bloberror.HasCode(dlErr, bloberror.BlobNotFound) {
+			return errors.New("blob not found")
 		}
-		return nil, fmt.Errorf("error downloading az blob to file: %w", err)
+		return fmt.Errorf("error downloading blob to file: %w", dlErr)
+	}
+
+	return nil
+}
+
+func (a *AzureBlobStorage) getToFile(ctx context.Context, blockBlobClient *blockblob.Client, filePath string) (*bindings.InvokeResponse, error) {
+	if err := downloadBlobToFile(ctx, blockBlobClient, filePath); err != nil {
+		return nil, err
 	}
 
 	return &bindings.InvokeResponse{
@@ -545,27 +553,10 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 			blockBlobClient := a.containerClient.NewBlockBlobClient(item.BlobName)
 
 			if item.FilePath != nil && *item.FilePath != "" {
-				// Stream to file via DownloadFile.
+				// Stream to file via shared download helper.
 				filePath := *item.FilePath
-				if mkdirErr := os.MkdirAll(filepath.Dir(filePath), 0o755); mkdirErr != nil {
-					results[i].Error = "error creating directory: " + mkdirErr.Error()
-					return nil
-				}
-
-				f, createErr := os.Create(filePath)
-				if createErr != nil {
-					results[i].Error = "error creating file: " + createErr.Error()
-					return nil
-				}
-				defer f.Close()
-
-				if _, dlErr := blockBlobClient.DownloadFile(gctx, f, nil); dlErr != nil {
-					os.Remove(filePath)
-					if bloberror.HasCode(dlErr, bloberror.BlobNotFound) {
-						results[i].Error = "blob not found"
-					} else {
-						results[i].Error = dlErr.Error()
-					}
+				if dlErr := downloadBlobToFile(gctx, blockBlobClient, filePath); dlErr != nil {
+					results[i].Error = dlErr.Error()
 					return nil
 				}
 
@@ -713,7 +704,7 @@ func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeR
 
 			// Build HTTP headers if contentType is specified.
 			var httpHeaders *blob.HTTPHeaders
-			if item.ContentType != nil {
+			if item.ContentType != nil && *item.ContentType != "" {
 				httpHeaders = &blob.HTTPHeaders{
 					BlobContentType: item.ContentType,
 				}

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -14,14 +14,18 @@ limitations under the License.
 package blobstorage
 
 import (
+	"bytes"
 	"context"
 	b64 "encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -29,6 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/dapr/components-contrib/bindings"
 	storagecommon "github.com/dapr/components-contrib/common/component/azure/blobstorage"
@@ -59,6 +64,17 @@ const (
 	// See: https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs#uri-parameters
 	maxResults  int32 = 5000
 	endpointKey       = "endpoint"
+
+	bulkGetOperation    bindings.OperationKind = "bulkGet"
+	bulkCreateOperation bindings.OperationKind = "bulkCreate"
+	bulkDeleteOperation bindings.OperationKind = "bulkDelete"
+
+	metadataKeyFilePath = "filePath"
+
+	defaultConcurrency int32 = 10
+
+	// Azure Blob Batch API supports up to 256 sub-requests per batch.
+	maxBatchDeleteSize = 256
 )
 
 var ErrMissingBlobName = errors.New("blobName is a required attribute")
@@ -91,6 +107,66 @@ type listPayload struct {
 	Include    listInclude `json:"include"`
 }
 
+type bulkGetItem struct {
+	BlobName string  `json:"blobName"`
+	FilePath *string `json:"filePath,omitempty"`
+}
+
+type bulkGetPayload struct {
+	// Items specifies explicit blob-to-file mappings.
+	Items []bulkGetItem `json:"items,omitempty"`
+	// Prefix lists blobs by prefix; requires DestinationDir.
+	Prefix *string `json:"prefix,omitempty"`
+	// DestinationDir is used as the base directory for prefix-discovered blobs.
+	DestinationDir *string `json:"destinationDir,omitempty"`
+	Concurrency    *int32  `json:"concurrency,omitempty"`
+}
+
+type bulkGetResponseItem struct {
+	BlobName string `json:"blobName"`
+	FilePath string `json:"filePath,omitempty"`
+	Data     string `json:"data,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+type bulkCreateItem struct {
+	BlobName    string  `json:"blobName"`
+	SourcePath  string  `json:"sourcePath,omitempty"`
+	Data        *string `json:"data,omitempty"`
+	ContentType *string `json:"contentType,omitempty"`
+}
+
+type bulkCreatePayload struct {
+	Items       []bulkCreateItem `json:"items"`
+	Concurrency *int32           `json:"concurrency,omitempty"`
+}
+
+type bulkCreateResponseItem struct {
+	BlobName string `json:"blobName"`
+	BlobURL  string `json:"blobURL,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+type bulkDeletePayload struct {
+	Prefix          *string  `json:"prefix,omitempty"`
+	BlobNames       []string `json:"blobNames,omitempty"`
+	DeleteSnapshots *string  `json:"deleteSnapshots,omitempty"`
+	Concurrency     *int32   `json:"concurrency,omitempty"`
+}
+
+type bulkDeleteResponseItem struct {
+	BlobName string `json:"blobName"`
+	Error    string `json:"error,omitempty"`
+}
+
+var (
+	ErrMissingBlobSelection       = errors.New("at least one of items or prefix is required")
+	ErrEmptyBulkCreateItems       = errors.New("items array must not be empty")
+	ErrMissingDestinationDir      = errors.New("destinationDir is required when using prefix")
+	ErrInvalidConcurrency         = errors.New("concurrency must be greater than 0")
+	ErrMissingBulkDeleteSelection = errors.New("at least one of prefix or blobNames is required")
+)
+
 // NewAzureBlobStorage returns a new Azure Blob Storage instance.
 func NewAzureBlobStorage(logger logger.Logger) bindings.OutputBinding {
 	return &AzureBlobStorage{logger: logger}
@@ -112,6 +188,9 @@ func (a *AzureBlobStorage) Operations() []bindings.OperationKind {
 		bindings.GetOperation,
 		bindings.DeleteOperation,
 		bindings.ListOperation,
+		bulkGetOperation,
+		bulkCreateOperation,
+		bulkDeleteOperation,
 	}
 }
 
@@ -184,6 +263,11 @@ func (a *AzureBlobStorage) get(ctx context.Context, req *bindings.InvokeRequest)
 		return nil, ErrMissingBlobName
 	}
 
+	// If filePath is set, stream directly to file via DownloadFile.
+	if filePath, ok := req.Metadata[metadataKeyFilePath]; ok && filePath != "" {
+		return a.getToFile(ctx, blockBlobClient, filePath)
+	}
+
 	downloadOptions := azblob.DownloadStreamOptions{
 		AccessConditions: &blob.AccessConditions{},
 	}
@@ -232,6 +316,34 @@ func (a *AzureBlobStorage) get(ctx context.Context, req *bindings.InvokeRequest)
 	return &bindings.InvokeResponse{
 		Data:     blobData,
 		Metadata: metadata,
+	}, nil
+}
+
+func (a *AzureBlobStorage) getToFile(ctx context.Context, blockBlobClient *blockblob.Client, filePath string) (*bindings.InvokeResponse, error) {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		return nil, fmt.Errorf("error creating directory for %q: %w", filePath, err)
+	}
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error creating file %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	_, err = blockBlobClient.DownloadFile(ctx, f, nil)
+	if err != nil {
+		// Clean up partial file on error.
+		os.Remove(filePath)
+		if bloberror.HasCode(err, bloberror.BlobNotFound) {
+			return nil, errors.New("blob not found")
+		}
+		return nil, fmt.Errorf("error downloading az blob to file: %w", err)
+	}
+
+	return &bindings.InvokeResponse{
+		Metadata: map[string]string{
+			metadataKeyFilePath: filePath,
+		},
 	}, nil
 }
 
@@ -344,6 +456,469 @@ func (a *AzureBlobStorage) list(ctx context.Context, req *bindings.InvokeRequest
 	}, nil
 }
 
+func getConcurrency(val *int32) (int, error) {
+	if val == nil {
+		return int(defaultConcurrency), nil
+	}
+	if *val <= 0 {
+		return 0, ErrInvalidConcurrency
+	}
+	return int(*val), nil
+}
+
+func (a *AzureBlobStorage) resolveBlobs(ctx context.Context, prefix *string, blobNames []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(blobNames))
+	result := make([]string, 0, len(blobNames))
+
+	// Add explicit blob names first.
+	for _, name := range blobNames {
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			result = append(result, name)
+		}
+	}
+
+	// If prefix is set, list blobs and merge.
+	if prefix != nil && *prefix != "" {
+		options := container.ListBlobsFlatOptions{
+			Prefix: prefix,
+		}
+		pager := a.containerClient.NewListBlobsFlatPager(&options)
+		for pager.More() {
+			resp, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error listing blobs with prefix %q: %w", *prefix, err)
+			}
+			for _, item := range resp.Segment.BlobItems {
+				if item.Name == nil {
+					continue
+				}
+				if _, ok := seen[*item.Name]; !ok {
+					seen[*item.Name] = struct{}{}
+					result = append(result, *item.Name)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	var payload bulkGetPayload
+	if req.Data != nil {
+		if err := json.Unmarshal(req.Data, &payload); err != nil {
+			return nil, fmt.Errorf("error parsing bulkGet payload: %w", err)
+		}
+	}
+
+	concurrency, err := getConcurrency(payload.Concurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the work list from explicit items and/or prefix discovery.
+	items, err := a.resolveBulkGetItems(ctx, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		return nil, ErrMissingBlobSelection
+	}
+
+	results := make([]bulkGetResponseItem, len(items))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for i, item := range items {
+		i, item := i, item
+		g.Go(func() error {
+			results[i].BlobName = item.BlobName
+			blockBlobClient := a.containerClient.NewBlockBlobClient(item.BlobName)
+
+			if item.FilePath != nil {
+				// Stream to file via DownloadFile.
+				filePath := *item.FilePath
+				if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+					results[i].Error = fmt.Sprintf("error creating directory: %s", err.Error())
+					return nil
+				}
+
+				f, err := os.Create(filePath)
+				if err != nil {
+					results[i].Error = fmt.Sprintf("error creating file: %s", err.Error())
+					return nil
+				}
+				defer f.Close()
+
+				_, err = blockBlobClient.DownloadFile(gctx, f, nil)
+				if err != nil {
+					os.Remove(filePath)
+					if bloberror.HasCode(err, bloberror.BlobNotFound) {
+						results[i].Error = "blob not found"
+					} else {
+						results[i].Error = err.Error()
+					}
+					return nil
+				}
+
+				results[i].FilePath = filePath
+			} else {
+				// Inline mode: download to memory and return data in response.
+				resp, err := blockBlobClient.DownloadStream(gctx, nil)
+				if err != nil {
+					if bloberror.HasCode(err, bloberror.BlobNotFound) {
+						results[i].Error = "blob not found"
+					} else {
+						results[i].Error = err.Error()
+					}
+					return nil
+				}
+				defer resp.Body.Close()
+
+				var buf bytes.Buffer
+				if a.metadata.DecodeBase64 {
+					// DecodeBase64 on get means encode the raw blob to base64 for the caller.
+					encoder := b64.NewEncoder(b64.StdEncoding, &buf)
+					if _, err = io.Copy(encoder, resp.Body); err != nil {
+						results[i].Error = err.Error()
+						return nil
+					}
+					if err = encoder.Close(); err != nil {
+						results[i].Error = err.Error()
+						return nil
+					}
+				} else {
+					if _, err = io.Copy(&buf, resp.Body); err != nil {
+						results[i].Error = err.Error()
+						return nil
+					}
+				}
+
+				results[i].Data = buf.String()
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("error in bulkGet: %w", err)
+	}
+
+	jsonResponse, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling bulkGet response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{
+		Data: jsonResponse,
+		Metadata: map[string]string{
+			metadataKeyNumber: strconv.Itoa(len(results)),
+		},
+	}, nil
+}
+
+// resolveBulkGetItems builds the work list for bulkGet.
+// Explicit items are taken as-is. Prefix-discovered blobs use destinationDir as base.
+func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bulkGetPayload) ([]bulkGetItem, error) {
+	seen := make(map[string]struct{})
+	var items []bulkGetItem
+
+	// Add explicit items first.
+	for _, item := range payload.Items {
+		if item.BlobName == "" {
+			continue
+		}
+		if _, ok := seen[item.BlobName]; !ok {
+			seen[item.BlobName] = struct{}{}
+			items = append(items, item)
+		}
+	}
+
+	// If prefix is set, discover blobs and map them into destinationDir.
+	if payload.Prefix != nil && *payload.Prefix != "" {
+		if payload.DestinationDir == nil || *payload.DestinationDir == "" {
+			return nil, ErrMissingDestinationDir
+		}
+
+		options := container.ListBlobsFlatOptions{
+			Prefix: payload.Prefix,
+		}
+		pager := a.containerClient.NewListBlobsFlatPager(&options)
+		for pager.More() {
+			resp, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error listing blobs with prefix %q: %w", *payload.Prefix, err)
+			}
+			for _, blobItem := range resp.Segment.BlobItems {
+				if blobItem.Name == nil {
+					continue
+				}
+				if _, ok := seen[*blobItem.Name]; !ok {
+					seen[*blobItem.Name] = struct{}{}
+					items = append(items, bulkGetItem{
+						BlobName: *blobItem.Name,
+						FilePath: ptr.Of(filepath.Join(*payload.DestinationDir, *blobItem.Name)),
+					})
+				}
+			}
+		}
+	}
+
+	return items, nil
+}
+
+func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	var payload bulkCreatePayload
+	if req.Data != nil {
+		if err := json.Unmarshal(req.Data, &payload); err != nil {
+			return nil, fmt.Errorf("error parsing bulkCreate payload: %w", err)
+		}
+	}
+
+	if len(payload.Items) == 0 {
+		return nil, ErrEmptyBulkCreateItems
+	}
+
+	for i, item := range payload.Items {
+		if item.BlobName == "" {
+			return nil, fmt.Errorf("item at index %d is missing blobName", i)
+		}
+		if item.SourcePath == "" && item.Data == nil {
+			return nil, fmt.Errorf("item at index %d is missing both data and sourcePath", i)
+		}
+	}
+
+	concurrency, err := getConcurrency(payload.Concurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]bulkCreateResponseItem, len(payload.Items))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for i, item := range payload.Items {
+		i, item := i, item
+		g.Go(func() error {
+			results[i].BlobName = item.BlobName
+
+			blockBlobClient := a.containerClient.NewBlockBlobClient(item.BlobName)
+
+			// Build HTTP headers if contentType is specified.
+			var httpHeaders *blob.HTTPHeaders
+			if item.ContentType != nil {
+				httpHeaders = &blob.HTTPHeaders{
+					BlobContentType: item.ContentType,
+				}
+			}
+
+			if item.Data != nil {
+				// Inline data mode: upload from the provided string.
+				var r io.Reader = strings.NewReader(*item.Data)
+				if a.metadata.DecodeBase64 {
+					r = b64.NewDecoder(b64.StdEncoding, r)
+				}
+				_, err := blockBlobClient.UploadStream(gctx, r, &blockblob.UploadStreamOptions{
+					HTTPHeaders: httpHeaders,
+				})
+				if err != nil {
+					results[i].Error = fmt.Sprintf("error uploading blob: %s", err.Error())
+					return nil
+				}
+			} else {
+				// File-based mode: upload from sourcePath.
+				f, err := os.Open(item.SourcePath)
+				if err != nil {
+					results[i].Error = fmt.Sprintf("error opening source file: %s", err.Error())
+					return nil
+				}
+				defer f.Close()
+
+				if a.metadata.DecodeBase64 {
+					decoder := b64.NewDecoder(b64.StdEncoding, f)
+					_, err = blockBlobClient.UploadStream(gctx, decoder, &blockblob.UploadStreamOptions{
+						HTTPHeaders: httpHeaders,
+					})
+				} else {
+					_, err = blockBlobClient.UploadFile(gctx, f, &blockblob.UploadFileOptions{
+						HTTPHeaders: httpHeaders,
+					})
+				}
+				if err != nil {
+					results[i].Error = fmt.Sprintf("error uploading blob: %s", err.Error())
+					return nil
+				}
+			}
+
+			results[i].BlobURL = blockBlobClient.URL()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("error in bulkCreate: %w", err)
+	}
+
+	jsonResponse, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling bulkCreate response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{
+		Data: jsonResponse,
+		Metadata: map[string]string{
+			metadataKeyNumber: strconv.Itoa(len(results)),
+		},
+	}, nil
+}
+
+func (a *AzureBlobStorage) bulkDelete(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	var payload bulkDeletePayload
+	if req.Data != nil {
+		if err := json.Unmarshal(req.Data, &payload); err != nil {
+			return nil, fmt.Errorf("error parsing bulkDelete payload: %w", err)
+		}
+	}
+
+	if payload.DeleteSnapshots != nil && *payload.DeleteSnapshots != "" {
+		deleteSnapshotsOption := azblob.DeleteSnapshotsOptionType(*payload.DeleteSnapshots)
+		if !a.isValidDeleteSnapshotsOptionType(deleteSnapshotsOption) {
+			return nil, fmt.Errorf("invalid delete snapshot option type: %s; allowed: %s",
+				*payload.DeleteSnapshots, azblob.PossibleDeleteSnapshotsOptionTypeValues())
+		}
+	}
+
+	concurrency, err := getConcurrency(payload.Concurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	names, err := a.resolveBlobs(ctx, payload.Prefix, payload.BlobNames)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(names) == 0 {
+		return nil, ErrMissingBlobSelection
+	}
+
+	// Build a name→indices map to handle duplicates correctly.
+	nameIndices := make(map[string][]int, len(names))
+	results := make([]bulkDeleteResponseItem, len(names))
+	for i, name := range names {
+		results[i].BlobName = name
+		nameIndices[name] = append(nameIndices[name], i)
+	}
+
+	var batchDeleteOpts *container.BatchDeleteOptions
+	if payload.DeleteSnapshots != nil && *payload.DeleteSnapshots != "" {
+		dsOpt := azblob.DeleteSnapshotsOptionType(*payload.DeleteSnapshots)
+		batchDeleteOpts = &container.BatchDeleteOptions{
+			DeleteOptions: blob.DeleteOptions{
+				DeleteSnapshots: &dsOpt,
+			},
+		}
+	}
+
+	// Try batch API first (more efficient), fall back to individual deletes on error.
+	batchErr := a.bulkDeleteBatch(ctx, names, nameIndices, results, batchDeleteOpts)
+	if batchErr != nil {
+		// Batch API may fail (e.g. SAS auth without proper permissions).
+		// Fall back to concurrent individual deletes.
+		a.logger.Warnf("batch delete failed, falling back to individual deletes: %v", batchErr)
+
+		deleteOptions := blob.DeleteOptions{
+			AccessConditions: &blob.AccessConditions{},
+		}
+		if batchDeleteOpts != nil {
+			deleteOptions.DeleteSnapshots = batchDeleteOpts.DeleteSnapshots
+		}
+
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(concurrency)
+
+		for i, name := range names {
+			i, name := i, name
+			g.Go(func() error {
+				blockBlobClient := a.containerClient.NewBlockBlobClient(name)
+				_, err := blockBlobClient.Delete(gctx, &deleteOptions)
+				if err != nil {
+					if bloberror.HasCode(err, bloberror.BlobNotFound) {
+						results[i].Error = "blob not found"
+					} else {
+						results[i].Error = err.Error()
+					}
+				}
+				return nil
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			return nil, fmt.Errorf("error in bulkDelete: %w", err)
+		}
+	}
+
+	jsonResponse, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling bulkDelete response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{
+		Data: jsonResponse,
+		Metadata: map[string]string{
+			metadataKeyNumber: strconv.Itoa(len(results)),
+		},
+	}, nil
+}
+
+// bulkDeleteBatch uses the Azure Blob Batch API to delete blobs in chunks of 256.
+func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, nameIndices map[string][]int, results []bulkDeleteResponseItem, opts *container.BatchDeleteOptions) error {
+	for batchStart := 0; batchStart < len(names); batchStart += maxBatchDeleteSize {
+		batchEnd := batchStart + maxBatchDeleteSize
+		if batchEnd > len(names) {
+			batchEnd = len(names)
+		}
+		batch := names[batchStart:batchEnd]
+
+		bb, err := a.containerClient.NewBatchBuilder()
+		if err != nil {
+			return fmt.Errorf("error creating batch builder: %w", err)
+		}
+
+		for _, name := range batch {
+			if err := bb.Delete(name, opts); err != nil {
+				return fmt.Errorf("error adding delete to batch for %q: %w", name, err)
+			}
+		}
+
+		resp, err := a.containerClient.SubmitBatch(ctx, bb, nil)
+		if err != nil {
+			return fmt.Errorf("error submitting batch delete: %w", err)
+		}
+
+		// Map batch responses back to results.
+		for _, item := range resp.Responses {
+			if item.BlobName == nil {
+				continue
+			}
+			if item.Error != nil {
+				for _, idx := range nameIndices[*item.BlobName] {
+					results[idx].Error = item.Error.Error()
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func (a *AzureBlobStorage) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	switch req.Operation {
 	case bindings.CreateOperation:
@@ -354,6 +929,12 @@ func (a *AzureBlobStorage) Invoke(ctx context.Context, req *bindings.InvokeReque
 		return a.delete(ctx, req)
 	case bindings.ListOperation:
 		return a.list(ctx, req)
+	case bulkGetOperation:
+		return a.bulkGet(ctx, req)
+	case bulkCreateOperation:
+		return a.bulkCreate(ctx, req)
+	case bulkDeleteOperation:
+		return a.bulkDelete(ctx, req)
 	default:
 		return nil, fmt.Errorf("unsupported operation %s", req.Operation)
 	}

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -125,8 +125,10 @@ type bulkGetPayload struct {
 type bulkGetResponseItem struct {
 	BlobName string `json:"blobName"`
 	FilePath string `json:"filePath,omitempty"`
-	Data     string `json:"data,omitempty"`
-	Error    string `json:"error,omitempty"`
+	// Data holds the blob content when using inline mode (no filePath).
+	// JSON-marshalled as base64 since it is []byte, which is safe for binary blobs.
+	Data  []byte `json:"data,omitempty"`
+	Error string `json:"error,omitempty"`
 }
 
 type bulkCreateItem struct {
@@ -600,7 +602,7 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 					}
 				}
 
-				results[i].Data = buf.String()
+				results[i].Data = buf.Bytes()
 			}
 			return nil
 		})
@@ -624,20 +626,21 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 }
 
 // resolveBulkGetItems builds the work list for bulkGet.
-// Explicit items are taken as-is. Prefix-discovered blobs use destinationDir as base.
+// Explicit items are preserved as-is (including duplicates with different filePaths).
+// Prefix-discovered blobs use destinationDir as base, skipping any already covered by explicit items.
 func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bulkGetPayload) ([]bulkGetItem, error) {
-	seen := make(map[string]struct{})
 	var items []bulkGetItem
 
-	// Add explicit items first.
+	// Track blob names from explicit items so prefix discovery doesn't duplicate them.
+	explicitNames := make(map[string]struct{})
+
+	// Add explicit items as-is (no dedup — same blob with different filePaths is valid).
 	for _, item := range payload.Items {
 		if item.BlobName == "" {
 			continue
 		}
-		if _, ok := seen[item.BlobName]; !ok {
-			seen[item.BlobName] = struct{}{}
-			items = append(items, item)
-		}
+		explicitNames[item.BlobName] = struct{}{}
+		items = append(items, item)
 	}
 
 	// If prefix is set, discover blobs and map them into destinationDir.
@@ -646,6 +649,7 @@ func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bul
 			return nil, ErrMissingDestinationDir
 		}
 
+		seen := make(map[string]struct{})
 		options := container.ListBlobsFlatOptions{
 			Prefix: payload.Prefix,
 		}
@@ -659,18 +663,46 @@ func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bul
 				if blobItem.Name == nil {
 					continue
 				}
-				if _, ok := seen[*blobItem.Name]; !ok {
-					seen[*blobItem.Name] = struct{}{}
-					items = append(items, bulkGetItem{
-						BlobName: *blobItem.Name,
-						FilePath: ptr.Of(filepath.Join(*payload.DestinationDir, *blobItem.Name)),
-					})
+				// Skip blobs already covered by explicit items.
+				if _, ok := explicitNames[*blobItem.Name]; ok {
+					continue
 				}
+				if _, ok := seen[*blobItem.Name]; ok {
+					continue
+				}
+				seen[*blobItem.Name] = struct{}{}
+
+				destPath := filepath.Join(*payload.DestinationDir, *blobItem.Name)
+				if err := validatePathWithinDir(*payload.DestinationDir, destPath); err != nil {
+					return nil, fmt.Errorf("unsafe blob name %q: %w", *blobItem.Name, err)
+				}
+				items = append(items, bulkGetItem{
+					BlobName: *blobItem.Name,
+					FilePath: ptr.Of(destPath),
+				})
 			}
 		}
 	}
 
 	return items, nil
+}
+
+// validatePathWithinDir ensures that resolvedPath is within baseDir,
+// preventing path traversal attacks from blob names like "../../../etc/passwd".
+func validatePathWithinDir(baseDir, resolvedPath string) error {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return fmt.Errorf("error resolving base directory: %w", err)
+	}
+	absResolved, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return fmt.Errorf("error resolving path: %w", err)
+	}
+	// Ensure the resolved path starts with the base directory.
+	if !strings.HasPrefix(absResolved, absBase+string(filepath.Separator)) && absResolved != absBase {
+		return fmt.Errorf("path %q escapes base directory %q", absResolved, absBase)
+	}
+	return nil
 }
 
 func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
@@ -806,7 +838,7 @@ func (a *AzureBlobStorage) bulkDelete(ctx context.Context, req *bindings.InvokeR
 	}
 
 	if len(names) == 0 {
-		return nil, ErrMissingBlobSelection
+		return nil, ErrMissingBulkDeleteSelection
 	}
 
 	// Build a name→indices map to handle duplicates correctly.
@@ -828,11 +860,16 @@ func (a *AzureBlobStorage) bulkDelete(ctx context.Context, req *bindings.InvokeR
 	}
 
 	// Try batch API first (more efficient), fall back to individual deletes on error.
-	batchErr := a.bulkDeleteBatch(ctx, names, nameIndices, results, batchDeleteOpts)
+	// completedCount tracks how many names were successfully processed by batch chunks,
+	// so the fallback only retries the remaining names.
+	completedCount, batchErr := a.bulkDeleteBatch(ctx, names, nameIndices, results, batchDeleteOpts)
 	if batchErr != nil {
 		// Batch API may fail (e.g. SAS auth without proper permissions).
-		// Fall back to concurrent individual deletes.
-		a.logger.Warnf("batch delete failed, falling back to individual deletes: %v", batchErr)
+		// Fall back to concurrent individual deletes for remaining names only.
+		a.logger.Warnf("batch delete failed after %d/%d items, falling back to individual deletes: %v", completedCount, len(names), batchErr)
+
+		remainingNames := names[completedCount:]
+		remainingOffset := completedCount
 
 		deleteOptions := blob.DeleteOptions{
 			AccessConditions: &blob.AccessConditions{},
@@ -844,16 +881,17 @@ func (a *AzureBlobStorage) bulkDelete(ctx context.Context, req *bindings.InvokeR
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(concurrency)
 
-		for i, name := range names {
-			i, name := i, name
+		for j, name := range remainingNames {
+			j, name := j, name
+			resultIdx := remainingOffset + j
 			g.Go(func() error {
 				blockBlobClient := a.containerClient.NewBlockBlobClient(name)
 				_, err := blockBlobClient.Delete(gctx, &deleteOptions)
 				if err != nil {
 					if bloberror.HasCode(err, bloberror.BlobNotFound) {
-						results[i].Error = "blob not found"
+						results[resultIdx].Error = "blob not found"
 					} else {
-						results[i].Error = err.Error()
+						results[resultIdx].Error = err.Error()
 					}
 				}
 				return nil
@@ -879,7 +917,8 @@ func (a *AzureBlobStorage) bulkDelete(ctx context.Context, req *bindings.InvokeR
 }
 
 // bulkDeleteBatch uses the Azure Blob Batch API to delete blobs in chunks of 256.
-func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, nameIndices map[string][]int, results []bulkDeleteResponseItem, opts *container.BatchDeleteOptions) error {
+// Returns the number of items in completed chunks (for fallback offset) and any error.
+func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, nameIndices map[string][]int, results []bulkDeleteResponseItem, opts *container.BatchDeleteOptions) (int, error) {
 	for batchStart := 0; batchStart < len(names); batchStart += maxBatchDeleteSize {
 		batchEnd := batchStart + maxBatchDeleteSize
 		if batchEnd > len(names) {
@@ -889,18 +928,18 @@ func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, 
 
 		bb, err := a.containerClient.NewBatchBuilder()
 		if err != nil {
-			return fmt.Errorf("error creating batch builder: %w", err)
+			return batchStart, fmt.Errorf("error creating batch builder: %w", err)
 		}
 
 		for _, name := range batch {
 			if err := bb.Delete(name, opts); err != nil {
-				return fmt.Errorf("error adding delete to batch for %q: %w", name, err)
+				return batchStart, fmt.Errorf("error adding delete to batch for %q: %w", name, err)
 			}
 		}
 
 		resp, err := a.containerClient.SubmitBatch(ctx, bb, nil)
 		if err != nil {
-			return fmt.Errorf("error submitting batch delete: %w", err)
+			return batchStart, fmt.Errorf("error submitting batch delete: %w", err)
 		}
 
 		// Map batch responses back to results.
@@ -916,7 +955,7 @@ func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, 
 		}
 	}
 
-	return nil
+	return len(names), nil
 }
 
 func (a *AzureBlobStorage) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
@@ -543,7 +545,7 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 			results[i].BlobName = item.BlobName
 			blockBlobClient := a.containerClient.NewBlockBlobClient(item.BlobName)
 
-			if item.FilePath != nil {
+			if item.FilePath != nil && *item.FilePath != "" {
 				// Stream to file via DownloadFile.
 				filePath := *item.FilePath
 				if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
@@ -584,22 +586,9 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 				defer resp.Body.Close()
 
 				var buf bytes.Buffer
-				if a.metadata.DecodeBase64 {
-					// DecodeBase64 on get means encode the raw blob to base64 for the caller.
-					encoder := b64.NewEncoder(b64.StdEncoding, &buf)
-					if _, err = io.Copy(encoder, resp.Body); err != nil {
-						results[i].Error = err.Error()
-						return nil
-					}
-					if err = encoder.Close(); err != nil {
-						results[i].Error = err.Error()
-						return nil
-					}
-				} else {
-					if _, err = io.Copy(&buf, resp.Body); err != nil {
-						results[i].Error = err.Error()
-						return nil
-					}
+				if _, err = io.Copy(&buf, resp.Body); err != nil {
+					results[i].Error = err.Error()
+					return nil
 				}
 
 				results[i].Data = buf.Bytes()
@@ -672,8 +661,8 @@ func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bul
 				}
 				seen[*blobItem.Name] = struct{}{}
 
-				destPath := filepath.Join(*payload.DestinationDir, *blobItem.Name)
-				if err := validatePathWithinDir(*payload.DestinationDir, destPath); err != nil {
+				destPath, err := securejoin.SecureJoin(*payload.DestinationDir, *blobItem.Name)
+				if err != nil {
 					return nil, fmt.Errorf("unsafe blob name %q: %w", *blobItem.Name, err)
 				}
 				items = append(items, bulkGetItem{
@@ -685,24 +674,6 @@ func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bul
 	}
 
 	return items, nil
-}
-
-// validatePathWithinDir ensures that resolvedPath is within baseDir,
-// preventing path traversal attacks from blob names like "../../../etc/passwd".
-func validatePathWithinDir(baseDir, resolvedPath string) error {
-	absBase, err := filepath.Abs(baseDir)
-	if err != nil {
-		return fmt.Errorf("error resolving base directory: %w", err)
-	}
-	absResolved, err := filepath.Abs(resolvedPath)
-	if err != nil {
-		return fmt.Errorf("error resolving path: %w", err)
-	}
-	// Ensure the resolved path starts with the base directory.
-	if !strings.HasPrefix(absResolved, absBase+string(filepath.Separator)) && absResolved != absBase {
-		return fmt.Errorf("path %q escapes base directory %q", absResolved, absBase)
-	}
-	return nil
 }
 
 func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -540,7 +540,6 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 	g.SetLimit(concurrency)
 
 	for i, item := range items {
-		i, item := i, item
 		g.Go(func() error {
 			results[i].BlobName = item.BlobName
 			blockBlobClient := a.containerClient.NewBlockBlobClient(item.BlobName)
@@ -548,25 +547,24 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 			if item.FilePath != nil && *item.FilePath != "" {
 				// Stream to file via DownloadFile.
 				filePath := *item.FilePath
-				if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
-					results[i].Error = fmt.Sprintf("error creating directory: %s", err.Error())
+				if mkdirErr := os.MkdirAll(filepath.Dir(filePath), 0o755); mkdirErr != nil {
+					results[i].Error = "error creating directory: " + mkdirErr.Error()
 					return nil
 				}
 
-				f, err := os.Create(filePath)
-				if err != nil {
-					results[i].Error = fmt.Sprintf("error creating file: %s", err.Error())
+				f, createErr := os.Create(filePath)
+				if createErr != nil {
+					results[i].Error = "error creating file: " + createErr.Error()
 					return nil
 				}
 				defer f.Close()
 
-				_, err = blockBlobClient.DownloadFile(gctx, f, nil)
-				if err != nil {
+				if _, dlErr := blockBlobClient.DownloadFile(gctx, f, nil); dlErr != nil {
 					os.Remove(filePath)
-					if bloberror.HasCode(err, bloberror.BlobNotFound) {
+					if bloberror.HasCode(dlErr, bloberror.BlobNotFound) {
 						results[i].Error = "blob not found"
 					} else {
-						results[i].Error = err.Error()
+						results[i].Error = dlErr.Error()
 					}
 					return nil
 				}
@@ -574,20 +572,20 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 				results[i].FilePath = filePath
 			} else {
 				// Inline mode: download to memory and return data in response.
-				resp, err := blockBlobClient.DownloadStream(gctx, nil)
-				if err != nil {
-					if bloberror.HasCode(err, bloberror.BlobNotFound) {
+				resp, dlErr := blockBlobClient.DownloadStream(gctx, nil)
+				if dlErr != nil {
+					if bloberror.HasCode(dlErr, bloberror.BlobNotFound) {
 						results[i].Error = "blob not found"
 					} else {
-						results[i].Error = err.Error()
+						results[i].Error = dlErr.Error()
 					}
 					return nil
 				}
 				defer resp.Body.Close()
 
 				var buf bytes.Buffer
-				if _, err = io.Copy(&buf, resp.Body); err != nil {
-					results[i].Error = err.Error()
+				if _, copyErr := io.Copy(&buf, resp.Body); copyErr != nil {
+					results[i].Error = copyErr.Error()
 					return nil
 				}
 
@@ -597,8 +595,8 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("error in bulkGet: %w", err)
+	if waitErr := g.Wait(); waitErr != nil {
+		return nil, fmt.Errorf("error in bulkGet: %w", waitErr)
 	}
 
 	jsonResponse, err := json.Marshal(results)
@@ -618,7 +616,7 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 // Explicit items are preserved as-is (including duplicates with different filePaths).
 // Prefix-discovered blobs use destinationDir as base, skipping any already covered by explicit items.
 func (a *AzureBlobStorage) resolveBulkGetItems(ctx context.Context, payload *bulkGetPayload) ([]bulkGetItem, error) {
-	var items []bulkGetItem
+	items := make([]bulkGetItem, 0, len(payload.Items))
 
 	// Track blob names from explicit items so prefix discovery doesn't duplicate them.
 	explicitNames := make(map[string]struct{})
@@ -708,7 +706,6 @@ func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeR
 	g.SetLimit(concurrency)
 
 	for i, item := range payload.Items {
-		i, item := i, item
 		g.Go(func() error {
 			results[i].BlobName = item.BlobName
 
@@ -728,34 +725,34 @@ func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeR
 				if a.metadata.DecodeBase64 {
 					r = b64.NewDecoder(b64.StdEncoding, r)
 				}
-				_, err := blockBlobClient.UploadStream(gctx, r, &blockblob.UploadStreamOptions{
+				if _, uploadErr := blockBlobClient.UploadStream(gctx, r, &blockblob.UploadStreamOptions{
 					HTTPHeaders: httpHeaders,
-				})
-				if err != nil {
-					results[i].Error = fmt.Sprintf("error uploading blob: %s", err.Error())
+				}); uploadErr != nil {
+					results[i].Error = "error uploading blob: " + uploadErr.Error()
 					return nil
 				}
 			} else {
 				// File-based mode: upload from sourcePath.
-				f, err := os.Open(item.SourcePath)
-				if err != nil {
-					results[i].Error = fmt.Sprintf("error opening source file: %s", err.Error())
+				f, openErr := os.Open(item.SourcePath)
+				if openErr != nil {
+					results[i].Error = "error opening source file: " + openErr.Error()
 					return nil
 				}
 				defer f.Close()
 
+				var uploadErr error
 				if a.metadata.DecodeBase64 {
 					decoder := b64.NewDecoder(b64.StdEncoding, f)
-					_, err = blockBlobClient.UploadStream(gctx, decoder, &blockblob.UploadStreamOptions{
+					_, uploadErr = blockBlobClient.UploadStream(gctx, decoder, &blockblob.UploadStreamOptions{
 						HTTPHeaders: httpHeaders,
 					})
 				} else {
-					_, err = blockBlobClient.UploadFile(gctx, f, &blockblob.UploadFileOptions{
+					_, uploadErr = blockBlobClient.UploadFile(gctx, f, &blockblob.UploadFileOptions{
 						HTTPHeaders: httpHeaders,
 					})
 				}
-				if err != nil {
-					results[i].Error = fmt.Sprintf("error uploading blob: %s", err.Error())
+				if uploadErr != nil {
+					results[i].Error = "error uploading blob: " + uploadErr.Error()
 					return nil
 				}
 			}
@@ -765,8 +762,8 @@ func (a *AzureBlobStorage) bulkCreate(ctx context.Context, req *bindings.InvokeR
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("error in bulkCreate: %w", err)
+	if waitErr := g.Wait(); waitErr != nil {
+		return nil, fmt.Errorf("error in bulkCreate: %w", waitErr)
 	}
 
 	jsonResponse, err := json.Marshal(results)
@@ -853,24 +850,22 @@ func (a *AzureBlobStorage) bulkDelete(ctx context.Context, req *bindings.InvokeR
 		g.SetLimit(concurrency)
 
 		for j, name := range remainingNames {
-			j, name := j, name
 			resultIdx := remainingOffset + j
 			g.Go(func() error {
 				blockBlobClient := a.containerClient.NewBlockBlobClient(name)
-				_, err := blockBlobClient.Delete(gctx, &deleteOptions)
-				if err != nil {
-					if bloberror.HasCode(err, bloberror.BlobNotFound) {
+				if _, delErr := blockBlobClient.Delete(gctx, &deleteOptions); delErr != nil {
+					if bloberror.HasCode(delErr, bloberror.BlobNotFound) {
 						results[resultIdx].Error = "blob not found"
 					} else {
-						results[resultIdx].Error = err.Error()
+						results[resultIdx].Error = delErr.Error()
 					}
 				}
 				return nil
 			})
 		}
 
-		if err := g.Wait(); err != nil {
-			return nil, fmt.Errorf("error in bulkDelete: %w", err)
+		if waitErr := g.Wait(); waitErr != nil {
+			return nil, fmt.Errorf("error in bulkDelete: %w", waitErr)
 		}
 	}
 
@@ -897,20 +892,20 @@ func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, 
 		}
 		batch := names[batchStart:batchEnd]
 
-		bb, err := a.containerClient.NewBatchBuilder()
-		if err != nil {
-			return batchStart, fmt.Errorf("error creating batch builder: %w", err)
+		bb, bbErr := a.containerClient.NewBatchBuilder()
+		if bbErr != nil {
+			return batchStart, fmt.Errorf("error creating batch builder: %w", bbErr)
 		}
 
 		for _, name := range batch {
-			if err := bb.Delete(name, opts); err != nil {
-				return batchStart, fmt.Errorf("error adding delete to batch for %q: %w", name, err)
+			if delErr := bb.Delete(name, opts); delErr != nil {
+				return batchStart, fmt.Errorf("error adding delete to batch for %q: %w", name, delErr)
 			}
 		}
 
-		resp, err := a.containerClient.SubmitBatch(ctx, bb, nil)
-		if err != nil {
-			return batchStart, fmt.Errorf("error submitting batch delete: %w", err)
+		resp, submitErr := a.containerClient.SubmitBatch(ctx, bb, nil)
+		if submitErr != nil {
+			return batchStart, fmt.Errorf("error submitting batch delete: %w", submitErr)
 		}
 
 		// Map batch responses back to results.

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -519,8 +519,10 @@ func TestBulkGetResponseItemJSON(t *testing.T) {
 		r := bulkGetResponseItem{BlobName: "test.txt", FilePath: fp}
 		data, err := json.Marshal(r)
 		require.NoError(t, err)
-		assert.Contains(t, string(data), fp)
 		assert.Contains(t, string(data), `"filePath":`)
+		var decoded bulkGetResponseItem
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, fp, decoded.FilePath)
 	})
 
 	t.Run("includes error when present", func(t *testing.T) {

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -534,4 +534,3 @@ func TestBulkGetResponseItemJSON(t *testing.T) {
 func TestMaxBatchDeleteSize(t *testing.T) {
 	assert.Equal(t, 256, maxBatchDeleteSize)
 }
-

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -15,6 +15,7 @@ package blobstorage
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,9 +121,10 @@ func TestBulkGetValidation(t *testing.T) {
 	})
 
 	t.Run("return error when items have only empty blobNames", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		payload := bulkGetPayload{
 			Items: []bulkGetItem{
-				{BlobName: "", FilePath: ptr.Of("/tmp/a")},
+				{BlobName: "", FilePath: ptr.Of(filepath.Join(tmpDir, "a"))},
 			},
 		}
 		data, err := json.Marshal(payload)
@@ -135,9 +137,11 @@ func TestBulkGetValidation(t *testing.T) {
 	})
 
 	t.Run("accept item with filePath for file mode", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		expectedPath := filepath.Join(tmpDir, "blob1")
 		payload := bulkGetPayload{
 			Items: []bulkGetItem{
-				{BlobName: "blob1", FilePath: ptr.Of("/tmp/blob1")},
+				{BlobName: "blob1", FilePath: ptr.Of(expectedPath)},
 			},
 		}
 		data, err := json.Marshal(payload)
@@ -148,7 +152,7 @@ func TestBulkGetValidation(t *testing.T) {
 		require.NoError(t, json.Unmarshal(data, &parsed))
 		require.Len(t, parsed.Items, 1)
 		require.NotNil(t, parsed.Items[0].FilePath)
-		assert.Equal(t, "/tmp/blob1", *parsed.Items[0].FilePath)
+		assert.Equal(t, expectedPath, *parsed.Items[0].FilePath)
 	})
 
 	t.Run("accept item without filePath for inline mode", func(t *testing.T) {
@@ -181,9 +185,10 @@ func TestBulkGetValidation(t *testing.T) {
 	})
 
 	t.Run("return error when concurrency is zero", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		payload := bulkGetPayload{
 			Items: []bulkGetItem{
-				{BlobName: "blob1", FilePath: ptr.Of("/tmp/blob1")},
+				{BlobName: "blob1", FilePath: ptr.Of(filepath.Join(tmpDir, "blob1"))},
 			},
 			Concurrency: ptr.Of(int32(0)),
 		}
@@ -197,9 +202,10 @@ func TestBulkGetValidation(t *testing.T) {
 	})
 
 	t.Run("return error when concurrency is negative", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		payload := bulkGetPayload{
 			Items: []bulkGetItem{
-				{BlobName: "blob1", FilePath: ptr.Of("/tmp/blob1")},
+				{BlobName: "blob1", FilePath: ptr.Of(filepath.Join(tmpDir, "blob1"))},
 			},
 			Concurrency: ptr.Of(int32(-1)),
 		}
@@ -244,10 +250,11 @@ func TestBulkCreateValidation(t *testing.T) {
 	})
 
 	t.Run("return error when item has empty blobName", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		payload := bulkCreatePayload{
 			Items: []bulkCreateItem{
-				{BlobName: "valid", SourcePath: "/tmp/file"},
-				{BlobName: "", SourcePath: "/tmp/file"},
+				{BlobName: "valid", SourcePath: filepath.Join(tmpDir, "file")},
+				{BlobName: "", SourcePath: filepath.Join(tmpDir, "file")},
 			},
 		}
 		data, err := json.Marshal(payload)
@@ -292,9 +299,10 @@ func TestBulkCreateValidation(t *testing.T) {
 	})
 
 	t.Run("return error when concurrency is zero", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		payload := bulkCreatePayload{
 			Items: []bulkCreateItem{
-				{BlobName: "blob1", SourcePath: "/tmp/file"},
+				{BlobName: "blob1", SourcePath: filepath.Join(tmpDir, "file")},
 			},
 			Concurrency: ptr.Of(int32(0)),
 		}
@@ -404,16 +412,27 @@ func TestInvokeUnsupportedOperation(t *testing.T) {
 
 func TestBulkPayloadParsing(t *testing.T) {
 	t.Run("bulkGet payload with concurrency and filePath pointer", func(t *testing.T) {
-		raw := `{"items":[{"blobName":"a.txt"},{"blobName":"b.txt","filePath":"/tmp/b.txt"}],"concurrency":5}`
+		tmpDir := t.TempDir()
+		expectedPath := filepath.Join(tmpDir, "b.txt")
+		payload := bulkGetPayload{
+			Items: []bulkGetItem{
+				{BlobName: "a.txt"},
+				{BlobName: "b.txt", FilePath: ptr.Of(expectedPath)},
+			},
+			Concurrency: ptr.Of(int32(5)),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
 		var p bulkGetPayload
-		err := json.Unmarshal([]byte(raw), &p)
+		err = json.Unmarshal(data, &p)
 		require.NoError(t, err)
 		require.Len(t, p.Items, 2)
 		assert.Equal(t, "a.txt", p.Items[0].BlobName)
 		assert.Nil(t, p.Items[0].FilePath)
 		assert.Equal(t, "b.txt", p.Items[1].BlobName)
 		require.NotNil(t, p.Items[1].FilePath)
-		assert.Equal(t, "/tmp/b.txt", *p.Items[1].FilePath)
+		assert.Equal(t, expectedPath, *p.Items[1].FilePath)
 		require.NotNil(t, p.Concurrency)
 		assert.Equal(t, int32(5), *p.Concurrency)
 	})
@@ -427,9 +446,20 @@ func TestBulkPayloadParsing(t *testing.T) {
 	})
 
 	t.Run("bulkCreate payload with inline data and contentType", func(t *testing.T) {
-		raw := `{"items":[{"blobName":"f1.txt","data":"hello"},{"blobName":"f2.txt","sourcePath":"/tmp/f2.txt","contentType":"text/plain"}],"concurrency":3}`
+		tmpDir := t.TempDir()
+		expectedPath := filepath.Join(tmpDir, "f2.txt")
+		payload := bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{BlobName: "f1.txt", Data: ptr.Of("hello")},
+				{BlobName: "f2.txt", SourcePath: expectedPath, ContentType: ptr.Of("text/plain")},
+			},
+			Concurrency: ptr.Of(int32(3)),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
 		var p bulkCreatePayload
-		err := json.Unmarshal([]byte(raw), &p)
+		err = json.Unmarshal(data, &p)
 		require.NoError(t, err)
 		assert.Len(t, p.Items, 2)
 		assert.Equal(t, "f1.txt", p.Items[0].BlobName)
@@ -438,7 +468,7 @@ func TestBulkPayloadParsing(t *testing.T) {
 		assert.Empty(t, p.Items[0].SourcePath)
 		assert.Nil(t, p.Items[0].ContentType)
 		assert.Equal(t, "f2.txt", p.Items[1].BlobName)
-		assert.Equal(t, "/tmp/f2.txt", p.Items[1].SourcePath)
+		assert.Equal(t, expectedPath, p.Items[1].SourcePath)
 		assert.Nil(t, p.Items[1].Data)
 		require.NotNil(t, p.Items[1].ContentType)
 		assert.Equal(t, "text/plain", *p.Items[1].ContentType)
@@ -484,10 +514,13 @@ func TestBulkGetResponseItemJSON(t *testing.T) {
 	})
 
 	t.Run("includes filePath when present", func(t *testing.T) {
-		r := bulkGetResponseItem{BlobName: "test.txt", FilePath: "/tmp/test.txt"}
+		tmpDir := t.TempDir()
+		fp := filepath.Join(tmpDir, "test.txt")
+		r := bulkGetResponseItem{BlobName: "test.txt", FilePath: fp}
 		data, err := json.Marshal(r)
 		require.NoError(t, err)
-		assert.Contains(t, string(data), `"filePath":"/tmp/test.txt"`)
+		assert.Contains(t, string(data), fp)
+		assert.Contains(t, string(data), `"filePath":`)
 	})
 
 	t.Run("includes error when present", func(t *testing.T) {
@@ -502,26 +535,3 @@ func TestMaxBatchDeleteSize(t *testing.T) {
 	assert.Equal(t, 256, maxBatchDeleteSize)
 }
 
-func TestValidatePathWithinDir(t *testing.T) {
-	t.Run("valid path within dir", func(t *testing.T) {
-		err := validatePathWithinDir("/tmp/dest", "/tmp/dest/subdir/file.txt")
-		require.NoError(t, err)
-	})
-
-	t.Run("path traversal rejected", func(t *testing.T) {
-		err := validatePathWithinDir("/tmp/dest", "/tmp/dest/../../../etc/passwd")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "escapes base directory")
-	})
-
-	t.Run("absolute path outside dir rejected", func(t *testing.T) {
-		err := validatePathWithinDir("/tmp/dest", "/etc/passwd")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "escapes base directory")
-	})
-
-	t.Run("path equal to base is valid", func(t *testing.T) {
-		err := validatePathWithinDir("/tmp/dest", "/tmp/dest")
-		require.NoError(t, err)
-	})
-}

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -14,12 +14,15 @@ limitations under the License.
 package blobstorage
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
 )
 
 func TestGetOption(t *testing.T) {
@@ -52,4 +55,448 @@ func TestDeleteOption(t *testing.T) {
 		_, err := blobStorage.delete(t.Context(), &r)
 		require.Error(t, err)
 	})
+}
+
+func TestGetConcurrency(t *testing.T) {
+	t.Run("returns default when nil", func(t *testing.T) {
+		c, err := getConcurrency(nil)
+		require.NoError(t, err)
+		assert.Equal(t, int(defaultConcurrency), c)
+	})
+
+	t.Run("returns parsed value when valid", func(t *testing.T) {
+		c, err := getConcurrency(ptr.Of(int32(20)))
+		require.NoError(t, err)
+		assert.Equal(t, 20, c)
+	})
+
+	t.Run("returns error when zero", func(t *testing.T) {
+		_, err := getConcurrency(ptr.Of(int32(0)))
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConcurrency)
+	})
+
+	t.Run("returns error when negative", func(t *testing.T) {
+		_, err := getConcurrency(ptr.Of(int32(-5)))
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConcurrency)
+	})
+
+	t.Run("returns 1 when set to 1", func(t *testing.T) {
+		c, err := getConcurrency(ptr.Of(int32(1)))
+		require.NoError(t, err)
+		assert.Equal(t, 1, c)
+	})
+}
+
+func TestBulkGetValidation(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	t.Run("return error when neither items nor prefix is provided", func(t *testing.T) {
+		payload := bulkGetPayload{}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingBlobSelection)
+	})
+
+	t.Run("return error when payload is nil", func(t *testing.T) {
+		r := bindings.InvokeRequest{}
+		_, err := blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingBlobSelection)
+	})
+
+	t.Run("return error when payload is invalid JSON", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data: []byte(`not json`),
+		}
+		_, err := blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing bulkGet payload")
+	})
+
+	t.Run("return error when items have only empty blobNames", func(t *testing.T) {
+		payload := bulkGetPayload{
+			Items: []bulkGetItem{
+				{BlobName: "", FilePath: ptr.Of("/tmp/a")},
+			},
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingBlobSelection)
+	})
+
+	t.Run("accept item with filePath for file mode", func(t *testing.T) {
+		payload := bulkGetPayload{
+			Items: []bulkGetItem{
+				{BlobName: "blob1", FilePath: ptr.Of("/tmp/blob1")},
+			},
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		// Verify the payload is valid (no validation errors about filePath).
+		var parsed bulkGetPayload
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		require.Len(t, parsed.Items, 1)
+		require.NotNil(t, parsed.Items[0].FilePath)
+		assert.Equal(t, "/tmp/blob1", *parsed.Items[0].FilePath)
+	})
+
+	t.Run("accept item without filePath for inline mode", func(t *testing.T) {
+		payload := bulkGetPayload{
+			Items: []bulkGetItem{
+				{BlobName: "blob1"},
+			},
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		// Verify the payload is valid — nil filePath means inline mode.
+		var parsed bulkGetPayload
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		require.Len(t, parsed.Items, 1)
+		assert.Nil(t, parsed.Items[0].FilePath)
+	})
+
+	t.Run("return error when prefix is set without destinationDir", func(t *testing.T) {
+		payload := bulkGetPayload{
+			Prefix: ptr.Of("some-prefix/"),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingDestinationDir)
+	})
+
+	t.Run("return error when concurrency is zero", func(t *testing.T) {
+		payload := bulkGetPayload{
+			Items: []bulkGetItem{
+				{BlobName: "blob1", FilePath: ptr.Of("/tmp/blob1")},
+			},
+			Concurrency: ptr.Of(int32(0)),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConcurrency)
+	})
+
+	t.Run("return error when concurrency is negative", func(t *testing.T) {
+		payload := bulkGetPayload{
+			Items: []bulkGetItem{
+				{BlobName: "blob1", FilePath: ptr.Of("/tmp/blob1")},
+			},
+			Concurrency: ptr.Of(int32(-1)),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkGet(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConcurrency)
+	})
+}
+
+func TestBulkCreateValidation(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	t.Run("return error when items array is empty", func(t *testing.T) {
+		payload := bulkCreatePayload{}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrEmptyBulkCreateItems)
+	})
+
+	t.Run("return error when payload is nil", func(t *testing.T) {
+		r := bindings.InvokeRequest{}
+		_, err := blobStorage.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrEmptyBulkCreateItems)
+	})
+
+	t.Run("return error when payload is invalid JSON", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data: []byte(`not json`),
+		}
+		_, err := blobStorage.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing bulkCreate payload")
+	})
+
+	t.Run("return error when item has empty blobName", func(t *testing.T) {
+		payload := bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{BlobName: "valid", SourcePath: "/tmp/file"},
+				{BlobName: "", SourcePath: "/tmp/file"},
+			},
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "item at index 1 is missing blobName")
+	})
+
+	t.Run("return error when item has neither data nor sourcePath", func(t *testing.T) {
+		payload := bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{BlobName: "blob1"},
+			},
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "item at index 0 is missing both data and sourcePath")
+	})
+
+	t.Run("accept item with inline data", func(t *testing.T) {
+		payload := bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{BlobName: "blob1", Data: ptr.Of("hello")},
+			},
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		// Verify the payload is valid — data is an acceptable source.
+		var parsed bulkCreatePayload
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		require.Len(t, parsed.Items, 1)
+		require.NotNil(t, parsed.Items[0].Data)
+		assert.Equal(t, "hello", *parsed.Items[0].Data)
+	})
+
+	t.Run("return error when concurrency is zero", func(t *testing.T) {
+		payload := bulkCreatePayload{
+			Items: []bulkCreateItem{
+				{BlobName: "blob1", SourcePath: "/tmp/file"},
+			},
+			Concurrency: ptr.Of(int32(0)),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkCreate(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConcurrency)
+	})
+}
+
+func TestBulkDeleteValidation(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	t.Run("return error when both prefix and blobNames are empty", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data: []byte(`{}`),
+		}
+		_, err := blobStorage.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingBlobSelection)
+	})
+
+	t.Run("return error when payload is nil", func(t *testing.T) {
+		r := bindings.InvokeRequest{}
+		_, err := blobStorage.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingBlobSelection)
+	})
+
+	t.Run("return error when payload is invalid JSON", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Data: []byte(`not json`),
+		}
+		_, err := blobStorage.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing bulkDelete payload")
+	})
+
+	t.Run("return error when deleteSnapshots is invalid", func(t *testing.T) {
+		payload := bulkDeletePayload{
+			BlobNames:       []string{"blob1"},
+			DeleteSnapshots: ptr.Of("invalidOption"),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid delete snapshot option type")
+	})
+
+	t.Run("return error when concurrency is negative", func(t *testing.T) {
+		payload := bulkDeletePayload{
+			BlobNames:   []string{"blob1"},
+			Concurrency: ptr.Of(int32(-1)),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		r := bindings.InvokeRequest{Data: data}
+		_, err = blobStorage.bulkDelete(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConcurrency)
+	})
+}
+
+func TestOperationsIncludesBulk(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+	ops := blobStorage.Operations()
+
+	expectedOps := []bindings.OperationKind{
+		bindings.CreateOperation,
+		bindings.GetOperation,
+		bindings.DeleteOperation,
+		bindings.ListOperation,
+		bulkGetOperation,
+		bulkCreateOperation,
+		bulkDeleteOperation,
+	}
+
+	for _, expected := range expectedOps {
+		found := false
+		for _, op := range ops {
+			if op == expected {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected operation %q not found in Operations()", expected)
+	}
+}
+
+func TestInvokeUnsupportedOperation(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	r := bindings.InvokeRequest{
+		Operation: "unsupported",
+	}
+	_, err := blobStorage.Invoke(t.Context(), &r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported operation")
+}
+
+func TestBulkPayloadParsing(t *testing.T) {
+	t.Run("bulkGet payload with concurrency and filePath pointer", func(t *testing.T) {
+		raw := `{"items":[{"blobName":"a.txt"},{"blobName":"b.txt","filePath":"/tmp/b.txt"}],"concurrency":5}`
+		var p bulkGetPayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		require.Len(t, p.Items, 2)
+		assert.Equal(t, "a.txt", p.Items[0].BlobName)
+		assert.Nil(t, p.Items[0].FilePath)
+		assert.Equal(t, "b.txt", p.Items[1].BlobName)
+		require.NotNil(t, p.Items[1].FilePath)
+		assert.Equal(t, "/tmp/b.txt", *p.Items[1].FilePath)
+		require.NotNil(t, p.Concurrency)
+		assert.Equal(t, int32(5), *p.Concurrency)
+	})
+
+	t.Run("bulkGet payload without concurrency is nil", func(t *testing.T) {
+		raw := `{"items":[{"blobName":"a.txt"}]}`
+		var p bulkGetPayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Nil(t, p.Concurrency)
+	})
+
+	t.Run("bulkCreate payload with inline data and contentType", func(t *testing.T) {
+		raw := `{"items":[{"blobName":"f1.txt","data":"hello"},{"blobName":"f2.txt","sourcePath":"/tmp/f2.txt","contentType":"text/plain"}],"concurrency":3}`
+		var p bulkCreatePayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Len(t, p.Items, 2)
+		assert.Equal(t, "f1.txt", p.Items[0].BlobName)
+		require.NotNil(t, p.Items[0].Data)
+		assert.Equal(t, "hello", *p.Items[0].Data)
+		assert.Empty(t, p.Items[0].SourcePath)
+		assert.Nil(t, p.Items[0].ContentType)
+		assert.Equal(t, "f2.txt", p.Items[1].BlobName)
+		assert.Equal(t, "/tmp/f2.txt", p.Items[1].SourcePath)
+		assert.Nil(t, p.Items[1].Data)
+		require.NotNil(t, p.Items[1].ContentType)
+		assert.Equal(t, "text/plain", *p.Items[1].ContentType)
+		require.NotNil(t, p.Concurrency)
+		assert.Equal(t, int32(3), *p.Concurrency)
+	})
+
+	t.Run("bulkCreate item with neither data nor sourcePath", func(t *testing.T) {
+		raw := `{"items":[{"blobName":"f1.txt"}]}`
+		var p bulkCreatePayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Nil(t, p.Items[0].Data)
+		assert.Empty(t, p.Items[0].SourcePath)
+	})
+
+	t.Run("bulkDelete payload", func(t *testing.T) {
+		raw := `{"blobNames":["x.txt","y.txt"]}`
+		var p bulkDeletePayload
+		err := json.Unmarshal([]byte(raw), &p)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"x.txt", "y.txt"}, p.BlobNames)
+	})
+}
+
+func TestBulkGetResponseItemJSON(t *testing.T) {
+	t.Run("omits empty fields", func(t *testing.T) {
+		r := bulkGetResponseItem{BlobName: "test.txt"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "filePath")
+		assert.NotContains(t, string(data), "data")
+		assert.NotContains(t, string(data), "error")
+		assert.Contains(t, string(data), `"blobName":"test.txt"`)
+	})
+
+	t.Run("includes data when present", func(t *testing.T) {
+		r := bulkGetResponseItem{BlobName: "test.txt", Data: "hello"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"data":"hello"`)
+	})
+
+	t.Run("includes filePath when present", func(t *testing.T) {
+		r := bulkGetResponseItem{BlobName: "test.txt", FilePath: "/tmp/test.txt"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"filePath":"/tmp/test.txt"`)
+	})
+
+	t.Run("includes error when present", func(t *testing.T) {
+		r := bulkGetResponseItem{BlobName: "test.txt", Error: "not found"}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"error":"not found"`)
+	})
+}
+
+func TestMaxBatchDeleteSize(t *testing.T) {
+	assert.Equal(t, 256, maxBatchDeleteSize)
 }

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -317,14 +317,14 @@ func TestBulkDeleteValidation(t *testing.T) {
 		}
 		_, err := blobStorage.bulkDelete(t.Context(), &r)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrMissingBlobSelection)
+		require.ErrorIs(t, err, ErrMissingBulkDeleteSelection)
 	})
 
 	t.Run("return error when payload is nil", func(t *testing.T) {
 		r := bindings.InvokeRequest{}
 		_, err := blobStorage.bulkDelete(t.Context(), &r)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrMissingBlobSelection)
+		require.ErrorIs(t, err, ErrMissingBulkDeleteSelection)
 	})
 
 	t.Run("return error when payload is invalid JSON", func(t *testing.T) {
@@ -476,10 +476,11 @@ func TestBulkGetResponseItemJSON(t *testing.T) {
 	})
 
 	t.Run("includes data when present", func(t *testing.T) {
-		r := bulkGetResponseItem{BlobName: "test.txt", Data: "hello"}
+		r := bulkGetResponseItem{BlobName: "test.txt", Data: []byte("hello")}
 		data, err := json.Marshal(r)
 		require.NoError(t, err)
-		assert.Contains(t, string(data), `"data":"hello"`)
+		// []byte is marshalled as base64 by encoding/json.
+		assert.Contains(t, string(data), `"data":"aGVsbG8="`)
 	})
 
 	t.Run("includes filePath when present", func(t *testing.T) {
@@ -499,4 +500,28 @@ func TestBulkGetResponseItemJSON(t *testing.T) {
 
 func TestMaxBatchDeleteSize(t *testing.T) {
 	assert.Equal(t, 256, maxBatchDeleteSize)
+}
+
+func TestValidatePathWithinDir(t *testing.T) {
+	t.Run("valid path within dir", func(t *testing.T) {
+		err := validatePathWithinDir("/tmp/dest", "/tmp/dest/subdir/file.txt")
+		require.NoError(t, err)
+	})
+
+	t.Run("path traversal rejected", func(t *testing.T) {
+		err := validatePathWithinDir("/tmp/dest", "/tmp/dest/../../../etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes base directory")
+	})
+
+	t.Run("absolute path outside dir rejected", func(t *testing.T) {
+		err := validatePathWithinDir("/tmp/dest", "/etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes base directory")
+	})
+
+	t.Run("path equal to base is valid", func(t *testing.T) {
+		err := validatePathWithinDir("/tmp/dest", "/tmp/dest")
+		require.NoError(t, err)
+	})
 }

--- a/bindings/azure/blobstorage/metadata.yaml
+++ b/bindings/azure/blobstorage/metadata.yaml
@@ -19,6 +19,12 @@ binding:
       description: "Delete blob"
     - name: list
       description: "List blob"
+    - name: bulkGet
+      description: "Download multiple blobs in parallel"
+    - name: bulkCreate
+      description: "Upload multiple blobs in parallel"
+    - name: bulkDelete
+      description: "Delete multiple blobs in parallel"
 capabilities: []
 builtinAuthenticationProfiles:
   - name: "azuread"

--- a/go.mod
+++ b/go.mod
@@ -142,6 +142,7 @@ require (
 	golang.org/x/mod v0.31.0
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/api v0.231.0
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11
@@ -455,7 +456,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.14.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
+++ b/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
@@ -952,11 +952,12 @@ func TestBlobStorage(t *testing.T) {
 			"blobNames": blobNames,
 		}
 		deleteData, _ := json.Marshal(deletePayload)
-		_, _ = client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+		_, cleanupErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
 			Data:      deleteData,
 		})
+		require.NoError(t, cleanupErr, "cleanup bulkDelete failed")
 
 		return nil
 	}
@@ -1013,11 +1014,12 @@ func TestBlobStorage(t *testing.T) {
 			"blobNames": blobNames,
 		}
 		deleteData, _ := json.Marshal(deletePayload)
-		_, _ = client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+		_, cleanupErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
 			Data:      deleteData,
 		})
+		require.NoError(t, cleanupErr, "cleanup bulkDelete failed")
 
 		return nil
 	}
@@ -1111,11 +1113,12 @@ func TestBlobStorage(t *testing.T) {
 			"blobNames": blobNames,
 		}
 		deleteData, _ := json.Marshal(deletePayload)
-		_, _ = client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+		_, cleanupErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
 			Data:      deleteData,
 		})
+		require.NoError(t, cleanupErr, "cleanup bulkDelete failed")
 
 		return nil
 	}

--- a/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
+++ b/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -630,8 +631,8 @@ func TestBlobStorage(t *testing.T) {
 
 		items := make([]map[string]string, len(blobNames))
 		for i, name := range blobNames {
-			filePath := sourceDir + "/" + name
-			require.NoError(t, os.MkdirAll(sourceDir+"/bulk", 0o755))
+			filePath := filepath.Join(sourceDir, name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0o755))
 			require.NoError(t, os.WriteFile(filePath, []byte(fileContents[i]), 0o644))
 			items[i] = map[string]string{
 				"blobName":   name,
@@ -643,7 +644,8 @@ func TestBlobStorage(t *testing.T) {
 		createPayload := map[string]interface{}{
 			"items": items,
 		}
-		createData, _ := json.Marshal(createPayload)
+		createData, marshalErr := json.Marshal(createPayload)
+		require.NoError(t, marshalErr)
 
 		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -658,13 +660,14 @@ func TestBlobStorage(t *testing.T) {
 		for i, name := range blobNames {
 			getItems[i] = map[string]string{
 				"blobName": name,
-				"filePath": destDir + "/" + name,
+				"filePath": filepath.Join(destDir, name),
 			}
 		}
 		getPayload := map[string]interface{}{
 			"items": getItems,
 		}
-		getData, _ := json.Marshal(getPayload)
+		getData, marshalErr := json.Marshal(getPayload)
+		require.NoError(t, marshalErr)
 
 		getOut, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -680,7 +683,7 @@ func TestBlobStorage(t *testing.T) {
 
 		// Verify downloaded file contents.
 		for i, name := range blobNames {
-			downloaded, readErr := os.ReadFile(destDir + "/" + name)
+			downloaded, readErr := os.ReadFile(filepath.Join(destDir, name))
 			require.NoError(t, readErr)
 			assert.Equal(t, fileContents[i], string(downloaded))
 		}
@@ -689,7 +692,8 @@ func TestBlobStorage(t *testing.T) {
 		deletePayload := map[string]interface{}{
 			"blobNames": blobNames,
 		}
-		deleteData, _ := json.Marshal(deletePayload)
+		deleteData, marshalErr := json.Marshal(deletePayload)
+		require.NoError(t, marshalErr)
 
 		_, invokeDeleteErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -732,7 +736,8 @@ func TestBlobStorage(t *testing.T) {
 			"prefix":         "bulkprefix/",
 			"destinationDir": destDir,
 		}
-		getData, _ := json.Marshal(getPayload)
+		getData, marshalErr := json.Marshal(getPayload)
+		require.NoError(t, marshalErr)
 
 		getOut, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -747,7 +752,7 @@ func TestBlobStorage(t *testing.T) {
 
 		// Verify files exist on disk.
 		for _, name := range blobNames {
-			data, readErr := os.ReadFile(destDir + "/" + name)
+			data, readErr := os.ReadFile(filepath.Join(destDir, name))
 			require.NoError(t, readErr)
 			assert.Equal(t, "content of "+name, string(data))
 		}
@@ -756,7 +761,8 @@ func TestBlobStorage(t *testing.T) {
 		deletePayload := map[string]interface{}{
 			"prefix": "bulkprefix/",
 		}
-		deleteData, _ := json.Marshal(deletePayload)
+		deleteData, marshalErr := json.Marshal(deletePayload)
+		require.NoError(t, marshalErr)
 		_, invokeDeleteErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
@@ -788,7 +794,7 @@ func TestBlobStorage(t *testing.T) {
 
 		// Get with filePath — should stream to file.
 		destDir := t.TempDir()
-		filePath := destDir + "/" + blobName
+		filePath := filepath.Join(destDir, blobName)
 		out, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "get",
@@ -832,8 +838,8 @@ func TestBlobStorage(t *testing.T) {
 		for i, name := range blobNames {
 			// Write base64-encoded content to source files.
 			encoded := base64.StdEncoding.EncodeToString([]byte(originalContent[i]))
-			filePath := sourceDir + "/" + name
-			require.NoError(t, os.MkdirAll(sourceDir+"/b64bulk", 0o755))
+			filePath := filepath.Join(sourceDir, name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0o755))
 			require.NoError(t, os.WriteFile(filePath, []byte(encoded), 0o644))
 			items[i] = map[string]string{
 				"blobName":   name,
@@ -845,7 +851,8 @@ func TestBlobStorage(t *testing.T) {
 		createPayload := map[string]interface{}{
 			"items": items,
 		}
-		createData, _ := json.Marshal(createPayload)
+		createData, marshalErr := json.Marshal(createPayload)
+		require.NoError(t, marshalErr)
 
 		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -865,7 +872,8 @@ func TestBlobStorage(t *testing.T) {
 		deletePayload := map[string]interface{}{
 			"blobNames": blobNames,
 		}
-		deleteData, _ := json.Marshal(deletePayload)
+		deleteData, marshalErr := json.Marshal(deletePayload)
+		require.NoError(t, marshalErr)
 		_, invokeDeleteErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
@@ -891,8 +899,8 @@ func TestBlobStorage(t *testing.T) {
 
 		items := make([]map[string]string, len(blobNames))
 		for i, name := range blobNames {
-			filePath := sourceDir + "/" + name
-			require.NoError(t, os.MkdirAll(sourceDir+"/plainbulk", 0o755))
+			filePath := filepath.Join(sourceDir, name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0o755))
 			require.NoError(t, os.WriteFile(filePath, []byte(contents[i]), 0o644))
 			items[i] = map[string]string{
 				"blobName":   name,
@@ -903,7 +911,8 @@ func TestBlobStorage(t *testing.T) {
 		createPayload := map[string]interface{}{
 			"items": items,
 		}
-		createData, _ := json.Marshal(createPayload)
+		createData, marshalErr := json.Marshal(createPayload)
+		require.NoError(t, marshalErr)
 
 		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -925,13 +934,14 @@ func TestBlobStorage(t *testing.T) {
 		for i, name := range blobNames {
 			getItems[i] = map[string]string{
 				"blobName": name,
-				"filePath": destDir + "/" + name,
+				"filePath": filepath.Join(destDir, name),
 			}
 		}
 		getPayload := map[string]interface{}{
 			"items": getItems,
 		}
-		getData, _ := json.Marshal(getPayload)
+		getData, marshalErr := json.Marshal(getPayload)
+		require.NoError(t, marshalErr)
 
 		_, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -942,7 +952,7 @@ func TestBlobStorage(t *testing.T) {
 
 		// Verify downloaded files.
 		for i, name := range blobNames {
-			downloaded, readErr := os.ReadFile(destDir + "/" + name)
+			downloaded, readErr := os.ReadFile(filepath.Join(destDir, name))
 			require.NoError(t, readErr)
 			assert.Equal(t, contents[i], string(downloaded))
 		}
@@ -951,7 +961,8 @@ func TestBlobStorage(t *testing.T) {
 		deletePayload := map[string]interface{}{
 			"blobNames": blobNames,
 		}
-		deleteData, _ := json.Marshal(deletePayload)
+		deleteData, marshalErr := json.Marshal(deletePayload)
+		require.NoError(t, marshalErr)
 		_, cleanupErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
@@ -985,7 +996,8 @@ func TestBlobStorage(t *testing.T) {
 			"items":       items,
 			"concurrency": 2,
 		}
-		createData, _ := json.Marshal(createPayload)
+		createData, marshalErr := json.Marshal(createPayload)
+		require.NoError(t, marshalErr)
 
 		createOut, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -1013,7 +1025,8 @@ func TestBlobStorage(t *testing.T) {
 		deletePayload := map[string]interface{}{
 			"blobNames": blobNames,
 		}
-		deleteData, _ := json.Marshal(deletePayload)
+		deleteData, marshalErr := json.Marshal(deletePayload)
+		require.NoError(t, marshalErr)
 		_, cleanupErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
@@ -1055,7 +1068,8 @@ func TestBlobStorage(t *testing.T) {
 		getPayload := map[string]interface{}{
 			"items": getItems,
 		}
-		getData, _ := json.Marshal(getPayload)
+		getData, marshalErr := json.Marshal(getPayload)
+		require.NoError(t, marshalErr)
 
 		getOut, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -1093,7 +1107,8 @@ func TestBlobStorage(t *testing.T) {
 		mixedPayload := map[string]interface{}{
 			"items": mixedItems,
 		}
-		mixedData, _ := json.Marshal(mixedPayload)
+		mixedData, marshalErr := json.Marshal(mixedPayload)
+		require.NoError(t, marshalErr)
 
 		mixedOut, mixedErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
@@ -1122,7 +1137,8 @@ func TestBlobStorage(t *testing.T) {
 		deletePayload := map[string]interface{}{
 			"blobNames": blobNames,
 		}
-		deleteData, _ := json.Marshal(deletePayload)
+		deleteData, marshalErr := json.Marshal(deletePayload)
+		require.NoError(t, marshalErr)
 		_, cleanupErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",
 			Operation: "bulkDelete",
@@ -1155,7 +1171,8 @@ func TestBlobStorage(t *testing.T) {
 		createPayload := map[string]interface{}{
 			"items": items,
 		}
-		createData, _ := json.Marshal(createPayload)
+		createData, marshalErr := json.Marshal(createPayload)
+		require.NoError(t, marshalErr)
 
 		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
 			Name:      "azure-blobstorage-output",

--- a/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
+++ b/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
@@ -614,6 +614,561 @@ func TestBlobStorage(t *testing.T) {
 		return nil
 	}
 
+	testBulkCreateGetDelete := func(ctx flow.Context) error {
+		// Tests the full lifecycle of bulk operations:
+		// bulkCreate → bulkGet → bulkDelete.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// Create temp source files.
+		sourceDir := t.TempDir()
+		blobNames := []string{"bulk/file1.txt", "bulk/file2.txt", "bulk/file3.txt"}
+		fileContents := []string{"content of file 1", "content of file 2", "content of file 3"}
+
+		items := make([]map[string]string, len(blobNames))
+		for i, name := range blobNames {
+			filePath := sourceDir + "/" + name
+			require.NoError(t, os.MkdirAll(sourceDir+"/bulk", 0o755))
+			require.NoError(t, os.WriteFile(filePath, []byte(fileContents[i]), 0o644))
+			items[i] = map[string]string{
+				"blobName":   name,
+				"sourcePath": filePath,
+			}
+		}
+
+		// bulkCreate — upload all files.
+		createPayload := map[string]interface{}{
+			"items": items,
+		}
+		createData, _ := json.Marshal(createPayload)
+
+		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkCreate",
+			Data:      createData,
+		})
+		require.NoError(t, invokeCreateErr)
+
+		// bulkGet — download all files to individual target paths.
+		destDir := t.TempDir()
+		getItems := make([]map[string]string, len(blobNames))
+		for i, name := range blobNames {
+			getItems[i] = map[string]string{
+				"blobName": name,
+				"filePath": destDir + "/" + name,
+			}
+		}
+		getPayload := map[string]interface{}{
+			"items": getItems,
+		}
+		getData, _ := json.Marshal(getPayload)
+
+		getOut, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkGet",
+			Data:      getData,
+		})
+		require.NoError(t, invokeGetErr)
+
+		// Verify response contains all items.
+		var getResults []map[string]interface{}
+		require.NoError(t, json.Unmarshal(getOut.Data, &getResults))
+		assert.Len(t, getResults, len(blobNames))
+
+		// Verify downloaded file contents.
+		for i, name := range blobNames {
+			downloaded, readErr := os.ReadFile(destDir + "/" + name)
+			require.NoError(t, readErr)
+			assert.Equal(t, fileContents[i], string(downloaded))
+		}
+
+		// bulkDelete — delete all blobs by explicit names.
+		deletePayload := map[string]interface{}{
+			"blobNames": blobNames,
+		}
+		deleteData, _ := json.Marshal(deletePayload)
+
+		_, invokeDeleteErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkDelete",
+			Data:      deleteData,
+		})
+		require.NoError(t, invokeDeleteErr)
+
+		// Verify all blobs are deleted.
+		listOut, listErr := listBlobRequest(ctx, client, "bulk/", "", -1, false, false, false, false, false)
+		require.NoError(t, listErr)
+		assert.Equal(t, "0", listOut.Metadata["number"])
+
+		return nil
+	}
+
+	testBulkGetByPrefix := func(ctx flow.Context) error {
+		// Tests bulkGet using prefix-based selection.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// Create some blobs with a common prefix.
+		blobNames := []string{"bulkprefix/a.txt", "bulkprefix/b.txt"}
+		for _, name := range blobNames {
+			_, err := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+				Name:      "azure-blobstorage-output",
+				Operation: "create",
+				Data:      []byte("content of " + name),
+				Metadata:  map[string]string{"blobName": name},
+			})
+			require.NoError(t, err)
+		}
+
+		// bulkGet by prefix.
+		destDir := t.TempDir()
+		getPayload := map[string]interface{}{
+			"prefix":         "bulkprefix/",
+			"destinationDir": destDir,
+		}
+		getData, _ := json.Marshal(getPayload)
+
+		getOut, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkGet",
+			Data:      getData,
+		})
+		require.NoError(t, invokeGetErr)
+
+		var getResults []map[string]interface{}
+		require.NoError(t, json.Unmarshal(getOut.Data, &getResults))
+		assert.Len(t, getResults, 2)
+
+		// Verify files exist on disk.
+		for _, name := range blobNames {
+			data, readErr := os.ReadFile(destDir + "/" + name)
+			require.NoError(t, readErr)
+			assert.Equal(t, "content of "+name, string(data))
+		}
+
+		// Cleanup via bulkDelete with prefix.
+		deletePayload := map[string]interface{}{
+			"prefix": "bulkprefix/",
+		}
+		deleteData, _ := json.Marshal(deletePayload)
+		_, invokeDeleteErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkDelete",
+			Data:      deleteData,
+		})
+		require.NoError(t, invokeDeleteErr)
+
+		return nil
+	}
+
+	testGetToFile := func(ctx flow.Context) error {
+		// Tests the single get operation with filePath metadata to stream to file.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// Create a blob.
+		content := "streaming get to file test content"
+		blobName := "gettofile-test.txt"
+		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "create",
+			Data:      []byte(content),
+			Metadata:  map[string]string{"blobName": blobName},
+		})
+		require.NoError(t, invokeCreateErr)
+
+		// Get with filePath — should stream to file.
+		destDir := t.TempDir()
+		filePath := destDir + "/" + blobName
+		out, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "get",
+			Metadata: map[string]string{
+				"blobName": blobName,
+				"filePath": filePath,
+			},
+		})
+		require.NoError(t, invokeGetErr)
+
+		// Response data should be empty (streamed to file).
+		assert.Empty(t, out.Data)
+		assert.Equal(t, filePath, out.Metadata["filePath"])
+
+		// Verify file content.
+		downloaded, readErr := os.ReadFile(filePath)
+		require.NoError(t, readErr)
+		assert.Equal(t, content, string(downloaded))
+
+		// Cleanup.
+		_, invokeDeleteErr := deleteBlobRequest(ctx, client, blobName, nil)
+		require.NoError(t, invokeDeleteErr)
+
+		return nil
+	}
+
+	testBulkCreateWithBase64 := func(ctx flow.Context) error {
+		// Tests bulkCreate with decodeBase64 enabled — source files contain
+		// base64-encoded data, which should be decoded during streaming upload.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		sourceDir := t.TempDir()
+		originalContent := []string{"binary content one", "binary content two"}
+		blobNames := []string{"b64bulk/file1.bin", "b64bulk/file2.bin"}
+
+		items := make([]map[string]string, len(blobNames))
+		for i, name := range blobNames {
+			// Write base64-encoded content to source files.
+			encoded := base64.StdEncoding.EncodeToString([]byte(originalContent[i]))
+			filePath := sourceDir + "/" + name
+			require.NoError(t, os.MkdirAll(sourceDir+"/b64bulk", 0o755))
+			require.NoError(t, os.WriteFile(filePath, []byte(encoded), 0o644))
+			items[i] = map[string]string{
+				"blobName":   name,
+				"sourcePath": filePath,
+			}
+		}
+
+		// bulkCreate with decodeBase64 component config.
+		createPayload := map[string]interface{}{
+			"items": items,
+		}
+		createData, _ := json.Marshal(createPayload)
+
+		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkCreate",
+			Data:      createData,
+		})
+		require.NoError(t, invokeCreateErr)
+
+		// Verify uploaded blobs contain decoded (original) content.
+		for i, name := range blobNames {
+			out, getErr := getBlobRequest(ctx, client, name, false)
+			require.NoError(t, getErr)
+			assert.Equal(t, originalContent[i], string(out.Data))
+		}
+
+		// Cleanup via bulkDelete.
+		deletePayload := map[string]interface{}{
+			"blobNames": blobNames,
+		}
+		deleteData, _ := json.Marshal(deletePayload)
+		_, invokeDeleteErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkDelete",
+			Data:      deleteData,
+		})
+		require.NoError(t, invokeDeleteErr)
+
+		return nil
+	}
+
+	testBulkCreatePlainEncoding := func(ctx flow.Context) error {
+		// Tests bulkCreate without base64 — source files contain plain
+		// text that should be uploaded as-is.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		sourceDir := t.TempDir()
+		contents := []string{"plain text file one", "plain text file two", "plain text file three"}
+		blobNames := []string{"plainbulk/a.txt", "plainbulk/b.txt", "plainbulk/c.txt"}
+
+		items := make([]map[string]string, len(blobNames))
+		for i, name := range blobNames {
+			filePath := sourceDir + "/" + name
+			require.NoError(t, os.MkdirAll(sourceDir+"/plainbulk", 0o755))
+			require.NoError(t, os.WriteFile(filePath, []byte(contents[i]), 0o644))
+			items[i] = map[string]string{
+				"blobName":   name,
+				"sourcePath": filePath,
+			}
+		}
+
+		createPayload := map[string]interface{}{
+			"items": items,
+		}
+		createData, _ := json.Marshal(createPayload)
+
+		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkCreate",
+			Data:      createData,
+		})
+		require.NoError(t, invokeCreateErr)
+
+		// Verify blobs contain exact plain text.
+		for i, name := range blobNames {
+			out, getErr := getBlobRequest(ctx, client, name, false)
+			require.NoError(t, getErr)
+			assert.Equal(t, contents[i], string(out.Data))
+		}
+
+		// bulkGet to individual file paths.
+		destDir := t.TempDir()
+		getItems := make([]map[string]string, len(blobNames))
+		for i, name := range blobNames {
+			getItems[i] = map[string]string{
+				"blobName": name,
+				"filePath": destDir + "/" + name,
+			}
+		}
+		getPayload := map[string]interface{}{
+			"items": getItems,
+		}
+		getData, _ := json.Marshal(getPayload)
+
+		_, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkGet",
+			Data:      getData,
+		})
+		require.NoError(t, invokeGetErr)
+
+		// Verify downloaded files.
+		for i, name := range blobNames {
+			downloaded, readErr := os.ReadFile(destDir + "/" + name)
+			require.NoError(t, readErr)
+			assert.Equal(t, contents[i], string(downloaded))
+		}
+
+		// Cleanup.
+		deletePayload := map[string]interface{}{
+			"blobNames": blobNames,
+		}
+		deleteData, _ := json.Marshal(deletePayload)
+		_, _ = client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkDelete",
+			Data:      deleteData,
+		})
+
+		return nil
+	}
+
+	testBulkCreateInlineData := func(ctx flow.Context) error {
+		// Tests bulkCreate using inline data (no source files).
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		blobNames := []string{"inline/a.txt", "inline/b.txt"}
+		contents := []string{"inline content A", "inline content B"}
+
+		// bulkCreate with inline data.
+		items := make([]map[string]interface{}, len(blobNames))
+		for i, name := range blobNames {
+			items[i] = map[string]interface{}{
+				"blobName": name,
+				"data":     contents[i],
+			}
+		}
+		createPayload := map[string]interface{}{
+			"items":       items,
+			"concurrency": 2,
+		}
+		createData, _ := json.Marshal(createPayload)
+
+		createOut, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkCreate",
+			Data:      createData,
+		})
+		require.NoError(t, invokeCreateErr)
+
+		var createResults []map[string]interface{}
+		require.NoError(t, json.Unmarshal(createOut.Data, &createResults))
+		require.Len(t, createResults, 2)
+		for _, r := range createResults {
+			assert.Empty(t, r["error"], "expected no error for %v", r["blobName"])
+			assert.NotEmpty(t, r["blobURL"], "expected blobURL for %v", r["blobName"])
+		}
+
+		// Verify via regular get.
+		for i, name := range blobNames {
+			out, getErr := getBlobRequest(ctx, client, name, false)
+			require.NoError(t, getErr)
+			assert.Equal(t, contents[i], string(out.Data))
+		}
+
+		// Cleanup.
+		deletePayload := map[string]interface{}{
+			"blobNames": blobNames,
+		}
+		deleteData, _ := json.Marshal(deletePayload)
+		_, _ = client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkDelete",
+			Data:      deleteData,
+		})
+
+		return nil
+	}
+
+	testBulkGetInlineData := func(ctx flow.Context) error {
+		// Tests bulkGet returning data inline (no filePath).
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// Create blobs first.
+		blobNames := []string{"inlineget/x.txt", "inlineget/y.txt"}
+		contents := []string{"data for x", "data for y"}
+		for i, name := range blobNames {
+			_, err := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+				Name:      "azure-blobstorage-output",
+				Operation: "create",
+				Data:      []byte(contents[i]),
+				Metadata:  map[string]string{"blobName": name},
+			})
+			require.NoError(t, err)
+		}
+
+		// bulkGet without filePath — should return data inline.
+		getItems := make([]map[string]string, len(blobNames))
+		for i, name := range blobNames {
+			getItems[i] = map[string]string{
+				"blobName": name,
+			}
+		}
+		getPayload := map[string]interface{}{
+			"items": getItems,
+		}
+		getData, _ := json.Marshal(getPayload)
+
+		getOut, invokeGetErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkGet",
+			Data:      getData,
+		})
+		require.NoError(t, invokeGetErr)
+
+		var getResults []map[string]interface{}
+		require.NoError(t, json.Unmarshal(getOut.Data, &getResults))
+		require.Len(t, getResults, 2)
+
+		expected := map[string]string{}
+		for i, name := range blobNames {
+			expected[name] = contents[i]
+		}
+		for _, r := range getResults {
+			blobName := r["blobName"].(string)
+			assert.Empty(t, r["error"], "expected no error for %s", blobName)
+			assert.Equal(t, expected[blobName], r["data"], "data mismatch for %s", blobName)
+			assert.Empty(t, r["filePath"], "filePath should be empty for inline mode")
+		}
+
+		// Test partial failure: one exists, one doesn't.
+		mixedItems := []map[string]string{
+			{"blobName": blobNames[0]},
+			{"blobName": "inlineget/nonexistent.txt"},
+		}
+		mixedPayload := map[string]interface{}{
+			"items": mixedItems,
+		}
+		mixedData, _ := json.Marshal(mixedPayload)
+
+		mixedOut, mixedErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkGet",
+			Data:      mixedData,
+		})
+		require.NoError(t, mixedErr)
+
+		var mixedResults []map[string]interface{}
+		require.NoError(t, json.Unmarshal(mixedOut.Data, &mixedResults))
+		require.Len(t, mixedResults, 2)
+		for _, r := range mixedResults {
+			if r["blobName"] == blobNames[0] {
+				assert.Empty(t, r["error"])
+				assert.Equal(t, contents[0], r["data"])
+			} else {
+				assert.NotEmpty(t, r["error"], "expected error for non-existent blob")
+			}
+		}
+
+		// Cleanup.
+		deletePayload := map[string]interface{}{
+			"blobNames": blobNames,
+		}
+		deleteData, _ := json.Marshal(deletePayload)
+		_, _ = client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkDelete",
+			Data:      deleteData,
+		})
+
+		return nil
+	}
+
+	testBulkCreateWithContentType := func(ctx flow.Context) error {
+		// Tests bulkCreate with per-item contentType.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		blobName := "contenttype/test.json"
+		contentType := "application/json"
+		data := `{"key":"value"}`
+
+		items := []map[string]interface{}{
+			{
+				"blobName":    blobName,
+				"data":        data,
+				"contentType": contentType,
+			},
+		}
+		createPayload := map[string]interface{}{
+			"items": items,
+		}
+		createData, _ := json.Marshal(createPayload)
+
+		_, invokeCreateErr := client.InvokeBinding(ctx, &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "bulkCreate",
+			Data:      createData,
+		})
+		require.NoError(t, invokeCreateErr)
+
+		// Verify content type via list with metadata.
+		listOut, listErr := listBlobRequest(ctx, client, "contenttype/", "", -1, false, false, false, false, false)
+		require.NoError(t, listErr)
+
+		var listItems []map[string]interface{}
+		require.NoError(t, json.Unmarshal(listOut.Data, &listItems))
+		require.Len(t, listItems, 1)
+		props, ok := listItems[0]["Properties"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, contentType, props["ContentType"])
+
+		// Cleanup.
+		_, invokeDeleteErr := deleteBlobRequest(ctx, client, blobName, nil)
+		require.NoError(t, invokeDeleteErr)
+
+		return nil
+	}
+
 	flow.New(t, "blobstorage binding authentication using service principal").
 		Step(sidecar.Run(sidecarName,
 			append(componentRuntimeOptions(),
@@ -649,6 +1204,13 @@ func TestBlobStorage(t *testing.T) {
 		Step("Creating a public blob does not work", testCreatePublicBlob(false, "")).
 		Step("Create blob with invalid content hash", testCreateBlobInvalidContentHash).
 		Step("Test snapshot deletion and listing", testSnapshotDeleteAndList).
+		Step("Bulk create, get, and delete", testBulkCreateGetDelete).
+		Step("Bulk get by prefix", testBulkGetByPrefix).
+		Step("Get to file", testGetToFile).
+		Step("Bulk create with plain encoding", testBulkCreatePlainEncoding).
+		Step("Bulk create with inline data", testBulkCreateInlineData).
+		Step("Bulk get inline data", testBulkGetInlineData).
+		Step("Bulk create with content type", testBulkCreateWithContentType).
 		Run()
 
 	ports, err = dapr_testing.GetFreePorts(2)
@@ -667,6 +1229,7 @@ func TestBlobStorage(t *testing.T) {
 			)...,
 		)).
 		Step("Create blob from file", testCreateBlobFromFile(true)).
+		Step("Bulk create with base64 decoding", testBulkCreateWithBase64).
 		Run()
 
 	ports, err = dapr_testing.GetFreePorts(2)

--- a/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
+++ b/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
@@ -1075,7 +1075,13 @@ func TestBlobStorage(t *testing.T) {
 		for _, r := range getResults {
 			blobName := r["blobName"].(string)
 			assert.Empty(t, r["error"], "expected no error for %s", blobName)
-			assert.Equal(t, expected[blobName], r["data"], "data mismatch for %s", blobName)
+			// Data is []byte in the response struct, which encoding/json marshals as base64.
+			// When unmarshalled into map[string]interface{}, it arrives as a base64 string.
+			dataB64, ok := r["data"].(string)
+			require.True(t, ok, "data should be a base64 string for %s", blobName)
+			decoded, decErr := base64.StdEncoding.DecodeString(dataB64)
+			require.NoError(t, decErr, "failed to decode base64 data for %s", blobName)
+			assert.Equal(t, expected[blobName], string(decoded), "data mismatch for %s", blobName)
 			assert.Empty(t, r["filePath"], "filePath should be empty for inline mode")
 		}
 
@@ -1102,7 +1108,11 @@ func TestBlobStorage(t *testing.T) {
 		for _, r := range mixedResults {
 			if r["blobName"] == blobNames[0] {
 				assert.Empty(t, r["error"])
-				assert.Equal(t, contents[0], r["data"])
+				dataB64, ok := r["data"].(string)
+				require.True(t, ok, "data should be a base64 string")
+				decoded, decErr := base64.StdEncoding.DecodeString(dataB64)
+				require.NoError(t, decErr, "failed to decode base64 data")
+				assert.Equal(t, contents[0], string(decoded))
 			} else {
 				assert.NotEmpty(t, r["error"], "expected error for non-existent blob")
 			}


### PR DESCRIPTION
- bulkGet: filePath is optional (*string); when nil, blob data is returned inline in the response instead of streaming to disk.
- bulkCreate: accept inline data via new "data" field as alternative to sourcePath; at least one of the two is required
- bulkCreate: add per-item contentType (*string) passed through as BlobContentType HTTP header
- bulkDelete: use Azure Blob Batch API (NewBatchBuilder/SubmitBatch) with 256-key chunking; falls back to concurrent individual deletes if batch API is unavailable

Fixes #3872