### PR TITLE
pubsub/kafka: per message partition support

### DIFF
--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -164,6 +164,7 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 	config.ChannelBufferSize = meta.channelBufferSize
 
 	config.Producer.Compression = meta.internalCompression
+	config.Producer.Partitioner = newDaprPartitioner
 
 	config.Net.KeepAlive = meta.ClientConnectionKeepAliveInterval
 	config.Metadata.RefreshFrequency = meta.ClientConnectionTopicMetadataRefreshInterval

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -29,6 +29,7 @@ import (
 const (
 	key                                      = "partitionKey"
 	keyMetadataKey                           = "__key"
+	partitionNumberKey                       = "partitionNumber"
 	timestampMetadataKey                     = "__timestamp"
 	offsetMetadataKey                        = "__offset"
 	partitionMetadataKey                     = "__partition"

--- a/common/component/kafka/partitioner.go
+++ b/common/component/kafka/partitioner.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/common/component/kafka/partitioner.go
+++ b/common/component/kafka/partitioner.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"fmt"
+
+	"github.com/IBM/sarama"
+)
+
+// daprPartitioner is a sarama.Partitioner that supports both explicit partition
+// selection (via msg.Partition >= 0) and hash-based partitioning (when
+// msg.Partition < 0). This allows per-message partition targeting via the
+// "partitionNumber" metadata key while preserving the default hash-based
+// behavior for messages using "partitionKey" or no key at all.
+type daprPartitioner struct {
+	hashPartitioner sarama.Partitioner
+}
+
+// newDaprPartitioner is a sarama.PartitionerConstructor that creates a
+// daprPartitioner wrapping a hash partitioner for the given topic.
+func newDaprPartitioner(topic string) sarama.Partitioner {
+	return &daprPartitioner{
+		hashPartitioner: sarama.NewHashPartitioner(topic),
+	}
+}
+
+func (p *daprPartitioner) Partition(message *sarama.ProducerMessage, numPartitions int32) (int32, error) {
+	if message.Partition >= 0 {
+		if message.Partition >= numPartitions {
+			return 0, fmt.Errorf("partition number %d is out of range, topic has %d partitions", message.Partition, numPartitions)
+		}
+		return message.Partition, nil
+	}
+	return p.hashPartitioner.Partition(message, numPartitions)
+}
+
+func (p *daprPartitioner) RequiresConsistency() bool {
+	return p.hashPartitioner.RequiresConsistency()
+}

--- a/common/component/kafka/partitioner_test.go
+++ b/common/component/kafka/partitioner_test.go
@@ -1,0 +1,74 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDaprPartitioner(t *testing.T) {
+	partitioner := newDaprPartitioner("test-topic")
+	numPartitions := int32(4)
+
+	t.Run("returns explicit partition when set", func(t *testing.T) {
+		msg := &sarama.ProducerMessage{Partition: 2}
+		partition, err := partitioner.Partition(msg, numPartitions)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), partition)
+	})
+
+	t.Run("returns partition 0 when explicitly set", func(t *testing.T) {
+		msg := &sarama.ProducerMessage{Partition: 0}
+		partition, err := partitioner.Partition(msg, numPartitions)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), partition)
+	})
+
+	t.Run("returns error when partition exceeds range", func(t *testing.T) {
+		msg := &sarama.ProducerMessage{Partition: 5}
+		_, err := partitioner.Partition(msg, numPartitions)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("returns error when partition equals numPartitions", func(t *testing.T) {
+		msg := &sarama.ProducerMessage{Partition: 4}
+		_, err := partitioner.Partition(msg, numPartitions)
+		require.Error(t, err)
+	})
+
+	t.Run("delegates to hash partitioner when partition is negative", func(t *testing.T) {
+		msg := &sarama.ProducerMessage{
+			Partition: -1,
+			Key:       sarama.StringEncoder("test-key"),
+		}
+		partition, err := partitioner.Partition(msg, numPartitions)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, partition, int32(0))
+		require.Less(t, partition, numPartitions)
+
+		// Same key should produce same partition (hash consistency)
+		msg2 := &sarama.ProducerMessage{
+			Partition: -1,
+			Key:       sarama.StringEncoder("test-key"),
+		}
+		partition2, err := partitioner.Partition(msg2, numPartitions)
+		require.NoError(t, err)
+		require.Equal(t, partition, partition2)
+	})
+
+	t.Run("delegates to hash partitioner when partition is unset sentinel", func(t *testing.T) {
+		msg := &sarama.ProducerMessage{
+			Partition: -1,
+		}
+		partition, err := partitioner.Partition(msg, numPartitions)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, partition, int32(0))
+		require.Less(t, partition, numPartitions)
+	})
+
+	t.Run("RequiresConsistency returns true", func(t *testing.T) {
+		require.True(t, partitioner.RequiresConsistency())
+	})
+}

--- a/common/component/kafka/partitioner_test.go
+++ b/common/component/kafka/partitioner_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Dapr Authors 
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/common/component/kafka/partitioner_test.go
+++ b/common/component/kafka/partitioner_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kafka
 
 import (

--- a/common/component/kafka/producer.go
+++ b/common/component/kafka/producer.go
@@ -89,7 +89,7 @@ func (k *Kafka) Publish(_ context.Context, topic string, data []byte, metadata m
 			msg.Key = sarama.StringEncoder(value)
 		case partitionNumberKey:
 			pNum, perr := parsePartitionNumber(value)
-			if err != nil {
+			if perr != nil {
 				return perr
 			}
 			msg.Partition = pNum

--- a/common/component/kafka/producer.go
+++ b/common/component/kafka/producer.go
@@ -88,9 +88,9 @@ func (k *Kafka) Publish(_ context.Context, topic string, data []byte, metadata m
 		case key, keyMetadataKey:
 			msg.Key = sarama.StringEncoder(value)
 		case partitionNumberKey:
-			pNum, err := parsePartitionNumber(value)
+			pNum, perr := parsePartitionNumber(value)
 			if err != nil {
-				return err
+				return perr
 			}
 			msg.Partition = pNum
 		}

--- a/common/component/kafka/producer.go
+++ b/common/component/kafka/producer.go
@@ -18,11 +18,24 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strconv"
 
 	"github.com/IBM/sarama"
 
 	"github.com/dapr/components-contrib/pubsub"
 )
+
+// parsePartitionNumber parses and validates a partition number string.
+func parsePartitionNumber(value string) (int32, error) {
+	pNum, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return -1, fmt.Errorf("invalid partitionNumber metadata value %q: %w", value, err)
+	}
+	if pNum < 0 {
+		return -1, fmt.Errorf("partitionNumber must be non-negative, got %d", pNum)
+	}
+	return int32(pNum), nil
+}
 
 func GetSyncProducer(config sarama.Config, brokers []string, maxMessageBytes int) (sarama.SyncProducer, error) {
 	// Add SyncProducer specific properties to copy of base config
@@ -65,14 +78,21 @@ func (k *Kafka) Publish(_ context.Context, topic string, data []byte, metadata m
 		return err
 	}
 	msg := &sarama.ProducerMessage{
-		Topic: topic,
-		Value: sarama.ByteEncoder(serializedData),
+		Topic:     topic,
+		Value:     sarama.ByteEncoder(serializedData),
+		Partition: -1,
 	}
 
 	for name, value := range metadata {
 		switch name {
 		case key, keyMetadataKey:
 			msg.Key = sarama.StringEncoder(value)
+		case partitionNumberKey:
+			pNum, err := parsePartitionNumber(value)
+			if err != nil {
+				return err
+			}
+			msg.Partition = pNum
 		}
 
 		if msg.Headers == nil {
@@ -119,8 +139,9 @@ func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.Bu
 			return k.mapKafkaProducerErrors(err, entries), err
 		}
 		msg := &sarama.ProducerMessage{
-			Topic: topic,
-			Value: sarama.ByteEncoder(serializedData),
+			Topic:     topic,
+			Value:     sarama.ByteEncoder(serializedData),
+			Partition: -1,
 		}
 		// From Sarama documentation
 		// This field is used to hold arbitrary data you wish to include so it
@@ -141,6 +162,12 @@ func (k *Kafka) BulkPublish(_ context.Context, topic string, entries []pubsub.Bu
 			switch name {
 			case key, keyMetadataKey:
 				msg.Key = sarama.StringEncoder(value)
+			case partitionNumberKey:
+				pNum, err := parsePartitionNumber(value)
+				if err != nil {
+					return pubsub.NewBulkPublishResponse(entries, err), err
+				}
+				msg.Partition = pNum
 			}
 
 			if msg.Headers == nil {

--- a/common/component/kafka/producer_test.go
+++ b/common/component/kafka/producer_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func arrangeKafkaWithAssertions(t *testing.T, msgCheckers ...saramamocks.MessageChecker) *Kafka {
-	mockP := saramamocks.NewSyncProducer(t, saramamocks.NewTestConfig())
+	config := saramamocks.NewTestConfig()
+	config.Producer.Partitioner = newDaprPartitioner
+	mockP := saramamocks.NewSyncProducer(t, config)
 
 	for _, msgChecker := range msgCheckers {
 		mockP.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(msgChecker)
@@ -41,6 +43,15 @@ func getSaramaHeadersFromMetadata(metadata map[string]string) []sarama.RecordHea
 func createMessageAsserter(t *testing.T, expectedKey sarama.Encoder, expectedHeaders map[string]string) saramamocks.MessageChecker {
 	return func(msg *sarama.ProducerMessage) error {
 		require.Equal(t, expectedKey, msg.Key)
+		require.ElementsMatch(t, getSaramaHeadersFromMetadata(expectedHeaders), msg.Headers)
+		return nil
+	}
+}
+
+func createMessageAsserterWithPartition(t *testing.T, expectedKey sarama.Encoder, expectedHeaders map[string]string, expectedPartition int32) saramamocks.MessageChecker {
+	return func(msg *sarama.ProducerMessage) error {
+		require.Equal(t, expectedKey, msg.Key)
+		require.Equal(t, expectedPartition, msg.Partition)
 		require.ElementsMatch(t, getSaramaHeadersFromMetadata(expectedHeaders), msg.Headers)
 		return nil
 	}
@@ -118,6 +129,83 @@ func TestPublish(t *testing.T) {
 
 		// assert
 		require.NoError(t, err)
+	})
+
+	t.Run("produce message with partitionNumber", func(t *testing.T) {
+		// arrange
+		metadata := map[string]string{
+			"a":               "a",
+			"partitionNumber": "3",
+		}
+		messageAsserter := createMessageAsserterWithPartition(t, nil, metadata, 3)
+		k := arrangeKafkaWithAssertions(t, messageAsserter)
+
+		// act
+		err := k.Publish(ctx, "a", []byte("a"), metadata)
+
+		// assert
+		require.NoError(t, err)
+	})
+
+	t.Run("produce message with partitionNumber zero", func(t *testing.T) {
+		// arrange
+		metadata := map[string]string{
+			"partitionNumber": "0",
+		}
+		messageAsserter := createMessageAsserterWithPartition(t, nil, metadata, 0)
+		k := arrangeKafkaWithAssertions(t, messageAsserter)
+
+		// act
+		err := k.Publish(ctx, "a", []byte("a"), metadata)
+
+		// assert
+		require.NoError(t, err)
+	})
+
+	t.Run("produce message with both partitionNumber and partitionKey", func(t *testing.T) {
+		// arrange
+		metadata := map[string]string{
+			"partitionKey":    "key",
+			"partitionNumber": "2",
+		}
+		messageAsserter := createMessageAsserterWithPartition(t, sarama.StringEncoder("key"), metadata, 2)
+		k := arrangeKafkaWithAssertions(t, messageAsserter)
+
+		// act
+		err := k.Publish(ctx, "a", []byte("a"), metadata)
+
+		// assert
+		require.NoError(t, err)
+	})
+
+	t.Run("produce message with invalid partitionNumber returns error", func(t *testing.T) {
+		// arrange
+		metadata := map[string]string{
+			"partitionNumber": "abc",
+		}
+		k := arrangeKafkaWithAssertions(t)
+
+		// act
+		err := k.Publish(ctx, "a", []byte("a"), metadata)
+
+		// assert
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid partitionNumber")
+	})
+
+	t.Run("produce message with negative partitionNumber returns error", func(t *testing.T) {
+		// arrange
+		metadata := map[string]string{
+			"partitionNumber": "-1",
+		}
+		k := arrangeKafkaWithAssertions(t)
+
+		// act
+		err := k.Publish(ctx, "a", []byte("a"), metadata)
+
+		// assert
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-negative")
 	})
 }
 
@@ -242,5 +330,74 @@ func TestBulkPublish(t *testing.T) {
 
 		// assert
 		require.NoError(t, err)
+	})
+
+	t.Run("bulk produce messages with partitionNumber in entry metadata", func(t *testing.T) {
+		// arrange
+		entries := []pubsub.BulkMessageEntry{
+			{
+				EntryId:     "0",
+				Event:       []byte("a"),
+				ContentType: "a",
+				Metadata:    map[string]string{"partitionNumber": "2"},
+			},
+			{
+				EntryId:     "1",
+				Event:       []byte("b"),
+				ContentType: "a",
+				Metadata:    map[string]string{"c": "c"},
+			},
+		}
+		messageAsserters := []saramamocks.MessageChecker{
+			createMessageAsserterWithPartition(t, nil, map[string]string{"partitionNumber": "2", "common": "common"}, 2),
+			createMessageAsserter(t, nil, map[string]string{"c": "c", "common": "common"}),
+		}
+		k := arrangeKafkaWithAssertions(t, messageAsserters...)
+
+		// act
+		_, err := k.BulkPublish(ctx, "a", entries, metadata)
+
+		// assert
+		require.NoError(t, err)
+	})
+
+	t.Run("bulk produce messages with invalid partitionNumber returns error", func(t *testing.T) {
+		// arrange
+		entries := []pubsub.BulkMessageEntry{
+			{
+				EntryId:     "0",
+				Event:       []byte("a"),
+				ContentType: "a",
+				Metadata:    map[string]string{"partitionNumber": "notanumber"},
+			},
+		}
+		k := arrangeKafkaWithAssertions(t)
+
+		// act
+		_, err := k.BulkPublish(ctx, "a", entries, metadata)
+
+		// assert
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid partitionNumber")
+	})
+
+	t.Run("bulk produce messages with negative partitionNumber returns error", func(t *testing.T) {
+		// arrange
+		entries := []pubsub.BulkMessageEntry{
+			{
+				EntryId:     "0",
+				Event:       []byte("a"),
+				ContentType: "a",
+				Metadata:    map[string]string{"partitionNumber": "-5"},
+			},
+		}
+		k := arrangeKafkaWithAssertions(t)
+
+		// act
+		_, err := k.BulkPublish(ctx, "a", entries, metadata)
+
+		// assert
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-negative")
 	})
 }

--- a/tests/certification/pubsub/kafka/kafka_test.go
+++ b/tests/certification/pubsub/kafka/kafka_test.go
@@ -251,6 +251,41 @@ func TestKafka(t *testing.T) {
 		}
 	}
 
+	// Test logic that sends messages to a specific partition number
+	// and verifies in-order delivery on that partition.
+	sendRecvPartitionNumberTest := func(watchers ...*watcher.Watcher) flow.Runnable {
+		return func(ctx flow.Context) error {
+			client := sidecar.GetClient(ctx, sidecarName1)
+
+			msgs := make([]string, numMessages)
+			for i := range msgs {
+				msgs[i] = fmt.Sprintf("Hello, PartitionNumber %03d", i)
+			}
+			for _, m := range watchers {
+				m.ExpectStrings(msgs...)
+			}
+
+			// Send all messages to partition 3 using partitionNumber metadata.
+			md := map[string]string{
+				"partitionNumber": "3",
+			}
+
+			ctx.Log("Sending messages with partitionNumber!")
+			for _, msg := range msgs {
+				err := client.PublishEvent(
+					ctx, pubsubName, topicName, msg,
+					dapr.PublishEventWithMetadata(md))
+				require.NoError(ctx, err, "error publishing message")
+			}
+
+			for _, m := range watchers {
+				m.Assert(ctx, time.Minute)
+			}
+
+			return nil
+		}
+	}
+
 	// sendMessagesInBackground and assertMessages are
 	// Runnables for testing publishing and consuming
 	// messages reliably when infrastructure and network
@@ -378,6 +413,12 @@ func TestKafka(t *testing.T) {
 		// Send messages using the same metadata/message key so we can expect
 		// in-order processing.
 		Step("send and wait(in-order)", sendRecvTest(metadata, consumerGroup1, consumerGroup2)).
+		Step("reset consumerGroup1 for partition number test", flow.Reset(consumerGroup1)).
+		Step("reset consumerGroup2 for partition number test", flow.Reset(consumerGroup2)).
+		//
+		// Send messages using partitionNumber metadata to target a specific
+		// partition directly. Messages to the same partition should be in-order.
+		Step("send and wait(partitionNumber in-order)", sendRecvPartitionNumberTest(consumerGroup1, consumerGroup2)).
 		// Run the avro consumer
 		Step(app.Run(appIDAvro, fmt.Sprintf(":%d", appPort+portOffset*3),
 			applicationAvro(appIDAvro, consumerGroupAvro))).


### PR DESCRIPTION
Allow publishers to target specific Kafka partitions directly via per-message "partitionNumber" metadata, bypassing hash-based partition assignment from "partitionKey".

Priority: `partitionNumber` > `partitionKey` > `default` (round-robin). Invalid or negative values return an error before sending.

A custom daprPartitioner wraps Sarama's hash partitioner to support both explicit partition selection (msg.Partition >= 0) and hash-based fallback (msg.Partition < 0) on the same producer.

Fixes dapr/components-contrib#3860