### PR TITLE
bindings/azure/blobstorage: Adds presign

### DIFF
--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -225,6 +225,17 @@ func (a *AzureBlobStorage) create(ctx context.Context, req *bindings.InvokeReque
 		blobName = id.String()
 	}
 
+	// Extract and validate signTTL before upload so we fail fast and don't
+	// persist it as blob metadata.
+	var signTTL string
+	if ttl, ok := req.Metadata[metadataKeySignTTL]; ok && ttl != "" {
+		if _, err := time.ParseDuration(ttl); err != nil {
+			return nil, fmt.Errorf("cannot parse signTTL duration %q: %w", ttl, err)
+		}
+		signTTL = ttl
+		delete(req.Metadata, metadataKeySignTTL)
+	}
+
 	blobHTTPHeaders, err := storagecommon.CreateBlobHTTPHeadersFromRequest(req.Metadata, nil, a.logger)
 	if err != nil {
 		return nil, err
@@ -256,11 +267,12 @@ func (a *AzureBlobStorage) create(ctx context.Context, req *bindings.InvokeReque
 	}
 
 	resp := createResponse{
-		BlobURL: blockBlobClient.URL(),
+		BlobURL:  blockBlobClient.URL(),
+		BlobName: blobName,
 	}
 
-	if ttl, ok := req.Metadata[metadataKeySignTTL]; ok && ttl != "" {
-		presignURL, presignErr := a.generateSASURL(blockBlobClient, ttl)
+	if signTTL != "" {
+		presignURL, presignErr := a.generateSASURL(blockBlobClient, signTTL)
 		if presignErr != nil {
 			return nil, fmt.Errorf("error generating SAS URL: %w", presignErr)
 		}
@@ -971,6 +983,9 @@ func (a *AzureBlobStorage) generateSASURL(blockBlobClient *blockblob.Client, ttl
 	d, err := time.ParseDuration(ttl)
 	if err != nil {
 		return "", fmt.Errorf("cannot parse signTTL duration %q: %w", ttl, err)
+	}
+	if d <= 0 {
+		return "", fmt.Errorf("signTTL must be a positive duration, got %q", ttl)
 	}
 
 	permissions := sas.BlobPermissions{Read: true}

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
@@ -64,12 +66,15 @@ const (
 	// Specifies the maximum number of blobs to return, including all BlobPrefix elements. If the request does not
 	// specify maxresults the server will return up to 5,000 items.
 	// See: https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs#uri-parameters
-	maxResults  int32 = 5000
-	endpointKey       = "endpoint"
+	// Defines the TTL for a presigned (SAS) URL as a Go duration string (e.g. "15m", "1h").
+	metadataKeySignTTL       = "signTTL"
+	maxResults         int32 = 5000
+	endpointKey              = "endpoint"
 
 	bulkGetOperation    bindings.OperationKind = "bulkGet"
 	bulkCreateOperation bindings.OperationKind = "bulkCreate"
 	bulkDeleteOperation bindings.OperationKind = "bulkDelete"
+	presignOperation    bindings.OperationKind = "presign"
 
 	metadataKeyFilePath = "filePath"
 
@@ -79,7 +84,10 @@ const (
 	maxBatchDeleteSize = 256
 )
 
-var ErrMissingBlobName = errors.New("blobName is a required attribute")
+var (
+	ErrMissingBlobName = errors.New("blobName is a required attribute")
+	ErrMissingSignTTL  = errors.New("signTTL is a required attribute for presign operations")
+)
 
 // AzureBlobStorage allows saving blobs to an Azure Blob Storage account.
 type AzureBlobStorage struct {
@@ -90,8 +98,13 @@ type AzureBlobStorage struct {
 }
 
 type createResponse struct {
-	BlobURL  string `json:"blobURL"`
-	BlobName string `json:"blobName"`
+	BlobURL    string `json:"blobURL"`
+	BlobName   string `json:"blobName"`
+	PresignURL string `json:"presignURL,omitempty"`
+}
+
+type presignResponse struct {
+	PresignURL string `json:"presignURL"`
 }
 
 type listInclude struct {
@@ -195,6 +208,7 @@ func (a *AzureBlobStorage) Operations() []bindings.OperationKind {
 		bulkGetOperation,
 		bulkCreateOperation,
 		bulkDeleteOperation,
+		presignOperation,
 	}
 }
 
@@ -244,6 +258,15 @@ func (a *AzureBlobStorage) create(ctx context.Context, req *bindings.InvokeReque
 	resp := createResponse{
 		BlobURL: blockBlobClient.URL(),
 	}
+
+	if ttl, ok := req.Metadata[metadataKeySignTTL]; ok && ttl != "" {
+		presignURL, presignErr := a.generateSASURL(blockBlobClient, ttl)
+		if presignErr != nil {
+			return nil, fmt.Errorf("error generating SAS URL: %w", presignErr)
+		}
+		resp.PresignURL = presignURL
+	}
+
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling create response for azure blob: %w", err)
@@ -603,6 +626,35 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 	}, nil
 }
 
+func (a *AzureBlobStorage) presign(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	blobName, ok := req.Metadata[metadataKeyBlobName]
+	if !ok || blobName == "" {
+		return nil, ErrMissingBlobName
+	}
+
+	ttl, ok := req.Metadata[metadataKeySignTTL]
+	if !ok || ttl == "" {
+		return nil, ErrMissingSignTTL
+	}
+
+	blockBlobClient := a.containerClient.NewBlockBlobClient(blobName)
+	presignURL, err := a.generateSASURL(blockBlobClient, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("error generating SAS URL: %w", err)
+	}
+
+	jsonResponse, err := json.Marshal(presignResponse{
+		PresignURL: presignURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling presign response: %w", err)
+	}
+
+	return &bindings.InvokeResponse{
+		Data: jsonResponse,
+	}, nil
+}
+
 // resolveBulkGetItems builds the work list for bulkGet.
 // Explicit items are preserved as-is (including duplicates with different filePaths).
 // Prefix-discovered blobs use destinationDir as base, skipping any already covered by explicit items.
@@ -915,6 +967,23 @@ func (a *AzureBlobStorage) bulkDeleteBatch(ctx context.Context, names []string, 
 	return len(names), nil
 }
 
+func (a *AzureBlobStorage) generateSASURL(blockBlobClient *blockblob.Client, ttl string) (string, error) {
+	d, err := time.ParseDuration(ttl)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse signTTL duration %q: %w", ttl, err)
+	}
+
+	permissions := sas.BlobPermissions{Read: true}
+	expiry := time.Now().Add(d)
+
+	sasURL, err := blockBlobClient.GetSASURL(permissions, expiry, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate SAS URL (ensure the binding is configured with an account key or connection string): %w", err)
+	}
+
+	return sasURL, nil
+}
+
 func (a *AzureBlobStorage) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	switch req.Operation {
 	case bindings.CreateOperation:
@@ -931,6 +1000,8 @@ func (a *AzureBlobStorage) Invoke(ctx context.Context, req *bindings.InvokeReque
 		return a.bulkCreate(ctx, req)
 	case bulkDeleteOperation:
 		return a.bulkDelete(ctx, req)
+	case presignOperation:
+		return a.presign(ctx, req)
 	default:
 		return nil, fmt.Errorf("unsupported operation %s", req.Operation)
 	}

--- a/bindings/azure/blobstorage/blobstorage.go
+++ b/bindings/azure/blobstorage/blobstorage.go
@@ -216,7 +216,6 @@ func (a *AzureBlobStorage) create(ctx context.Context, req *bindings.InvokeReque
 	var blobName string
 	if val, ok := req.Metadata[metadataKeyBlobName]; ok && val != "" {
 		blobName = val
-		delete(req.Metadata, metadataKeyBlobName)
 	} else {
 		id, err := uuid.NewRandom()
 		if err != nil {
@@ -225,18 +224,19 @@ func (a *AzureBlobStorage) create(ctx context.Context, req *bindings.InvokeReque
 		blobName = id.String()
 	}
 
-	// Extract and validate signTTL before upload so we fail fast and don't
-	// persist it as blob metadata.
-	var signTTL string
-	if ttl, ok := req.Metadata[metadataKeySignTTL]; ok && ttl != "" {
-		if _, err := time.ParseDuration(ttl); err != nil {
-			return nil, fmt.Errorf("cannot parse signTTL duration %q: %w", ttl, err)
+	// Extract signTTL before upload so we can fail fast and avoid persisting
+	// it as blob metadata. We copy metadata rather than mutating the request.
+	signTTL := req.Metadata[metadataKeySignTTL]
+
+	uploadMetadata := make(map[string]string, len(req.Metadata))
+	for k, v := range req.Metadata {
+		if k == metadataKeySignTTL || k == metadataKeyBlobName {
+			continue
 		}
-		signTTL = ttl
-		delete(req.Metadata, metadataKeySignTTL)
+		uploadMetadata[k] = v
 	}
 
-	blobHTTPHeaders, err := storagecommon.CreateBlobHTTPHeadersFromRequest(req.Metadata, nil, a.logger)
+	blobHTTPHeaders, err := storagecommon.CreateBlobHTTPHeadersFromRequest(uploadMetadata, nil, a.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -254,29 +254,33 @@ func (a *AzureBlobStorage) create(ctx context.Context, req *bindings.InvokeReque
 		req.Data = decoded
 	}
 
+	blockBlobClient := a.containerClient.NewBlockBlobClient(blobName)
+
+	// Generate the SAS URL before uploading so we don't leave an orphaned
+	// blob if SAS generation fails.
+	var presignURL string
+	if signTTL != "" {
+		presignURL, err = a.generateSASURL(blockBlobClient, signTTL)
+		if err != nil {
+			return nil, fmt.Errorf("error generating SAS URL: %w", err)
+		}
+	}
+
 	uploadOptions := azblob.UploadBufferOptions{
-		Metadata:                storagecommon.SanitizeMetadata(a.logger, req.Metadata),
+		Metadata:                storagecommon.SanitizeMetadata(a.logger, uploadMetadata),
 		HTTPHeaders:             &blobHTTPHeaders,
 		TransactionalContentMD5: blobHTTPHeaders.BlobContentMD5,
 	}
 
-	blockBlobClient := a.containerClient.NewBlockBlobClient(blobName)
 	_, err = blockBlobClient.UploadBuffer(ctx, req.Data, &uploadOptions)
 	if err != nil {
 		return nil, fmt.Errorf("error uploading az blob: %w", err)
 	}
 
 	resp := createResponse{
-		BlobURL:  blockBlobClient.URL(),
-		BlobName: blobName,
-	}
-
-	if signTTL != "" {
-		presignURL, presignErr := a.generateSASURL(blockBlobClient, signTTL)
-		if presignErr != nil {
-			return nil, fmt.Errorf("error generating SAS URL: %w", presignErr)
-		}
-		resp.PresignURL = presignURL
+		BlobURL:    blockBlobClient.URL(),
+		BlobName:   blobName,
+		PresignURL: presignURL,
 	}
 
 	b, err := json.Marshal(resp)
@@ -638,7 +642,7 @@ func (a *AzureBlobStorage) bulkGet(ctx context.Context, req *bindings.InvokeRequ
 	}, nil
 }
 
-func (a *AzureBlobStorage) presign(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+func (a *AzureBlobStorage) presign(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
 	blobName, ok := req.Metadata[metadataKeyBlobName]
 	if !ok || blobName == "" {
 		return nil, ErrMissingBlobName
@@ -1016,7 +1020,7 @@ func (a *AzureBlobStorage) Invoke(ctx context.Context, req *bindings.InvokeReque
 	case bulkDeleteOperation:
 		return a.bulkDelete(ctx, req)
 	case presignOperation:
-		return a.presign(ctx, req)
+		return a.presign(req)
 	default:
 		return nil, fmt.Errorf("unsupported operation %s", req.Operation)
 	}

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -535,4 +537,176 @@ func TestBulkGetResponseItemJSON(t *testing.T) {
 
 func TestMaxBatchDeleteSize(t *testing.T) {
 	assert.Equal(t, 256, maxBatchDeleteSize)
+}
+
+func TestPresignOption(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	t.Run("return error if blobName is missing", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Metadata: map[string]string{
+				"signTTL": "15m",
+			},
+		}
+		_, err := blobStorage.presign(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingBlobName)
+	})
+
+	t.Run("return error if signTTL is missing", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Metadata: map[string]string{
+				"blobName": "test-blob",
+			},
+		}
+		_, err := blobStorage.presign(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingSignTTL)
+	})
+
+	t.Run("return error if signTTL is empty", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Metadata: map[string]string{
+				"blobName": "test-blob",
+				"signTTL":  "",
+			},
+		}
+		_, err := blobStorage.presign(t.Context(), &r)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingSignTTL)
+	})
+
+	t.Run("return error if signTTL is invalid duration", func(t *testing.T) {
+		// Need a container client for this test path (past metadata validation)
+		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+		require.NoError(t, err)
+		client, err := container.NewClientWithSharedKeyCredential(
+			"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+		)
+		require.NoError(t, err)
+		blobStorage.containerClient = client
+
+		r := bindings.InvokeRequest{
+			Metadata: map[string]string{
+				"blobName": "test-blob",
+				"signTTL":  "not-a-duration",
+			},
+		}
+		_, err = blobStorage.presign(t.Context(), &r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot parse signTTL duration")
+	})
+
+	t.Run("generate SAS URL with valid shared key credential", func(t *testing.T) {
+		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+		require.NoError(t, err)
+		client, err := container.NewClientWithSharedKeyCredential(
+			"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+		)
+		require.NoError(t, err)
+		blobStorage.containerClient = client
+
+		r := bindings.InvokeRequest{
+			Metadata: map[string]string{
+				"blobName": "test-blob",
+				"signTTL":  "15m",
+			},
+		}
+		resp, err := blobStorage.presign(t.Context(), &r)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		var presignResp presignResponse
+		err = json.Unmarshal(resp.Data, &presignResp)
+		require.NoError(t, err)
+		assert.Contains(t, presignResp.PresignURL, "testaccount.blob.core.windows.net")
+		assert.Contains(t, presignResp.PresignURL, "testcontainer")
+		assert.Contains(t, presignResp.PresignURL, "test-blob")
+		assert.Contains(t, presignResp.PresignURL, "sig=")
+		assert.Contains(t, presignResp.PresignURL, "se=")
+		assert.Contains(t, presignResp.PresignURL, "sp=r")
+	})
+}
+
+func TestPresignViaInvoke(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+	require.NoError(t, err)
+	client, err := container.NewClientWithSharedKeyCredential(
+		"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+	)
+	require.NoError(t, err)
+	blobStorage.containerClient = client
+
+	t.Run("invoke presign operation", func(t *testing.T) {
+		r := bindings.InvokeRequest{
+			Operation: presignOperation,
+			Metadata: map[string]string{
+				"blobName": "test-blob",
+				"signTTL":  "1h",
+			},
+		}
+		resp, err := blobStorage.Invoke(t.Context(), &r)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		var presignResp presignResponse
+		err = json.Unmarshal(resp.Data, &presignResp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, presignResp.PresignURL)
+		assert.Contains(t, presignResp.PresignURL, "sig=")
+	})
+}
+
+func TestGenerateSASURL(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+
+	t.Run("return error for invalid TTL", func(t *testing.T) {
+		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+		require.NoError(t, err)
+		client, err := container.NewClientWithSharedKeyCredential(
+			"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+		)
+		require.NoError(t, err)
+		blobStorage.containerClient = client
+
+		blockBlobClient := client.NewBlockBlobClient("test-blob")
+		_, err = blobStorage.generateSASURL(blockBlobClient, "invalid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot parse signTTL duration")
+	})
+
+	t.Run("generate valid SAS URL", func(t *testing.T) {
+		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+		require.NoError(t, err)
+		client, err := container.NewClientWithSharedKeyCredential(
+			"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+		)
+		require.NoError(t, err)
+		blobStorage.containerClient = client
+
+		blockBlobClient := client.NewBlockBlobClient("myfile.txt")
+		sasURL, err := blobStorage.generateSASURL(blockBlobClient, "30m")
+		require.NoError(t, err)
+		assert.Contains(t, sasURL, "testaccount.blob.core.windows.net")
+		assert.Contains(t, sasURL, "testcontainer")
+		assert.Contains(t, sasURL, "myfile.txt")
+		assert.Contains(t, sasURL, "sig=")
+		assert.Contains(t, sasURL, "sp=r")
+	})
+}
+
+func TestOperationsIncludesPresign(t *testing.T) {
+	blobStorage := NewAzureBlobStorage(logger.NewLogger("test")).(*AzureBlobStorage)
+	ops := blobStorage.Operations()
+
+	found := false
+	for _, op := range ops {
+		if op == presignOperation {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Operations() should include presign")
 }

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -677,6 +677,36 @@ func TestGenerateSASURL(t *testing.T) {
 		require.Contains(t, err.Error(), "cannot parse signTTL duration")
 	})
 
+	t.Run("return error for zero TTL", func(t *testing.T) {
+		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+		require.NoError(t, err)
+		client, err := container.NewClientWithSharedKeyCredential(
+			"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+		)
+		require.NoError(t, err)
+		blobStorage.containerClient = client
+
+		blockBlobClient := client.NewBlockBlobClient("test-blob")
+		_, err = blobStorage.generateSASURL(blockBlobClient, "0s")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signTTL must be a positive duration")
+	})
+
+	t.Run("return error for negative TTL", func(t *testing.T) {
+		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
+		require.NoError(t, err)
+		client, err := container.NewClientWithSharedKeyCredential(
+			"https://testaccount.blob.core.windows.net/testcontainer", cred, nil,
+		)
+		require.NoError(t, err)
+		blobStorage.containerClient = client
+
+		blockBlobClient := client.NewBlockBlobClient("test-blob")
+		_, err = blobStorage.generateSASURL(blockBlobClient, "-5m")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signTTL must be a positive duration")
+	})
+
 	t.Run("generate valid SAS URL", func(t *testing.T) {
 		cred, err := azblob.NewSharedKeyCredential("testaccount", "dGVzdGtleQ==")
 		require.NoError(t, err)

--- a/bindings/azure/blobstorage/blobstorage_test.go
+++ b/bindings/azure/blobstorage/blobstorage_test.go
@@ -548,7 +548,7 @@ func TestPresignOption(t *testing.T) {
 				"signTTL": "15m",
 			},
 		}
-		_, err := blobStorage.presign(t.Context(), &r)
+		_, err := blobStorage.presign(&r)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrMissingBlobName)
 	})
@@ -559,7 +559,7 @@ func TestPresignOption(t *testing.T) {
 				"blobName": "test-blob",
 			},
 		}
-		_, err := blobStorage.presign(t.Context(), &r)
+		_, err := blobStorage.presign(&r)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrMissingSignTTL)
 	})
@@ -571,7 +571,7 @@ func TestPresignOption(t *testing.T) {
 				"signTTL":  "",
 			},
 		}
-		_, err := blobStorage.presign(t.Context(), &r)
+		_, err := blobStorage.presign(&r)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrMissingSignTTL)
 	})
@@ -592,7 +592,7 @@ func TestPresignOption(t *testing.T) {
 				"signTTL":  "not-a-duration",
 			},
 		}
-		_, err = blobStorage.presign(t.Context(), &r)
+		_, err = blobStorage.presign(&r)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot parse signTTL duration")
 	})
@@ -612,7 +612,7 @@ func TestPresignOption(t *testing.T) {
 				"signTTL":  "15m",
 			},
 		}
-		resp, err := blobStorage.presign(t.Context(), &r)
+		resp, err := blobStorage.presign(&r)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 

--- a/bindings/azure/blobstorage/metadata.yaml
+++ b/bindings/azure/blobstorage/metadata.yaml
@@ -25,6 +25,8 @@ binding:
       description: "Upload multiple blobs in parallel"
     - name: bulkDelete
       description: "Delete multiple blobs in parallel"
+    - name: presign
+      description: "Generate a presigned SAS URL for a blob. Requires 'blobName' and 'signTTL' metadata. Only supported when the binding is configured with an account key or connection string."
 capabilities: []
 builtinAuthenticationProfiles:
   - name: "azuread"

--- a/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
+++ b/tests/certification/bindings/azure/blobstorage/blobstorage_test.go
@@ -563,6 +563,157 @@ func TestBlobStorage(t *testing.T) {
 		return nil
 	}
 
+	testPresignBlob := func(ctx flow.Context) error {
+		// verifies the presign operation generates a valid SAS URL that can be used to access a blob.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// create a blob first.
+		input := "presign test content"
+		dataBytes := []byte(input)
+
+		invokeCreateRequest := &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "create",
+			Data:      dataBytes,
+			Metadata: map[string]string{
+				"blobName":    "presign-test.txt",
+				"contentType": "text/plain",
+			},
+		}
+
+		_, invokeCreateErr := client.InvokeBinding(ctx, invokeCreateRequest)
+		require.NoError(t, invokeCreateErr)
+
+		// presign the blob.
+		invokePresignRequest := &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "presign",
+			Data:      nil,
+			Metadata: map[string]string{
+				"blobName": "presign-test.txt",
+				"signTTL":  "15m",
+			},
+		}
+
+		out, invokePresignErr := client.InvokeBinding(ctx, invokePresignRequest)
+		require.NoError(t, invokePresignErr)
+
+		var presignResp struct {
+			PresignURL string `json:"presignURL"`
+		}
+		unmarshalErr := json.Unmarshal(out.Data, &presignResp)
+		require.NoError(t, unmarshalErr)
+		assert.NotEmpty(t, presignResp.PresignURL)
+		assert.Contains(t, presignResp.PresignURL, "sig=")
+		assert.Contains(t, presignResp.PresignURL, "se=")
+		assert.Contains(t, presignResp.PresignURL, "sp=r")
+
+		// verify the SAS URL can be used to access the blob via HTTP GET.
+		resp, httpErr := http.Get(presignResp.PresignURL) //nolint:gosec
+		require.NoError(t, httpErr)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, input, string(body))
+
+		// cleanup.
+		_, invokeDeleteErr := deleteBlobRequest(ctx, client, "presign-test.txt", nil)
+		require.NoError(t, invokeDeleteErr)
+
+		return nil
+	}
+
+	testPresignBlobErrors := func(ctx flow.Context) error {
+		// verifies the presign operation returns errors for missing metadata.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		// missing blobName.
+		invokePresignNoBlobName := &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "presign",
+			Data:      nil,
+			Metadata: map[string]string{
+				"signTTL": "15m",
+			},
+		}
+		_, err := client.InvokeBinding(ctx, invokePresignNoBlobName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blobName is a required attribute")
+
+		// missing signTTL.
+		invokePresignNoTTL := &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "presign",
+			Data:      nil,
+			Metadata: map[string]string{
+				"blobName": "nonexistent.txt",
+			},
+		}
+		_, err = client.InvokeBinding(ctx, invokePresignNoTTL)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "signTTL is a required attribute")
+
+		return nil
+	}
+
+	testCreateWithPresign := func(ctx flow.Context) error {
+		// verifies that passing signTTL during create returns a presigned URL in the response.
+		client, clientErr := daprsdk.NewClientWithPort(fmt.Sprint(currentGRPCPort))
+		if clientErr != nil {
+			panic(clientErr)
+		}
+		defer client.Close()
+
+		input := "create with presign content"
+		dataBytes := []byte(input)
+
+		invokeCreateRequest := &daprsdk.InvokeBindingRequest{
+			Name:      "azure-blobstorage-output",
+			Operation: "create",
+			Data:      dataBytes,
+			Metadata: map[string]string{
+				"blobName":    "create-presign-test.txt",
+				"contentType": "text/plain",
+				"signTTL":     "15m",
+			},
+		}
+
+		out, invokeCreateErr := client.InvokeBinding(ctx, invokeCreateRequest)
+		require.NoError(t, invokeCreateErr)
+
+		var createResp struct {
+			BlobURL    string `json:"blobURL"`
+			PresignURL string `json:"presignURL"`
+		}
+		unmarshalErr := json.Unmarshal(out.Data, &createResp)
+		require.NoError(t, unmarshalErr)
+		assert.NotEmpty(t, createResp.BlobURL)
+		assert.NotEmpty(t, createResp.PresignURL)
+		assert.Contains(t, createResp.PresignURL, "sig=")
+
+		// verify the SAS URL works.
+		resp, httpErr := http.Get(createResp.PresignURL) //nolint:gosec
+		require.NoError(t, httpErr)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, input, string(body))
+
+		// cleanup.
+		_, invokeDeleteErr := deleteBlobRequest(ctx, client, "create-presign-test.txt", nil)
+		require.NoError(t, invokeDeleteErr)
+
+		return nil
+	}
+
 	testSnapshotDeleteAndList := func(ctx flow.Context) error {
 		// verifies the list operation can list snapshots.
 		// verifies the delete operation can delete snapshots.
@@ -1241,6 +1392,9 @@ func TestBlobStorage(t *testing.T) {
 		Step("Bulk create with inline data", testBulkCreateInlineData).
 		Step("Bulk get inline data", testBulkGetInlineData).
 		Step("Bulk create with content type", testBulkCreateWithContentType).
+		Step("Presign blob and verify SAS URL", testPresignBlob).
+		Step("Presign blob error cases", testPresignBlobErrors).
+		Step("Create blob with presign URL", testCreateWithPresign).
 		Run()
 
 	ports, err = dapr_testing.GetFreePorts(2)


### PR DESCRIPTION
Add SAS URL generation support to the Azure Blob Storage binding, enabling users to generate temporary read-only access URLs for blobs without downloading the blob content.

Add new "presign" operation requiring "blobName" and "signTTL" metadata. Optionally return a presigned SAS URL during "create" when "signTTL" is provided in request metadata.

Fixes #3817