### PR TITLE
feat(pubsub/pulsar): register CloudEvents envelope Avro schema with Pulsar Schema Registry

### DIFF
--- a/pubsub/pulsar/cloudevents_schema.go
+++ b/pubsub/pulsar/cloudevents_schema.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pulsar
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Avro schema structs with deterministic JSON field ordering.
+// Using structs instead of maps guarantees consistent json.Marshal output
+// across process restarts, preventing spurious schema version bumps in the
+// Pulsar Schema Registry (which hashes raw schema bytes for versioning).
+
+type avroRecordSchema struct {
+	Type      string        `json:"type"`
+	Name      string        `json:"name"`
+	Namespace string        `json:"namespace"`
+	Fields    []interface{} `json:"fields"`
+}
+
+type avroRequiredField struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type avroNullableField struct {
+	Name    string `json:"name"`
+	Type    [2]any `json:"type"`
+	Default any    `json:"default"` // nil any marshals to JSON null
+}
+
+// wrapInCloudEventsAvroSchema takes a user-provided inner Avro schema JSON string
+// and returns a CloudEvents envelope Avro schema with the inner schema embedded
+// as the "data" field type. This ensures the Pulsar Schema Registry entry matches
+// the actual wire format when Dapr wraps payloads in CloudEvents envelopes.
+//
+// The generated schema follows the CloudEvents Avro format specification:
+// https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/avro-format.md
+func wrapInCloudEventsAvroSchema(innerSchemaJSON string) (string, error) {
+	var innerSchema interface{}
+	if err := json.Unmarshal([]byte(innerSchemaJSON), &innerSchema); err != nil {
+		return "", fmt.Errorf("failed to parse inner Avro schema: %w", err)
+	}
+
+	nullStr := [2]any{"null", "string"}
+
+	envelope := avroRecordSchema{
+		Type:      "record",
+		Name:      "CloudEvent",
+		Namespace: "io.cloudevents",
+		Fields: []interface{}{
+			avroRequiredField{Name: "id", Type: "string"},
+			avroRequiredField{Name: "source", Type: "string"},
+			avroRequiredField{Name: "specversion", Type: "string"},
+			avroRequiredField{Name: "type", Type: "string"},
+			avroNullableField{Name: "datacontenttype", Type: nullStr},
+			avroNullableField{Name: "subject", Type: nullStr},
+			avroNullableField{Name: "time", Type: nullStr},
+			avroNullableField{Name: "topic", Type: nullStr},
+			avroNullableField{Name: "pubsubname", Type: nullStr},
+			avroNullableField{Name: "traceid", Type: nullStr},
+			avroNullableField{Name: "traceparent", Type: nullStr},
+			avroNullableField{Name: "tracestate", Type: nullStr},
+			avroNullableField{Name: "expiration", Type: nullStr},
+			avroNullableField{Name: "data", Type: [2]any{"null", innerSchema}},
+			avroNullableField{Name: "data_base64", Type: nullStr},
+		},
+	}
+
+	result, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal CloudEvents envelope schema: %w", err)
+	}
+
+	return string(result), nil
+}
+
+// normalizeCloudEventForAvro takes a Dapr-produced CE envelope JSON and parses
+// the stringified "data" field into a proper JSON object so goavro can encode it
+// against the inner Avro record type.
+//
+// Dapr produces: {"data": "{\"testId\":0}", ...}
+// goavro expects: {"data": {"testId":0}, ...}
+//
+// Uses json.RawMessage to avoid parsing/re-serialising the other ~15 CE fields.
+func normalizeCloudEventForAvro(ceJSON []byte) ([]byte, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(ceJSON, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse CloudEvents envelope: %w", err)
+	}
+
+	dataRaw := raw["data"]
+	if len(dataRaw) == 0 || dataRaw[0] != '"' {
+		// data is null, an object, or absent — no normalization needed.
+		return ceJSON, nil
+	}
+
+	// data is a JSON string — unquote to get the inner JSON bytes.
+	var innerStr string
+	if err := json.Unmarshal(dataRaw, &innerStr); err != nil {
+		return nil, fmt.Errorf("failed to unquote stringified data field: %w", err)
+	}
+
+	// Validate the inner JSON is well-formed before embedding it.
+	if !json.Valid([]byte(innerStr)) {
+		return nil, fmt.Errorf("data field contains invalid JSON: %s", innerStr)
+	}
+
+	raw["data"] = json.RawMessage(innerStr)
+
+	return json.Marshal(raw)
+}

--- a/pubsub/pulsar/cloudevents_schema_test.go
+++ b/pubsub/pulsar/cloudevents_schema_test.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pulsar
+
+import (
+	"encoding/json"
+	"testing"
+
+	goavro "github.com/linkedin/goavro/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapInCloudEventsAvroSchema(t *testing.T) {
+	innerSchema := `{
+		"type": "record",
+		"name": "OrderEvent",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "orderId", "type": "string"},
+			{"name": "amount", "type": "double"}
+		]
+	}`
+
+	t.Run("generates valid Avro schema", func(t *testing.T) {
+		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		require.NoError(t, err)
+
+		// Must compile as a valid Avro schema
+		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+		require.NoError(t, err)
+		assert.NotNil(t, codec)
+	})
+
+	t.Run("contains all CloudEvents required fields", func(t *testing.T) {
+		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		require.NoError(t, err)
+
+		var schema map[string]interface{}
+		err = json.Unmarshal([]byte(ceSchema), &schema)
+		require.NoError(t, err)
+
+		assert.Equal(t, "CloudEvent", schema["name"])
+		assert.Equal(t, "io.cloudevents", schema["namespace"])
+
+		fields := schema["fields"].([]interface{})
+		fieldNames := make([]string, len(fields))
+		for i, f := range fields {
+			fieldNames[i] = f.(map[string]interface{})["name"].(string)
+		}
+
+		// Required CE attributes
+		assert.Contains(t, fieldNames, "id")
+		assert.Contains(t, fieldNames, "source")
+		assert.Contains(t, fieldNames, "specversion")
+		assert.Contains(t, fieldNames, "type")
+		// Optional CE attributes
+		assert.Contains(t, fieldNames, "datacontenttype")
+		assert.Contains(t, fieldNames, "subject")
+		assert.Contains(t, fieldNames, "time")
+		// Dapr extension attributes
+		assert.Contains(t, fieldNames, "topic")
+		assert.Contains(t, fieldNames, "pubsubname")
+		assert.Contains(t, fieldNames, "traceid")
+		assert.Contains(t, fieldNames, "traceparent")
+		assert.Contains(t, fieldNames, "tracestate")
+		// Data field
+		assert.Contains(t, fieldNames, "data")
+	})
+
+	t.Run("validates a full CloudEvents envelope", func(t *testing.T) {
+		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		require.NoError(t, err)
+
+		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+		require.NoError(t, err)
+
+		// Standard JSON encoding: union values are plain values, not {"type": value}
+		ceJSON := `{
+			"id": "abc-123",
+			"source": "Dapr",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": "application/json",
+			"subject": null,
+			"time": "2026-03-20T10:00:00Z",
+			"topic": "orders",
+			"pubsubname": "mypubsub",
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": {"orderId": "order-1", "amount": 99.99},
+			"data_base64": null
+		}`
+
+		native, _, err := codec.NativeFromTextual([]byte(ceJSON))
+		require.NoError(t, err)
+		assert.NotNil(t, native)
+	})
+
+	t.Run("rejects envelope missing required CE field", func(t *testing.T) {
+		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		require.NoError(t, err)
+
+		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+		require.NoError(t, err)
+
+		// Missing "source" field
+		ceJSON := `{
+			"id": "abc-123",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": null,
+			"subject": null,
+			"time": null,
+			"topic": null,
+			"pubsubname": null,
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": null,
+			"data_base64": null
+		}`
+
+		_, _, err = codec.NativeFromTextual([]byte(ceJSON))
+		require.Error(t, err)
+	})
+
+	t.Run("validates envelope with null data", func(t *testing.T) {
+		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		require.NoError(t, err)
+
+		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+		require.NoError(t, err)
+
+		ceJSON := `{
+			"id": "abc-123",
+			"source": "Dapr",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": null,
+			"subject": null,
+			"time": null,
+			"topic": null,
+			"pubsubname": null,
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": null,
+			"data_base64": null
+		}`
+
+		native, _, err := codec.NativeFromTextual([]byte(ceJSON))
+		require.NoError(t, err)
+		assert.NotNil(t, native)
+	})
+}
+
+func TestWrapInCloudEventsAvroSchema_NestedRecord(t *testing.T) {
+	innerSchema := `{
+		"type": "record",
+		"name": "Enrollment",
+		"namespace": "test",
+		"fields": [
+			{"name": "id", "type": "int"},
+			{"name": "student", "type": {
+				"type": "record",
+				"name": "Student",
+				"fields": [
+					{"name": "name", "type": "string"},
+					{"name": "age", "type": "int"}
+				]
+			}}
+		]
+	}`
+
+	ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+	require.NoError(t, err)
+
+	codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+	require.NoError(t, err)
+
+	ceJSON := `{
+		"id": "evt-1",
+		"source": "Dapr",
+		"specversion": "1.0",
+		"type": "com.dapr.event.sent",
+		"datacontenttype": null,
+		"subject": null,
+		"time": null,
+		"topic": null,
+		"pubsubname": null,
+		"traceid": null,
+		"traceparent": null,
+		"tracestate": null,
+		"expiration": null,
+		"data": {"id": 1, "student": {"name": "Alice", "age": 20}},
+		"data_base64": null
+	}`
+
+	native, _, err := codec.NativeFromTextual([]byte(ceJSON))
+	require.NoError(t, err)
+	assert.NotNil(t, native)
+}
+
+func TestWrapInCloudEventsAvroSchema_Expiration(t *testing.T) {
+	innerSchema := `{
+		"type": "record",
+		"name": "Event",
+		"fields": [{"name": "id", "type": "int"}]
+	}`
+
+	ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+	require.NoError(t, err)
+
+	codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+	require.NoError(t, err)
+
+	ceJSON := `{
+		"id": "evt-1",
+		"source": "Dapr",
+		"specversion": "1.0",
+		"type": "com.dapr.event.sent",
+		"datacontenttype": null,
+		"subject": null,
+		"time": null,
+		"topic": null,
+		"pubsubname": null,
+		"traceid": null,
+		"traceparent": null,
+		"tracestate": null,
+		"expiration": "2026-03-20T12:00:00Z",
+		"data": {"id": 1},
+		"data_base64": null
+	}`
+
+	native, _, err := codec.NativeFromTextual([]byte(ceJSON))
+	require.NoError(t, err)
+	assert.NotNil(t, native)
+}
+
+func TestWrapInCloudEventsAvroSchema_DataBase64(t *testing.T) {
+	innerSchema := `{
+		"type": "record",
+		"name": "Event",
+		"fields": [{"name": "id", "type": "int"}]
+	}`
+
+	ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+	require.NoError(t, err)
+
+	codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
+	require.NoError(t, err)
+
+	// Binary content uses data_base64 instead of data
+	ceJSON := `{
+		"id": "evt-1",
+		"source": "Dapr",
+		"specversion": "1.0",
+		"type": "com.dapr.event.sent",
+		"datacontenttype": "application/octet-stream",
+		"subject": null,
+		"time": null,
+		"topic": null,
+		"pubsubname": null,
+		"traceid": null,
+		"traceparent": null,
+		"tracestate": null,
+		"expiration": null,
+		"data": null,
+		"data_base64": "SGVsbG8gV29ybGQ="
+	}`
+
+	native, _, err := codec.NativeFromTextual([]byte(ceJSON))
+	require.NoError(t, err)
+	assert.NotNil(t, native)
+}
+
+func TestWrapInCloudEventsAvroSchema_InvalidInput(t *testing.T) {
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, err := wrapInCloudEventsAvroSchema(`{not valid json}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse inner Avro schema")
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, err := wrapInCloudEventsAvroSchema(``)
+		require.Error(t, err)
+	})
+}

--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -50,7 +50,10 @@ type pulsarMetadata struct {
 }
 
 type schemaMetadata struct {
-	protocol string
-	value    string
-	codec    *goavro.Codec // cached Avro codec, compiled once at init
+	protocol  string
+	value     string        // inner schema JSON (user-provided)
+	codec     *goavro.Codec // cached Avro codec for inner schema, compiled once at init
+	ceValue   string        // CloudEvents envelope schema JSON (generated)
+	ceCodec   *goavro.Codec // cached Avro codec for CE envelope schema
+	rawSchema bool          // true when topic is configured with .rawschema=true
 }

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -193,6 +193,16 @@ metadata:
           {"name": "Name","type": "string"}
         ]
       }
+  - name: "<topic-name>.rawschema"
+    type: bool
+    description: |
+      When set to "true", registers the user-provided Avro schema as-is with the Pulsar Schema Registry
+      instead of wrapping it in a CloudEvents envelope schema. This setting only controls which schema is
+      registered; it does not change the wire format. Callers must also publish messages with
+      rawPayload=true to send events without a CloudEvents envelope. Use this for topics that are
+      intended to exclusively receive raw domain payloads.
+    default: 'false'
+    example: '"true", "false"'
   - name: "<topic-name>.jsonschema"
     type: string
     description: |

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -28,7 +29,7 @@ import (
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/apache/pulsar-client-go/pulsar/crypto"
 	lru "github.com/hashicorp/golang-lru/v2"
-	goavro "github.com/linkedin/goavro/v2"
+	"github.com/linkedin/goavro/v2"
 
 	"github.com/dapr/components-contrib/common/authentication/oauth2"
 	"github.com/dapr/components-contrib/metadata"
@@ -69,6 +70,7 @@ const (
 	topicJSONSchemaIdentifier  = ".jsonschema"
 	topicAvroSchemaIdentifier  = ".avroschema"
 	topicProtoSchemaIdentifier = ".protoschema"
+	topicRawSchemaIdentifier   = ".rawschema"
 
 	// defaultBatchingMaxPublishDelay init default for maximum delay to batch messages.
 	defaultBatchingMaxPublishDelay = 10 * time.Millisecond
@@ -190,6 +192,19 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		return nil, errors.New("invalid compression level. Accepted values are `default`, `faster` and `better`")
 	}
 
+	// First pass: collect per-topic rawSchema flags.
+	rawSchemaTopics := make(map[string]bool)
+	for k, v := range meta.Properties {
+		if strings.HasSuffix(k, topicRawSchemaIdentifier) {
+			topic := k[:len(k)-len(topicRawSchemaIdentifier)]
+			parsed, parseErr := strconv.ParseBool(v)
+			if parseErr != nil {
+				return nil, fmt.Errorf("invalid value for %q: %w", k, parseErr)
+			}
+			rawSchemaTopics[topic] = parsed
+		}
+	}
+
 	for k, v := range meta.Properties {
 		switch {
 		case strings.HasSuffix(k, topicJSONSchemaIdentifier):
@@ -204,11 +219,27 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 			if codecErr != nil {
 				return nil, fmt.Errorf("failed to parse avro schema for topic %q: %w", topic, codecErr)
 			}
-			m.internalTopicSchemas[topic] = schemaMetadata{
-				protocol: avroProtocol,
-				value:    v,
-				codec:    codec,
+			sm := schemaMetadata{
+				protocol:  avroProtocol,
+				value:     v,
+				codec:     codec,
+				rawSchema: rawSchemaTopics[topic],
 			}
+			// Only wrap in CloudEvents envelope when the topic is not
+			// configured with rawSchema=true.
+			if !sm.rawSchema {
+				ceSchemaJSON, ceErr := wrapInCloudEventsAvroSchema(v)
+				if ceErr != nil {
+					return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
+				}
+				ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+				if ceCodecErr != nil {
+					return nil, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
+				}
+				sm.ceValue = ceSchemaJSON
+				sm.ceCodec = ceCodec
+			}
+			m.internalTopicSchemas[topic] = sm
 		case strings.HasSuffix(k, topicProtoSchemaIdentifier):
 			topic := k[:len(k)-len(topicProtoSchemaIdentifier)]
 			m.internalTopicSchemas[topic] = schemaMetadata{
@@ -330,7 +361,7 @@ func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 		}
 
 		if hasSchema {
-			opts.Schema = getPulsarSchema(sm)
+			opts.Schema = getRegistrationSchema(sm)
 		}
 
 		if p.useProducerEncryption() {
@@ -367,6 +398,16 @@ func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 	return nil
 }
 
+// getRegistrationSchema returns the Pulsar schema to register with the broker.
+// For Avro topics with a CE envelope, it returns the CE envelope schema;
+// otherwise it falls back to the inner schema.
+func getRegistrationSchema(sm schemaMetadata) pulsar.Schema {
+	if sm.ceValue != "" {
+		return pulsar.NewAvroSchema(sm.ceValue, nil)
+	}
+	return getPulsarSchema(sm)
+}
+
 func getPulsarSchema(metadata schemaMetadata) pulsar.Schema {
 	switch metadata.protocol {
 	case jsonProtocol:
@@ -398,10 +439,33 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 
 		msg.Value = obj
 	case avroProtocol:
-		// Use the cached goavro codec (compiled once at init) to validate JSON
-		// against the Avro schema. NativeFromTextual parses JSON and validates it
-		// in one step — if the data doesn't conform, it returns an error.
-		native, _, nativeErr := schema.codec.NativeFromTextual(req.Data)
+		// Select the appropriate codec based on whether the payload is raw or
+		// wrapped in a CloudEvents envelope. When rawPayload=true, the data is the
+		// inner domain event; otherwise it's the full CloudEvents envelope.
+		isRaw, rawErr := metadata.IsRawPayload(req.Metadata)
+		if rawErr != nil {
+			return nil, fmt.Errorf("invalid rawPayload metadata: %w", rawErr)
+		}
+		if isRaw && !schema.rawSchema {
+			return nil, errors.New("rawPayload=true is not compatible with Avro schema topics using CloudEvents envelope; use a topic configured with rawschema=true")
+		}
+		if !isRaw && schema.rawSchema {
+			return nil, errors.New("rawschema=true topics require per-message rawPayload=true; otherwise Dapr wraps in a CloudEvents envelope that won't match the registered schema")
+		}
+		codec := schema.ceCodec
+		data := req.Data
+		if schema.ceCodec == nil {
+			codec = schema.codec
+		} else {
+			// Dapr's CE envelope encodes the "data" field as a JSON string;
+			// the Avro codec expects a nested record. Normalize before encoding.
+			normalized, normErr := normalizeCloudEventForAvro(req.Data)
+			if normErr != nil {
+				return nil, fmt.Errorf("failed to normalize CloudEvents data for Avro: %w", normErr)
+			}
+			data = normalized
+		}
+		native, _, nativeErr := codec.NativeFromTextual(data)
 		if nativeErr != nil {
 			return nil, fmt.Errorf("avro schema validation failed: %w", nativeErr)
 		}
@@ -608,7 +672,7 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 	}
 
 	if sm, ok := p.metadata.internalTopicSchemas[req.Topic]; ok {
-		options.Schema = getPulsarSchema(sm)
+		options.Schema = getRegistrationSchema(sm)
 	}
 	consumer, err := p.client.Subscribe(options)
 	if err != nil {
@@ -677,12 +741,18 @@ func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, msg puls
 	// so we must do it explicitly here.
 	// The goavro codec was compiled once at init in parsePulsarMetadata.
 	if sm, ok := p.metadata.internalTopicSchemas[originTopic]; ok && sm.protocol == avroProtocol {
-		native, _, decodeErr := sm.codec.NativeFromBinary(data)
+		// Use the CE envelope codec when available (matches the schema registered
+		// with the producer/consumer), otherwise fall back to the inner codec.
+		codec := sm.ceCodec
+		if codec == nil {
+			codec = sm.codec
+		}
+		native, _, decodeErr := codec.NativeFromBinary(data)
 		if decodeErr != nil {
 			msg.Nack(msg.Message)
 			return fmt.Errorf("avro decode failed for topic %q: %w", originTopic, decodeErr)
 		}
-		jsonBytes, encodeErr := sm.codec.TextualFromNative(nil, native)
+		jsonBytes, encodeErr := codec.TextualFromNative(nil, native)
 		if encodeErr != nil {
 			msg.Nack(msg.Message)
 			return fmt.Errorf("avro to json conversion failed for topic %q: %w", originTopic, encodeErr)

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-// newAvroSchemaMetadata creates a schemaMetadata with a pre-compiled goavro codec,
-// matching the production path where codecs are compiled once at init.
+// newAvroSchemaMetadata creates a schemaMetadata with only the inner goavro codec
+// (no CE envelope). This is equivalent to a rawschema=true topic. Used by the
+// Avro type-validation tests that predate CE support and test schema validation
+// logic in isolation with inner-schema payloads.
 func newAvroSchemaMetadata(t *testing.T, avroSchemaJSON string) schemaMetadata {
 	t.Helper()
 	codec, err := goavro.NewCodecForStandardJSONFull(avroSchemaJSON)
@@ -44,6 +46,28 @@ func newAvroSchemaMetadata(t *testing.T, avroSchemaJSON string) schemaMetadata {
 		protocol: avroProtocol,
 		value:    avroSchemaJSON,
 		codec:    codec,
+	}
+}
+
+// newAvroSchemaMetadataWithCE creates a schemaMetadata with pre-compiled goavro codecs
+// for both the inner schema and the CloudEvents envelope schema, matching the
+// default production path where codecs are compiled once at init.
+func newAvroSchemaMetadataWithCE(t *testing.T, avroSchemaJSON string) schemaMetadata {
+	t.Helper()
+	codec, err := goavro.NewCodecForStandardJSONFull(avroSchemaJSON)
+	require.NoError(t, err, "failed to compile test avro schema")
+
+	ceSchemaJSON, err := wrapInCloudEventsAvroSchema(avroSchemaJSON)
+	require.NoError(t, err, "failed to generate CE envelope schema")
+	ceCodec, err := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+	require.NoError(t, err, "failed to compile CE envelope schema")
+
+	return schemaMetadata{
+		protocol: avroProtocol,
+		value:    avroSchemaJSON,
+		codec:    codec,
+		ceValue:  ceSchemaJSON,
+		ceCodec:  ceCodec,
 	}
 }
 
@@ -1133,6 +1157,246 @@ func TestParsePublishMetadataAvroSchemaInvalidSchemaDefinition(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse avro schema")
 }
 
+func TestParsePublishMetadataAvroCloudEventsEnvelope(t *testing.T) {
+	avroSchemaJSON := `{
+		"type": "record",
+		"name": "OrderEvent",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "orderId", "type": "string"},
+			{"name": "amount", "type": "double"}
+		]
+	}`
+
+	sm := newAvroSchemaMetadataWithCE(t, avroSchemaJSON)
+
+	t.Run("valid CloudEvents envelope", func(t *testing.T) {
+		cePayload := `{
+			"id": "abc-123",
+			"source": "Dapr",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": "application/json",
+			"subject": null,
+			"time": "2026-03-20T10:00:00Z",
+			"topic": "orders",
+			"pubsubname": "mypubsub",
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": {"orderId": "order-1", "amount": 99.99},
+			"data_base64": null
+		}`
+		req := &pubsub.PublishRequest{
+			Data: []byte(cePayload),
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg)
+		assert.NotNil(t, msg.Value)
+	})
+
+	t.Run("CE envelope with stringified data", func(t *testing.T) {
+		// Dapr's runtime serialises the data field as a JSON string, e.g.
+		// "data": "{\"orderId\":\"order-1\",\"amount\":99.99}"
+		// normalizeCloudEventForAvro must parse it before Avro encoding.
+		cePayload := `{
+			"id": "abc-123",
+			"source": "Dapr",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": "application/json",
+			"subject": null,
+			"time": "2026-03-20T10:00:00Z",
+			"topic": "orders",
+			"pubsubname": "mypubsub",
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": "{\"orderId\":\"order-1\",\"amount\":99.99}",
+			"data_base64": null
+		}`
+		req := &pubsub.PublishRequest{
+			Data: []byte(cePayload),
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg)
+		assert.NotNil(t, msg.Value)
+	})
+
+	t.Run("CE envelope with null data", func(t *testing.T) {
+		cePayload := `{
+			"id": "abc-123",
+			"source": "Dapr",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": null,
+			"subject": null,
+			"time": null,
+			"topic": null,
+			"pubsubname": null,
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": null,
+			"data_base64": null
+		}`
+		req := &pubsub.PublishRequest{
+			Data: []byte(cePayload),
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg)
+	})
+
+	t.Run("CE envelope missing required CE field fails", func(t *testing.T) {
+		// Missing "source" field
+		cePayload := `{
+			"id": "abc-123",
+			"specversion": "1.0",
+			"type": "com.dapr.event.sent",
+			"datacontenttype": null,
+			"subject": null,
+			"time": null,
+			"topic": null,
+			"pubsubname": null,
+			"traceid": null,
+			"traceparent": null,
+			"tracestate": null,
+			"expiration": null,
+			"data": null,
+			"data_base64": null
+		}`
+		req := &pubsub.PublishRequest{
+			Data: []byte(cePayload),
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "avro schema validation failed")
+	})
+
+	t.Run("rawPayload rejected on CE schema topic", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data:     []byte(`{"orderId": "order-1", "amount": 99.99}`),
+			Metadata: map[string]string{"rawPayload": "true"},
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rawPayload=true is not compatible")
+	})
+}
+
+func TestParsePulsarMetadataCECodecCompiled(t *testing.T) {
+	avroSchemaJSON := `{
+		"type": "record",
+		"name": "TestEvent",
+		"fields": [
+			{"name": "id", "type": "int"}
+		]
+	}`
+
+	m := pubsub.Metadata{}
+	m.Properties = map[string]string{
+		"host":                                "a",
+		"mytopic" + topicAvroSchemaIdentifier: avroSchemaJSON,
+	}
+
+	meta, err := parsePulsarMetadata(m)
+	require.NoError(t, err)
+
+	sm, ok := meta.internalTopicSchemas["mytopic"]
+	require.True(t, ok)
+	assert.NotNil(t, sm.codec, "inner codec should be compiled")
+	assert.NotNil(t, sm.ceCodec, "CE envelope codec should be compiled")
+	assert.NotEmpty(t, sm.ceValue, "CE envelope schema JSON should be set")
+}
+
+func TestParsePulsarMetadataRawSchemaSkipsCE(t *testing.T) {
+	avroSchemaJSON := `{
+		"type": "record",
+		"name": "TestEvent",
+		"fields": [
+			{"name": "id", "type": "int"}
+		]
+	}`
+
+	m := pubsub.Metadata{}
+	m.Properties = map[string]string{
+		"host":                                "a",
+		"mytopic" + topicAvroSchemaIdentifier: avroSchemaJSON,
+		"mytopic" + topicRawSchemaIdentifier:  "true",
+	}
+
+	meta, err := parsePulsarMetadata(m)
+	require.NoError(t, err)
+
+	sm, ok := meta.internalTopicSchemas["mytopic"]
+	require.True(t, ok)
+	assert.NotNil(t, sm.codec, "inner codec should be compiled")
+	assert.Nil(t, sm.ceCodec, "CE envelope codec should NOT be set for rawSchema topics")
+	assert.Empty(t, sm.ceValue, "CE envelope schema JSON should NOT be set for rawSchema topics")
+	assert.True(t, sm.rawSchema, "rawSchema flag should be set")
+}
+
+func TestParsePulsarMetadataRawSchemaInvalidBool(t *testing.T) {
+	m := pubsub.Metadata{}
+	m.Properties = map[string]string{
+		"host":                                "a",
+		"mytopic" + topicAvroSchemaIdentifier: `{"type":"record","name":"T","fields":[{"name":"id","type":"int"}]}`,
+		"mytopic" + topicRawSchemaIdentifier:  "yes",
+	}
+
+	_, err := parsePulsarMetadata(m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid value for")
+}
+
+func TestParsePublishMetadataAvroRawSchemaTopic(t *testing.T) {
+	avroSchemaJSON := `{
+		"type": "record",
+		"name": "OrderEvent",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "orderId", "type": "string"},
+			{"name": "amount", "type": "double"}
+		]
+	}`
+
+	// Build schema metadata without CE wrapping (simulates rawSchema=true topic).
+	codec, err := goavro.NewCodecForStandardJSONFull(avroSchemaJSON)
+	require.NoError(t, err)
+	sm := schemaMetadata{
+		protocol:  avroProtocol,
+		value:     avroSchemaJSON,
+		codec:     codec,
+		rawSchema: true,
+	}
+
+	t.Run("rawPayload succeeds with inner schema", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data:     []byte(`{"orderId": "order-1", "amount": 99.99}`),
+			Metadata: map[string]string{"rawPayload": "true"},
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg)
+		assert.NotNil(t, msg.Value)
+	})
+
+	t.Run("non-raw rejected on rawschema topic", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{"orderId": "order-1", "amount": 99.99}`),
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rawschema=true topics require per-message rawPayload=true")
+	})
+}
+
 func TestMissingHost(t *testing.T) {
 	m := pubsub.Metadata{}
 	m.Properties = map[string]string{"host": ""}
@@ -1954,6 +2218,74 @@ func TestHandleMessageAvroDecodeRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(receivedData, &decoded), "handleMessage must deliver JSON, not Avro binary")
 	assert.EqualValues(t, 42, decoded["id"])
 	assert.Equal(t, "hello", decoded["name"])
+}
+
+func TestHandleMessageAvroCEEnvelopeDecodeRoundTrip(t *testing.T) {
+	const innerSchema = `{"type":"record","name":"Event","fields":[{"name":"id","type":"int"},{"name":"name","type":"string"}]}`
+	const topic = "ce-topic"
+
+	innerCodec, err := goavro.NewCodecForStandardJSONFull(innerSchema)
+	require.NoError(t, err)
+
+	ceSchemaJSON, err := wrapInCloudEventsAvroSchema(innerSchema)
+	require.NoError(t, err)
+	ceCodec, err := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+	require.NoError(t, err)
+
+	// Encode a CE envelope as Avro binary (simulating what the Pulsar producer sends).
+	ceJSON := `{
+		"id": "evt-1",
+		"source": "Dapr",
+		"specversion": "1.0",
+		"type": "com.dapr.event.sent",
+		"datacontenttype": "application/json",
+		"subject": null,
+		"time": null,
+		"topic": "ce-topic",
+		"pubsubname": null,
+		"traceid": null,
+		"traceparent": null,
+		"tracestate": null,
+		"expiration": null,
+		"data": {"id": 42, "name": "hello"},
+		"data_base64": null
+	}`
+	native, _, err := ceCodec.NativeFromTextual([]byte(ceJSON))
+	require.NoError(t, err)
+	avroBinary, err := ceCodec.BinaryFromNative(nil, native)
+	require.NoError(t, err)
+
+	p := &Pulsar{
+		logger: logger.NewLogger("test"),
+		metadata: pulsarMetadata{
+			internalTopicSchemas: map[string]schemaMetadata{
+				topic: {protocol: avroProtocol, value: innerSchema, codec: innerCodec, ceValue: ceSchemaJSON, ceCodec: ceCodec},
+			},
+		},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{payload: avroBinary, properties: map[string]string{}, topic: topic}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedData []byte
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedData = m.Data
+		return nil
+	}
+
+	err = p.handleMessage(t.Context(), topic, cm, handler)
+	require.NoError(t, err)
+	assert.True(t, consumer.acked)
+
+	// The handler must receive valid JSON with the full CE envelope.
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(receivedData, &decoded), "handleMessage must deliver JSON")
+	assert.Equal(t, "evt-1", decoded["id"])
+	assert.Equal(t, "1.0", decoded["specversion"])
+	data := decoded["data"].(map[string]any)
+	assert.EqualValues(t, 42, data["id"])
+	assert.Equal(t, "hello", data["name"])
 }
 
 func TestHandleMessageAvroDecodeError(t *testing.T) {

--- a/tests/certification/pubsub/pulsar/components/auth-none/consumer_ten/pulsar.yaml
+++ b/tests/certification/pubsub/pulsar/components/auth-none/consumer_ten/pulsar.yaml
@@ -1,0 +1,18 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification10
+  - name: redeliveryDelay
+    value: 200ms
+  - name: certification-pubsub-topic-avro-raw.avroschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"
+  - name: certification-pubsub-topic-avro-raw.rawschema
+    value: "true"

--- a/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_ten/pulsar.yml.tmpl
+++ b/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_ten/pulsar.yml.tmpl
@@ -1,0 +1,30 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification10
+  - name: redeliveryDelay
+    value: 200ms
+  - name: certification-pubsub-topic-avro-raw.avroschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"
+  - name: certification-pubsub-topic-avro-raw.rawschema
+    value: "true"
+  - name: oauth2TokenURL
+    value: https://localhost:8085/issuer1/token
+  - name: oauth2ClientID
+    value: foo
+  - name: oauth2ClientSecret
+    value: bar
+  - name: oauth2Scopes
+    value: openid
+  - name: oauth2Audiences
+    value: pulsar
+  - name: oauth2TokenCAPEM
+    value: "{{ .OAuth2CAPEM }}"

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -73,6 +73,7 @@ const (
 	messageKey                  = "partitionKey"
 	pubsubName                  = "messagebus"
 	topicActiveName             = "certification-pubsub-topic-active"
+	topicAvroRawName            = "certification-pubsub-topic-avro-raw"
 	topicPassiveName            = "certification-pubsub-topic-passive"
 	topicToBeCreated            = "certification-topic-per-test-run"
 	topicDefaultName            = "certification-topic-default"
@@ -955,6 +956,42 @@ func publishSchemaMessages(sidecarName string, topicName string, messageWatchers
 	}
 }
 
+// publishAvroSchemaMessagesCE publishes Avro schema messages without rawPayload,
+// allowing Dapr to wrap them in a CloudEvents envelope.
+func publishAvroSchemaMessagesCE(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
+	return func(ctx flow.Context) error {
+		messages := make([]string, numMessages)
+		for i := range messages {
+			test := &avroSchemaTest{
+				TestID:   i,
+				TestName: uuid.New().String(),
+			}
+
+			b, err := json.Marshal(test)
+			require.NoError(ctx, err, "error marshaling avroSchemaTest")
+			messages[i] = string(b)
+		}
+
+		for _, messageWatcher := range messageWatchers {
+			messageWatcher.ExpectStrings(messages...)
+		}
+
+		client := sidecar.GetClient(ctx, sidecarName)
+
+		ctx.Logf("Publishing messages (CE wrapped). sidecarName: %s, topicName: %s", sidecarName, topicName)
+
+		for _, message := range messages {
+			ctx.Logf("Publishing: %q", message)
+
+			err := client.PublishEvent(ctx, pubsubName, topicName, message)
+			require.NoError(ctx, err, "error publishing message")
+		}
+		return nil
+	}
+}
+
+// publishAvroSchemaMessages publishes Avro schema messages with rawPayload=true,
+// bypassing CloudEvents wrapping. Used with rawSchema=true topics.
 func publishAvroSchemaMessages(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
 	return func(ctx flow.Context) error {
 		messages := make([]string, numMessages)
@@ -1031,17 +1068,18 @@ func (p *pulsarSuite) TestPulsarSchema() {
 		Run()
 }
 
+// TestPulsarAvroSchema tests Avro schema with CloudEvents envelope wrapping.
+// The sidecar registers the CE-wrapped schema on subscribe; no pre-registration needed.
 func (p *pulsarSuite) TestPulsarAvroSchema() {
 	t := p.T()
 	consumerGroup1 := watcher.NewUnordered()
 
-	avroSchema := `{"type":"record","name":"Example","namespace":"test","fields":[{"name":"testId","type":"int"},{"name":"testName","type":"string"}]}`
-
 	flow.New(t, "pulsar certification avro schema test").
 
-		// Run subscriberApplication app1
+		// subscriberSchemaApplication subscribes without rawPayload, so Dapr
+		// unwraps the CloudEvents envelope and delivers the inner data field.
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
-			subscriberAvroSchemaApplication(appID1, topicActiveName, consumerGroup1))).
+			subscriberSchemaApplication(appID1, topicActiveName, consumerGroup1))).
 		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
 		Step("wait", flow.Sleep(10*time.Second)).
 		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
@@ -1064,8 +1102,58 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 
 			return err
 		})).
-		// Pre-register the Avro schema on the topic so the sidecar's
-		// subscribe call finds it already present on the broker.
+		Step(sidecar.Run(sidecarName1,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_nine")),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
+			)...,
+		)).
+		Step("publish messages to topic1", publishAvroSchemaMessagesCE(sidecarName1, topicActiveName, consumerGroup1)).
+		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
+		Run()
+}
+
+// TestPulsarAvroSchemaRaw tests Avro schema with rawSchema=true, bypassing
+// CloudEvents envelope wrapping. The raw user schema is pre-registered on the
+// topic and the component uses it directly without CE wrapping.
+func (p *pulsarSuite) TestPulsarAvroSchemaRaw() {
+	t := p.T()
+	consumerGroup1 := watcher.NewUnordered()
+
+	avroSchema := `{"type":"record","name":"Example","namespace":"test","fields":[{"name":"testId","type":"int"},{"name":"testName","type":"string"}]}`
+
+	flow.New(t, "pulsar certification avro schema raw test").
+
+		// Run subscriberApplication app1
+		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
+			subscriberAvroSchemaApplication(appID1, topicAvroRawName, consumerGroup1))).
+		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
+		Step("wait", flow.Sleep(10*time.Second)).
+		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
+			client, err := p.client(t)
+			if err != nil {
+				return fmt.Errorf("could not create pulsar client: %v", err)
+			}
+
+			defer client.Close()
+
+			consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+				Topic:            "topic-1",
+				SubscriptionName: "my-sub",
+				Type:             pulsar.Shared,
+			})
+			if err != nil {
+				return fmt.Errorf("could not create pulsar Topic: %v", err)
+			}
+			defer consumer.Close()
+
+			return err
+		})).
+		// Pre-register the raw Avro schema on the topic. Because consumer_ten
+		// uses rawschema=true, the sidecar subscribes with the same raw schema
+		// (no CloudEvents wrapping), so Pulsar accepts the consumer.
 		Step("register avro schema on topic", func(ctx flow.Context) error {
 			client, err := p.client(t)
 			if err != nil {
@@ -1074,7 +1162,7 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 			defer client.Close()
 
 			producer, err := client.CreateProducer(pulsar.ProducerOptions{
-				Topic:  "persistent://public/default/" + topicActiveName,
+				Topic:  "persistent://public/default/" + topicAvroRawName,
 				Schema: pulsar.NewAvroSchema(avroSchema, nil),
 			})
 			if err != nil {
@@ -1086,13 +1174,13 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 		}).
 		Step(sidecar.Run(sidecarName1,
 			append(componentRuntimeOptions(),
-				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_nine")),
+				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_ten")),
 				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
 				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort)),
 				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
 			)...,
 		)).
-		Step("publish messages to topic1", publishAvroSchemaMessages(sidecarName1, topicActiveName, consumerGroup1)).
+		Step("publish messages to topic1", publishAvroSchemaMessages(sidecarName1, topicAvroRawName, consumerGroup1)).
 		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
 		Run()
 }


### PR DESCRIPTION
# Description
 When Dapr publishes to Pulsar with CloudEvents wrapping enabled (the default), the wire format is a CloudEvents envelope containing the user's domain event in the `data` field. Previously, the Avro schema
  registered with the Pulsar Schema Registry was the **inner domain event schema**, not the CloudEvents envelope — causing a mismatch between the schema in the registry and the actual messages stored in the topic.

  This PR fixes the mismatch by wrapping the user-provided Avro schema inside a CloudEvents envelope Avro schema before registering it with the broker.

| | Default publish | `rawschema=true` on publish request |
  |---|---|---|
  | **No `.avroschema`** | Dapr wraps in CE envelope (JSON). No schema registered with Pulsar. Sent as raw bytes. | Dapr sends raw bytes. No schema validation. No wrapping. |
  | **`.avroschema` without `.rawschema` flag** | Dapr wraps in CE envelope. Producer registers **CE envelope schema**. Validates against CE codec. | **Rejected** with error. Producer schema is CE envelope, raw  payload would mismatch. |
  | **`.avroschema` with `.rawschema=true` flag** | Misconfiguration. Producer registers **inner schema** but Dapr wraps in CE envelope — wire format won't match schema. | Producer registers **inner schema**.  Validates against inner codec. Wire format matches. |

  ## Changes

  - **CloudEvents Avro schema wrapping** (`cloudevents_schema.go`): new `wrapInCloudEventsAvroSchema()` embeds the user's inner schema as the `data` field of a CloudEvents envelope record, following the
  [CloudEvents Avro format spec](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/avro-format.md)
  - **Schema metadata** (`metadata.go`): `schemaMetadata` now stores both the inner codec (`codec`/`value`) and the CE envelope codec (`ceCodec`/`ceValue`)
  - **Producer & consumer registration** (`pulsar.go`): use the CE envelope schema when available for both `Publish` and `Subscribe`
  - **Avro publish validation** (`pulsar.go`): select the correct codec (CE envelope vs inner) at publish time; reject `rawschema=true` on CE-wrapped topics with a clear error
  - **Topic-level `rawschema` flag** (`pulsar.go`, `metadata.yaml`): new `<topic-name>.rawSchema=true` metadata option skips CE envelope wrapping for dedicated raw-payload topics, registering the inner schema
  directly with the broker

  ## Topic-level `rawschema` configuration

  Pulsar enforces a single schema per topic. Since the CE envelope schema differs from the inner schema, `rawsc hema=true` messages cannot be sent to a CE-wrapped topic. This PR provides two options:

  **Default (CE-wrapped topic):**
  ```yaml
  metadata:
    - name: orders.avroschema
      value: '{"type":"record","name":"Order","fields":[...]}'

  Raw-payload-only topic (skips CE wrapping):
  metadata:
    - name: orders-raw.avroschema
      value: '{"type":"record","name":"Order","fields":[...]}'
    - name: orders-raw.rawschema
      value: "true"
```
  Publishing with rawschema=true to a CE-wrapped topic returns:
  rawschema=true is not compatible with Avro schema topics using CloudEvents envelope; use a separate topic for raw payloads


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
