### PR TITLE
fix(pubsub/pulsar): validate JSON schema payloads against schema definition using goavro codec

### DIFF
--- a/pubsub/pulsar/cloudevents_schema.go
+++ b/pubsub/pulsar/cloudevents_schema.go
@@ -101,7 +101,8 @@ func wrapInCloudEventsSchema(innerSchemaJSON string) (string, error) {
 // Dapr produces: {"data": "{\"testId\":0}", ...}
 // goavro expects: {"data": {"testId":0}, ...}
 //
-// Uses json.RawMessage to avoid parsing/re-serialising the other ~15 CE fields.
+// Uses json.RawMessage to avoid fully parsing the other ~15 CE fields, though
+// the envelope is re-marshaled (which may reorder top-level keys).
 func normalizeCloudEventData(ceJSON []byte) ([]byte, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(ceJSON, &raw); err != nil {

--- a/pubsub/pulsar/cloudevents_schema.go
+++ b/pubsub/pulsar/cloudevents_schema.go
@@ -51,7 +51,7 @@ type avroNullableField struct {
 func wrapInCloudEventsAvroSchema(innerSchemaJSON string) (string, error) {
 	var innerSchema interface{}
 	if err := json.Unmarshal([]byte(innerSchemaJSON), &innerSchema); err != nil {
-		return "", fmt.Errorf("failed to parse inner Avro schema: %w", err)
+		return "", fmt.Errorf("failed to parse inner schema: %w", err)
 	}
 
 	nullStr := [2]any{"null", "string"}

--- a/pubsub/pulsar/cloudevents_schema.go
+++ b/pubsub/pulsar/cloudevents_schema.go
@@ -18,10 +18,11 @@ import (
 	"fmt"
 )
 
-// Avro schema structs with deterministic JSON field ordering.
-// Using structs instead of maps guarantees consistent json.Marshal output
-// across process restarts, preventing spurious schema version bumps in the
-// Pulsar Schema Registry (which hashes raw schema bytes for versioning).
+// CloudEvents envelope schema structs with deterministic JSON field ordering.
+// Used for both Avro and JSON schema topics. Using structs instead of maps
+// guarantees consistent json.Marshal output across process restarts, preventing
+// spurious schema version bumps in the Pulsar Schema Registry (which hashes
+// raw schema bytes for versioning).
 
 type avroRecordSchema struct {
 	Type      string        `json:"type"`

--- a/pubsub/pulsar/cloudevents_schema.go
+++ b/pubsub/pulsar/cloudevents_schema.go
@@ -41,14 +41,18 @@ type avroNullableField struct {
 	Default any    `json:"default"` // nil any marshals to JSON null
 }
 
-// wrapInCloudEventsAvroSchema takes a user-provided inner Avro schema JSON string
-// and returns a CloudEvents envelope Avro schema with the inner schema embedded
-// as the "data" field type. This ensures the Pulsar Schema Registry entry matches
-// the actual wire format when Dapr wraps payloads in CloudEvents envelopes.
+// wrapInCloudEventsSchema takes a user-provided inner schema JSON string and
+// returns a CloudEvents envelope schema with the inner schema embedded as the
+// "data" field type. This ensures the Pulsar Schema Registry entry matches the
+// actual wire format when Dapr wraps payloads in CloudEvents envelopes.
+//
+// Used for both Avro and JSON schema topics — the envelope structure is the same
+// regardless of the schema type because both use the Avro-compatible JSON
+// representation internally (goavro codec).
 //
 // The generated schema follows the CloudEvents Avro format specification:
 // https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/avro-format.md
-func wrapInCloudEventsAvroSchema(innerSchemaJSON string) (string, error) {
+func wrapInCloudEventsSchema(innerSchemaJSON string) (string, error) {
 	var innerSchema interface{}
 	if err := json.Unmarshal([]byte(innerSchemaJSON), &innerSchema); err != nil {
 		return "", fmt.Errorf("failed to parse inner schema: %w", err)
@@ -87,15 +91,18 @@ func wrapInCloudEventsAvroSchema(innerSchemaJSON string) (string, error) {
 	return string(result), nil
 }
 
-// normalizeCloudEventForAvro takes a Dapr-produced CE envelope JSON and parses
+// normalizeCloudEventData takes a Dapr-produced CE envelope JSON and parses
 // the stringified "data" field into a proper JSON object so goavro can encode it
-// against the inner Avro record type.
+// against the inner record type.
+//
+// Used for both Avro and JSON schema topics — Dapr may stringify the data field
+// in either case, and the goavro codec expects a nested object.
 //
 // Dapr produces: {"data": "{\"testId\":0}", ...}
 // goavro expects: {"data": {"testId":0}, ...}
 //
 // Uses json.RawMessage to avoid parsing/re-serialising the other ~15 CE fields.
-func normalizeCloudEventForAvro(ceJSON []byte) ([]byte, error) {
+func normalizeCloudEventData(ceJSON []byte) ([]byte, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(ceJSON, &raw); err != nil {
 		return nil, fmt.Errorf("failed to parse CloudEvents envelope: %w", err)

--- a/pubsub/pulsar/cloudevents_schema.go
+++ b/pubsub/pulsar/cloudevents_schema.go
@@ -24,19 +24,19 @@ import (
 // spurious schema version bumps in the Pulsar Schema Registry (which hashes
 // raw schema bytes for versioning).
 
-type avroRecordSchema struct {
+type ceRecordSchema struct {
 	Type      string        `json:"type"`
 	Name      string        `json:"name"`
 	Namespace string        `json:"namespace"`
 	Fields    []interface{} `json:"fields"`
 }
 
-type avroRequiredField struct {
+type ceRequiredField struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
-type avroNullableField struct {
+type ceNullableField struct {
 	Name    string `json:"name"`
 	Type    [2]any `json:"type"`
 	Default any    `json:"default"` // nil any marshals to JSON null
@@ -61,26 +61,26 @@ func wrapInCloudEventsSchema(innerSchemaJSON string) (string, error) {
 
 	nullStr := [2]any{"null", "string"}
 
-	envelope := avroRecordSchema{
+	envelope := ceRecordSchema{
 		Type:      "record",
 		Name:      "CloudEvent",
 		Namespace: "io.cloudevents",
 		Fields: []interface{}{
-			avroRequiredField{Name: "id", Type: "string"},
-			avroRequiredField{Name: "source", Type: "string"},
-			avroRequiredField{Name: "specversion", Type: "string"},
-			avroRequiredField{Name: "type", Type: "string"},
-			avroNullableField{Name: "datacontenttype", Type: nullStr},
-			avroNullableField{Name: "subject", Type: nullStr},
-			avroNullableField{Name: "time", Type: nullStr},
-			avroNullableField{Name: "topic", Type: nullStr},
-			avroNullableField{Name: "pubsubname", Type: nullStr},
-			avroNullableField{Name: "traceid", Type: nullStr},
-			avroNullableField{Name: "traceparent", Type: nullStr},
-			avroNullableField{Name: "tracestate", Type: nullStr},
-			avroNullableField{Name: "expiration", Type: nullStr},
-			avroNullableField{Name: "data", Type: [2]any{"null", innerSchema}},
-			avroNullableField{Name: "data_base64", Type: nullStr},
+			ceRequiredField{Name: "id", Type: "string"},
+			ceRequiredField{Name: "source", Type: "string"},
+			ceRequiredField{Name: "specversion", Type: "string"},
+			ceRequiredField{Name: "type", Type: "string"},
+			ceNullableField{Name: "datacontenttype", Type: nullStr},
+			ceNullableField{Name: "subject", Type: nullStr},
+			ceNullableField{Name: "time", Type: nullStr},
+			ceNullableField{Name: "topic", Type: nullStr},
+			ceNullableField{Name: "pubsubname", Type: nullStr},
+			ceNullableField{Name: "traceid", Type: nullStr},
+			ceNullableField{Name: "traceparent", Type: nullStr},
+			ceNullableField{Name: "tracestate", Type: nullStr},
+			ceNullableField{Name: "expiration", Type: nullStr},
+			ceNullableField{Name: "data", Type: [2]any{"null", innerSchema}},
+			ceNullableField{Name: "data_base64", Type: nullStr},
 		},
 	}
 

--- a/pubsub/pulsar/cloudevents_schema_test.go
+++ b/pubsub/pulsar/cloudevents_schema_test.go
@@ -294,7 +294,7 @@ func TestWrapInCloudEventsAvroSchema_InvalidInput(t *testing.T) {
 	t.Run("malformed JSON", func(t *testing.T) {
 		_, err := wrapInCloudEventsAvroSchema(`{not valid json}`)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to parse inner Avro schema")
+		assert.Contains(t, err.Error(), "failed to parse inner schema")
 	})
 
 	t.Run("empty string", func(t *testing.T) {

--- a/pubsub/pulsar/cloudevents_schema_test.go
+++ b/pubsub/pulsar/cloudevents_schema_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWrapInCloudEventsAvroSchema(t *testing.T) {
+func TestWrapInCloudEventsSchema(t *testing.T) {
 	innerSchema := `{
 		"type": "record",
 		"name": "OrderEvent",
@@ -170,7 +170,7 @@ func TestWrapInCloudEventsAvroSchema(t *testing.T) {
 	})
 }
 
-func TestWrapInCloudEventsAvroSchema_NestedRecord(t *testing.T) {
+func TestWrapInCloudEventsSchema_NestedRecord(t *testing.T) {
 	innerSchema := `{
 		"type": "record",
 		"name": "Enrollment",
@@ -217,7 +217,7 @@ func TestWrapInCloudEventsAvroSchema_NestedRecord(t *testing.T) {
 	assert.NotNil(t, native)
 }
 
-func TestWrapInCloudEventsAvroSchema_Expiration(t *testing.T) {
+func TestWrapInCloudEventsSchema_Expiration(t *testing.T) {
 	innerSchema := `{
 		"type": "record",
 		"name": "Event",
@@ -253,7 +253,7 @@ func TestWrapInCloudEventsAvroSchema_Expiration(t *testing.T) {
 	assert.NotNil(t, native)
 }
 
-func TestWrapInCloudEventsAvroSchema_DataBase64(t *testing.T) {
+func TestWrapInCloudEventsSchema_DataBase64(t *testing.T) {
 	innerSchema := `{
 		"type": "record",
 		"name": "Event",
@@ -290,7 +290,7 @@ func TestWrapInCloudEventsAvroSchema_DataBase64(t *testing.T) {
 	assert.NotNil(t, native)
 }
 
-func TestWrapInCloudEventsAvroSchema_InvalidInput(t *testing.T) {
+func TestWrapInCloudEventsSchema_InvalidInput(t *testing.T) {
 	t.Run("malformed JSON", func(t *testing.T) {
 		_, err := wrapInCloudEventsSchema(`{not valid json}`)
 		require.Error(t, err)

--- a/pubsub/pulsar/cloudevents_schema_test.go
+++ b/pubsub/pulsar/cloudevents_schema_test.go
@@ -34,7 +34,7 @@ func TestWrapInCloudEventsAvroSchema(t *testing.T) {
 	}`
 
 	t.Run("generates valid Avro schema", func(t *testing.T) {
-		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 		require.NoError(t, err)
 
 		// Must compile as a valid Avro schema
@@ -44,7 +44,7 @@ func TestWrapInCloudEventsAvroSchema(t *testing.T) {
 	})
 
 	t.Run("contains all CloudEvents required fields", func(t *testing.T) {
-		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 		require.NoError(t, err)
 
 		var schema map[string]interface{}
@@ -80,7 +80,7 @@ func TestWrapInCloudEventsAvroSchema(t *testing.T) {
 	})
 
 	t.Run("validates a full CloudEvents envelope", func(t *testing.T) {
-		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 		require.NoError(t, err)
 
 		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
@@ -111,7 +111,7 @@ func TestWrapInCloudEventsAvroSchema(t *testing.T) {
 	})
 
 	t.Run("rejects envelope missing required CE field", func(t *testing.T) {
-		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 		require.NoError(t, err)
 
 		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
@@ -140,7 +140,7 @@ func TestWrapInCloudEventsAvroSchema(t *testing.T) {
 	})
 
 	t.Run("validates envelope with null data", func(t *testing.T) {
-		ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+		ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 		require.NoError(t, err)
 
 		codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
@@ -188,7 +188,7 @@ func TestWrapInCloudEventsAvroSchema_NestedRecord(t *testing.T) {
 		]
 	}`
 
-	ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+	ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 	require.NoError(t, err)
 
 	codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
@@ -224,7 +224,7 @@ func TestWrapInCloudEventsAvroSchema_Expiration(t *testing.T) {
 		"fields": [{"name": "id", "type": "int"}]
 	}`
 
-	ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+	ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 	require.NoError(t, err)
 
 	codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
@@ -260,7 +260,7 @@ func TestWrapInCloudEventsAvroSchema_DataBase64(t *testing.T) {
 		"fields": [{"name": "id", "type": "int"}]
 	}`
 
-	ceSchema, err := wrapInCloudEventsAvroSchema(innerSchema)
+	ceSchema, err := wrapInCloudEventsSchema(innerSchema)
 	require.NoError(t, err)
 
 	codec, err := goavro.NewCodecForStandardJSONFull(ceSchema)
@@ -292,13 +292,13 @@ func TestWrapInCloudEventsAvroSchema_DataBase64(t *testing.T) {
 
 func TestWrapInCloudEventsAvroSchema_InvalidInput(t *testing.T) {
 	t.Run("malformed JSON", func(t *testing.T) {
-		_, err := wrapInCloudEventsAvroSchema(`{not valid json}`)
+		_, err := wrapInCloudEventsSchema(`{not valid json}`)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse inner schema")
 	})
 
 	t.Run("empty string", func(t *testing.T) {
-		_, err := wrapInCloudEventsAvroSchema(``)
+		_, err := wrapInCloudEventsSchema(``)
 		require.Error(t, err)
 	})
 }

--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -52,8 +52,8 @@ type pulsarMetadata struct {
 type schemaMetadata struct {
 	protocol  string
 	value     string        // inner schema JSON (user-provided)
-	codec     *goavro.Codec // cached Avro codec for inner schema, compiled once at init
+	codec     *goavro.Codec // cached goavro codec for inner schema, compiled once at init
 	ceValue   string        // CloudEvents envelope schema JSON (generated)
-	ceCodec   *goavro.Codec // cached Avro codec for CE envelope schema
+	ceCodec   *goavro.Codec // cached goavro codec for CE envelope schema
 	rawSchema bool          // true when topic is configured with .rawschema=true
 }

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -196,11 +196,11 @@ metadata:
   - name: "<topic-name>.rawschema"
     type: bool
     description: |
-      When set to "true", registers the user-provided Avro schema as-is with the Pulsar Schema Registry
-      instead of wrapping it in a CloudEvents envelope schema. This setting only controls which schema is
-      registered; it does not change the wire format. Callers must also publish messages with
-      rawPayload=true to send events without a CloudEvents envelope. Use this for topics that are
-      intended to exclusively receive raw domain payloads.
+      When set to "true", registers the user-provided schema as-is with the Pulsar Schema Registry
+      instead of wrapping it in a CloudEvents envelope schema. Applies to both Avro (.avroschema) and
+      JSON (.jsonschema) schema topics. Callers must also publish messages with rawPayload=true to
+      send events without a CloudEvents envelope. Use this for topics that are intended to exclusively
+      receive raw domain payloads.
     default: 'false'
     example: '"true", "false"'
   - name: "<topic-name>.jsonschema"

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -15,7 +15,6 @@ package pulsar
 
 import (
 	"context"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -209,9 +208,24 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		switch {
 		case strings.HasSuffix(k, topicJSONSchemaIdentifier):
 			topic := k[:len(k)-len(topicJSONSchemaIdentifier)]
+			codec, codecErr := goavro.NewCodecForStandardJSONFull(v)
+			if codecErr != nil {
+				return nil, fmt.Errorf("failed to parse json schema for topic %q: %w", topic, codecErr)
+			}
+			ceSchemaJSON, ceErr := wrapInCloudEventsAvroSchema(v)
+			if ceErr != nil {
+				return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
+			}
+			ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+			if ceCodecErr != nil {
+				return nil, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
+			}
 			m.internalTopicSchemas[topic] = schemaMetadata{
 				protocol: jsonProtocol,
 				value:    v,
+				codec:    codec,
+				ceValue:  ceSchemaJSON,
+				ceCodec:  ceCodec,
 			}
 		case strings.HasSuffix(k, topicAvroSchemaIdentifier):
 			topic := k[:len(k)-len(topicAvroSchemaIdentifier)]
@@ -403,7 +417,12 @@ func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 // otherwise it falls back to the inner schema.
 func getRegistrationSchema(sm schemaMetadata) pulsar.Schema {
 	if sm.ceValue != "" {
-		return pulsar.NewAvroSchema(sm.ceValue, nil)
+		switch sm.protocol {
+		case jsonProtocol:
+			return pulsar.NewJSONSchema(sm.ceValue, nil)
+		default:
+			return pulsar.NewAvroSchema(sm.ceValue, nil)
+		}
 	}
 	return getPulsarSchema(sm)
 }
@@ -431,13 +450,23 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 	case "":
 		msg.Payload = req.Data
 	case jsonProtocol:
-		var obj interface{}
-		err = json.Unmarshal(req.Data, &obj)
-		if err != nil {
-			return nil, err
+		isRaw, rawErr := metadata.IsRawPayload(req.Metadata)
+		if rawErr != nil {
+			return nil, fmt.Errorf("invalid rawPayload metadata: %w", rawErr)
+		}
+		if isRaw && schema.ceCodec != nil {
+			return nil, errors.New("rawPayload=true is not compatible with JSON schema topics using CloudEvents envelope; use a separate topic for raw payloads")
+		}
+		codec := schema.ceCodec
+		if schema.ceCodec == nil {
+			codec = schema.codec
+		}
+		native, _, nativeErr := codec.NativeFromTextual(req.Data)
+		if nativeErr != nil {
+			return nil, fmt.Errorf("json schema validation failed: %w", nativeErr)
 		}
 
-		msg.Value = obj
+		msg.Value = native
 	case avroProtocol:
 		// Select the appropriate codec based on whether the payload is raw or
 		// wrapped in a CloudEvents envelope. When rawPayload=true, the data is the

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -69,7 +69,10 @@ const (
 	topicJSONSchemaIdentifier  = ".jsonschema"
 	topicAvroSchemaIdentifier  = ".avroschema"
 	topicProtoSchemaIdentifier = ".protoschema"
-	topicRawSchemaIdentifier   = ".rawschema"
+	// topicRawSchemaIdentifier opts a topic out of CloudEvents envelope wrapping.
+	// Applies to both Avro and JSON schema topics. When rawschema=true, publishers
+	// must set per-message rawPayload=true and send the inner domain event directly.
+	topicRawSchemaIdentifier = ".rawschema"
 
 	// defaultBatchingMaxPublishDelay init default for maximum delay to batch messages.
 	defaultBatchingMaxPublishDelay = 10 * time.Millisecond
@@ -419,8 +422,8 @@ func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 }
 
 // getRegistrationSchema returns the Pulsar schema to register with the broker.
-// For Avro topics with a CE envelope, it returns the CE envelope schema;
-// otherwise it falls back to the inner schema.
+// For Avro or JSON schema topics with a CE envelope, it returns the CE envelope
+// schema (Avro or JSON respectively); otherwise it falls back to the inner schema.
 func getRegistrationSchema(sm schemaMetadata) pulsar.Schema {
 	if sm.ceValue != "" {
 		switch sm.protocol {

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -146,6 +146,37 @@ func NewPulsar(l logger.Logger) pubsub.PubSub {
 	}
 }
 
+// buildSchemaMetadata compiles a goavro codec for the given schema and, when
+// rawSchema is false, wraps it in a CloudEvents envelope schema. Used for both
+// JSON and Avro schema topics — the only difference is the protocol identifier.
+func buildSchemaMetadata(topic, schemaJSON, protocol string, rawSchema bool) (schemaMetadata, error) {
+	codec, codecErr := goavro.NewCodecForStandardJSONFull(schemaJSON)
+	if codecErr != nil {
+		return schemaMetadata{}, fmt.Errorf("failed to parse %s schema for topic %q: %w", protocol, topic, codecErr)
+	}
+	sm := schemaMetadata{
+		protocol:  protocol,
+		value:     schemaJSON,
+		codec:     codec,
+		rawSchema: rawSchema,
+	}
+	// Only wrap in CloudEvents envelope when the topic is not
+	// configured with rawSchema=true.
+	if !sm.rawSchema {
+		ceSchemaJSON, ceErr := wrapInCloudEventsSchema(schemaJSON)
+		if ceErr != nil {
+			return schemaMetadata{}, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
+		}
+		ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+		if ceCodecErr != nil {
+			return schemaMetadata{}, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
+		}
+		sm.ceValue = ceSchemaJSON
+		sm.ceCodec = ceCodec
+	}
+	return sm, nil
+}
+
 func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 	m := pulsarMetadata{
 		Persistent:              true,
@@ -212,56 +243,16 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		switch {
 		case strings.HasSuffix(k, topicJSONSchemaIdentifier):
 			topic := k[:len(k)-len(topicJSONSchemaIdentifier)]
-			codec, codecErr := goavro.NewCodecForStandardJSONFull(v)
-			if codecErr != nil {
-				return nil, fmt.Errorf("failed to parse json schema for topic %q: %w", topic, codecErr)
-			}
-			sm := schemaMetadata{
-				protocol:  jsonProtocol,
-				value:     v,
-				codec:     codec,
-				rawSchema: rawSchemaTopics[topic],
-			}
-			// Only wrap in CloudEvents envelope when the topic is not
-			// configured with rawSchema=true.
-			if !sm.rawSchema {
-				ceSchemaJSON, ceErr := wrapInCloudEventsSchema(v)
-				if ceErr != nil {
-					return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
-				}
-				ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
-				if ceCodecErr != nil {
-					return nil, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
-				}
-				sm.ceValue = ceSchemaJSON
-				sm.ceCodec = ceCodec
+			sm, smErr := buildSchemaMetadata(topic, v, jsonProtocol, rawSchemaTopics[topic])
+			if smErr != nil {
+				return nil, smErr
 			}
 			m.internalTopicSchemas[topic] = sm
 		case strings.HasSuffix(k, topicAvroSchemaIdentifier):
 			topic := k[:len(k)-len(topicAvroSchemaIdentifier)]
-			codec, codecErr := goavro.NewCodecForStandardJSONFull(v)
-			if codecErr != nil {
-				return nil, fmt.Errorf("failed to parse avro schema for topic %q: %w", topic, codecErr)
-			}
-			sm := schemaMetadata{
-				protocol:  avroProtocol,
-				value:     v,
-				codec:     codec,
-				rawSchema: rawSchemaTopics[topic],
-			}
-			// Only wrap in CloudEvents envelope when the topic is not
-			// configured with rawSchema=true.
-			if !sm.rawSchema {
-				ceSchemaJSON, ceErr := wrapInCloudEventsSchema(v)
-				if ceErr != nil {
-					return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
-				}
-				ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
-				if ceCodecErr != nil {
-					return nil, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
-				}
-				sm.ceValue = ceSchemaJSON
-				sm.ceCodec = ceCodec
+			sm, smErr := buildSchemaMetadata(topic, v, avroProtocol, rawSchemaTopics[topic])
+			if smErr != nil {
+				return nil, smErr
 			}
 			m.internalTopicSchemas[topic] = sm
 		case strings.HasSuffix(k, topicProtoSchemaIdentifier):

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -540,7 +540,7 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 
 		msg.Value = native
 	default:
-		return nil, fmt.Errorf("unsupported schema protocol %q: only json, avro, and proto are supported", schema.protocol)
+		return nil, fmt.Errorf("publish-time validation is not supported for schema protocol %q; only json and avro schemas are validated", schema.protocol)
 	}
 
 	for name, value := range req.Metadata {

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -15,6 +15,7 @@ package pulsar
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -224,7 +225,7 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 			// Only wrap in CloudEvents envelope when the topic is not
 			// configured with rawSchema=true.
 			if !sm.rawSchema {
-				ceSchemaJSON, ceErr := wrapInCloudEventsAvroSchema(v)
+				ceSchemaJSON, ceErr := wrapInCloudEventsSchema(v)
 				if ceErr != nil {
 					return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
 				}
@@ -251,7 +252,7 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 			// Only wrap in CloudEvents envelope when the topic is not
 			// configured with rawSchema=true.
 			if !sm.rawSchema {
-				ceSchemaJSON, ceErr := wrapInCloudEventsAvroSchema(v)
+				ceSchemaJSON, ceErr := wrapInCloudEventsSchema(v)
 				if ceErr != nil {
 					return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
 				}
@@ -481,18 +482,26 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 			// Dapr's CE envelope can encode the "data" field as a JSON string;
 			// the JSON schema CloudEvents codec expects a nested object. Normalize
 			// before validation, reusing the Avro normalization helper.
-			normalized, normErr := normalizeCloudEventForAvro(data)
+			normalized, normErr := normalizeCloudEventData(data)
 			if normErr != nil {
 				return nil, fmt.Errorf("failed to normalize CloudEvents data for JSON schema: %w", normErr)
 			}
 			data = normalized
 		}
-		native, _, nativeErr := codec.NativeFromTextual(data)
+		// Validate the payload against the schema using goavro, but do NOT use
+		// the goavro "native" value as msg.Value. goavro wraps union types as
+		// map[string]any{"string": "..."} which changes the JSON wire format.
+		// Instead, use a standard json.Unmarshal result for the Pulsar JSON encoder.
+		_, _, nativeErr := codec.NativeFromTextual(data)
 		if nativeErr != nil {
 			return nil, fmt.Errorf("json schema validation failed: %w", nativeErr)
 		}
 
-		msg.Value = native
+		var obj interface{}
+		if err = json.Unmarshal(data, &obj); err != nil {
+			return nil, fmt.Errorf("json schema unmarshal after validation: %w", err)
+		}
+		msg.Value = obj
 	case avroProtocol:
 		// Select the appropriate codec based on whether the payload is raw or
 		// wrapped in a CloudEvents envelope. When rawPayload=true, the data is the
@@ -518,7 +527,7 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 		if schema.ceCodec != nil {
 			// Dapr's CE envelope encodes the "data" field as a JSON string;
 			// the Avro codec expects a nested record. Normalize before encoding.
-			normalized, normErr := normalizeCloudEventForAvro(req.Data)
+			normalized, normErr := normalizeCloudEventData(req.Data)
 			if normErr != nil {
 				return nil, fmt.Errorf("failed to normalize CloudEvents data for Avro: %w", normErr)
 			}

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -539,6 +539,8 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 		}
 
 		msg.Value = native
+	default:
+		return nil, fmt.Errorf("unsupported schema protocol %q: only json, avro, and proto are supported", schema.protocol)
 	}
 
 	for name, value := range req.Metadata {

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -212,21 +212,27 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 			if codecErr != nil {
 				return nil, fmt.Errorf("failed to parse json schema for topic %q: %w", topic, codecErr)
 			}
-			ceSchemaJSON, ceErr := wrapInCloudEventsAvroSchema(v)
-			if ceErr != nil {
-				return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
+			sm := schemaMetadata{
+				protocol:  jsonProtocol,
+				value:     v,
+				codec:     codec,
+				rawSchema: rawSchemaTopics[topic],
 			}
-			ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
-			if ceCodecErr != nil {
-				return nil, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
+			// Only wrap in CloudEvents envelope when the topic is not
+			// configured with rawSchema=true.
+			if !sm.rawSchema {
+				ceSchemaJSON, ceErr := wrapInCloudEventsAvroSchema(v)
+				if ceErr != nil {
+					return nil, fmt.Errorf("failed to generate CloudEvents envelope schema for topic %q: %w", topic, ceErr)
+				}
+				ceCodec, ceCodecErr := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+				if ceCodecErr != nil {
+					return nil, fmt.Errorf("failed to parse CloudEvents envelope schema for topic %q: %w", topic, ceCodecErr)
+				}
+				sm.ceValue = ceSchemaJSON
+				sm.ceCodec = ceCodec
 			}
-			m.internalTopicSchemas[topic] = schemaMetadata{
-				protocol: jsonProtocol,
-				value:    v,
-				codec:    codec,
-				ceValue:  ceSchemaJSON,
-				ceCodec:  ceCodec,
-			}
+			m.internalTopicSchemas[topic] = sm
 		case strings.HasSuffix(k, topicAvroSchemaIdentifier):
 			topic := k[:len(k)-len(topicAvroSchemaIdentifier)]
 			codec, codecErr := goavro.NewCodecForStandardJSONFull(v)
@@ -454,8 +460,11 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 		if rawErr != nil {
 			return nil, fmt.Errorf("invalid rawPayload metadata: %w", rawErr)
 		}
-		if isRaw && schema.ceCodec != nil {
-			return nil, errors.New("rawPayload=true is not compatible with JSON schema topics using CloudEvents envelope; use a separate topic for raw payloads")
+		if isRaw && !schema.rawSchema {
+			return nil, errors.New("rawPayload=true is not compatible with JSON schema topics using CloudEvents envelope; use a topic configured with rawschema=true")
+		}
+		if !isRaw && schema.rawSchema {
+			return nil, errors.New("rawschema=true topics require per-message rawPayload=true; otherwise Dapr wraps in a CloudEvents envelope that won't match the registered schema")
 		}
 		codec := schema.ceCodec
 		if schema.ceCodec == nil {

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -467,13 +467,24 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 			return nil, errors.New("rawschema=true topics require per-message rawPayload=true; otherwise Dapr wraps in a CloudEvents envelope that won't match the registered schema")
 		}
 		codec := schema.ceCodec
+		data := req.Data
 		if schema.ceCodec == nil {
 			codec = schema.codec
 		}
 		if codec == nil {
 			return nil, errors.New("no JSON schema codec available: schema metadata is missing a compiled codec for this topic")
 		}
-		native, _, nativeErr := codec.NativeFromTextual(req.Data)
+		if schema.ceCodec != nil {
+			// Dapr's CE envelope can encode the "data" field as a JSON string;
+			// the JSON schema CloudEvents codec expects a nested object. Normalize
+			// before validation, reusing the Avro normalization helper.
+			normalized, normErr := normalizeCloudEventForAvro(data)
+			if normErr != nil {
+				return nil, fmt.Errorf("failed to normalize CloudEvents data for JSON schema: %w", normErr)
+			}
+			data = normalized
+		}
+		native, _, nativeErr := codec.NativeFromTextual(data)
 		if nativeErr != nil {
 			return nil, fmt.Errorf("json schema validation failed: %w", nativeErr)
 		}

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -461,6 +461,9 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 		if schema.ceCodec == nil {
 			codec = schema.codec
 		}
+		if codec == nil {
+			return nil, errors.New("no JSON schema codec available: schema metadata is missing a compiled codec for this topic")
+		}
 		native, _, nativeErr := codec.NativeFromTextual(req.Data)
 		if nativeErr != nil {
 			return nil, fmt.Errorf("json schema validation failed: %w", nativeErr)
@@ -485,7 +488,11 @@ func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 		data := req.Data
 		if schema.ceCodec == nil {
 			codec = schema.codec
-		} else {
+		}
+		if codec == nil {
+			return nil, errors.New("no Avro schema codec available: schema metadata is missing a compiled codec for this topic")
+		}
+		if schema.ceCodec != nil {
 			// Dapr's CE envelope encodes the "data" field as a JSON string;
 			// the Avro codec expects a nested record. Normalize before encoding.
 			normalized, normErr := normalizeCloudEventForAvro(req.Data)

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -450,7 +450,11 @@ func getPulsarSchema(metadata schemaMetadata) pulsar.Schema {
 	}
 }
 
-// parsePublishMetadata parse publish metadata.
+// parsePublishMetadata constructs a ProducerMessage from the publish request.
+// For JSON and Avro schema topics it validates the payload against the registered
+// schema (including CE envelope normalization when applicable), enforces the
+// rawPayload/rawSchema contract, and maps partition keys, delivery timing, and
+// custom properties onto the message.
 func parsePublishMetadata(req *pubsub.PublishRequest, schema schemaMetadata) (
 	msg *pulsar.ProducerMessage, err error,
 ) {

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -378,6 +378,9 @@ const (
 	testAvroSchema1 = `{"type":"record","name":"S1","fields":[{"name":"id","type":"int"}]}`
 	testAvroSchema2 = `{"type":"record","name":"S2","fields":[{"name":"id","type":"int"}]}`
 	testAvroSchema3 = `{"type":"record","name":"S3","fields":[{"name":"id","type":"int"}]}`
+
+	testJSONSchema1 = `{"type":"record","name":"J1","fields":[{"name":"name","type":"string"}]}`
+	testJSONSchema2 = `{"type":"record","name":"J2","fields":[{"name":"age","type":"int"}]}`
 )
 
 func TestParsePulsarSchemaMetadata(t *testing.T) {
@@ -385,16 +388,20 @@ func TestParsePulsarSchemaMetadata(t *testing.T) {
 		m := pubsub.Metadata{}
 		m.Properties = map[string]string{
 			"host":                         "a",
-			"obiwan.jsonschema":            "1",
-			"kenobi.jsonschema.jsonschema": "2",
+			"obiwan.jsonschema":            testJSONSchema1,
+			"kenobi.jsonschema.jsonschema": testJSONSchema2,
 		}
 		meta, err := parsePulsarMetadata(m)
 
 		require.NoError(t, err)
 		assert.Equal(t, "a", meta.Host)
 		assert.Len(t, meta.internalTopicSchemas, 2)
-		assert.Equal(t, "1", meta.internalTopicSchemas["obiwan"].value)
-		assert.Equal(t, "2", meta.internalTopicSchemas["kenobi.jsonschema"].value)
+		assert.JSONEq(t, testJSONSchema1, meta.internalTopicSchemas["obiwan"].value)
+		assert.NotNil(t, meta.internalTopicSchemas["obiwan"].codec)
+		assert.NotEmpty(t, meta.internalTopicSchemas["obiwan"].ceValue)
+		assert.NotNil(t, meta.internalTopicSchemas["obiwan"].ceCodec)
+		assert.JSONEq(t, testJSONSchema2, meta.internalTopicSchemas["kenobi.jsonschema"].value)
+		assert.NotNil(t, meta.internalTopicSchemas["kenobi.jsonschema"].codec)
 	})
 
 	t.Run("test avro", func(t *testing.T) {
@@ -436,7 +443,7 @@ func TestParsePulsarSchemaMetadata(t *testing.T) {
 		m.Properties = map[string]string{
 			"host":              "a",
 			"obiwan.avroschema": testAvroSchema1,
-			"kenobi.jsonschema": "2",
+			"kenobi.jsonschema": testJSONSchema1,
 		}
 		meta, err := parsePulsarMetadata(m)
 
@@ -444,7 +451,8 @@ func TestParsePulsarSchemaMetadata(t *testing.T) {
 		assert.Equal(t, "a", meta.Host)
 		assert.Len(t, meta.internalTopicSchemas, 2)
 		assert.JSONEq(t, testAvroSchema1, meta.internalTopicSchemas["obiwan"].value)
-		assert.Equal(t, "2", meta.internalTopicSchemas["kenobi"].value)
+		assert.JSONEq(t, testJSONSchema1, meta.internalTopicSchemas["kenobi"].value)
+		assert.NotNil(t, meta.internalTopicSchemas["kenobi"].codec)
 		assert.Equal(t, avroProtocol, meta.internalTopicSchemas["obiwan"].protocol)
 		assert.Equal(t, jsonProtocol, meta.internalTopicSchemas["kenobi"].protocol) //nolint:testifylint
 	})
@@ -454,7 +462,7 @@ func TestParsePulsarSchemaMetadata(t *testing.T) {
 		m.Properties = map[string]string{
 			"host":              "a",
 			"obiwan.avroschema": testAvroSchema1,
-			"kenobi.jsonschema": "2",
+			"kenobi.jsonschema": testJSONSchema1,
 			"darth.protoschema": "3",
 		}
 		meta, err := parsePulsarMetadata(m)
@@ -463,11 +471,23 @@ func TestParsePulsarSchemaMetadata(t *testing.T) {
 		assert.Equal(t, "a", meta.Host)
 		assert.Len(t, meta.internalTopicSchemas, 3)
 		assert.JSONEq(t, testAvroSchema1, meta.internalTopicSchemas["obiwan"].value)
-		assert.Equal(t, "2", meta.internalTopicSchemas["kenobi"].value)
+		assert.JSONEq(t, testJSONSchema1, meta.internalTopicSchemas["kenobi"].value)
+		assert.NotNil(t, meta.internalTopicSchemas["kenobi"].codec)
 		assert.Equal(t, "3", meta.internalTopicSchemas["darth"].value)
 		assert.Equal(t, avroProtocol, meta.internalTopicSchemas["obiwan"].protocol)
 		assert.Equal(t, jsonProtocol, meta.internalTopicSchemas["kenobi"].protocol) //nolint:testifylint
 		assert.Equal(t, protoProtocol, meta.internalTopicSchemas["darth"].protocol)
+	})
+
+	t.Run("test json invalid schema rejected at init", func(t *testing.T) {
+		m := pubsub.Metadata{}
+		m.Properties = map[string]string{
+			"host":              "a",
+			"obiwan.jsonschema": `{"type":"bogus"}`,
+		}
+		_, err := parsePulsarMetadata(m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse json schema")
 	})
 
 	t.Run("test funky edge case", func(t *testing.T) {
@@ -1155,6 +1175,134 @@ func TestParsePublishMetadataAvroSchemaInvalidSchemaDefinition(t *testing.T) {
 	_, err := parsePulsarMetadata(m)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse avro schema")
+}
+
+func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
+	jsonSchemaJSON := `{
+		"type": "record",
+		"name": "User",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "name", "type": "string"},
+			{"name": "age", "type": "int"}
+		]
+	}`
+	codec, err := goavro.NewCodecForStandardJSONFull(jsonSchemaJSON)
+	require.NoError(t, err)
+
+	sm := schemaMetadata{
+		protocol: jsonProtocol,
+		value:    jsonSchemaJSON,
+		codec:    codec,
+	}
+
+	t.Run("valid payload passes validation", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{"name":"Alice","age":30}`),
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg.Value)
+	})
+
+	t.Run("invalid payload rejected", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{"name":"Alice","age":"not_a_number"}`),
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json schema validation failed")
+	})
+
+	t.Run("missing required field rejected", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{"name":"Alice"}`),
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json schema validation failed")
+	})
+
+	t.Run("not valid json rejected", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{broken json`),
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json schema validation failed")
+	})
+
+	t.Run("rawPayload true without CE codec uses inner codec", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data:     []byte(`{"name":"Alice","age":30}`),
+			Metadata: map[string]string{"rawPayload": "true"},
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg.Value)
+	})
+}
+
+func TestParsePublishMetadataJSONSchemaCloudEventsEnvelope(t *testing.T) {
+	jsonSchemaJSON := `{
+		"type": "record",
+		"name": "OrderEvent",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "orderId", "type": "string"},
+			{"name": "amount", "type": "double"}
+		]
+	}`
+
+	codec, err := goavro.NewCodecForStandardJSONFull(jsonSchemaJSON)
+	require.NoError(t, err)
+	ceSchemaJSON, err := wrapInCloudEventsAvroSchema(jsonSchemaJSON)
+	require.NoError(t, err)
+	ceCodec, err := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
+	require.NoError(t, err)
+
+	sm := schemaMetadata{
+		protocol: jsonProtocol,
+		value:    jsonSchemaJSON,
+		codec:    codec,
+		ceValue:  ceSchemaJSON,
+		ceCodec:  ceCodec,
+	}
+
+	t.Run("valid CE envelope passes", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{
+				"id": "evt-1",
+				"source": "/test",
+				"specversion": "1.0",
+				"type": "com.example.order",
+				"datacontenttype": "application/json",
+				"subject": null,
+				"time": null,
+				"topic": null,
+				"pubsubname": null,
+				"traceid": null,
+				"traceparent": null,
+				"tracestate": null,
+				"expiration": null,
+				"data": {"orderId": "123", "amount": 9.99},
+				"data_base64": null
+			}`),
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg.Value)
+	})
+
+	t.Run("rawPayload rejected with CE envelope", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data:     []byte(`{"orderId": "123", "amount": 9.99}`),
+			Metadata: map[string]string{"rawPayload": "true"},
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rawPayload=true is not compatible with JSON schema topics")
+	})
 }
 
 func TestParsePublishMetadataAvroCloudEventsEnvelope(t *testing.T) {

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -1232,14 +1232,14 @@ func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "json schema validation failed")
 	})
 
-	t.Run("rawPayload true without CE codec uses inner codec", func(t *testing.T) {
+	t.Run("rawPayload rejected without rawSchema", func(t *testing.T) {
 		req := &pubsub.PublishRequest{
 			Data:     []byte(`{"name":"Alice","age":30}`),
 			Metadata: map[string]string{"rawPayload": "true"},
 		}
-		msg, err := parsePublishMetadata(req, sm)
-		require.NoError(t, err)
-		assert.NotNil(t, msg.Value)
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rawPayload=true is not compatible with JSON schema topics")
 	})
 }
 
@@ -1302,6 +1302,75 @@ func TestParsePublishMetadataJSONSchemaCloudEventsEnvelope(t *testing.T) {
 		_, err := parsePublishMetadata(req, sm)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "rawPayload=true is not compatible with JSON schema topics")
+	})
+}
+
+func TestParsePulsarMetadataJSONRawSchemaSkipsCE(t *testing.T) {
+	jsonSchemaJSON := `{
+		"type": "record",
+		"name": "TestEvent",
+		"fields": [
+			{"name": "id", "type": "int"}
+		]
+	}`
+
+	m := pubsub.Metadata{}
+	m.Properties = map[string]string{
+		"host":                                "a",
+		"mytopic" + topicJSONSchemaIdentifier: jsonSchemaJSON,
+		"mytopic" + topicRawSchemaIdentifier:  "true",
+	}
+
+	meta, err := parsePulsarMetadata(m)
+	require.NoError(t, err)
+
+	sm, ok := meta.internalTopicSchemas["mytopic"]
+	require.True(t, ok)
+	assert.NotNil(t, sm.codec, "inner codec should be compiled")
+	assert.Nil(t, sm.ceCodec, "CE envelope codec should NOT be set for rawSchema topics")
+	assert.Empty(t, sm.ceValue, "CE envelope schema JSON should NOT be set for rawSchema topics")
+	assert.True(t, sm.rawSchema, "rawSchema flag should be set")
+}
+
+func TestParsePublishMetadataJSONRawSchemaTopic(t *testing.T) {
+	jsonSchemaJSON := `{
+		"type": "record",
+		"name": "OrderEvent",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "orderId", "type": "string"},
+			{"name": "amount", "type": "double"}
+		]
+	}`
+
+	// Build schema metadata without CE wrapping (simulates rawSchema=true topic).
+	codec, err := goavro.NewCodecForStandardJSONFull(jsonSchemaJSON)
+	require.NoError(t, err)
+	sm := schemaMetadata{
+		protocol:  jsonProtocol,
+		value:     jsonSchemaJSON,
+		codec:     codec,
+		rawSchema: true,
+	}
+
+	t.Run("rawPayload succeeds with inner schema", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data:     []byte(`{"orderId": "order-1", "amount": 99.99}`),
+			Metadata: map[string]string{"rawPayload": "true"},
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg)
+		assert.NotNil(t, msg.Value)
+	})
+
+	t.Run("non-raw rejected on rawschema topic", func(t *testing.T) {
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{"orderId": "order-1", "amount": 99.99}`),
+		}
+		_, err := parsePublishMetadata(req, sm)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rawschema=true topics require per-message rawPayload=true")
 	})
 }
 

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -1190,15 +1190,20 @@ func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
 	codec, err := goavro.NewCodecForStandardJSONFull(jsonSchemaJSON)
 	require.NoError(t, err)
 
+	// rawSchema=true with only the inner codec matches the production state
+	// produced by parsePulsarMetadata when a topic has both .jsonschema and
+	// .rawschema=true configured. All subtests use rawPayload=true accordingly.
 	sm := schemaMetadata{
-		protocol: jsonProtocol,
-		value:    jsonSchemaJSON,
-		codec:    codec,
+		protocol:  jsonProtocol,
+		value:     jsonSchemaJSON,
+		codec:     codec,
+		rawSchema: true,
 	}
 
 	t.Run("valid payload passes validation", func(t *testing.T) {
 		req := &pubsub.PublishRequest{
-			Data: []byte(`{"name":"Alice","age":30}`),
+			Data:     []byte(`{"name":"Alice","age":30}`),
+			Metadata: map[string]string{"rawPayload": "true"},
 		}
 		msg, err := parsePublishMetadata(req, sm)
 		require.NoError(t, err)
@@ -1207,7 +1212,8 @@ func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
 
 	t.Run("invalid payload rejected", func(t *testing.T) {
 		req := &pubsub.PublishRequest{
-			Data: []byte(`{"name":"Alice","age":"not_a_number"}`),
+			Data:     []byte(`{"name":"Alice","age":"not_a_number"}`),
+			Metadata: map[string]string{"rawPayload": "true"},
 		}
 		_, err := parsePublishMetadata(req, sm)
 		require.Error(t, err)
@@ -1216,7 +1222,8 @@ func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
 
 	t.Run("missing required field rejected", func(t *testing.T) {
 		req := &pubsub.PublishRequest{
-			Data: []byte(`{"name":"Alice"}`),
+			Data:     []byte(`{"name":"Alice"}`),
+			Metadata: map[string]string{"rawPayload": "true"},
 		}
 		_, err := parsePublishMetadata(req, sm)
 		require.Error(t, err)
@@ -1225,21 +1232,21 @@ func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
 
 	t.Run("not valid json rejected", func(t *testing.T) {
 		req := &pubsub.PublishRequest{
-			Data: []byte(`{broken json`),
+			Data:     []byte(`{broken json`),
+			Metadata: map[string]string{"rawPayload": "true"},
 		}
 		_, err := parsePublishMetadata(req, sm)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "json schema validation failed")
 	})
 
-	t.Run("rawPayload rejected without rawSchema", func(t *testing.T) {
+	t.Run("non-raw rejected on rawSchema topic", func(t *testing.T) {
 		req := &pubsub.PublishRequest{
-			Data:     []byte(`{"name":"Alice","age":30}`),
-			Metadata: map[string]string{"rawPayload": "true"},
+			Data: []byte(`{"name":"Alice","age":30}`),
 		}
 		_, err := parsePublishMetadata(req, sm)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "rawPayload=true is not compatible with JSON schema topics")
+		assert.Contains(t, err.Error(), "rawschema=true topics require per-message rawPayload=true")
 	})
 }
 

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -1303,6 +1303,33 @@ func TestParsePublishMetadataJSONSchemaCloudEventsEnvelope(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "rawPayload=true is not compatible with JSON schema topics")
 	})
+
+	t.Run("CE envelope with stringified data is normalized", func(t *testing.T) {
+		// Dapr can produce CE envelopes where "data" is a JSON string rather
+		// than a nested object. The JSON schema path must normalize it.
+		req := &pubsub.PublishRequest{
+			Data: []byte(`{
+				"id": "evt-2",
+				"source": "/test",
+				"specversion": "1.0",
+				"type": "com.example.order",
+				"datacontenttype": "application/json",
+				"subject": null,
+				"time": null,
+				"topic": null,
+				"pubsubname": null,
+				"traceid": null,
+				"traceparent": null,
+				"tracestate": null,
+				"expiration": null,
+				"data": "{\"orderId\": \"456\", \"amount\": 19.99}",
+				"data_base64": null
+			}`),
+		}
+		msg, err := parsePublishMetadata(req, sm)
+		require.NoError(t, err)
+		assert.NotNil(t, msg.Value)
+	})
 }
 
 func TestParsePulsarMetadataJSONRawSchemaSkipsCE(t *testing.T) {

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -1178,6 +1178,46 @@ func TestParsePublishMetadataAvroSchemaInvalidSchemaDefinition(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse avro schema")
 }
 
+func TestBuildSchemaMetadata(t *testing.T) {
+	validSchema := `{"type":"record","name":"E","namespace":"test","fields":[{"name":"id","type":"int"}]}`
+
+	tests := []struct {
+		name      string
+		schema    string
+		protocol  string
+		rawSchema bool
+		wantCE    bool
+		wantErr   bool
+	}{
+		{name: "json with CE wrapping", schema: validSchema, protocol: jsonProtocol, rawSchema: false, wantCE: true},
+		{name: "json raw skips CE", schema: validSchema, protocol: jsonProtocol, rawSchema: true, wantCE: false},
+		{name: "avro with CE wrapping", schema: validSchema, protocol: avroProtocol, rawSchema: false, wantCE: true},
+		{name: "avro raw skips CE", schema: validSchema, protocol: avroProtocol, rawSchema: true, wantCE: false},
+		{name: "invalid schema", schema: `{bad}`, protocol: jsonProtocol, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm, err := buildSchemaMetadata("test-topic", tt.schema, tt.protocol, tt.rawSchema)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.protocol, sm.protocol)
+			assert.Equal(t, tt.schema, sm.value)
+			assert.Equal(t, tt.rawSchema, sm.rawSchema)
+			assert.NotNil(t, sm.codec)
+			if tt.wantCE {
+				assert.NotNil(t, sm.ceCodec)
+				assert.NotEmpty(t, sm.ceValue)
+			} else {
+				assert.Nil(t, sm.ceCodec)
+				assert.Empty(t, sm.ceValue)
+			}
+		})
+	}
+}
+
 func TestParsePublishMetadataJSONSchemaValidation(t *testing.T) {
 	jsonSchemaJSON := `{
 		"type": "record",

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -57,7 +57,7 @@ func newAvroSchemaMetadataWithCE(t *testing.T, avroSchemaJSON string) schemaMeta
 	codec, err := goavro.NewCodecForStandardJSONFull(avroSchemaJSON)
 	require.NoError(t, err, "failed to compile test avro schema")
 
-	ceSchemaJSON, err := wrapInCloudEventsAvroSchema(avroSchemaJSON)
+	ceSchemaJSON, err := wrapInCloudEventsSchema(avroSchemaJSON)
 	require.NoError(t, err, "failed to generate CE envelope schema")
 	ceCodec, err := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
 	require.NoError(t, err, "failed to compile CE envelope schema")
@@ -1256,7 +1256,7 @@ func TestParsePublishMetadataJSONSchemaCloudEventsEnvelope(t *testing.T) {
 
 	codec, err := goavro.NewCodecForStandardJSONFull(jsonSchemaJSON)
 	require.NoError(t, err)
-	ceSchemaJSON, err := wrapInCloudEventsAvroSchema(jsonSchemaJSON)
+	ceSchemaJSON, err := wrapInCloudEventsSchema(jsonSchemaJSON)
 	require.NoError(t, err)
 	ceCodec, err := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
 	require.NoError(t, err)
@@ -1444,7 +1444,7 @@ func TestParsePublishMetadataAvroCloudEventsEnvelope(t *testing.T) {
 	t.Run("CE envelope with stringified data", func(t *testing.T) {
 		// Dapr's runtime serialises the data field as a JSON string, e.g.
 		// "data": "{\"orderId\":\"order-1\",\"amount\":99.99}"
-		// normalizeCloudEventForAvro must parse it before Avro encoding.
+		// normalizeCloudEventData must parse it before Avro encoding.
 		cePayload := `{
 			"id": "abc-123",
 			"source": "Dapr",
@@ -2471,7 +2471,7 @@ func TestHandleMessageAvroCEEnvelopeDecodeRoundTrip(t *testing.T) {
 	innerCodec, err := goavro.NewCodecForStandardJSONFull(innerSchema)
 	require.NoError(t, err)
 
-	ceSchemaJSON, err := wrapInCloudEventsAvroSchema(innerSchema)
+	ceSchemaJSON, err := wrapInCloudEventsSchema(innerSchema)
 	require.NoError(t, err)
 	ceCodec, err := goavro.NewCodecForStandardJSONFull(ceSchemaJSON)
 	require.NoError(t, err)

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -35,9 +35,10 @@ import (
 )
 
 // newAvroSchemaMetadata creates a schemaMetadata with only the inner goavro codec
-// (no CE envelope). This is equivalent to a rawschema=true topic. Used by the
-// Avro type-validation tests that predate CE support and test schema validation
-// logic in isolation with inner-schema payloads.
+// (no CE envelope, rawSchema=false). This does NOT match any production state
+// exactly — it bypasses both CE envelope validation and rawSchema enforcement.
+// Used by legacy Avro type-validation tests that predate CE support and test
+// schema validation logic in isolation with inner-schema payloads.
 func newAvroSchemaMetadata(t *testing.T, avroSchemaJSON string) schemaMetadata {
 	t.Helper()
 	codec, err := goavro.NewCodecForStandardJSONFull(avroSchemaJSON)

--- a/tests/certification/pubsub/pulsar/components/auth-none/consumer_eleven/pulsar.yaml
+++ b/tests/certification/pubsub/pulsar/components/auth-none/consumer_eleven/pulsar.yaml
@@ -1,0 +1,18 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification11
+  - name: redeliveryDelay
+    value: 200ms
+  # Pulsar JSON schema uses Avro-compatible record definitions (not JSON Schema Draft).
+  # The component wraps this in a CloudEvents envelope schema automatically.
+  - name: certification-pubsub-topic-json-ce.jsonschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"

--- a/tests/certification/pubsub/pulsar/components/auth-none/consumer_four/pulsar.yaml
+++ b/tests/certification/pubsub/pulsar/components/auth-none/consumer_four/pulsar.yaml
@@ -13,4 +13,4 @@ spec:
   - name: redeliveryDelay
     value: 200ms
   - name: certification-pubsub-topic-active.jsonschema
-    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"ID\",\"type\":\"int\"},{\"name\":\"Name\",\"type\":\"string\"}]}"
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\"}]}"

--- a/tests/certification/pubsub/pulsar/components/auth-none/consumer_twelve/pulsar.yaml
+++ b/tests/certification/pubsub/pulsar/components/auth-none/consumer_twelve/pulsar.yaml
@@ -1,0 +1,20 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification12
+  - name: redeliveryDelay
+    value: 200ms
+  # Pulsar JSON schema uses Avro-compatible record definitions (not JSON Schema Draft).
+  # rawschema=true skips CloudEvents wrapping; publishers must use rawPayload=true.
+  - name: certification-pubsub-topic-json-raw.jsonschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"
+  - name: certification-pubsub-topic-json-raw.rawschema
+    value: "true"

--- a/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_eleven/pulsar.yml.tmpl
+++ b/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_eleven/pulsar.yml.tmpl
@@ -1,0 +1,30 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification11
+  - name: redeliveryDelay
+    value: 200ms
+  # Pulsar JSON schema uses Avro-compatible record definitions (not JSON Schema Draft).
+  # The component wraps this in a CloudEvents envelope schema automatically.
+  - name: certification-pubsub-topic-json-ce.jsonschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"
+  - name: oauth2TokenURL
+    value: https://localhost:8085/issuer1/token
+  - name: oauth2ClientID
+    value: foo
+  - name: oauth2ClientSecret
+    value: bar
+  - name: oauth2Scopes
+    value: openid
+  - name: oauth2Audiences
+    value: pulsar
+  - name: oauth2TokenCAPEM
+    value: "{{ .OAuth2CAPEM }}"

--- a/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_four/pulsar.yml.tmpl
+++ b/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_four/pulsar.yml.tmpl
@@ -13,7 +13,7 @@ spec:
   - name: redeliveryDelay
     value: 200ms
   - name: certification-pubsub-topic-active.jsonschema
-    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"ID\",\"type\":\"int\"},{\"name\":\"Name\",\"type\":\"string\"}]}"
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\"}]}"
   - name: oauth2TokenURL
     value: https://localhost:8085/issuer1/token
   - name: oauth2ClientID

--- a/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_twelve/pulsar.yml.tmpl
+++ b/tests/certification/pubsub/pulsar/components/auth-oauth2/consumer_twelve/pulsar.yml.tmpl
@@ -1,0 +1,32 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.pulsar
+  version: v1
+  metadata:
+  - name: host
+    value: "localhost:6650"
+  - name: consumerID
+    value: certification12
+  - name: redeliveryDelay
+    value: 200ms
+  # Pulsar JSON schema uses Avro-compatible record definitions (not JSON Schema Draft).
+  # rawschema=true skips CloudEvents wrapping; publishers must use rawPayload=true.
+  - name: certification-pubsub-topic-json-raw.jsonschema
+    value: "{\"type\":\"record\",\"name\":\"Example\",\"namespace\":\"test\",\"fields\":[{\"name\":\"testId\",\"type\":\"int\"},{\"name\":\"testName\",\"type\":\"string\"}]}"
+  - name: certification-pubsub-topic-json-raw.rawschema
+    value: "true"
+  - name: oauth2TokenURL
+    value: https://localhost:8085/issuer1/token
+  - name: oauth2ClientID
+    value: foo
+  - name: oauth2ClientSecret
+    value: bar
+  - name: oauth2Scopes
+    value: openid
+  - name: oauth2Audiences
+    value: pulsar
+  - name: oauth2TokenCAPEM
+    value: "{{ .OAuth2CAPEM }}"

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -74,6 +74,8 @@ const (
 	pubsubName                  = "messagebus"
 	topicActiveName             = "certification-pubsub-topic-active"
 	topicAvroRawName            = "certification-pubsub-topic-avro-raw"
+	topicJSONCEName             = "certification-pubsub-topic-json-ce"
+	topicJSONRawName            = "certification-pubsub-topic-json-raw"
 	topicPassiveName            = "certification-pubsub-topic-passive"
 	topicToBeCreated            = "certification-topic-per-test-run"
 	topicDefaultName            = "certification-topic-default"
@@ -956,9 +958,10 @@ func publishSchemaMessages(sidecarName string, topicName string, messageWatchers
 	}
 }
 
-// publishAvroSchemaMessagesCE publishes Avro schema messages without rawPayload,
-// allowing Dapr to wrap them in a CloudEvents envelope.
-func publishAvroSchemaMessagesCE(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
+// publishSchemaMessagesCE publishes schema-validated messages without rawPayload,
+// allowing Dapr to wrap them in a CloudEvents envelope. Works for both Avro and
+// JSON schema topics since the payload shape (avroSchemaTest) is the same.
+func publishSchemaMessagesCE(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
 	return func(ctx flow.Context) error {
 		messages := make([]string, numMessages)
 		for i := range messages {
@@ -990,9 +993,10 @@ func publishAvroSchemaMessagesCE(sidecarName string, topicName string, messageWa
 	}
 }
 
-// publishAvroSchemaMessages publishes Avro schema messages with rawPayload=true,
-// bypassing CloudEvents wrapping. Used with rawSchema=true topics.
-func publishAvroSchemaMessages(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
+// publishSchemaMessagesRaw publishes schema-validated messages with rawPayload=true,
+// bypassing CloudEvents wrapping. Used with rawSchema=true topics for both Avro
+// and JSON schema types.
+func publishSchemaMessagesRaw(sidecarName string, topicName string, messageWatchers ...*watcher.Watcher) flow.Runnable {
 	return func(ctx flow.Context) error {
 		messages := make([]string, numMessages)
 		for i := range messages {
@@ -1110,7 +1114,7 @@ func (p *pulsarSuite) TestPulsarAvroSchema() {
 				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
 			)...,
 		)).
-		Step("publish messages to topic1", publishAvroSchemaMessagesCE(sidecarName1, topicActiveName, consumerGroup1)).
+		Step("publish messages to topic1", publishSchemaMessagesCE(sidecarName1, topicActiveName, consumerGroup1)).
 		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
 		Run()
 }
@@ -1180,7 +1184,125 @@ func (p *pulsarSuite) TestPulsarAvroSchemaRaw() {
 				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
 			)...,
 		)).
-		Step("publish messages to topic1", publishAvroSchemaMessages(sidecarName1, topicAvroRawName, consumerGroup1)).
+		Step("publish messages to topic1", publishSchemaMessagesRaw(sidecarName1, topicAvroRawName, consumerGroup1)).
+		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
+		Run()
+}
+
+// TestPulsarJSONSchema tests JSON schema with CloudEvents envelope wrapping.
+// The sidecar registers the CE-wrapped schema on subscribe; no pre-registration needed.
+func (p *pulsarSuite) TestPulsarJSONSchema() {
+	t := p.T()
+	consumerGroup1 := watcher.NewUnordered()
+
+	flow.New(t, "pulsar certification json schema CE test").
+
+		// subscriberSchemaApplication subscribes without rawPayload, so Dapr
+		// unwraps the CloudEvents envelope and delivers the inner data field.
+		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
+			subscriberSchemaApplication(appID1, topicJSONCEName, consumerGroup1))).
+		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
+		Step("wait", flow.Sleep(10*time.Second)).
+		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
+			client, err := p.client(t)
+			if err != nil {
+				return fmt.Errorf("could not create pulsar client: %v", err)
+			}
+
+			defer client.Close()
+
+			consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+				Topic:            "topic-1",
+				SubscriptionName: "my-sub",
+				Type:             pulsar.Shared,
+			})
+			if err != nil {
+				return fmt.Errorf("could not create pulsar Topic: %v", err)
+			}
+			defer consumer.Close()
+
+			return err
+		})).
+		Step(sidecar.Run(sidecarName1,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_eleven")),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
+			)...,
+		)).
+		Step("publish messages to topic1", publishSchemaMessagesCE(sidecarName1, topicJSONCEName, consumerGroup1)).
+		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
+		Run()
+}
+
+// TestPulsarJSONSchemaRaw tests JSON schema with rawSchema=true, bypassing
+// CloudEvents envelope wrapping. The raw user schema is pre-registered on the
+// topic and the component uses it directly without CE wrapping.
+func (p *pulsarSuite) TestPulsarJSONSchemaRaw() {
+	t := p.T()
+	consumerGroup1 := watcher.NewUnordered()
+
+	// Pulsar JSON schema uses Avro-compatible record definitions, not JSON Schema Draft.
+	jsonSchema := `{"type":"record","name":"Example","namespace":"test","fields":[{"name":"testId","type":"int"},{"name":"testName","type":"string"}]}`
+
+	flow.New(t, "pulsar certification json schema raw test").
+
+		// Run subscriberApplication app1
+		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
+			subscriberAvroSchemaApplication(appID1, topicJSONRawName, consumerGroup1))).
+		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
+		Step("wait", flow.Sleep(10*time.Second)).
+		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
+			client, err := p.client(t)
+			if err != nil {
+				return fmt.Errorf("could not create pulsar client: %v", err)
+			}
+
+			defer client.Close()
+
+			consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+				Topic:            "topic-1",
+				SubscriptionName: "my-sub",
+				Type:             pulsar.Shared,
+			})
+			if err != nil {
+				return fmt.Errorf("could not create pulsar Topic: %v", err)
+			}
+			defer consumer.Close()
+
+			return err
+		})).
+		// Pre-register the raw JSON schema on the topic. Because consumer_twelve
+		// uses rawschema=true, the sidecar subscribes with the same raw schema
+		// (no CloudEvents wrapping), so Pulsar accepts the consumer.
+		Step("register json schema on topic", func(ctx flow.Context) error {
+			client, err := p.client(t)
+			if err != nil {
+				return fmt.Errorf("could not create pulsar client: %v", err)
+			}
+			defer client.Close()
+
+			producer, err := client.CreateProducer(pulsar.ProducerOptions{
+				Topic:  "persistent://public/default/" + topicJSONRawName,
+				Schema: pulsar.NewJSONSchema(jsonSchema, nil),
+			})
+			if err != nil {
+				return fmt.Errorf("could not create producer to register json schema: %v", err)
+			}
+			producer.Close()
+
+			return nil
+		}).
+		Step(sidecar.Run(sidecarName1,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath(filepath.Join(p.componentsPath, "consumer_twelve")),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort)),
+			)...,
+		)).
+		Step("publish messages to topic1", publishSchemaMessagesRaw(sidecarName1, topicJSONRawName, consumerGroup1)).
 		Step("verify if app1 has received messages published to topic", assertMessages(10*time.Second, consumerGroup1)).
 		Run()
 }

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -1202,7 +1202,6 @@ func (p *pulsarSuite) TestPulsarJSONSchema() {
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
 			subscriberSchemaApplication(appID1, topicJSONCEName, consumerGroup1))).
 		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
-		Step("wait", flow.Sleep(10*time.Second)).
 		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
 			client, err := p.client(t)
 			if err != nil {
@@ -1252,7 +1251,6 @@ func (p *pulsarSuite) TestPulsarJSONSchemaRaw() {
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
 			subscriberRawSchemaApplication(appID1, topicJSONRawName, consumerGroup1))).
 		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
-		Step("wait", flow.Sleep(10*time.Second)).
 		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
 			client, err := p.client(t)
 			if err != nil {

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -890,7 +890,7 @@ type avroSchemaTest struct {
 	TestName string `json:"testName"`
 }
 
-func subscriberAvroSchemaApplication(appID string, topicName string, messagesWatcher *watcher.Watcher) app.SetupFn {
+func subscriberRawSchemaApplication(appID string, topicName string, messagesWatcher *watcher.Watcher) app.SetupFn {
 	return func(ctx flow.Context, s common.Service) error {
 		return multierr.Combine(
 			s.AddTopicEventHandler(&common.Subscription{
@@ -907,13 +907,13 @@ func subscriberAvroSchemaApplication(appID string, topicName string, messagesWat
 				if err := json.Unmarshal([]byte(dataStr), &obj); err != nil {
 					ctx.Logf("failed to unmarshal Avro schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
 					// Non-retryable error so the test fails clearly on bad payloads.
-					return false, fmt.Errorf("subscriberAvroSchemaApplication: unmarshal payload: %w", err)
+					return false, fmt.Errorf("subscriberRawSchemaApplication: unmarshal payload: %w", err)
 				}
 				normalized, err := json.Marshal(obj)
 				if err != nil {
 					ctx.Logf("failed to marshal normalized Avro schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
 					// Non-retryable error so the test fails clearly on bad normalization.
-					return false, fmt.Errorf("subscriberAvroSchemaApplication: marshal normalized payload: %w", err)
+					return false, fmt.Errorf("subscriberRawSchemaApplication: marshal normalized payload: %w", err)
 				}
 				messagesWatcher.Observe(string(normalized))
 				ctx.Logf("Message Received appID: %s,pubsub: %s, topic: %s, id: %s, data: %s", appID, e.PubsubName, e.Topic, e.ID, e.Data)
@@ -1132,7 +1132,7 @@ func (p *pulsarSuite) TestPulsarAvroSchemaRaw() {
 
 		// Run subscriberApplication app1
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
-			subscriberAvroSchemaApplication(appID1, topicAvroRawName, consumerGroup1))).
+			subscriberRawSchemaApplication(appID1, topicAvroRawName, consumerGroup1))).
 		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
 		Step("wait", flow.Sleep(10*time.Second)).
 		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
@@ -1250,7 +1250,7 @@ func (p *pulsarSuite) TestPulsarJSONSchemaRaw() {
 
 		// Run subscriberApplication app1
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),
-			subscriberAvroSchemaApplication(appID1, topicJSONRawName, consumerGroup1))).
+			subscriberRawSchemaApplication(appID1, topicJSONRawName, consumerGroup1))).
 		Step(dockercompose.Run(clusterName, p.dockerComposeYAML)).
 		Step("wait", flow.Sleep(10*time.Second)).
 		Step("wait for pulsar readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {

--- a/tests/certification/pubsub/pulsar/pulsar_test.go
+++ b/tests/certification/pubsub/pulsar/pulsar_test.go
@@ -905,13 +905,13 @@ func subscriberRawSchemaApplication(appID string, topicName string, messagesWatc
 				dataStr := fmt.Sprintf("%s", e.Data)
 				var obj avroSchemaTest
 				if err := json.Unmarshal([]byte(dataStr), &obj); err != nil {
-					ctx.Logf("failed to unmarshal Avro schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
+					ctx.Logf("failed to unmarshal raw schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
 					// Non-retryable error so the test fails clearly on bad payloads.
 					return false, fmt.Errorf("subscriberRawSchemaApplication: unmarshal payload: %w", err)
 				}
 				normalized, err := json.Marshal(obj)
 				if err != nil {
-					ctx.Logf("failed to marshal normalized Avro schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
+					ctx.Logf("failed to marshal normalized raw schema payload in subscriber (appID=%s, topic=%s, id=%s): %v", appID, e.Topic, e.ID, err)
 					// Non-retryable error so the test fails clearly on bad normalization.
 					return false, fmt.Errorf("subscriberRawSchemaApplication: marshal normalized payload: %w", err)
 				}


### PR DESCRIPTION
## Description

  - The `.jsonschema` path only checked `json.Unmarshal` (valid JSON) without validating against the schema definition. Since Pulsar JSON schemas use Avro schema definitions, this reuses the same `goavro` codec
  compilation and `NativeFromTextual` validation that the `.avroschema` path already uses.
  - Compile goavro codec at init time for `.jsonschema` topics — invalid schemas now fail fast at startup instead of silently at publish time
  - Generate and compile CloudEvents envelope schema for JSON topics, registered with `NewJSONSchema` (not `NewAvroSchema`)
  - Replace bare `json.Unmarshal` with `codec.NativeFromTextual` at publish time for full structural validation
  - Add `rawPayload` guard matching the Avro path
 
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
