### PR TITLE
fix(pubsub/pulsar): read processMode from component metadata and add async backpressure

### DIFF
--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -38,6 +38,7 @@ type pulsarMetadata struct {
 	PrivateKey                       string                    `mapstructure:"privateKey"`
 	Keys                             string                    `mapstructure:"keys"`
 	MaxConcurrentHandlers            uint                      `mapstructure:"maxConcurrentHandlers"`
+	ProcessMode                      string                    `mapstructure:"processMode"`
 	ReceiverQueueSize                int                       `mapstructure:"receiverQueueSize"`
 	SubscriptionType                 string                    `mapstructure:"subscribeType"`
 	SubscriptionInitialPosition      string                    `mapstructure:"subscribeInitialPosition"`

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -217,6 +217,18 @@ metadata:
           {"name": "Name","type": "string"}
         ]
       }
+  - name: processMode
+    type: string
+    description: |
+      Controls whether messages are processed synchronously or asynchronously.
+      In sync mode, messages are handled one at a time in order.
+      In async mode, up to maxConcurrentHandlers messages are processed concurrently.
+      Can be overridden per subscription via subscription metadata.
+    default: '"async"'
+    example: '"sync"'
+    allowedValues:
+      - sync
+      - async
   - name: maxConcurrentHandlers
     type: number
     description: |

--- a/pubsub/pulsar/process_mode_test.go
+++ b/pubsub/pulsar/process_mode_test.go
@@ -22,6 +22,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -39,7 +40,7 @@ import (
 
 // ---------------------------------------------------------------------------
 // Mock types for testing listenMessage without a real Pulsar broker.
-// These are shared across process_mode_test.go and pulsar_semaphore_test.go.
+// These are shared across process_mode_test.go and pulsar_backpressure_test.go.
 // ---------------------------------------------------------------------------
 
 // mockMessage provides the minimum pulsarclient.Message implementation needed
@@ -63,7 +64,7 @@ func (m *mockMessage) GetSchemaValue(_ interface{}) error                    { r
 func (m *mockMessage) RedeliveryCount() uint32                               { return 0 }
 func (m *mockMessage) IsReplicated() bool                                    { return false }
 func (m *mockMessage) GetReplicatedFrom() string                             { return "" }
-func (m *mockMessage) GetEncryptionContext() *pulsarclient.EncryptionContext  { return nil }
+func (m *mockMessage) GetEncryptionContext() *pulsarclient.EncryptionContext { return nil }
 func (m *mockMessage) Index() *uint64                                        { return nil }
 func (m *mockMessage) BrokerPublishTime() *time.Time                         { return nil }
 func (m *mockMessage) SchemaVersion() []byte                                 { return nil }
@@ -87,35 +88,45 @@ type ackTrackingConsumer struct {
 }
 
 func (c *ackTrackingConsumer) Chan() <-chan pulsarclient.ConsumerMessage { return c.Ch }
-func (c *ackTrackingConsumer) Subscription() string                     { return "test-sub" }
-func (c *ackTrackingConsumer) Unsubscribe() error                       { return nil }
-func (c *ackTrackingConsumer) UnsubscribeForce() error                  { return nil }
+func (c *ackTrackingConsumer) Subscription() string                      { return "test-sub" }
+func (c *ackTrackingConsumer) Unsubscribe() error                        { return nil }
+func (c *ackTrackingConsumer) UnsubscribeForce() error                   { return nil }
+
 func (c *ackTrackingConsumer) GetLastMessageIDs() ([]pulsarclient.TopicMessageID, error) {
 	return nil, nil
 }
-func (c *ackTrackingConsumer) Receive(_ context.Context) (pulsarclient.Message, error) {
-	msg := <-c.Ch
-	return msg.Message, nil
+
+func (c *ackTrackingConsumer) Receive(ctx context.Context) (pulsarclient.Message, error) {
+	select {
+	case msg, ok := <-c.Ch:
+		if !ok {
+			return nil, errors.New("consumer closed")
+		}
+		return msg.Message, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
+
 func (c *ackTrackingConsumer) Ack(_ pulsarclient.Message) error {
 	c.ackCount.Add(1)
 	return nil
 }
 func (c *ackTrackingConsumer) AckID(_ pulsarclient.MessageID) error       { return nil }
-func (c *ackTrackingConsumer) AckIDList(_ []pulsarclient.MessageID) error  { return nil }
+func (c *ackTrackingConsumer) AckIDList(_ []pulsarclient.MessageID) error { return nil }
 func (c *ackTrackingConsumer) AckWithTxn(_ pulsarclient.Message, _ pulsarclient.Transaction) error {
 	return nil
 }
-func (c *ackTrackingConsumer) AckCumulative(_ pulsarclient.Message) error     { return nil }
-func (c *ackTrackingConsumer) AckIDCumulative(_ pulsarclient.MessageID) error { return nil }
+func (c *ackTrackingConsumer) AckCumulative(_ pulsarclient.Message) error             { return nil }
+func (c *ackTrackingConsumer) AckIDCumulative(_ pulsarclient.MessageID) error         { return nil }
 func (c *ackTrackingConsumer) ReconsumeLater(_ pulsarclient.Message, _ time.Duration) {}
 func (c *ackTrackingConsumer) ReconsumeLaterWithCustomProperties(
 	_ pulsarclient.Message, _ map[string]string, _ time.Duration,
 ) {
 }
-func (c *ackTrackingConsumer) Nack(_ pulsarclient.Message)      {}
-func (c *ackTrackingConsumer) NackID(_ pulsarclient.MessageID)  {}
-func (c *ackTrackingConsumer) Close()                           {}
+func (c *ackTrackingConsumer) Nack(_ pulsarclient.Message)         {}
+func (c *ackTrackingConsumer) NackID(_ pulsarclient.MessageID)     {}
+func (c *ackTrackingConsumer) Close()                              {}
 func (c *ackTrackingConsumer) Seek(_ pulsarclient.MessageID) error { return nil }
 func (c *ackTrackingConsumer) SeekByTime(_ time.Time) error        { return nil }
 func (c *ackTrackingConsumer) Name() string                        { return "mock-consumer" }
@@ -152,7 +163,7 @@ func newPubsubMetadata(kvs map[string]string) pubsub.Metadata {
 }
 
 // newProcessModePulsar builds a minimal *Pulsar wired with a component-level
-// ProcessMode. MaxConcurrentHandlers is set high so the semaphore does not
+// ProcessMode. MaxConcurrentHandlers is set high so the worker pool does not
 // artificially constrain concurrency in async tests.
 func newProcessModePulsar(componentProcessMode string) *Pulsar {
 	return &Pulsar{
@@ -243,11 +254,20 @@ func TestParsePulsarMetadataZeroMaxConcurrentHandlers(t *testing.T) {
 
 // effectiveProcessMode mirrors the resolution in listenMessage:
 // component metadata is already normalized to lowercase by parsePulsarMetadata;
-// subscription metadata override is lowercased at point of use.
+// subscription metadata override is lowercased and validated at point of use.
 func effectiveProcessMode(componentMode string, subMeta map[string]string) string {
 	mode := strings.ToLower(componentMode)
+	if mode == "" {
+		mode = processModeAsync
+	}
 	if v, ok := subMeta[processModeKey]; ok {
-		mode = strings.ToLower(v)
+		override := strings.ToLower(v)
+		switch override {
+		case processModeAsync, processModeSync:
+			mode = override
+		default:
+			// Invalid override is ignored; keep component default.
+		}
 	}
 	return mode
 }
@@ -318,7 +338,7 @@ func TestResolveProcessMode(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			mode := effectiveProcessMode(tc.componentMode, tc.subMeta)
-			gotSync := strings.ToLower(mode) == processModeSync
+			gotSync := strings.EqualFold(mode, processModeSync)
 			assert.Equal(t, tc.wantSync, gotSync,
 				"effectiveProcessMode(%q, %v) = %q; wantSync=%v",
 				tc.componentMode, tc.subMeta, mode, tc.wantSync)
@@ -356,7 +376,7 @@ func TestListenMessageSyncMode_ComponentMetadata(t *testing.T) {
 	consumer := newMockConsumer(numMessages)
 	p := newProcessModePulsar("sync")
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -374,14 +394,22 @@ func TestListenMessageSyncMode_ComponentMetadata(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
-
-	// Handler 1 is blocked; handler 2 must NOT have been invoked yet.
-	assert.Equal(t, int32(1), handlerCallCount.Load(),
+	// Wait until exactly one handler invocation has occurred. Since the handler
+	// blocks on the 'released' channel, this ensures the second handler has not
+	// been invoked while the first is still running.
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
 		"sync mode: second handler must not fire while first is still running")
 
 	close(released)
-	time.Sleep(100 * time.Millisecond)
+	// After releasing the first handler, wait until all messages have been handled
+	// before cancelling the context.
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == int32(numMessages)
+	}, 2*time.Second, 10*time.Millisecond,
+		"all messages must be handled before cancel")
+
 	cancel()
 
 	select {
@@ -422,7 +450,7 @@ func TestListenMessageAsyncMode_ComponentMetadata(t *testing.T) {
 	consumer := newMockConsumer(numMessages)
 	p := newProcessModePulsar("async")
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -440,10 +468,19 @@ func TestListenMessageAsyncMode_ComponentMetadata(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	time.Sleep(150 * time.Millisecond)
+	// Wait until all handlers have started (they all block on the barrier).
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == int32(numMessages)
+	}, 2*time.Second, 10*time.Millisecond,
+		"async mode: all handlers should start concurrently")
 
 	close(barrier)
-	time.Sleep(100 * time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"all handlers should complete after barrier release")
+
 	cancel()
 
 	select {
@@ -474,7 +511,7 @@ func TestListenMessageSubscriptionOverridesComponent(t *testing.T) {
 	consumer := newMockConsumer(2)
 	p := newProcessModePulsar("async") // component says async
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -491,13 +528,18 @@ func TestListenMessageSubscriptionOverridesComponent(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
-
-	assert.Equal(t, int32(1), handlerCallCount.Load(),
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
 		"subscription sync override: second handler must not fire while first is running")
 
 	close(released)
-	time.Sleep(100 * time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"both messages should be handled after release")
+
 	cancel()
 
 	select {
@@ -534,7 +576,7 @@ func TestListenMessageDefaultFallbackAsync(t *testing.T) {
 	consumer := newMockConsumer(numMessages)
 	p := newProcessModePulsar("") // no processMode set anywhere
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -552,9 +594,18 @@ func TestListenMessageDefaultFallbackAsync(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	time.Sleep(150 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == int32(numMessages)
+	}, 2*time.Second, 10*time.Millisecond,
+		"default async: all handlers should start concurrently")
+
 	close(barrier)
-	time.Sleep(100 * time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"all handlers should complete after barrier release")
+
 	cancel()
 
 	select {
@@ -591,7 +642,7 @@ func TestListenMessageCaseInsensitiveSync(t *testing.T) {
 			consumer := newMockConsumer(2)
 			p := newProcessModePulsar("") // no component-level processMode
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			req := pubsub.SubscribeRequest{
@@ -608,13 +659,18 @@ func TestListenMessageCaseInsensitiveSync(t *testing.T) {
 				p.listenMessage(ctx, req, consumer, handler)
 			}()
 
-			time.Sleep(50 * time.Millisecond)
-
-			assert.Equal(t, int32(1), callCount.Load(),
+			require.Eventually(t, func() bool {
+				return callCount.Load() == 1
+			}, 2*time.Second, 10*time.Millisecond,
 				"processMode %q should be treated as sync; second handler fired prematurely", variant)
 
 			close(released)
-			time.Sleep(100 * time.Millisecond)
+
+			require.Eventually(t, func() bool {
+				return callCount.Load() == 2
+			}, 2*time.Second, 10*time.Millisecond,
+				"both messages should be handled after release")
+
 			cancel()
 
 			select {

--- a/pubsub/pulsar/process_mode_test.go
+++ b/pubsub/pulsar/process_mode_test.go
@@ -1,0 +1,639 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Tests for the processMode bug fix:
+//
+//   - processMode was read only from req.Metadata (subscription metadata) and
+//     silently ignored when set in component YAML metadata (pulsarMetadata).
+//   - Fix: pulsarMetadata now carries ProcessMode; listenMessage resolves the
+//     effective mode by using component metadata as the default and letting
+//     subscription metadata override it.
+package pulsar
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pulsarclient "github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mdpkg "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+// ---------------------------------------------------------------------------
+// Mock types for testing listenMessage without a real Pulsar broker.
+// These are shared across process_mode_test.go and pulsar_semaphore_test.go.
+// ---------------------------------------------------------------------------
+
+// mockMessage provides the minimum pulsarclient.Message implementation needed
+// by handleMessage.
+type mockMessage struct {
+	payload    []byte
+	properties map[string]string
+	topic      string
+}
+
+func (m *mockMessage) Payload() []byte                                       { return m.payload }
+func (m *mockMessage) ID() pulsarclient.MessageID                            { return mockMsgID{} }
+func (m *mockMessage) Properties() map[string]string                         { return m.properties }
+func (m *mockMessage) Topic() string                                         { return m.topic }
+func (m *mockMessage) ProducerName() string                                  { return "" }
+func (m *mockMessage) PublishTime() time.Time                                { return time.Time{} }
+func (m *mockMessage) EventTime() time.Time                                  { return time.Time{} }
+func (m *mockMessage) Key() string                                           { return "" }
+func (m *mockMessage) OrderingKey() string                                   { return "" }
+func (m *mockMessage) GetSchemaValue(_ interface{}) error                    { return nil }
+func (m *mockMessage) RedeliveryCount() uint32                               { return 0 }
+func (m *mockMessage) IsReplicated() bool                                    { return false }
+func (m *mockMessage) GetReplicatedFrom() string                             { return "" }
+func (m *mockMessage) GetEncryptionContext() *pulsarclient.EncryptionContext  { return nil }
+func (m *mockMessage) Index() *uint64                                        { return nil }
+func (m *mockMessage) BrokerPublishTime() *time.Time                         { return nil }
+func (m *mockMessage) SchemaVersion() []byte                                 { return nil }
+
+// mockMsgID satisfies pulsarclient.MessageID.
+type mockMsgID struct{}
+
+func (mockMsgID) Serialize() []byte   { return nil }
+func (mockMsgID) LedgerID() int64     { return 0 }
+func (mockMsgID) EntryID() int64      { return 0 }
+func (mockMsgID) BatchIdx() int32     { return 0 }
+func (mockMsgID) PartitionIdx() int32 { return 0 }
+func (mockMsgID) BatchSize() int32    { return 0 }
+func (mockMsgID) String() string      { return "mock-id" }
+
+// ackTrackingConsumer routes messages through a controllable channel and
+// records Ack calls. It implements the full pulsarclient.Consumer interface.
+type ackTrackingConsumer struct {
+	Ch       chan pulsarclient.ConsumerMessage
+	ackCount atomic.Int64
+}
+
+func (c *ackTrackingConsumer) Chan() <-chan pulsarclient.ConsumerMessage { return c.Ch }
+func (c *ackTrackingConsumer) Subscription() string                     { return "test-sub" }
+func (c *ackTrackingConsumer) Unsubscribe() error                       { return nil }
+func (c *ackTrackingConsumer) UnsubscribeForce() error                  { return nil }
+func (c *ackTrackingConsumer) GetLastMessageIDs() ([]pulsarclient.TopicMessageID, error) {
+	return nil, nil
+}
+func (c *ackTrackingConsumer) Receive(_ context.Context) (pulsarclient.Message, error) {
+	msg := <-c.Ch
+	return msg.Message, nil
+}
+func (c *ackTrackingConsumer) Ack(_ pulsarclient.Message) error {
+	c.ackCount.Add(1)
+	return nil
+}
+func (c *ackTrackingConsumer) AckID(_ pulsarclient.MessageID) error       { return nil }
+func (c *ackTrackingConsumer) AckIDList(_ []pulsarclient.MessageID) error  { return nil }
+func (c *ackTrackingConsumer) AckWithTxn(_ pulsarclient.Message, _ pulsarclient.Transaction) error {
+	return nil
+}
+func (c *ackTrackingConsumer) AckCumulative(_ pulsarclient.Message) error     { return nil }
+func (c *ackTrackingConsumer) AckIDCumulative(_ pulsarclient.MessageID) error { return nil }
+func (c *ackTrackingConsumer) ReconsumeLater(_ pulsarclient.Message, _ time.Duration) {}
+func (c *ackTrackingConsumer) ReconsumeLaterWithCustomProperties(
+	_ pulsarclient.Message, _ map[string]string, _ time.Duration,
+) {
+}
+func (c *ackTrackingConsumer) Nack(_ pulsarclient.Message)      {}
+func (c *ackTrackingConsumer) NackID(_ pulsarclient.MessageID)  {}
+func (c *ackTrackingConsumer) Close()                           {}
+func (c *ackTrackingConsumer) Seek(_ pulsarclient.MessageID) error { return nil }
+func (c *ackTrackingConsumer) SeekByTime(_ time.Time) error        { return nil }
+func (c *ackTrackingConsumer) Name() string                        { return "mock-consumer" }
+func (c *ackTrackingConsumer) Topic() string                       { return "mock-topic" }
+
+// newMockConsumer creates an ackTrackingConsumer with the given channel buffer size.
+func newMockConsumer(bufSize int) *ackTrackingConsumer {
+	return &ackTrackingConsumer{
+		Ch: make(chan pulsarclient.ConsumerMessage, bufSize),
+	}
+}
+
+// sendMsg pushes a ConsumerMessage with the given consumer and payload onto ch.
+func sendMsg(ch chan<- pulsarclient.ConsumerMessage, consumer pulsarclient.Consumer, payload []byte) {
+	ch <- pulsarclient.ConsumerMessage{
+		Consumer: consumer,
+		Message: &mockMessage{
+			payload:    payload,
+			properties: map[string]string{},
+			topic:      "persistent://public/default/test-topic",
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers local to process_mode tests
+// ---------------------------------------------------------------------------
+
+// newPubsubMetadata builds a pubsub.Metadata with the given key-value pairs.
+func newPubsubMetadata(kvs map[string]string) pubsub.Metadata {
+	m := pubsub.Metadata{}
+	m.Base = mdpkg.Base{Properties: kvs}
+	return m
+}
+
+// newProcessModePulsar builds a minimal *Pulsar wired with a component-level
+// ProcessMode. MaxConcurrentHandlers is set high so the semaphore does not
+// artificially constrain concurrency in async tests.
+func newProcessModePulsar(componentProcessMode string) *Pulsar {
+	return &Pulsar{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+		metadata: pulsarMetadata{
+			ProcessMode:           componentProcessMode,
+			MaxConcurrentHandlers: 100,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: parsePulsarMetadata — ProcessMode field
+// ---------------------------------------------------------------------------
+
+func TestParsePulsarMetadataProcessMode(t *testing.T) {
+	tt := []struct {
+		name        string
+		processMode string
+		expected    string
+	}{
+		{
+			name:        "sync processMode normalized to lowercase",
+			processMode: "sync",
+			expected:    "sync",
+		},
+		{
+			name:        "async processMode normalized to lowercase",
+			processMode: "async",
+			expected:    "async",
+		},
+		{
+			name:        "empty processMode stored as empty string",
+			processMode: "",
+			expected:    "",
+		},
+		{
+			name:        "mixed-case Sync normalized to lowercase",
+			processMode: "Sync",
+			expected:    "sync",
+		},
+		{
+			name:        "upper-case SYNC normalized to lowercase",
+			processMode: "SYNC",
+			expected:    "sync",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newPubsubMetadata(map[string]string{
+				"host":        "pulsar://localhost:6650",
+				"processMode": tc.processMode,
+			})
+
+			meta, err := parsePulsarMetadata(m)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, meta.ProcessMode)
+		})
+	}
+}
+
+func TestParsePulsarMetadataProcessModeInvalid(t *testing.T) {
+	m := newPubsubMetadata(map[string]string{
+		"host":        "pulsar://localhost:6650",
+		"processMode": "snc",
+	})
+	_, err := parsePulsarMetadata(m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid processMode")
+}
+
+func TestParsePulsarMetadataZeroMaxConcurrentHandlers(t *testing.T) {
+	m := newPubsubMetadata(map[string]string{
+		"host":                  "pulsar://localhost:6650",
+		"maxConcurrentHandlers": "0",
+	})
+	meta, err := parsePulsarMetadata(m)
+	require.NoError(t, err)
+	assert.Equal(t, uint(100), meta.MaxConcurrentHandlers,
+		"MaxConcurrentHandlers=0 should fall back to default (100)")
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: effective processMode resolution (component vs subscription)
+// ---------------------------------------------------------------------------
+
+// effectiveProcessMode mirrors the resolution in listenMessage:
+// component metadata is already normalized to lowercase by parsePulsarMetadata;
+// subscription metadata override is lowercased at point of use.
+func effectiveProcessMode(componentMode string, subMeta map[string]string) string {
+	mode := strings.ToLower(componentMode)
+	if v, ok := subMeta[processModeKey]; ok {
+		mode = strings.ToLower(v)
+	}
+	return mode
+}
+
+func TestResolveProcessMode(t *testing.T) {
+	tt := []struct {
+		name          string
+		componentMode string
+		subMeta       map[string]string
+		wantSync      bool
+	}{
+		{
+			name:          "component sync, no subscription override",
+			componentMode: "sync",
+			subMeta:       map[string]string{},
+			wantSync:      true,
+		},
+		{
+			name:          "component async, no subscription override",
+			componentMode: "async",
+			subMeta:       map[string]string{},
+			wantSync:      false,
+		},
+		{
+			name:          "component empty (default), no subscription override",
+			componentMode: "",
+			subMeta:       map[string]string{},
+			wantSync:      false,
+		},
+		{
+			name:          "component sync overridden by subscription async",
+			componentMode: "sync",
+			subMeta:       map[string]string{processModeKey: "async"},
+			wantSync:      false,
+		},
+		{
+			name:          "component async overridden by subscription sync",
+			componentMode: "async",
+			subMeta:       map[string]string{processModeKey: "sync"},
+			wantSync:      true,
+		},
+		{
+			name:          "component empty overridden by subscription sync",
+			componentMode: "",
+			subMeta:       map[string]string{processModeKey: "sync"},
+			wantSync:      true,
+		},
+		{
+			name:          "case insensitive Sync from component",
+			componentMode: "Sync",
+			subMeta:       map[string]string{},
+			wantSync:      true,
+		},
+		{
+			name:          "case insensitive SYNC from subscription override",
+			componentMode: "async",
+			subMeta:       map[string]string{processModeKey: "SYNC"},
+			wantSync:      true,
+		},
+		{
+			name:          "nil subscription metadata map uses component mode",
+			componentMode: "sync",
+			subMeta:       nil,
+			wantSync:      true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mode := effectiveProcessMode(tc.componentMode, tc.subMeta)
+			gotSync := strings.ToLower(mode) == processModeSync
+			assert.Equal(t, tc.wantSync, gotSync,
+				"effectiveProcessMode(%q, %v) = %q; wantSync=%v",
+				tc.componentMode, tc.subMeta, mode, tc.wantSync)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration-style tests: listenMessage processing order
+// ---------------------------------------------------------------------------
+
+// TestListenMessageSyncMode_ComponentMetadata verifies that when ProcessMode is
+// "sync" in component metadata, the next message is not dispatched until the
+// current handler returns.
+func TestListenMessageSyncMode_ComponentMetadata(t *testing.T) {
+	const numMessages = 3
+
+	released := make(chan struct{})
+	var callOrder []int
+	var orderMu sync.Mutex
+	var handlerCallCount atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		n := int(handlerCallCount.Add(1))
+		orderMu.Lock()
+		callOrder = append(callOrder, n)
+		orderMu.Unlock()
+
+		if n == 1 {
+			<-released // block until the test releases
+		}
+		return nil
+	}
+
+	consumer := newMockConsumer(numMessages)
+	p := newProcessModePulsar("sync")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{}, // no subscription override
+	}
+
+	for i := range numMessages {
+		sendMsg(consumer.Ch, consumer, []byte{byte(i)})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Handler 1 is blocked; handler 2 must NOT have been invoked yet.
+	assert.Equal(t, int32(1), handlerCallCount.Load(),
+		"sync mode: second handler must not fire while first is still running")
+
+	close(released)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+
+	assert.Equal(t, int32(numMessages), handlerCallCount.Load(), "all messages must be handled")
+
+	orderMu.Lock()
+	defer orderMu.Unlock()
+	assert.Equal(t, []int{1, 2, 3}, callOrder, "sync mode must process messages in strict order")
+}
+
+// TestListenMessageAsyncMode_ComponentMetadata verifies that when ProcessMode
+// is "async" in component metadata, multiple messages can be in-flight simultaneously.
+func TestListenMessageAsyncMode_ComponentMetadata(t *testing.T) {
+	const numMessages = 3
+
+	barrier := make(chan struct{})
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		cur := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		<-barrier
+		inFlight.Add(-1)
+		return nil
+	}
+
+	consumer := newMockConsumer(numMessages)
+	p := newProcessModePulsar("async")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{},
+	}
+
+	for i := range numMessages {
+		sendMsg(consumer.Ch, consumer, []byte{byte(i)})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+
+	close(barrier)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+	p.wg.Wait()
+
+	assert.Greater(t, maxInFlight.Load(), int32(1),
+		"async mode must process messages concurrently; max in-flight was %d", maxInFlight.Load())
+}
+
+// TestListenMessageSubscriptionOverridesComponent verifies that subscription
+// metadata "sync" overrides component-level "async".
+func TestListenMessageSubscriptionOverridesComponent(t *testing.T) {
+	released := make(chan struct{})
+	var handlerCallCount atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		n := handlerCallCount.Add(1)
+		if n == 1 {
+			<-released
+		}
+		return nil
+	}
+
+	consumer := newMockConsumer(2)
+	p := newProcessModePulsar("async") // component says async
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: "sync"}, // subscription overrides to sync
+	}
+
+	sendMsg(consumer.Ch, consumer, []byte("msg1"))
+	sendMsg(consumer.Ch, consumer, []byte("msg2"))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, int32(1), handlerCallCount.Load(),
+		"subscription sync override: second handler must not fire while first is running")
+
+	close(released)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+
+	assert.Equal(t, int32(2), handlerCallCount.Load())
+}
+
+// TestListenMessageDefaultFallbackAsync verifies that when no processMode is
+// configured anywhere, the system defaults to async (concurrent) processing.
+func TestListenMessageDefaultFallbackAsync(t *testing.T) {
+	const numMessages = 3
+
+	barrier := make(chan struct{})
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		cur := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		<-barrier
+		inFlight.Add(-1)
+		return nil
+	}
+
+	consumer := newMockConsumer(numMessages)
+	p := newProcessModePulsar("") // no processMode set anywhere
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{},
+	}
+
+	for i := range numMessages {
+		sendMsg(consumer.Ch, consumer, []byte{byte(i)})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	close(barrier)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+	p.wg.Wait()
+
+	assert.Greater(t, maxInFlight.Load(), int32(1),
+		"default (empty processMode) must fall back to async; max concurrent was %d", maxInFlight.Load())
+}
+
+// TestListenMessageCaseInsensitiveSync verifies that mixed-case "Sync", "SYNC",
+// and "sYnC" in subscription metadata all trigger synchronous processing.
+// Component metadata is normalized to lowercase at parse time, so case
+// insensitivity for component metadata is tested via TestParsePulsarMetadataProcessMode.
+func TestListenMessageCaseInsensitiveSync(t *testing.T) {
+	variants := []string{"Sync", "SYNC", "sYnC"}
+
+	for _, variant := range variants {
+		t.Run("processMode="+variant, func(t *testing.T) {
+			released := make(chan struct{})
+			var callCount atomic.Int32
+
+			handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+				n := callCount.Add(1)
+				if n == 1 {
+					<-released
+				}
+				return nil
+			}
+
+			consumer := newMockConsumer(2)
+			p := newProcessModePulsar("") // no component-level processMode
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			req := pubsub.SubscribeRequest{
+				Topic:    "test-topic",
+				Metadata: map[string]string{processModeKey: variant}, // subscription override with mixed case
+			}
+
+			sendMsg(consumer.Ch, consumer, []byte("msg1"))
+			sendMsg(consumer.Ch, consumer, []byte("msg2"))
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				p.listenMessage(ctx, req, consumer, handler)
+			}()
+
+			time.Sleep(50 * time.Millisecond)
+
+			assert.Equal(t, int32(1), callCount.Load(),
+				"processMode %q should be treated as sync; second handler fired prematurely", variant)
+
+			close(released)
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("listenMessage did not exit after context cancel")
+			}
+		})
+	}
+}
+
+// TestGetComponentMetadataIncludesProcessMode verifies that GetComponentMetadata
+// exposes the processMode field so operator tooling can discover it.
+func TestGetComponentMetadataIncludesProcessMode(t *testing.T) {
+	p := &Pulsar{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+	}
+	metaInfo := p.GetComponentMetadata()
+	_, ok := metaInfo["processMode"]
+	assert.True(t, ok, "GetComponentMetadata must expose processMode field")
+}

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -201,7 +201,8 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		return nil, fmt.Errorf("invalid processMode %q: accepted values are %q and %q", m.ProcessMode, processModeAsync, processModeSync)
 	}
 
-	// Guard against zero MaxConcurrentHandlers which would deadlock the semaphore.
+	// Guard against zero MaxConcurrentHandlers: a zero-size work channel with no
+	// workers would block the dispatch loop immediately.
 	if m.MaxConcurrentHandlers == 0 {
 		m.MaxConcurrentHandlers = defaultConcurrency
 	}
@@ -720,47 +721,90 @@ func (p *Pulsar) listenMessage(ctx context.Context, req pubsub.SubscribeRequest,
 	// Resolve effective process mode: component metadata is already normalized
 	// to lowercase in parsePulsarMetadata; subscription metadata may override.
 	mode := p.metadata.ProcessMode
+	if mode == "" {
+		mode = processModeAsync
+	}
 	if v, ok := req.Metadata[processModeKey]; ok {
-		mode = strings.ToLower(v)
+		override := strings.ToLower(v)
+		switch override {
+		case processModeAsync, processModeSync:
+			mode = override
+		default:
+			p.logger.Warnf(
+				"Invalid process mode %q in subscription metadata for topic %s; using component default %q",
+				v, req.Topic, mode,
+			)
+		}
 	}
 
-	// Semaphore to bound the number of concurrent async handler goroutines.
-	// The semaphore slot is acquired before spawning a goroutine (outside the
-	// goroutine) so that the read loop blocks — providing backpressure —
-	// when MaxConcurrentHandlers goroutines are already active.
-	sem := make(chan struct{}, p.metadata.MaxConcurrentHandlers)
-
 	originTopic := req.Topic
+
+	if mode == processModeSync {
+		p.listenMessageSync(ctx, originTopic, consumer, handler)
+	} else {
+		p.listenMessageAsync(ctx, originTopic, consumer, handler)
+	}
+}
+
+// listenMessageSync processes messages sequentially on the calling goroutine.
+func (p *Pulsar) listenMessageSync(ctx context.Context, originTopic string, consumer pulsar.Consumer, handler pubsub.Handler) {
 	for {
 		select {
-		case msg := <-consumer.Chan():
-			if mode == processModeSync { //nolint:gocritic
-				if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
-					p.logger.Errorf("Error sync processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
-				}
-			} else { // async process mode by default
-				// Acquire a semaphore slot before spawning the goroutine.
-				// Use a select so that context cancellation unblocks a waiting acquire.
-				select {
-				case sem <- struct{}{}:
-				case <-ctx.Done():
-					return
-				}
-				p.wg.Add(1)
-				go func(msg pulsar.ConsumerMessage) {
-					defer p.wg.Done()
-					defer func() { <-sem }()
-					if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
-						p.logger.Errorf("Error async processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
-					}
-				}(msg)
+		case msg, ok := <-consumer.Chan():
+			if !ok {
+				return
 			}
-
+			if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
+				p.logger.Errorf("Error sync processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
+			}
 		case <-ctx.Done():
 			p.logger.Debugf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
 			return
 		}
 	}
+}
+
+// listenMessageAsync pre-spawns MaxConcurrentHandlers worker goroutines that
+// read directly from the consumer channel. Backpressure is achieved naturally:
+// when all workers are busy processing messages, the consumer channel fills up
+// and the SDK stops requesting more messages from the broker. There is no
+// intermediate work channel, so MaxConcurrentHandlers bounds both the number
+// of concurrent handlers and the consumer channel buffer (set in Subscribe).
+func (p *Pulsar) listenMessageAsync(ctx context.Context, originTopic string, consumer pulsar.Consumer, handler pubsub.Handler) {
+	// Use a local WaitGroup for workers so that we can wait for in-flight
+	// handlers to finish their Ack/Nack calls before returning. The caller
+	// defers consumer.Close(), so returning early would close the consumer
+	// while workers are still processing messages.
+	var workerWg sync.WaitGroup
+
+	// Pre-spawn a fixed pool of worker goroutines reading from consumer.Chan().
+	for range p.metadata.MaxConcurrentHandlers {
+		workerWg.Add(1)
+		go func() {
+			defer workerWg.Done()
+			for {
+				select {
+				case msg, ok := <-consumer.Chan():
+					if !ok {
+						return
+					}
+					if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
+						p.logger.Errorf("Error async processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Block until context is cancelled, then wait for workers to finish
+	// processing in-flight messages before returning. This ensures
+	// consumer.Close() (deferred by the caller) does not race with
+	// Ack/Nack calls from active workers.
+	<-ctx.Done()
+	p.logger.Debugf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
+	workerWg.Wait()
 }
 
 func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, msg pulsar.ConsumerMessage, handler pubsub.Handler) error {

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -192,6 +192,20 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		return nil, errors.New("invalid compression level. Accepted values are `default`, `faster` and `better`")
 	}
 
+	// Normalize and validate processMode.
+	m.ProcessMode = strings.ToLower(m.ProcessMode)
+	switch m.ProcessMode {
+	case processModeSync, processModeAsync, "":
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid processMode %q: accepted values are %q and %q", m.ProcessMode, processModeAsync, processModeSync)
+	}
+
+	// Guard against zero MaxConcurrentHandlers which would deadlock the semaphore.
+	if m.MaxConcurrentHandlers == 0 {
+		m.MaxConcurrentHandlers = defaultConcurrency
+	}
+
 	// First pass: collect per-topic rawSchema flags.
 	rawSchemaTopics := make(map[string]bool)
 	for k, v := range meta.Properties {
@@ -703,30 +717,47 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 func (p *Pulsar) listenMessage(ctx context.Context, req pubsub.SubscribeRequest, consumer pulsar.Consumer, handler pubsub.Handler) {
 	defer consumer.Close()
 
+	// Resolve effective process mode: component metadata is already normalized
+	// to lowercase in parsePulsarMetadata; subscription metadata may override.
+	mode := p.metadata.ProcessMode
+	if v, ok := req.Metadata[processModeKey]; ok {
+		mode = strings.ToLower(v)
+	}
+
+	// Semaphore to bound the number of concurrent async handler goroutines.
+	// The semaphore slot is acquired before spawning a goroutine (outside the
+	// goroutine) so that the read loop blocks — providing backpressure —
+	// when MaxConcurrentHandlers goroutines are already active.
+	sem := make(chan struct{}, p.metadata.MaxConcurrentHandlers)
+
 	originTopic := req.Topic
-	var err error
 	for {
 		select {
 		case msg := <-consumer.Chan():
-			if strings.ToLower(req.Metadata[processModeKey]) == processModeSync { //nolint:gocritic
-				err = p.handleMessage(ctx, originTopic, msg, handler)
-				if err != nil && !errors.Is(err, context.Canceled) {
+			if mode == processModeSync { //nolint:gocritic
+				if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
 					p.logger.Errorf("Error sync processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
 				}
 			} else { // async process mode by default
-				// Go routine to handle multiple messages at once.
+				// Acquire a semaphore slot before spawning the goroutine.
+				// Use a select so that context cancellation unblocks a waiting acquire.
+				select {
+				case sem <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
 				p.wg.Add(1)
 				go func(msg pulsar.ConsumerMessage) {
 					defer p.wg.Done()
-					err = p.handleMessage(ctx, originTopic, msg, handler)
-					if err != nil && !errors.Is(err, context.Canceled) {
+					defer func() { <-sem }()
+					if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
 						p.logger.Errorf("Error async processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
 					}
 				}(msg)
 			}
 
 		case <-ctx.Done():
-			p.logger.Errorf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
+			p.logger.Debugf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
 			return
 		}
 	}

--- a/pubsub/pulsar/pulsar_backpressure_test.go
+++ b/pubsub/pulsar/pulsar_backpressure_test.go
@@ -13,16 +13,17 @@ limitations under the License.
 
 package pulsar
 
-// Tests for the async semaphore concurrency limit in listenMessage.
+// Tests for the async worker pool backpressure in listenMessage.
 //
 // The bug: in async mode every message spawned a goroutine with NO upper bound.
 // MaxConcurrentHandlers (default 100) only controlled the channel buffer size —
 // NOT the number of concurrent goroutines. This caused tens of thousands of
 // unacked messages to accumulate.
 //
-// Fix: a semaphore channel of size MaxConcurrentHandlers is created inside
-// listenMessage. The loop blocks on semaphore acquisition before spawning each
-// async goroutine, and releases the slot when the goroutine finishes.
+// Fix: listenMessage pre-spawns MaxConcurrentHandlers worker goroutines that
+// read directly from the consumer channel. Backpressure is achieved naturally:
+// when all workers are busy the consumer channel fills up, and the SDK stops
+// requesting more messages from the broker.
 //
 // Shared mock types (mockMessage, ackTrackingConsumer, sendMsg) are defined in
 // process_mode_test.go.
@@ -43,7 +44,7 @@ import (
 )
 
 // newTestPulsarWithConcurrency builds a minimal *Pulsar with controlled
-// MaxConcurrentHandlers for semaphore tests.
+// MaxConcurrentHandlers for worker pool concurrency tests.
 func newTestPulsarWithConcurrency(maxConcurrent uint) *Pulsar {
 	return &Pulsar{
 		logger:  logger.NewLogger("test"),
@@ -135,7 +136,7 @@ func TestListenMessage_AsyncConcurrencyLimit(t *testing.T) {
 				consumer.Ch <- msg
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 
 			req := pubsub.SubscribeRequest{
@@ -159,7 +160,7 @@ func TestListenMessage_AsyncConcurrencyLimit(t *testing.T) {
 			<-done
 			p.wg.Wait()
 
-			assert.LessOrEqual(t, peakConcurrency.Load(), int64(tc.maxConcurrent),
+			assert.LessOrEqual(t, peakConcurrency.Load(), int64(tc.maxConcurrent), //nolint:gosec // test value, no overflow risk
 				"peak concurrent handlers exceeded MaxConcurrentHandlers=%d", tc.maxConcurrent)
 			assert.Equal(t, int64(tc.messagesToSend), processed.Load(),
 				"all messages should have been processed")
@@ -189,7 +190,7 @@ func TestListenMessage_AsyncAllMessagesProcessed(t *testing.T) {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -214,10 +215,11 @@ func TestListenMessage_AsyncAllMessagesProcessed(t *testing.T) {
 	assert.Equal(t, int64(messagesToSend), processed.Load())
 }
 
-// TestListenMessage_ContextCancellationUnblocksSemaphore tests that cancelling
-// the context while the semaphore is full causes listenMessage to return
-// promptly without blocking indefinitely on semaphore acquisition.
-func TestListenMessage_ContextCancellationUnblocksSemaphore(t *testing.T) {
+// TestListenMessage_ContextCancellationUnblocksWorkerPool verifies that
+// cancelling the context while a worker is blocked in its handler causes
+// listenMessage to return promptly, and that in-flight handlers are allowed
+// to complete cleanly once unblocked.
+func TestListenMessage_ContextCancellationUnblocksWorkerPool(t *testing.T) {
 	const maxConcurrent = 1
 
 	p := newTestPulsarWithConcurrency(maxConcurrent)
@@ -226,24 +228,20 @@ func TestListenMessage_ContextCancellationUnblocksSemaphore(t *testing.T) {
 	handlerStarted := make(chan struct{})
 	handlerCanProceed := make(chan struct{})
 
-	var handlerCallCount atomic.Int64
-
 	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
-		count := handlerCallCount.Add(1)
-		if count == 1 {
-			// Signal that the first handler started, then block.
-			close(handlerStarted)
-			<-handlerCanProceed
+		// Signal that the handler started, then block.
+		select {
+		case handlerStarted <- struct{}{}:
+		default:
 		}
+		<-handlerCanProceed
 		return nil
 	}
 
-	// First message: blocks in the handler, holding the semaphore slot.
-	// Second message: queued; the loop will block on semaphore acquisition for it.
 	sendMsg(consumer.Ch, consumer, []byte("first"))
 	sendMsg(consumer.Ch, consumer, []byte("second"))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	req := pubsub.SubscribeRequest{
 		Topic:    "test-topic",
@@ -256,28 +254,29 @@ func TestListenMessage_ContextCancellationUnblocksSemaphore(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	// Wait for the first handler to start and hold the semaphore.
-	<-handlerStarted
-
-	// Cancel context; this should unblock the semaphore wait for the second message.
-	cancel()
-
-	// listenMessage should return within a reasonable time after context cancellation.
+	// Wait for the worker to start processing and block.
 	select {
-	case <-done:
-		// Expected: loop exited due to context cancellation.
+	case <-handlerStarted:
 	case <-time.After(2 * time.Second):
-		t.Fatal("listenMessage did not exit after context cancellation — semaphore likely blocked")
+		t.Fatal("handler did not start within timeout")
 	}
 
-	// Allow the blocked handler to finish cleanly.
+	// Cancel context and unblock the handler so the worker can finish.
+	cancel()
 	close(handlerCanProceed)
-	p.wg.Wait()
+
+	// listenMessage waits for workers to finish before returning.
+	select {
+	case <-done:
+		// Expected: listenMessage exited after workers completed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage did not exit after context cancellation and handler release")
+	}
 }
 
-// TestListenMessage_SyncModeNotAffectedBySemaphore verifies that sync mode still
-// processes messages serially and is not broken by the semaphore addition.
-func TestListenMessage_SyncModeNotAffectedBySemaphore(t *testing.T) {
+// TestListenMessage_SyncModeNotAffectedByWorkerPool verifies that sync mode still
+// processes messages serially and is not broken by the async worker pool.
+func TestListenMessage_SyncModeNotAffectedByWorkerPool(t *testing.T) {
 	const messagesToSend = 5
 
 	// semaphore is not used in sync mode; provide any value.
@@ -314,7 +313,7 @@ func TestListenMessage_SyncModeNotAffectedBySemaphore(t *testing.T) {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -343,26 +342,32 @@ func TestListenMessage_SyncModeNotAffectedBySemaphore(t *testing.T) {
 }
 
 // TestListenMessage_BackpressureStopsChannelDrain verifies that when all
-// semaphore slots are occupied by slow handlers, the consumer channel stops
-// draining — the loop blocks on semaphore acquisition rather than reading more.
+// workers are busy, the consumer channel stops draining — workers block in
+// their handlers and stop reading from consumer.Chan().
+//
+// With maxConcurrent=2, workers pull one message each and block. The remaining
+// messages stay in the consumer channel. There is no intermediate work channel.
 func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
 	const maxConcurrent = 2
 
 	p := newTestPulsarWithConcurrency(maxConcurrent)
 
-	// Buffer large enough that extra messages can queue behind the semaphore.
+	// Buffer large enough that extra messages can queue.
 	consumer := newMockConsumer(20)
 
 	handlerStarted := make(chan struct{}, maxConcurrent)
 	handlerCanProceed := make(chan struct{})
 
 	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
-		handlerStarted <- struct{}{}
+		select {
+		case handlerStarted <- struct{}{}:
+		default:
+		}
 		<-handlerCanProceed
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -370,9 +375,10 @@ func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
 		Metadata: map[string]string{processModeKey: processModeAsync},
 	}
 
-	// Pre-fill exactly maxConcurrent messages to occupy all semaphore slots.
-	for i := 0; i < maxConcurrent; i++ {
-		sendMsg(consumer.Ch, consumer, []byte("occupying"))
+	// Send enough messages to leave plenty in the consumer channel after workers start.
+	const totalMessages = 10
+	for range totalMessages {
+		sendMsg(consumer.Ch, consumer, []byte("msg"))
 	}
 
 	done := make(chan struct{})
@@ -381,8 +387,8 @@ func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	// Wait for all slots to be taken.
-	for i := 0; i < maxConcurrent; i++ {
+	// Wait for all workers to be busy.
+	for range maxConcurrent {
 		select {
 		case <-handlerStarted:
 		case <-time.After(2 * time.Second):
@@ -390,23 +396,17 @@ func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
 		}
 	}
 
-	// Now add more messages while the semaphore is fully occupied.
-	const extraMessages = 5
-	for i := 0; i < extraMessages; i++ {
-		sendMsg(consumer.Ch, consumer, []byte("extra"))
-	}
+	// Workers read directly from consumer.Chan(). Once all workers are blocked
+	// in their handlers, they stop pulling messages. The consumer channel should
+	// retain all messages beyond what the workers took (totalMessages - maxConcurrent).
+	minRemaining := totalMessages - maxConcurrent
 
-	// Give the loop a chance to drain (it should NOT drain since semaphore is full).
-	time.Sleep(100 * time.Millisecond)
-
-	// The channel should be nearly full. The loop reads one message at a time:
-	// it removes the message from the channel and THEN blocks on the semaphore.
-	// So at most one message is "in flight" inside the select (removed from the
-	// channel but waiting for a semaphore slot). All remaining messages stay queued.
-	channelLen := len(consumer.Ch)
-	assert.GreaterOrEqual(t, channelLen, extraMessages-1,
-		"backpressure: channel should retain most messages when semaphore is full (got %d, want >= %d)",
-		channelLen, extraMessages-1)
+	// Verify backpressure: the consumer channel must never drop below minRemaining.
+	require.Never(t, func() bool {
+		return len(consumer.Ch) < minRemaining
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"backpressure: consumer channel should retain at least %d messages",
+		minRemaining)
 
 	// Unblock handlers and let everything finish.
 	close(handlerCanProceed)
@@ -416,9 +416,10 @@ func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
 	p.wg.Wait()
 }
 
-// TestListenMessage_GracefulShutdown verifies that after listenMessage exits,
-// all in-flight handler goroutines complete (p.wg.Wait() returns promptly),
-// demonstrating that Close() will not leak goroutines.
+// TestListenMessage_GracefulShutdown verifies that listenMessage waits for
+// all in-flight handlers to complete before returning, ensuring that
+// consumer.Close() (deferred by listenMessage) does not race with Ack/Nack
+// calls from active workers.
 func TestListenMessage_GracefulShutdown(t *testing.T) {
 	const (
 		maxConcurrent  = 3
@@ -434,13 +435,15 @@ func TestListenMessage_GracefulShutdown(t *testing.T) {
 	}
 
 	handlerCanProceed := make(chan struct{})
+	var handlersStarted atomic.Int64
 
 	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		handlersStarted.Add(1)
 		<-handlerCanProceed
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	req := pubsub.SubscribeRequest{
 		Topic:    "test-topic",
@@ -453,37 +456,29 @@ func TestListenMessage_GracefulShutdown(t *testing.T) {
 		p.listenMessage(ctx, req, consumer, handler)
 	}()
 
-	// Give some handlers time to start and block.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until handlers have started and are blocked.
+	require.Eventually(t, func() bool {
+		return handlersStarted.Load() >= int64(maxConcurrent)
+	}, 2*time.Second, 10*time.Millisecond,
+		"handlers did not start within timeout")
 
-	// Cancel the context to trigger shutdown of the listen loop.
+	// Cancel the context to trigger shutdown. listenMessageAsync will wait
+	// for in-flight workers before returning.
 	cancel()
 
-	// Wait for listenMessage to exit.
-	select {
-	case <-listenDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("listenMessage did not exit after context cancel")
-	}
-
-	// Allow handlers to proceed.
+	// Unblock the handlers so workers can finish.
 	close(handlerCanProceed)
 
-	waitDone := make(chan struct{})
-	go func() {
-		defer close(waitDone)
-		p.wg.Wait()
-	}()
-
+	// listenMessage should return after all workers complete.
 	select {
-	case <-waitDone:
+	case <-listenDone:
 	case <-time.After(3 * time.Second):
-		t.Fatal("wg.Wait() did not return within timeout — goroutines may be leaked")
+		t.Fatal("listenMessage did not exit after context cancel and handler release — workers may be leaked")
 	}
 }
 
 // TestListenMessage_HandlerErrorDoesNotLeakGoroutine verifies that handlers
-// returning errors do not cause goroutine leaks under the semaphore.
+// returning errors do not cause goroutine leaks under the worker pool.
 func TestListenMessage_HandlerErrorDoesNotLeakGoroutine(t *testing.T) {
 	const (
 		maxConcurrent  = 5
@@ -504,7 +499,7 @@ func TestListenMessage_HandlerErrorDoesNotLeakGoroutine(t *testing.T) {
 		return assert.AnError
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{
@@ -573,7 +568,7 @@ func TestListenMessage_KeyVerification(t *testing.T) {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	req := pubsub.SubscribeRequest{

--- a/pubsub/pulsar/pulsar_semaphore_test.go
+++ b/pubsub/pulsar/pulsar_semaphore_test.go
@@ -1,0 +1,605 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pulsar
+
+// Tests for the async semaphore concurrency limit in listenMessage.
+//
+// The bug: in async mode every message spawned a goroutine with NO upper bound.
+// MaxConcurrentHandlers (default 100) only controlled the channel buffer size —
+// NOT the number of concurrent goroutines. This caused tens of thousands of
+// unacked messages to accumulate.
+//
+// Fix: a semaphore channel of size MaxConcurrentHandlers is created inside
+// listenMessage. The loop blocks on semaphore acquisition before spawning each
+// async goroutine, and releases the slot when the goroutine finishes.
+//
+// Shared mock types (mockMessage, ackTrackingConsumer, sendMsg) are defined in
+// process_mode_test.go.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pulsarclient "github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+// newTestPulsarWithConcurrency builds a minimal *Pulsar with controlled
+// MaxConcurrentHandlers for semaphore tests.
+func newTestPulsarWithConcurrency(maxConcurrent uint) *Pulsar {
+	return &Pulsar{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+		metadata: pulsarMetadata{
+			MaxConcurrentHandlers: maxConcurrent,
+		},
+	}
+}
+
+// makeConsumerMessagesN creates n ConsumerMessages using the provided consumer.
+func makeConsumerMessagesN(consumer pulsarclient.Consumer, n int) []pulsarclient.ConsumerMessage {
+	msgs := make([]pulsarclient.ConsumerMessage, n)
+	for i := range msgs {
+		msgs[i] = pulsarclient.ConsumerMessage{
+			Consumer: consumer,
+			Message: &mockMessage{
+				payload:    []byte("hello"),
+				properties: map[string]string{},
+				topic:      "persistent://public/default/test-topic",
+			},
+		}
+	}
+	return msgs
+}
+
+// TestListenMessage_AsyncConcurrencyLimit verifies that in async mode,
+// the number of concurrently executing handlers never exceeds MaxConcurrentHandlers.
+// This is the primary regression test for the unbounded goroutine bug.
+func TestListenMessage_AsyncConcurrencyLimit(t *testing.T) {
+	tt := []struct {
+		name              string
+		maxConcurrent     uint
+		messagesToSend    int
+		handlerSleepDelay time.Duration
+	}{
+		{
+			name:              "limit 1 with 10 messages",
+			maxConcurrent:     1,
+			messagesToSend:    10,
+			handlerSleepDelay: 20 * time.Millisecond,
+		},
+		{
+			name:              "limit 5 with 50 messages",
+			maxConcurrent:     5,
+			messagesToSend:    50,
+			handlerSleepDelay: 50 * time.Millisecond,
+		},
+		{
+			name:              "limit 10 with 30 messages",
+			maxConcurrent:     10,
+			messagesToSend:    30,
+			handlerSleepDelay: 20 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestPulsarWithConcurrency(tc.maxConcurrent)
+
+			consumer := newMockConsumer(tc.messagesToSend)
+
+			var (
+				currentConcurrency atomic.Int64
+				peakConcurrency    atomic.Int64
+				processed          atomic.Int64
+			)
+
+			handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+				current := currentConcurrency.Add(1)
+				defer currentConcurrency.Add(-1)
+
+				// Atomically track peak concurrency.
+				for {
+					peak := peakConcurrency.Load()
+					if current <= peak || peakConcurrency.CompareAndSwap(peak, current) {
+						break
+					}
+				}
+
+				time.Sleep(tc.handlerSleepDelay)
+				processed.Add(1)
+				return nil
+			}
+
+			// Pre-fill the consumer channel with all messages before starting.
+			msgs := makeConsumerMessagesN(consumer, tc.messagesToSend)
+			for _, msg := range msgs {
+				consumer.Ch <- msg
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			req := pubsub.SubscribeRequest{
+				Topic:    "test-topic",
+				Metadata: map[string]string{processModeKey: processModeAsync},
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				p.listenMessage(ctx, req, consumer, handler)
+			}()
+
+			// Wait until all messages are processed.
+			require.Eventually(t, func() bool {
+				return processed.Load() == int64(tc.messagesToSend)
+			}, 30*time.Second, 5*time.Millisecond,
+				"not all messages were processed within timeout")
+
+			cancel()
+			<-done
+			p.wg.Wait()
+
+			assert.LessOrEqual(t, peakConcurrency.Load(), int64(tc.maxConcurrent),
+				"peak concurrent handlers exceeded MaxConcurrentHandlers=%d", tc.maxConcurrent)
+			assert.Equal(t, int64(tc.messagesToSend), processed.Load(),
+				"all messages should have been processed")
+		})
+	}
+}
+
+// TestListenMessage_AsyncAllMessagesProcessed ensures no messages are dropped
+// even under concurrency limiting with a fast handler.
+func TestListenMessage_AsyncAllMessagesProcessed(t *testing.T) {
+	const (
+		maxConcurrent  = 5
+		messagesToSend = 100
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var processed atomic.Int64
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		processed.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 10*time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	assert.Equal(t, int64(messagesToSend), processed.Load())
+}
+
+// TestListenMessage_ContextCancellationUnblocksSemaphore tests that cancelling
+// the context while the semaphore is full causes listenMessage to return
+// promptly without blocking indefinitely on semaphore acquisition.
+func TestListenMessage_ContextCancellationUnblocksSemaphore(t *testing.T) {
+	const maxConcurrent = 1
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(2)
+
+	handlerStarted := make(chan struct{})
+	handlerCanProceed := make(chan struct{})
+
+	var handlerCallCount atomic.Int64
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		count := handlerCallCount.Add(1)
+		if count == 1 {
+			// Signal that the first handler started, then block.
+			close(handlerStarted)
+			<-handlerCanProceed
+		}
+		return nil
+	}
+
+	// First message: blocks in the handler, holding the semaphore slot.
+	// Second message: queued; the loop will block on semaphore acquisition for it.
+	sendMsg(consumer.Ch, consumer, []byte("first"))
+	sendMsg(consumer.Ch, consumer, []byte("second"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait for the first handler to start and hold the semaphore.
+	<-handlerStarted
+
+	// Cancel context; this should unblock the semaphore wait for the second message.
+	cancel()
+
+	// listenMessage should return within a reasonable time after context cancellation.
+	select {
+	case <-done:
+		// Expected: loop exited due to context cancellation.
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage did not exit after context cancellation — semaphore likely blocked")
+	}
+
+	// Allow the blocked handler to finish cleanly.
+	close(handlerCanProceed)
+	p.wg.Wait()
+}
+
+// TestListenMessage_SyncModeNotAffectedBySemaphore verifies that sync mode still
+// processes messages serially and is not broken by the semaphore addition.
+func TestListenMessage_SyncModeNotAffectedBySemaphore(t *testing.T) {
+	const messagesToSend = 5
+
+	// semaphore is not used in sync mode; provide any value.
+	p := newTestPulsarWithConcurrency(3)
+
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var (
+		maxObservedConcurrency int64
+		mu                     sync.Mutex
+		currentConcurrency     int64
+		processed              atomic.Int64
+	)
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		mu.Lock()
+		currentConcurrency++
+		if currentConcurrency > maxObservedConcurrency {
+			maxObservedConcurrency = currentConcurrency
+		}
+		mu.Unlock()
+
+		time.Sleep(10 * time.Millisecond)
+		processed.Add(1)
+
+		mu.Lock()
+		currentConcurrency--
+		mu.Unlock()
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeSync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 5*time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	// In sync mode, concurrency should always be exactly 1.
+	assert.Equal(t, int64(1), maxObservedConcurrency,
+		"sync mode should process exactly one message at a time")
+	assert.Equal(t, int64(messagesToSend), processed.Load())
+}
+
+// TestListenMessage_BackpressureStopsChannelDrain verifies that when all
+// semaphore slots are occupied by slow handlers, the consumer channel stops
+// draining — the loop blocks on semaphore acquisition rather than reading more.
+func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
+	const maxConcurrent = 2
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+
+	// Buffer large enough that extra messages can queue behind the semaphore.
+	consumer := newMockConsumer(20)
+
+	handlerStarted := make(chan struct{}, maxConcurrent)
+	handlerCanProceed := make(chan struct{})
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		handlerStarted <- struct{}{}
+		<-handlerCanProceed
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	// Pre-fill exactly maxConcurrent messages to occupy all semaphore slots.
+	for i := 0; i < maxConcurrent; i++ {
+		sendMsg(consumer.Ch, consumer, []byte("occupying"))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait for all slots to be taken.
+	for i := 0; i < maxConcurrent; i++ {
+		select {
+		case <-handlerStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handlers did not start within timeout")
+		}
+	}
+
+	// Now add more messages while the semaphore is fully occupied.
+	const extraMessages = 5
+	for i := 0; i < extraMessages; i++ {
+		sendMsg(consumer.Ch, consumer, []byte("extra"))
+	}
+
+	// Give the loop a chance to drain (it should NOT drain since semaphore is full).
+	time.Sleep(100 * time.Millisecond)
+
+	// The channel should be nearly full. The loop reads one message at a time:
+	// it removes the message from the channel and THEN blocks on the semaphore.
+	// So at most one message is "in flight" inside the select (removed from the
+	// channel but waiting for a semaphore slot). All remaining messages stay queued.
+	channelLen := len(consumer.Ch)
+	assert.GreaterOrEqual(t, channelLen, extraMessages-1,
+		"backpressure: channel should retain most messages when semaphore is full (got %d, want >= %d)",
+		channelLen, extraMessages-1)
+
+	// Unblock handlers and let everything finish.
+	close(handlerCanProceed)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+}
+
+// TestListenMessage_GracefulShutdown verifies that after listenMessage exits,
+// all in-flight handler goroutines complete (p.wg.Wait() returns promptly),
+// demonstrating that Close() will not leak goroutines.
+func TestListenMessage_GracefulShutdown(t *testing.T) {
+	const (
+		maxConcurrent  = 3
+		messagesToSend = 6
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	handlerCanProceed := make(chan struct{})
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		<-handlerCanProceed
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	listenDone := make(chan struct{})
+	go func() {
+		defer close(listenDone)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Give some handlers time to start and block.
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel the context to trigger shutdown of the listen loop.
+	cancel()
+
+	// Wait for listenMessage to exit.
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage did not exit after context cancel")
+	}
+
+	// Allow handlers to proceed.
+	close(handlerCanProceed)
+
+	waitDone := make(chan struct{})
+	go func() {
+		defer close(waitDone)
+		p.wg.Wait()
+	}()
+
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("wg.Wait() did not return within timeout — goroutines may be leaked")
+	}
+}
+
+// TestListenMessage_HandlerErrorDoesNotLeakGoroutine verifies that handlers
+// returning errors do not cause goroutine leaks under the semaphore.
+func TestListenMessage_HandlerErrorDoesNotLeakGoroutine(t *testing.T) {
+	const (
+		maxConcurrent  = 5
+		messagesToSend = 20
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var processed atomic.Int64
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		processed.Add(1)
+		return assert.AnError
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 5*time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	assert.Equal(t, int64(messagesToSend), processed.Load(),
+		"all messages should be processed even when handlers return errors")
+}
+
+// TestListenMessage_KeyVerification is the canonical scenario from the spec:
+//   - MaxConcurrentHandlers = 5
+//   - 50 messages sent through a mock consumer channel
+//   - each handler sleeps for 50ms
+//   - peak concurrency must not exceed 5
+//   - all 50 messages must be processed
+func TestListenMessage_KeyVerification(t *testing.T) {
+	const (
+		maxConcurrent     = 5
+		messagesToSend    = 50
+		handlerSleepDelay = 50 * time.Millisecond
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var (
+		currentConcurrency atomic.Int64
+		peakConcurrency    atomic.Int64
+		processed          atomic.Int64
+	)
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		current := currentConcurrency.Add(1)
+		defer currentConcurrency.Add(-1)
+
+		for {
+			peak := peakConcurrency.Load()
+			if current <= peak || peakConcurrency.CompareAndSwap(peak, current) {
+				break
+			}
+		}
+
+		time.Sleep(handlerSleepDelay)
+		processed.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 30*time.Second, 10*time.Millisecond,
+		"all 50 messages should be processed within the timeout")
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	assert.LessOrEqual(t, peakConcurrency.Load(), int64(maxConcurrent),
+		"peak concurrent handlers (%d) exceeded MaxConcurrentHandlers (%d)",
+		peakConcurrency.Load(), maxConcurrent)
+
+	assert.Equal(t, int64(messagesToSend), processed.Load(),
+		"all 50 messages should have been processed")
+}


### PR DESCRIPTION
## Summary

Two fixes for the Pulsar pubsub component that caused unbounded unacked messages (~30k observed in production):

- **processMode silently ignored from component metadata**: `processMode` was only read from subscription request metadata (`req.Metadata`), so setting `processMode: sync` in the component YAML spec had no effect. Users believed they were running sync but were actually running async. Fix: add `ProcessMode` to `pulsarMetadata` struct, normalize to lowercase at parse time, validate accepted values, and resolve effective mode in `listenMessage` using component metadata as default with subscription metadata override.

- **Async mode has no concurrency limit (no backpressure)**: Every message spawned a goroutine with no upper bound. `MaxConcurrentHandlers` only controlled the channel buffer size, not the number of concurrent goroutines. Fix: add a semaphore channel that limits concurrent async handlers to `MaxConcurrentHandlers`, creating real backpressure — when all slots are full the loop stops reading from the channel, the channel fills up, and the SDK stops requesting more messages from the broker.

Additional fixes:
- Pre-existing data race where a shared `err` variable was written by concurrent goroutines in async mode
- `MaxConcurrentHandlers=0` now falls back to default (100) instead of deadlocking the semaphore
- Invalid `processMode` values now return an error at parse time instead of silently falling through to async
- Normal context cancellation logged at Debug level instead of Error
- Graceful shutdown: listenMessageAsync waits for in-flight handlers to complete before returning, ensuring consumer.Close() does not race with Ack/Nack calls from active workers

### Files changed
- `pubsub/pulsar/metadata.go` — added `ProcessMode` field
- `pubsub/pulsar/pulsar.go` — updated `listenMessage` with mode resolution + semaphore, validation in `parsePulsarMetadata`
- `pubsub/pulsar/process_mode_test.go` — 22 test cases for processMode resolution (unit + integration)
- `pubsub/pulsar/pulsar_backpressure_test.go` — 8 test cases for async backpressure (concurrency limits, backpressure propagation, graceful shutdown, error handling)

## Test plan
- [x] All existing Pulsar unit tests pass
- [x] Race detector passes clean (`go test -race`)
- [x] processMode parsed and normalized correctly from component metadata (sync, async, empty, case variants)
- [x] Invalid processMode values rejected at parse time
- [x] MaxConcurrentHandlers=0 falls back to default
- [x] Subscription metadata overrides component metadata
- [x] Default (no processMode) falls back to async
- [x] Sync mode processes messages sequentially (verified via blocking handler)
- [x] Async concurrency never exceeds MaxConcurrentHandlers (peak tracking with atomic counter)
- [x] Backpressure propagates: channel stops draining when semaphore is full
- [x] Context cancellation unblocks semaphore acquisition
- [x] Graceful shutdown: all in-flight goroutines complete
- [x] Handler errors don't leak goroutines or semaphore slots
- [x] Key verification: 5 slots, 50 messages, 50ms handler — peak ≤ 5, all 50 processed