### PR TITLE
fwd port: ollama: add missing endpoint metadata field to spec (#4287)

### DIFF
--- a/conversation/ollama/metadata.yaml
+++ b/conversation/ollama/metadata.yaml
@@ -22,3 +22,10 @@ metadata:
       A time-to-live value for a prompt cache to expire. Uses Golang durations
     type: string
     example: '10m'
+  - name: endpoint
+    required: false
+    description: |
+      The URL of the Ollama server.
+    type: string
+    example: 'http://10.20.23.21:11434/v1'
+    default: 'http://localhost:11434/v1'


### PR DESCRIPTION
supercede https://github.com/dapr/components-contrib/pull/4296 bc I ran the DCO commands and the history then looked off. Opened this one instead