### PR TITLE
fix(pubsub/rabbitmq): use unique consumer tags to prevent subscription disruption on restart

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -564,13 +564,13 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 			}
 
 			err = r.listenMessages(ctx, channel, msgs, req.Topic, handler)
+			// Always cancel the consumer server-side so RabbitMQ can
+			// release the registration. noWait=true avoids blocking if
+			// the channel is already closing.
+			if cancelErr := channel.Cancel(consumerTag, true); cancelErr != nil {
+				r.logger.Debugf("%s failed to cancel consumer %s: %v", logMessagePrefix, consumerTag, cancelErr)
+			}
 			if err != nil {
-				// Best-effort cleanup: cancel the consumer server-side so
-				// RabbitMQ can release the registration. noWait=true avoids
-				// blocking if the channel is already closing.
-				if cancelErr := channel.Cancel(consumerTag, true); cancelErr != nil {
-					r.logger.Debugf("%s failed to cancel consumer %s: %v", logMessagePrefix, consumerTag, cancelErr)
-				}
 				errFuncName = "listenMessages"
 				break
 			}
@@ -583,7 +583,7 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 			return
 		}
 
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 			// Subscription context was canceled
 			r.logger.Infof("%s subscription for %s has context canceled", logMessagePrefix, queueName)
 			return

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -26,6 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 
 	common "github.com/dapr/components-contrib/common/component/rabbitmq"
@@ -91,6 +93,7 @@ type rabbitMQChannelBroker interface {
 	QueueDeclare(name string, durable bool, autoDelete bool, exclusive bool, noWait bool, args amqp.Table) (amqp.Queue, error)
 	QueueBind(name string, key string, exchange string, noWait bool, args amqp.Table) error
 	Consume(queue string, consumer string, autoAck bool, exclusive bool, noLocal bool, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
+	Cancel(consumer string, noWait bool) error
 	Nack(tag uint64, multiple bool, requeue bool) error
 	Ack(tag uint64, multiple bool) error
 	ExchangeDeclare(name string, kind string, durable bool, autoDelete bool, internal bool, noWait bool, args amqp.Table) error
@@ -528,9 +531,19 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 				break
 			}
 
+			// Generate a unique consumer tag to avoid "attempt to reuse consumer tag"
+			// errors when re-subscribing, which would cause a connection-level exception
+			// and disrupt all other subscriptions sharing this channel.
+			// AMQP 0-9-1 limits consumer tags to 255 bytes. Truncate from the
+			// left so the UUID suffix (which guarantees uniqueness) is preserved.
+			consumerTag := queueName + "-" + uuid.NewString()
+			const maxConsumerTagLen = 255
+			if len(consumerTag) > maxConsumerTagLen {
+				consumerTag = consumerTag[len(consumerTag)-maxConsumerTagLen:]
+			}
 			msgs, err = channel.Consume(
 				q.Name,
-				queueName,          // consumerID
+				consumerTag,        // unique consumerID per subscription attempt
 				r.metadata.AutoAck, // autoAck
 				false,              // exclusive
 				false,              // noLocal
@@ -542,6 +555,8 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 				break
 			}
 
+			r.logger.Debugf("%s registered consumer %s for queue %s", logMessagePrefix, consumerTag, q.Name)
+
 			// one-time notification on successful subscribe
 			if ackCh != nil {
 				ackCh <- false
@@ -550,17 +565,25 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 
 			err = r.listenMessages(ctx, channel, msgs, req.Topic, handler)
 			if err != nil {
+				// Best-effort cleanup: cancel the consumer server-side so
+				// RabbitMQ can release the registration. noWait=true avoids
+				// blocking if the channel is already closing.
+				if cancelErr := channel.Cancel(consumerTag, true); cancelErr != nil {
+					r.logger.Debugf("%s failed to cancel consumer %s: %v", logMessagePrefix, consumerTag, cancelErr)
+				}
 				errFuncName = "listenMessages"
 				break
 			}
 		}
 
-		if strings.Contains(err.Error(), errorInvalidQueueType) {
-			ackCh <- true
+		if err != nil && strings.Contains(err.Error(), errorInvalidQueueType) {
+			if ackCh != nil {
+				ackCh <- true
+			}
 			return
 		}
 
-		if err == context.Canceled || err == context.DeadlineExceeded {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			// Subscription context was canceled
 			r.logger.Infof("%s subscription for %s has context canceled", logMessagePrefix, queueName)
 			return

--- a/pubsub/rabbitmq/rabbitmq_integration_test.go
+++ b/pubsub/rabbitmq/rabbitmq_integration_test.go
@@ -1,0 +1,212 @@
+//go:build integration_test
+// +build integration_test
+
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mdata "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	testRabbitMQURL = "amqp://test:test@localhost:5672"
+)
+
+// TestSubscriptionRestart verifies that restarting one subscription does not
+// disrupt other active subscriptions sharing the same connection/channel.
+//
+// Regression test for https://github.com/dapr/java-sdk/issues/1701 where
+// reusing consumer tags on the shared channel caused a connection-level
+// "attempt to reuse consumer tag" exception that killed all subscriptions.
+func TestSubscriptionRestart(t *testing.T) {
+	// Verify RabbitMQ is reachable
+	conn, err := amqp.Dial(testRabbitMQURL)
+	require.NoError(t, err, "RabbitMQ must be running at %s", testRabbitMQURL)
+	conn.Close()
+
+	log := logger.NewLogger("test")
+
+	r := NewRabbitMQ(log).(*rabbitMQ)
+	err = r.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataConnectionStringKey: testRabbitMQURL,
+			metadataConsumerIDKey:       "integration-test",
+			metadataDurableKey:          "true",
+			metadataDeleteWhenUnusedKey: "false",
+			metadataRequeueInFailureKey: "true",
+		},
+	}})
+	require.NoError(t, err)
+	defer r.Close()
+
+	topicStable := "stable-topic"
+	topicRestart := "restart-topic"
+
+	var stableCount atomic.Int32
+	var restartCount atomic.Int32
+
+	stableHandler := func(_ context.Context, msg *pubsub.NewMessage) error {
+		stableCount.Add(1)
+		return nil
+	}
+	restartHandler := func(_ context.Context, msg *pubsub.NewMessage) error {
+		restartCount.Add(1)
+		return nil
+	}
+
+	// Subscribe to both topics
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	err = r.Subscribe(ctx, pubsub.SubscribeRequest{Topic: topicStable}, stableHandler)
+	require.NoError(t, err)
+
+	// Use a separate context for the restart topic so we can cancel it independently
+	restartCtx, restartCancel := context.WithCancel(t.Context())
+
+	err = r.Subscribe(restartCtx, pubsub.SubscribeRequest{Topic: topicRestart}, restartHandler)
+	require.NoError(t, err)
+
+	// Phase 1: Verify both subscriptions receive messages
+	publishN(t, r, topicStable, 5)
+	publishN(t, r, topicRestart, 5)
+
+	assert.Eventually(t, func() bool {
+		return stableCount.Load() >= 5 && restartCount.Load() >= 5
+	}, 10*time.Second, 100*time.Millisecond, "both subscriptions should receive messages")
+
+	t.Logf("Phase 1 passed: stable=%d, restart=%d", stableCount.Load(), restartCount.Load())
+
+	// Phase 2: Cancel the restart subscription (simulates stopping a streaming subscription)
+	restartCancel()
+	time.Sleep(2 * time.Second)
+
+	// Phase 3: Re-subscribe to the restart topic.
+	// Before the fix, this would reuse the same consumer tag and cause
+	// RabbitMQ to throw a connection-level "attempt to reuse consumer tag" error,
+	// killing the stable subscription too.
+	restartCount.Store(0)
+	stableCount.Store(0)
+
+	restartCtx2, restartCancel2 := context.WithCancel(t.Context())
+	defer restartCancel2()
+
+	err = r.Subscribe(restartCtx2, pubsub.SubscribeRequest{Topic: topicRestart}, restartHandler)
+	require.NoError(t, err, "re-subscribe should succeed without connection errors")
+
+	// Phase 4: Verify the stable subscription was NOT disrupted
+	publishN(t, r, topicStable, 5)
+	publishN(t, r, topicRestart, 5)
+
+	assert.Eventually(t, func() bool {
+		return stableCount.Load() >= 5
+	}, 10*time.Second, 100*time.Millisecond,
+		"stable subscription must still work after restart (got %d messages)", stableCount.Load())
+
+	assert.Eventually(t, func() bool {
+		return restartCount.Load() >= 5
+	}, 10*time.Second, 100*time.Millisecond,
+		"restarted subscription must receive messages (got %d messages)", restartCount.Load())
+
+	t.Logf("Phase 4 passed: stable=%d, restart=%d", stableCount.Load(), restartCount.Load())
+}
+
+// TestMultipleSubscriptionsIsolation verifies that multiple concurrent
+// subscriptions operate independently on the shared channel.
+func TestMultipleSubscriptionsIsolation(t *testing.T) {
+	conn, err := amqp.Dial(testRabbitMQURL)
+	require.NoError(t, err, "RabbitMQ must be running at %s", testRabbitMQURL)
+	conn.Close()
+
+	log := logger.NewLogger("test")
+
+	r := NewRabbitMQ(log).(*rabbitMQ)
+	err = r.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataConnectionStringKey: testRabbitMQURL,
+			metadataConsumerIDKey:       "isolation-test",
+			metadataDurableKey:          "true",
+			metadataDeleteWhenUnusedKey: "false",
+		},
+	}})
+	require.NoError(t, err)
+	defer r.Close()
+
+	const numTopics = 5
+	const msgsPerTopic = 10
+
+	var counts [numTopics]atomic.Int32
+
+	// Subscribe to all topics
+	for i := range numTopics {
+		topic := fmt.Sprintf("isolation-topic-%d", i)
+		idx := i
+		err := r.Subscribe(t.Context(), pubsub.SubscribeRequest{Topic: topic}, func(_ context.Context, msg *pubsub.NewMessage) error {
+			counts[idx].Add(1)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	// Publish concurrently
+	var wg sync.WaitGroup
+	for i := range numTopics {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			topic := fmt.Sprintf("isolation-topic-%d", i)
+			publishN(t, r, topic, msgsPerTopic)
+		}(i)
+	}
+	wg.Wait()
+
+	// All topics should receive their messages
+	assert.Eventually(t, func() bool {
+		for i := range numTopics {
+			if counts[i].Load() < msgsPerTopic {
+				return false
+			}
+		}
+		return true
+	}, 15*time.Second, 100*time.Millisecond, "all topics should receive messages")
+
+	for i := range numTopics {
+		t.Logf("topic %d: %d messages", i, counts[i].Load())
+	}
+}
+
+func publishN(t *testing.T, r pubsub.PubSub, topic string, n int) {
+	t.Helper()
+	for i := range n {
+		err := r.Publish(t.Context(), &pubsub.PublishRequest{
+			Topic: topic,
+			Data:  []byte(fmt.Sprintf("msg-%d", i)),
+		})
+		require.NoError(t, err)
+	}
+}

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -511,6 +511,10 @@ func (r *rabbitMQInMemoryBroker) Consume(queue string, consumer string, autoAck 
 	return r.buffer, nil
 }
 
+func (r *rabbitMQInMemoryBroker) Cancel(consumer string, noWait bool) error {
+	return nil
+}
+
 func (r *rabbitMQInMemoryBroker) Nack(tag uint64, multiple bool, requeue bool) error {
 	return nil
 }


### PR DESCRIPTION
# Description

Fixes an issue where stopping and restarting a streaming subscription caused **all** active subscriptions to lose their RabbitMQ connection with `Exception (504) Reason: "channel/connection is not open"`.

**Root cause:** The component used the queue name as the AMQP consumer tag. When a subscription was restarted, `channel.Consume()` reused the same tag on the shared channel. RabbitMQ rejects duplicate consumer tags with a connection-level `not_allowed` exception, which kills the entire connection —  disrupting every subscription, not just the restarted one.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: 
- https://github.com/dapr/components-contrib/issues/4328
- https://github.com/dapr/java-sdk/issues/1701

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
