### PR TITLE
fix(ci): create GitHub release with metadata bundle in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -51,33 +51,8 @@ jobs:
   create-github-release:
     name: Create GitHub release with metadata bundle
     needs: create-release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      # Normalize: strip any leading v, then re-add it
-      RELEASE_TAG: v${{ inputs.rel_version }}
-    steps:
-      - name: Normalize release tag
-        id: tag
-        run: |
-          TAG=$(echo "$RELEASE_TAG" | sed -r 's/^v?[vV]?([0-9])/v\1/')
-          echo "name=$TAG" >> "$GITHUB_OUTPUT"
-      - name: Check out code at release tag
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.tag.outputs.name }}
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: 'false'
-      - name: Build component-metadata-bundle.json
-        run: make bundle-component-metadata
-      - name: Create GitHub release with release notes and metadata bundle
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.DAPR_BOT_TOKEN }}
-          tag_name: ${{ steps.tag.outputs.name }}
-          generate_release_notes: true
-          files: component-metadata-bundle.json
+    uses: ./.github/workflows/generate-component-metadata-for-tag.yml
+    with:
+      tag: v${{ inputs.rel_version }}
+    secrets:
+      DAPR_BOT_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -29,8 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      release_tag: v${{ inputs.rel_version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -56,11 +54,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # Normalize: strip any leading v, then re-add it
+      RELEASE_TAG: v${{ inputs.rel_version }}
     steps:
+      - name: Normalize release tag
+        id: tag
+        run: |
+          TAG=$(echo "$RELEASE_TAG" | sed -r 's/^v?[vV]?([0-9])/v\1/')
+          echo "name=$TAG" >> "$GITHUB_OUTPUT"
       - name: Check out code at release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ needs.create-release.outputs.release_tag }}
+          ref: ${{ steps.tag.outputs.name }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -72,6 +78,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.DAPR_BOT_TOKEN }}
-          tag_name: ${{ needs.create-release.outputs.release_tag }}
+          tag_name: ${{ steps.tag.outputs.name }}
           generate_release_notes: true
           files: component-metadata-bundle.json

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -18,7 +18,7 @@ on:
     inputs:
       rel_version:
         description: 'Release version (examples: 1.16.0-rc.1, 1.16.0)'
-        required: true 
+        required: true
         type: string
 
 permissions: {}
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_tag: v${{ inputs.rel_version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -47,3 +49,29 @@ jobs:
           # Update origin with token
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           ./.github/scripts/create-release.sh ${{ inputs.rel_version }}
+
+  create-github-release:
+    name: Create GitHub release with metadata bundle
+    needs: create-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release.outputs.release_tag }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: 'false'
+      - name: Build component-metadata-bundle.json
+        run: make bundle-component-metadata
+      - name: Create GitHub release with release notes and metadata bundle
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.DAPR_BOT_TOKEN }}
+          tag_name: ${{ needs.create-release.outputs.release_tag }}
+          generate_release_notes: true
+          files: component-metadata-bundle.json

--- a/.github/workflows/generate-component-metadata-for-tag.yml
+++ b/.github/workflows/generate-component-metadata-for-tag.yml
@@ -1,6 +1,15 @@
 name: Generate and Upload Component Metadata Bundle on Push to Tag
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: 'Git tag to build metadata for (e.g., v1.16.0)'
+    secrets:
+      DAPR_BOT_TOKEN:
+        required: true
   workflow_dispatch:
   push:
     tags:
@@ -10,13 +19,15 @@ permissions: {}
 
 jobs:
   upload-bundle:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.tag != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || '' }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -28,5 +39,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.DAPR_BOT_TOKEN }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: component-metadata-bundle.json

--- a/.github/workflows/generate-component-metadata-for-tag.yml
+++ b/.github/workflows/generate-component-metadata-for-tag.yml
@@ -1,6 +1,7 @@
 name: Generate and Upload Component Metadata Bundle on Push to Tag
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'
@@ -9,7 +10,7 @@ permissions: {}
 
 jobs:
   upload-bundle:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Adds a `create-github-release` job to `create-release.yaml` that runs after tag creation
- This job checks out the tag, builds the component metadata bundle, and creates the GitHub Release with auto-generated release notes
- Eliminates the dependency on `generate-component-metadata-for-tag.yml` being triggered by tag push events