### PR TITLE
[1.16] cherrypick 4309

### DIFF
--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -38,6 +38,7 @@ type pulsarMetadata struct {
 	PrivateKey                       string                    `mapstructure:"privateKey"`
 	Keys                             string                    `mapstructure:"keys"`
 	MaxConcurrentHandlers            uint                      `mapstructure:"maxConcurrentHandlers"`
+	ProcessMode                      string                    `mapstructure:"processMode"`
 	ReceiverQueueSize                int                       `mapstructure:"receiverQueueSize"`
 	SubscriptionType                 string                    `mapstructure:"subscribeType"`
 	SubscriptionInitialPosition      string                    `mapstructure:"subscribeInitialPosition"`

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -191,6 +191,18 @@ metadata:
           {"name": "Name","type": "string"}
         ]
       }
+  - name: processMode
+    type: string
+    description: |
+      Controls whether messages are processed synchronously or asynchronously.
+      In sync mode, messages are handled one at a time in order.
+      In async mode, up to maxConcurrentHandlers messages are processed concurrently.
+      Can be overridden per subscription via subscription metadata.
+    default: '"async"'
+    example: '"sync"'
+    allowedValues:
+      - sync
+      - async
   - name: maxConcurrentHandlers
     type: number
     description: |

--- a/pubsub/pulsar/process_mode_test.go
+++ b/pubsub/pulsar/process_mode_test.go
@@ -1,0 +1,695 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Tests for the processMode bug fix:
+//
+//   - processMode was read only from req.Metadata (subscription metadata) and
+//     silently ignored when set in component YAML metadata (pulsarMetadata).
+//   - Fix: pulsarMetadata now carries ProcessMode; listenMessage resolves the
+//     effective mode by using component metadata as the default and letting
+//     subscription metadata override it.
+package pulsar
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pulsarclient "github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mdpkg "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+// ---------------------------------------------------------------------------
+// Mock types for testing listenMessage without a real Pulsar broker.
+// These are shared across process_mode_test.go and pulsar_backpressure_test.go.
+// ---------------------------------------------------------------------------
+
+// mockMessage provides the minimum pulsarclient.Message implementation needed
+// by handleMessage.
+type mockMessage struct {
+	payload    []byte
+	properties map[string]string
+	topic      string
+}
+
+func (m *mockMessage) Payload() []byte                                       { return m.payload }
+func (m *mockMessage) ID() pulsarclient.MessageID                            { return mockMsgID{} }
+func (m *mockMessage) Properties() map[string]string                         { return m.properties }
+func (m *mockMessage) Topic() string                                         { return m.topic }
+func (m *mockMessage) ProducerName() string                                  { return "" }
+func (m *mockMessage) PublishTime() time.Time                                { return time.Time{} }
+func (m *mockMessage) EventTime() time.Time                                  { return time.Time{} }
+func (m *mockMessage) Key() string                                           { return "" }
+func (m *mockMessage) OrderingKey() string                                   { return "" }
+func (m *mockMessage) GetSchemaValue(_ interface{}) error                    { return nil }
+func (m *mockMessage) RedeliveryCount() uint32                               { return 0 }
+func (m *mockMessage) IsReplicated() bool                                    { return false }
+func (m *mockMessage) GetReplicatedFrom() string                             { return "" }
+func (m *mockMessage) GetEncryptionContext() *pulsarclient.EncryptionContext { return nil }
+func (m *mockMessage) Index() *uint64                                        { return nil }
+func (m *mockMessage) BrokerPublishTime() *time.Time                         { return nil }
+func (m *mockMessage) SchemaVersion() []byte                                 { return nil }
+
+// mockMsgID satisfies pulsarclient.MessageID.
+type mockMsgID struct{}
+
+func (mockMsgID) Serialize() []byte   { return nil }
+func (mockMsgID) LedgerID() int64     { return 0 }
+func (mockMsgID) EntryID() int64      { return 0 }
+func (mockMsgID) BatchIdx() int32     { return 0 }
+func (mockMsgID) PartitionIdx() int32 { return 0 }
+func (mockMsgID) BatchSize() int32    { return 0 }
+func (mockMsgID) String() string      { return "mock-id" }
+
+// ackTrackingConsumer routes messages through a controllable channel and
+// records Ack calls. It implements the full pulsarclient.Consumer interface.
+type ackTrackingConsumer struct {
+	Ch       chan pulsarclient.ConsumerMessage
+	ackCount atomic.Int64
+}
+
+func (c *ackTrackingConsumer) Chan() <-chan pulsarclient.ConsumerMessage { return c.Ch }
+func (c *ackTrackingConsumer) Subscription() string                      { return "test-sub" }
+func (c *ackTrackingConsumer) Unsubscribe() error                        { return nil }
+func (c *ackTrackingConsumer) UnsubscribeForce() error                   { return nil }
+
+func (c *ackTrackingConsumer) GetLastMessageIDs() ([]pulsarclient.TopicMessageID, error) {
+	return nil, nil
+}
+
+func (c *ackTrackingConsumer) Receive(ctx context.Context) (pulsarclient.Message, error) {
+	select {
+	case msg, ok := <-c.Ch:
+		if !ok {
+			return nil, errors.New("consumer closed")
+		}
+		return msg.Message, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (c *ackTrackingConsumer) Ack(_ pulsarclient.Message) error {
+	c.ackCount.Add(1)
+	return nil
+}
+func (c *ackTrackingConsumer) AckID(_ pulsarclient.MessageID) error       { return nil }
+func (c *ackTrackingConsumer) AckIDList(_ []pulsarclient.MessageID) error { return nil }
+func (c *ackTrackingConsumer) AckWithTxn(_ pulsarclient.Message, _ pulsarclient.Transaction) error {
+	return nil
+}
+func (c *ackTrackingConsumer) AckCumulative(_ pulsarclient.Message) error             { return nil }
+func (c *ackTrackingConsumer) AckIDCumulative(_ pulsarclient.MessageID) error         { return nil }
+func (c *ackTrackingConsumer) ReconsumeLater(_ pulsarclient.Message, _ time.Duration) {}
+func (c *ackTrackingConsumer) ReconsumeLaterWithCustomProperties(
+	_ pulsarclient.Message, _ map[string]string, _ time.Duration,
+) {
+}
+func (c *ackTrackingConsumer) Nack(_ pulsarclient.Message)         {}
+func (c *ackTrackingConsumer) NackID(_ pulsarclient.MessageID)     {}
+func (c *ackTrackingConsumer) Close()                              {}
+func (c *ackTrackingConsumer) Seek(_ pulsarclient.MessageID) error { return nil }
+func (c *ackTrackingConsumer) SeekByTime(_ time.Time) error        { return nil }
+func (c *ackTrackingConsumer) Name() string                        { return "mock-consumer" }
+func (c *ackTrackingConsumer) Topic() string                       { return "mock-topic" }
+
+// newMockConsumer creates an ackTrackingConsumer with the given channel buffer size.
+func newMockConsumer(bufSize int) *ackTrackingConsumer {
+	return &ackTrackingConsumer{
+		Ch: make(chan pulsarclient.ConsumerMessage, bufSize),
+	}
+}
+
+// sendMsg pushes a ConsumerMessage with the given consumer and payload onto ch.
+func sendMsg(ch chan<- pulsarclient.ConsumerMessage, consumer pulsarclient.Consumer, payload []byte) {
+	ch <- pulsarclient.ConsumerMessage{
+		Consumer: consumer,
+		Message: &mockMessage{
+			payload:    payload,
+			properties: map[string]string{},
+			topic:      "persistent://public/default/test-topic",
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers local to process_mode tests
+// ---------------------------------------------------------------------------
+
+// newPubsubMetadata builds a pubsub.Metadata with the given key-value pairs.
+func newPubsubMetadata(kvs map[string]string) pubsub.Metadata {
+	m := pubsub.Metadata{}
+	m.Base = mdpkg.Base{Properties: kvs}
+	return m
+}
+
+// newProcessModePulsar builds a minimal *Pulsar wired with a component-level
+// ProcessMode. MaxConcurrentHandlers is set high so the worker pool does not
+// artificially constrain concurrency in async tests.
+func newProcessModePulsar(componentProcessMode string) *Pulsar {
+	return &Pulsar{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+		metadata: pulsarMetadata{
+			ProcessMode:           componentProcessMode,
+			MaxConcurrentHandlers: 100,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: parsePulsarMetadata — ProcessMode field
+// ---------------------------------------------------------------------------
+
+func TestParsePulsarMetadataProcessMode(t *testing.T) {
+	tt := []struct {
+		name        string
+		processMode string
+		expected    string
+	}{
+		{
+			name:        "sync processMode normalized to lowercase",
+			processMode: "sync",
+			expected:    "sync",
+		},
+		{
+			name:        "async processMode normalized to lowercase",
+			processMode: "async",
+			expected:    "async",
+		},
+		{
+			name:        "empty processMode stored as empty string",
+			processMode: "",
+			expected:    "",
+		},
+		{
+			name:        "mixed-case Sync normalized to lowercase",
+			processMode: "Sync",
+			expected:    "sync",
+		},
+		{
+			name:        "upper-case SYNC normalized to lowercase",
+			processMode: "SYNC",
+			expected:    "sync",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newPubsubMetadata(map[string]string{
+				"host":        "pulsar://localhost:6650",
+				"processMode": tc.processMode,
+			})
+
+			meta, err := parsePulsarMetadata(m)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, meta.ProcessMode)
+		})
+	}
+}
+
+func TestParsePulsarMetadataProcessModeInvalid(t *testing.T) {
+	m := newPubsubMetadata(map[string]string{
+		"host":        "pulsar://localhost:6650",
+		"processMode": "snc",
+	})
+	_, err := parsePulsarMetadata(m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid processMode")
+}
+
+func TestParsePulsarMetadataZeroMaxConcurrentHandlers(t *testing.T) {
+	m := newPubsubMetadata(map[string]string{
+		"host":                  "pulsar://localhost:6650",
+		"maxConcurrentHandlers": "0",
+	})
+	meta, err := parsePulsarMetadata(m)
+	require.NoError(t, err)
+	assert.Equal(t, uint(100), meta.MaxConcurrentHandlers,
+		"MaxConcurrentHandlers=0 should fall back to default (100)")
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: effective processMode resolution (component vs subscription)
+// ---------------------------------------------------------------------------
+
+// effectiveProcessMode mirrors the resolution in listenMessage:
+// component metadata is already normalized to lowercase by parsePulsarMetadata;
+// subscription metadata override is lowercased and validated at point of use.
+func effectiveProcessMode(componentMode string, subMeta map[string]string) string {
+	mode := strings.ToLower(componentMode)
+	if mode == "" {
+		mode = processModeAsync
+	}
+	if v, ok := subMeta[processModeKey]; ok {
+		override := strings.ToLower(v)
+		switch override {
+		case processModeAsync, processModeSync:
+			mode = override
+		default:
+			// Invalid override is ignored; keep component default.
+		}
+	}
+	return mode
+}
+
+func TestResolveProcessMode(t *testing.T) {
+	tt := []struct {
+		name          string
+		componentMode string
+		subMeta       map[string]string
+		wantSync      bool
+	}{
+		{
+			name:          "component sync, no subscription override",
+			componentMode: "sync",
+			subMeta:       map[string]string{},
+			wantSync:      true,
+		},
+		{
+			name:          "component async, no subscription override",
+			componentMode: "async",
+			subMeta:       map[string]string{},
+			wantSync:      false,
+		},
+		{
+			name:          "component empty (default), no subscription override",
+			componentMode: "",
+			subMeta:       map[string]string{},
+			wantSync:      false,
+		},
+		{
+			name:          "component sync overridden by subscription async",
+			componentMode: "sync",
+			subMeta:       map[string]string{processModeKey: "async"},
+			wantSync:      false,
+		},
+		{
+			name:          "component async overridden by subscription sync",
+			componentMode: "async",
+			subMeta:       map[string]string{processModeKey: "sync"},
+			wantSync:      true,
+		},
+		{
+			name:          "component empty overridden by subscription sync",
+			componentMode: "",
+			subMeta:       map[string]string{processModeKey: "sync"},
+			wantSync:      true,
+		},
+		{
+			name:          "case insensitive Sync from component",
+			componentMode: "Sync",
+			subMeta:       map[string]string{},
+			wantSync:      true,
+		},
+		{
+			name:          "case insensitive SYNC from subscription override",
+			componentMode: "async",
+			subMeta:       map[string]string{processModeKey: "SYNC"},
+			wantSync:      true,
+		},
+		{
+			name:          "nil subscription metadata map uses component mode",
+			componentMode: "sync",
+			subMeta:       nil,
+			wantSync:      true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mode := effectiveProcessMode(tc.componentMode, tc.subMeta)
+			gotSync := strings.EqualFold(mode, processModeSync)
+			assert.Equal(t, tc.wantSync, gotSync,
+				"effectiveProcessMode(%q, %v) = %q; wantSync=%v",
+				tc.componentMode, tc.subMeta, mode, tc.wantSync)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration-style tests: listenMessage processing order
+// ---------------------------------------------------------------------------
+
+// TestListenMessageSyncMode_ComponentMetadata verifies that when ProcessMode is
+// "sync" in component metadata, the next message is not dispatched until the
+// current handler returns.
+func TestListenMessageSyncMode_ComponentMetadata(t *testing.T) {
+	const numMessages = 3
+
+	released := make(chan struct{})
+	var callOrder []int
+	var orderMu sync.Mutex
+	var handlerCallCount atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		n := int(handlerCallCount.Add(1))
+		orderMu.Lock()
+		callOrder = append(callOrder, n)
+		orderMu.Unlock()
+
+		if n == 1 {
+			<-released // block until the test releases
+		}
+		return nil
+	}
+
+	consumer := newMockConsumer(numMessages)
+	p := newProcessModePulsar("sync")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{}, // no subscription override
+	}
+
+	for i := range numMessages {
+		sendMsg(consumer.Ch, consumer, []byte{byte(i)})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait until exactly one handler invocation has occurred. Since the handler
+	// blocks on the 'released' channel, this ensures the second handler has not
+	// been invoked while the first is still running.
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"sync mode: second handler must not fire while first is still running")
+
+	close(released)
+	// After releasing the first handler, wait until all messages have been handled
+	// before cancelling the context.
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == int32(numMessages)
+	}, 2*time.Second, 10*time.Millisecond,
+		"all messages must be handled before cancel")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+
+	assert.Equal(t, int32(numMessages), handlerCallCount.Load(), "all messages must be handled")
+
+	orderMu.Lock()
+	defer orderMu.Unlock()
+	assert.Equal(t, []int{1, 2, 3}, callOrder, "sync mode must process messages in strict order")
+}
+
+// TestListenMessageAsyncMode_ComponentMetadata verifies that when ProcessMode
+// is "async" in component metadata, multiple messages can be in-flight simultaneously.
+func TestListenMessageAsyncMode_ComponentMetadata(t *testing.T) {
+	const numMessages = 3
+
+	barrier := make(chan struct{})
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		cur := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		<-barrier
+		inFlight.Add(-1)
+		return nil
+	}
+
+	consumer := newMockConsumer(numMessages)
+	p := newProcessModePulsar("async")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{},
+	}
+
+	for i := range numMessages {
+		sendMsg(consumer.Ch, consumer, []byte{byte(i)})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait until all handlers have started (they all block on the barrier).
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == int32(numMessages)
+	}, 2*time.Second, 10*time.Millisecond,
+		"async mode: all handlers should start concurrently")
+
+	close(barrier)
+
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"all handlers should complete after barrier release")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+	p.wg.Wait()
+
+	assert.Greater(t, maxInFlight.Load(), int32(1),
+		"async mode must process messages concurrently; max in-flight was %d", maxInFlight.Load())
+}
+
+// TestListenMessageSubscriptionOverridesComponent verifies that subscription
+// metadata "sync" overrides component-level "async".
+func TestListenMessageSubscriptionOverridesComponent(t *testing.T) {
+	released := make(chan struct{})
+	var handlerCallCount atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		n := handlerCallCount.Add(1)
+		if n == 1 {
+			<-released
+		}
+		return nil
+	}
+
+	consumer := newMockConsumer(2)
+	p := newProcessModePulsar("async") // component says async
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: "sync"}, // subscription overrides to sync
+	}
+
+	sendMsg(consumer.Ch, consumer, []byte("msg1"))
+	sendMsg(consumer.Ch, consumer, []byte("msg2"))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"subscription sync override: second handler must not fire while first is running")
+
+	close(released)
+
+	require.Eventually(t, func() bool {
+		return handlerCallCount.Load() == 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"both messages should be handled after release")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+
+	assert.Equal(t, int32(2), handlerCallCount.Load())
+}
+
+// TestListenMessageDefaultFallbackAsync verifies that when no processMode is
+// configured anywhere, the system defaults to async (concurrent) processing.
+func TestListenMessageDefaultFallbackAsync(t *testing.T) {
+	const numMessages = 3
+
+	barrier := make(chan struct{})
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+		cur := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		<-barrier
+		inFlight.Add(-1)
+		return nil
+	}
+
+	consumer := newMockConsumer(numMessages)
+	p := newProcessModePulsar("") // no processMode set anywhere
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{},
+	}
+
+	for i := range numMessages {
+		sendMsg(consumer.Ch, consumer, []byte{byte(i)})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == int32(numMessages)
+	}, 2*time.Second, 10*time.Millisecond,
+		"default async: all handlers should start concurrently")
+
+	close(barrier)
+
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"all handlers should complete after barrier release")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage goroutine did not exit after context cancel")
+	}
+	p.wg.Wait()
+
+	assert.Greater(t, maxInFlight.Load(), int32(1),
+		"default (empty processMode) must fall back to async; max concurrent was %d", maxInFlight.Load())
+}
+
+// TestListenMessageCaseInsensitiveSync verifies that mixed-case "Sync", "SYNC",
+// and "sYnC" in subscription metadata all trigger synchronous processing.
+// Component metadata is normalized to lowercase at parse time, so case
+// insensitivity for component metadata is tested via TestParsePulsarMetadataProcessMode.
+func TestListenMessageCaseInsensitiveSync(t *testing.T) {
+	variants := []string{"Sync", "SYNC", "sYnC"}
+
+	for _, variant := range variants {
+		t.Run("processMode="+variant, func(t *testing.T) {
+			released := make(chan struct{})
+			var callCount atomic.Int32
+
+			handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+				n := callCount.Add(1)
+				if n == 1 {
+					<-released
+				}
+				return nil
+			}
+
+			consumer := newMockConsumer(2)
+			p := newProcessModePulsar("") // no component-level processMode
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			req := pubsub.SubscribeRequest{
+				Topic:    "test-topic",
+				Metadata: map[string]string{processModeKey: variant}, // subscription override with mixed case
+			}
+
+			sendMsg(consumer.Ch, consumer, []byte("msg1"))
+			sendMsg(consumer.Ch, consumer, []byte("msg2"))
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				p.listenMessage(ctx, req, consumer, handler)
+			}()
+
+			require.Eventually(t, func() bool {
+				return callCount.Load() == 1
+			}, 2*time.Second, 10*time.Millisecond,
+				"processMode %q should be treated as sync; second handler fired prematurely", variant)
+
+			close(released)
+
+			require.Eventually(t, func() bool {
+				return callCount.Load() == 2
+			}, 2*time.Second, 10*time.Millisecond,
+				"both messages should be handled after release")
+
+			cancel()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("listenMessage did not exit after context cancel")
+			}
+		})
+	}
+}
+
+// TestGetComponentMetadataIncludesProcessMode verifies that GetComponentMetadata
+// exposes the processMode field so operator tooling can discover it.
+func TestGetComponentMetadataIncludesProcessMode(t *testing.T) {
+	p := &Pulsar{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+	}
+	metaInfo := p.GetComponentMetadata()
+	_, ok := metaInfo["processMode"]
+	assert.True(t, ok, "GetComponentMetadata must expose processMode field")
+}

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -213,8 +213,8 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		return nil, fmt.Errorf("invalid processMode %q: accepted values are %q and %q", m.ProcessMode, processModeAsync, processModeSync)
 	}
 
-	// Guard against zero MaxConcurrentHandlers: a zero-size work channel with no
-	// workers would block the dispatch loop immediately.
+	// Normalize zero MaxConcurrentHandlers to the component default so the
+	// async concurrency limiter always uses a positive bound.
 	if m.MaxConcurrentHandlers == 0 {
 		m.MaxConcurrentHandlers = defaultConcurrency
 	}
@@ -711,33 +711,93 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 func (p *Pulsar) listenMessage(ctx context.Context, req pubsub.SubscribeRequest, consumer pulsar.Consumer, handler pubsub.Handler) {
 	defer consumer.Close()
 
+	// Resolve effective process mode: component metadata is already normalized
+	// to lowercase in parsePulsarMetadata; subscription metadata may override.
+	mode := p.metadata.ProcessMode
+	if mode == "" {
+		mode = processModeAsync
+	}
+	if v, ok := req.Metadata[processModeKey]; ok {
+		override := strings.ToLower(v)
+		switch override {
+		case processModeAsync, processModeSync:
+			mode = override
+		default:
+			p.logger.Warnf(
+				"Invalid process mode %q in subscription metadata for topic %s; using component default %q",
+				v, req.Topic, mode,
+			)
+		}
+	}
+
 	originTopic := req.Topic
-	var err error
+
+	if mode == processModeSync {
+		p.listenMessageSync(ctx, originTopic, consumer, handler)
+	} else {
+		p.listenMessageAsync(ctx, originTopic, consumer, handler)
+	}
+}
+
+// listenMessageSync processes messages sequentially on the calling goroutine.
+func (p *Pulsar) listenMessageSync(ctx context.Context, originTopic string, consumer pulsar.Consumer, handler pubsub.Handler) {
 	for {
 		select {
-		case msg := <-consumer.Chan():
-			if strings.ToLower(req.Metadata[processModeKey]) == processModeSync { //nolint:gocritic
-				err = p.handleMessage(ctx, originTopic, msg, handler)
-				if err != nil && !errors.Is(err, context.Canceled) {
-					p.logger.Errorf("Error sync processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
-				}
-			} else { // async process mode by default
-				// Go routine to handle multiple messages at once.
-				p.wg.Add(1)
-				go func(msg pulsar.ConsumerMessage) {
-					defer p.wg.Done()
-					err = p.handleMessage(ctx, originTopic, msg, handler)
-					if err != nil && !errors.Is(err, context.Canceled) {
-						p.logger.Errorf("Error async processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
-					}
-				}(msg)
+		case msg, ok := <-consumer.Chan():
+			if !ok {
+				return
 			}
-
+			if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
+				p.logger.Errorf("Error sync processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
+			}
 		case <-ctx.Done():
-			p.logger.Errorf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
+			p.logger.Debugf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
 			return
 		}
 	}
+}
+
+// listenMessageAsync pre-spawns MaxConcurrentHandlers worker goroutines that
+// read directly from the consumer channel. Backpressure is achieved naturally:
+// when all workers are busy processing messages, the consumer channel fills up
+// and the SDK stops requesting more messages from the broker. There is no
+// intermediate work channel, so MaxConcurrentHandlers bounds both the number
+// of concurrent handlers and the consumer channel buffer (set in Subscribe).
+func (p *Pulsar) listenMessageAsync(ctx context.Context, originTopic string, consumer pulsar.Consumer, handler pubsub.Handler) {
+	// Use a local WaitGroup for workers so that we can wait for in-flight
+	// handlers to finish their Ack/Nack calls before returning. The caller
+	// defers consumer.Close(), so returning early would close the consumer
+	// while workers are still processing messages.
+	var workerWg sync.WaitGroup
+
+	// Pre-spawn a fixed pool of worker goroutines reading from consumer.Chan().
+	for range p.metadata.MaxConcurrentHandlers {
+		workerWg.Add(1)
+		go func() {
+			defer workerWg.Done()
+			for {
+				select {
+				case msg, ok := <-consumer.Chan():
+					if !ok {
+						return
+					}
+					if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
+						p.logger.Errorf("Error async processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Block until context is cancelled, then wait for workers to finish
+	// processing in-flight messages before returning. This ensures
+	// consumer.Close() (deferred by the caller) does not race with
+	// Ack/Nack calls from active workers.
+	<-ctx.Done()
+	p.logger.Debugf("Subscription context done. Closing consumer. Err: %s", ctx.Err())
+	workerWg.Wait()
 }
 
 func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, msg pulsar.ConsumerMessage, handler pubsub.Handler) error {

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -204,6 +204,21 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 		return nil, errors.New("invalid subscription mode")
 	}
 
+	// Normalize and validate processMode.
+	m.ProcessMode = strings.ToLower(m.ProcessMode)
+	switch m.ProcessMode {
+	case processModeSync, processModeAsync, "":
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid processMode %q: accepted values are %q and %q", m.ProcessMode, processModeAsync, processModeSync)
+	}
+
+	// Guard against zero MaxConcurrentHandlers: a zero-size work channel with no
+	// workers would block the dispatch loop immediately.
+	if m.MaxConcurrentHandlers == 0 {
+		m.MaxConcurrentHandlers = defaultConcurrency
+	}
+
 	// First pass: collect per-topic rawSchema flags.
 	rawSchemaTopics := make(map[string]bool)
 	for k, v := range meta.Properties {

--- a/pubsub/pulsar/pulsar_backpressure_test.go
+++ b/pubsub/pulsar/pulsar_backpressure_test.go
@@ -1,0 +1,600 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pulsar
+
+// Tests for the async worker pool backpressure in listenMessage.
+//
+// The bug: in async mode every message spawned a goroutine with NO upper bound.
+// MaxConcurrentHandlers (default 100) only controlled the channel buffer size —
+// NOT the number of concurrent goroutines. This caused tens of thousands of
+// unacked messages to accumulate.
+//
+// Fix: listenMessage pre-spawns MaxConcurrentHandlers worker goroutines that
+// read directly from the consumer channel. Backpressure is achieved naturally:
+// when all workers are busy the consumer channel fills up, and the SDK stops
+// requesting more messages from the broker.
+//
+// Shared mock types (mockMessage, ackTrackingConsumer, sendMsg) are defined in
+// process_mode_test.go.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pulsarclient "github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+// newTestPulsarWithConcurrency builds a minimal *Pulsar with controlled
+// MaxConcurrentHandlers for worker pool concurrency tests.
+func newTestPulsarWithConcurrency(maxConcurrent uint) *Pulsar {
+	return &Pulsar{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+		metadata: pulsarMetadata{
+			MaxConcurrentHandlers: maxConcurrent,
+		},
+	}
+}
+
+// makeConsumerMessagesN creates n ConsumerMessages using the provided consumer.
+func makeConsumerMessagesN(consumer pulsarclient.Consumer, n int) []pulsarclient.ConsumerMessage {
+	msgs := make([]pulsarclient.ConsumerMessage, n)
+	for i := range msgs {
+		msgs[i] = pulsarclient.ConsumerMessage{
+			Consumer: consumer,
+			Message: &mockMessage{
+				payload:    []byte("hello"),
+				properties: map[string]string{},
+				topic:      "persistent://public/default/test-topic",
+			},
+		}
+	}
+	return msgs
+}
+
+// TestListenMessage_AsyncConcurrencyLimit verifies that in async mode,
+// the number of concurrently executing handlers never exceeds MaxConcurrentHandlers.
+// This is the primary regression test for the unbounded goroutine bug.
+func TestListenMessage_AsyncConcurrencyLimit(t *testing.T) {
+	tt := []struct {
+		name              string
+		maxConcurrent     uint
+		messagesToSend    int
+		handlerSleepDelay time.Duration
+	}{
+		{
+			name:              "limit 1 with 10 messages",
+			maxConcurrent:     1,
+			messagesToSend:    10,
+			handlerSleepDelay: 20 * time.Millisecond,
+		},
+		{
+			name:              "limit 5 with 50 messages",
+			maxConcurrent:     5,
+			messagesToSend:    50,
+			handlerSleepDelay: 50 * time.Millisecond,
+		},
+		{
+			name:              "limit 10 with 30 messages",
+			maxConcurrent:     10,
+			messagesToSend:    30,
+			handlerSleepDelay: 20 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestPulsarWithConcurrency(tc.maxConcurrent)
+
+			consumer := newMockConsumer(tc.messagesToSend)
+
+			var (
+				currentConcurrency atomic.Int64
+				peakConcurrency    atomic.Int64
+				processed          atomic.Int64
+			)
+
+			handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+				current := currentConcurrency.Add(1)
+				defer currentConcurrency.Add(-1)
+
+				// Atomically track peak concurrency.
+				for {
+					peak := peakConcurrency.Load()
+					if current <= peak || peakConcurrency.CompareAndSwap(peak, current) {
+						break
+					}
+				}
+
+				time.Sleep(tc.handlerSleepDelay)
+				processed.Add(1)
+				return nil
+			}
+
+			// Pre-fill the consumer channel with all messages before starting.
+			msgs := makeConsumerMessagesN(consumer, tc.messagesToSend)
+			for _, msg := range msgs {
+				consumer.Ch <- msg
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+
+			req := pubsub.SubscribeRequest{
+				Topic:    "test-topic",
+				Metadata: map[string]string{processModeKey: processModeAsync},
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				p.listenMessage(ctx, req, consumer, handler)
+			}()
+
+			// Wait until all messages are processed.
+			require.Eventually(t, func() bool {
+				return processed.Load() == int64(tc.messagesToSend)
+			}, 30*time.Second, 5*time.Millisecond,
+				"not all messages were processed within timeout")
+
+			cancel()
+			<-done
+			p.wg.Wait()
+
+			assert.LessOrEqual(t, peakConcurrency.Load(), int64(tc.maxConcurrent), //nolint:gosec // test value, no overflow risk
+				"peak concurrent handlers exceeded MaxConcurrentHandlers=%d", tc.maxConcurrent)
+			assert.Equal(t, int64(tc.messagesToSend), processed.Load(),
+				"all messages should have been processed")
+		})
+	}
+}
+
+// TestListenMessage_AsyncAllMessagesProcessed ensures no messages are dropped
+// even under concurrency limiting with a fast handler.
+func TestListenMessage_AsyncAllMessagesProcessed(t *testing.T) {
+	const (
+		maxConcurrent  = 5
+		messagesToSend = 100
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var processed atomic.Int64
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		processed.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 10*time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	assert.Equal(t, int64(messagesToSend), processed.Load())
+}
+
+// TestListenMessage_ContextCancellationUnblocksWorkerPool verifies that
+// cancelling the context while a worker is blocked in its handler causes
+// listenMessage to return promptly, and that in-flight handlers are allowed
+// to complete cleanly once unblocked.
+func TestListenMessage_ContextCancellationUnblocksWorkerPool(t *testing.T) {
+	const maxConcurrent = 1
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(2)
+
+	handlerStarted := make(chan struct{})
+	handlerCanProceed := make(chan struct{})
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		// Signal that the handler started, then block.
+		select {
+		case handlerStarted <- struct{}{}:
+		default:
+		}
+		<-handlerCanProceed
+		return nil
+	}
+
+	sendMsg(consumer.Ch, consumer, []byte("first"))
+	sendMsg(consumer.Ch, consumer, []byte("second"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait for the worker to start processing and block.
+	select {
+	case <-handlerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not start within timeout")
+	}
+
+	// Cancel context and unblock the handler so the worker can finish.
+	cancel()
+	close(handlerCanProceed)
+
+	// listenMessage waits for workers to finish before returning.
+	select {
+	case <-done:
+		// Expected: listenMessage exited after workers completed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenMessage did not exit after context cancellation and handler release")
+	}
+}
+
+// TestListenMessage_SyncModeNotAffectedByWorkerPool verifies that sync mode still
+// processes messages serially and is not broken by the async worker pool.
+func TestListenMessage_SyncModeNotAffectedByWorkerPool(t *testing.T) {
+	const messagesToSend = 5
+
+	// semaphore is not used in sync mode; provide any value.
+	p := newTestPulsarWithConcurrency(3)
+
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var (
+		maxObservedConcurrency int64
+		mu                     sync.Mutex
+		currentConcurrency     int64
+		processed              atomic.Int64
+	)
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		mu.Lock()
+		currentConcurrency++
+		if currentConcurrency > maxObservedConcurrency {
+			maxObservedConcurrency = currentConcurrency
+		}
+		mu.Unlock()
+
+		time.Sleep(10 * time.Millisecond)
+		processed.Add(1)
+
+		mu.Lock()
+		currentConcurrency--
+		mu.Unlock()
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeSync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 5*time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	// In sync mode, concurrency should always be exactly 1.
+	assert.Equal(t, int64(1), maxObservedConcurrency,
+		"sync mode should process exactly one message at a time")
+	assert.Equal(t, int64(messagesToSend), processed.Load())
+}
+
+// TestListenMessage_BackpressureStopsChannelDrain verifies that when all
+// workers are busy, the consumer channel stops draining — workers block in
+// their handlers and stop reading from consumer.Chan().
+//
+// With maxConcurrent=2, workers pull one message each and block. The remaining
+// messages stay in the consumer channel. There is no intermediate work channel.
+func TestListenMessage_BackpressureStopsChannelDrain(t *testing.T) {
+	const maxConcurrent = 2
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+
+	// Buffer large enough that extra messages can queue.
+	consumer := newMockConsumer(20)
+
+	handlerStarted := make(chan struct{}, maxConcurrent)
+	handlerCanProceed := make(chan struct{})
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		select {
+		case handlerStarted <- struct{}{}:
+		default:
+		}
+		<-handlerCanProceed
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	// Send enough messages to leave plenty in the consumer channel after workers start.
+	const totalMessages = 10
+	for range totalMessages {
+		sendMsg(consumer.Ch, consumer, []byte("msg"))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait for all workers to be busy.
+	for range maxConcurrent {
+		select {
+		case <-handlerStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handlers did not start within timeout")
+		}
+	}
+
+	// Workers read directly from consumer.Chan(). Once all workers are blocked
+	// in their handlers, they stop pulling messages. The consumer channel should
+	// retain all messages beyond what the workers took (totalMessages - maxConcurrent).
+	minRemaining := totalMessages - maxConcurrent
+
+	// Verify backpressure: the consumer channel must never drop below minRemaining.
+	require.Never(t, func() bool {
+		return len(consumer.Ch) < minRemaining
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"backpressure: consumer channel should retain at least %d messages",
+		minRemaining)
+
+	// Unblock handlers and let everything finish.
+	close(handlerCanProceed)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+}
+
+// TestListenMessage_GracefulShutdown verifies that listenMessage waits for
+// all in-flight handlers to complete before returning, ensuring that
+// consumer.Close() (deferred by listenMessage) does not race with Ack/Nack
+// calls from active workers.
+func TestListenMessage_GracefulShutdown(t *testing.T) {
+	const (
+		maxConcurrent  = 3
+		messagesToSend = 6
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	handlerCanProceed := make(chan struct{})
+	var handlersStarted atomic.Int64
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		handlersStarted.Add(1)
+		<-handlerCanProceed
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	listenDone := make(chan struct{})
+	go func() {
+		defer close(listenDone)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	// Wait until handlers have started and are blocked.
+	require.Eventually(t, func() bool {
+		return handlersStarted.Load() >= int64(maxConcurrent)
+	}, 2*time.Second, 10*time.Millisecond,
+		"handlers did not start within timeout")
+
+	// Cancel the context to trigger shutdown. listenMessageAsync will wait
+	// for in-flight workers before returning.
+	cancel()
+
+	// Unblock the handlers so workers can finish.
+	close(handlerCanProceed)
+
+	// listenMessage should return after all workers complete.
+	select {
+	case <-listenDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("listenMessage did not exit after context cancel and handler release — workers may be leaked")
+	}
+}
+
+// TestListenMessage_HandlerErrorDoesNotLeakGoroutine verifies that handlers
+// returning errors do not cause goroutine leaks under the worker pool.
+func TestListenMessage_HandlerErrorDoesNotLeakGoroutine(t *testing.T) {
+	const (
+		maxConcurrent  = 5
+		messagesToSend = 20
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var processed atomic.Int64
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		processed.Add(1)
+		return assert.AnError
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 5*time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	assert.Equal(t, int64(messagesToSend), processed.Load(),
+		"all messages should be processed even when handlers return errors")
+}
+
+// TestListenMessage_KeyVerification is the canonical scenario from the spec:
+//   - MaxConcurrentHandlers = 5
+//   - 50 messages sent through a mock consumer channel
+//   - each handler sleeps for 50ms
+//   - peak concurrency must not exceed 5
+//   - all 50 messages must be processed
+func TestListenMessage_KeyVerification(t *testing.T) {
+	const (
+		maxConcurrent     = 5
+		messagesToSend    = 50
+		handlerSleepDelay = 50 * time.Millisecond
+	)
+
+	p := newTestPulsarWithConcurrency(maxConcurrent)
+	consumer := newMockConsumer(messagesToSend)
+
+	msgs := makeConsumerMessagesN(consumer, messagesToSend)
+	for _, msg := range msgs {
+		consumer.Ch <- msg
+	}
+
+	var (
+		currentConcurrency atomic.Int64
+		peakConcurrency    atomic.Int64
+		processed          atomic.Int64
+	)
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error {
+		current := currentConcurrency.Add(1)
+		defer currentConcurrency.Add(-1)
+
+		for {
+			peak := peakConcurrency.Load()
+			if current <= peak || peakConcurrency.CompareAndSwap(peak, current) {
+				break
+			}
+		}
+
+		time.Sleep(handlerSleepDelay)
+		processed.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "test-topic",
+		Metadata: map[string]string{processModeKey: processModeAsync},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.listenMessage(ctx, req, consumer, handler)
+	}()
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == messagesToSend
+	}, 30*time.Second, 10*time.Millisecond,
+		"all 50 messages should be processed within the timeout")
+
+	cancel()
+	<-done
+	p.wg.Wait()
+
+	assert.LessOrEqual(t, peakConcurrency.Load(), int64(maxConcurrent),
+		"peak concurrent handlers (%d) exceeded MaxConcurrentHandlers (%d)",
+		peakConcurrency.Load(), maxConcurrent)
+
+	assert.Equal(t, int64(messagesToSend), processed.Load(),
+		"all 50 messages should have been processed")
+}


### PR DESCRIPTION
[backport this PR.](https://github.com/dapr/components-contrib/pull/4309) 

[since this PR failed to backport it.](https://github.com/dapr/components-contrib/pull/4336)