### PR TITLE
[1.18] Azure appconfig - include contentType and label in metadata

### DIFF
--- a/configuration/azure/appconfig/appconfig.go
+++ b/configuration/azure/appconfig/appconfig.go
@@ -181,8 +181,9 @@ func (r *ConfigurationStore) getAll(ctx context.Context, req *configuration.GetR
 
 	for allSettingsPgr.More() {
 		timeoutContext, cancel := context.WithTimeout(ctx, r.metadata.RequestTimeout)
-		defer cancel()
-		if revResp, err := allSettingsPgr.NextPage(timeoutContext); err == nil {
+		revResp, err := allSettingsPgr.NextPage(timeoutContext)
+		cancel()
+		if err == nil {
 			for _, setting := range revResp.Settings {
 				item := settingToConfigurationItem(setting)
 
@@ -199,7 +200,9 @@ func settingToConfigurationItem(setting azappconfig.Setting) *configuration.Item
 	item := &configuration.Item{
 		Metadata: map[string]string{},
 	}
-	item.Value = *setting.Value
+	if setting.Value != nil {
+		item.Value = *setting.Value
+	}
 	if setting.Label != nil {
 		item.Metadata["label"] = *setting.Label
 	}

--- a/configuration/azure/appconfig/appconfig.go
+++ b/configuration/azure/appconfig/appconfig.go
@@ -153,13 +153,7 @@ func (r *ConfigurationStore) Get(ctx context.Context, req *configuration.GetRequ
 				return &configuration.GetResponse{}, err
 			}
 
-			item := &configuration.Item{
-				Metadata: map[string]string{},
-			}
-			item.Value = *resp.Value
-			if resp.Label != nil {
-				item.Metadata["label"] = *resp.Label
-			}
+			item := settingToConfigurationItem(resp.Setting)
 
 			items[key] = item
 		}
@@ -190,13 +184,7 @@ func (r *ConfigurationStore) getAll(ctx context.Context, req *configuration.GetR
 		defer cancel()
 		if revResp, err := allSettingsPgr.NextPage(timeoutContext); err == nil {
 			for _, setting := range revResp.Settings {
-				item := &configuration.Item{
-					Metadata: map[string]string{},
-				}
-				item.Value = *setting.Value
-				if setting.Label != nil {
-					item.Metadata["label"] = *setting.Label
-				}
+				item := settingToConfigurationItem(setting)
 
 				items[*setting.Key] = item
 			}
@@ -205,6 +193,21 @@ func (r *ConfigurationStore) getAll(ctx context.Context, req *configuration.GetR
 		}
 	}
 	return items, nil
+}
+
+func settingToConfigurationItem(setting azappconfig.Setting) *configuration.Item {
+	item := &configuration.Item{
+		Metadata: map[string]string{},
+	}
+	item.Value = *setting.Value
+	if setting.Label != nil {
+		item.Metadata["label"] = *setting.Label
+	}
+	if setting.ContentType != nil {
+		item.Metadata["contentType"] = *setting.ContentType
+	}
+
+	return item
 }
 
 func (r *ConfigurationStore) getLabelFromMetadata(metadata map[string]string) *string {

--- a/configuration/azure/appconfig/appconfig_test.go
+++ b/configuration/azure/appconfig/appconfig_test.go
@@ -43,6 +43,8 @@ func (m *MockConfigurationStore) GetSetting(ctx context.Context, key string, opt
 
 		settings.Key = ptr.Of("testKey")
 		settings.Value = ptr.Of("testValue")
+		settings.Label = ptr.Of("testLabel")
+		settings.ContentType = ptr.Of("application/json")
 
 		resp := azappconfig.GetSettingResponse{}
 		resp.Setting = settings
@@ -58,10 +60,14 @@ func (m *MockConfigurationStore) NewListSettingsPager(selector azappconfig.Setti
 	setting1 := azappconfig.Setting{}
 	setting1.Key = ptr.Of("testKey-1")
 	setting1.Value = ptr.Of("testValue-1")
+	setting1.Label = ptr.Of("testLabel-1")
+	setting1.ContentType = ptr.Of("application/json")
 
 	setting2 := azappconfig.Setting{}
 	setting2.Key = ptr.Of("testKey-2")
 	setting2.Value = ptr.Of("testValue-2")
+	setting2.Label = ptr.Of("testLabel-2")
+	setting2.ContentType = ptr.Of("text/plain")
 	settings[0] = setting1
 	settings[1] = setting2
 
@@ -113,6 +119,8 @@ func Test_getConfigurationWithProvidedKeys(t *testing.T) {
 		res, err := s.Get(t.Context(), &req)
 		require.NoError(t, err)
 		assert.Len(t, res.Items, 1)
+		assert.Equal(t, "application/json", res.Items["testKey"].Metadata["contentType"])
+		assert.Equal(t, "testLabel", res.Items["testKey"].Metadata["label"])
 	})
 }
 
@@ -189,6 +197,10 @@ func Test_getConfigurationWithNoProvidedKeys(t *testing.T) {
 		res, err := s.Get(t.Context(), &req)
 		require.NoError(t, err)
 		assert.Len(t, res.Items, 2)
+		assert.Equal(t, "application/json", res.Items["testKey-1"].Metadata["contentType"])
+		assert.Equal(t, "testLabel-1", res.Items["testKey-1"].Metadata["label"])
+		assert.Equal(t, "text/plain", res.Items["testKey-2"].Metadata["contentType"])
+		assert.Equal(t, "testLabel-2", res.Items["testKey-2"].Metadata["label"])
 	})
 }
 

--- a/configuration/azure/appconfig/appconfig_test.go
+++ b/configuration/azure/appconfig/appconfig_test.go
@@ -41,7 +41,7 @@ func (m *MockConfigurationStore) GetSetting(ctx context.Context, key string, opt
 	if key == "testKey" || key == "test_sentinel_key" {
 		settings := azappconfig.Setting{}
 
-		settings.Key = ptr.Of("testKey")
+		settings.Key = ptr.Of(key)
 		settings.Value = ptr.Of("testValue")
 		settings.Label = ptr.Of("testLabel")
 		settings.ContentType = ptr.Of("application/json")


### PR DESCRIPTION
# Description

This PR updates the Azure App Configuration configuration store to surface additional Azure setting properties in the returned `configuration.Item.Metadata`, and adds unit test assertions to validate those metadata fields.

**Changes:**
- Refactors setting → `configuration.Item` conversion into a helper (`settingToConfigurationItem`).
- Adds `contentType` (and validates `label`) to returned item metadata.
- Updates mocks and tests to populate/assert `Label` and `ContentType`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/components-contrib/issues/4308

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5118

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
