### PR TITLE
feat(state/oracledatabase): add BulkGet chunking to avoid Oracle IN-list limit

### DIFF
--- a/state/oracledatabase/metadata.yaml
+++ b/state/oracledatabase/metadata.yaml
@@ -28,3 +28,15 @@ metadata:
     description: The location of the Oracle wallet.
     example: "/path/to/wallet"
     default: ""
+  - name: bulkGetChunkSize
+    type: number
+    required: false
+    description: |
+      Maximum number of keys per internal SQL query when using BulkGet.
+      When the total number of requested keys exceeds this value, multiple
+      chunked queries are executed sequentially. Valid values are between 1
+      and 1000 (Oracle's documented IN-list expression limit). Values less
+      than or equal to 0 use the default value of 1000. Values above 1000
+      are clamped with a warning log.
+    example: "100"
+    default: "1000"

--- a/state/oracledatabase/oracledatabase_integration_test.go
+++ b/state/oracledatabase/oracledatabase_integration_test.go
@@ -124,6 +124,10 @@ func TestOracleDatabaseIntegration(t *testing.T) {
 		testBulkGet(t, ods)
 	})
 
+	t.Run("Bulk get chunking exceeds Oracle IN-list limit", func(t *testing.T) {
+		testBulkGetChunkingExceedsLimit(t, ods)
+	})
+
 	t.Run("Update and delete with etag succeeds", func(t *testing.T) {
 		updateAndDeleteWithEtagSucceeds(t, ods)
 	})
@@ -730,6 +734,66 @@ func testBulkGet(t *testing.T, ods state.Store) {
 	}
 
 	err = ods.BulkDelete(t.Context(), deleteReq, state.BulkStoreOpts{})
+	require.NoError(t, err)
+}
+
+// testBulkGetChunkingExceedsLimit verifies that BulkGet succeeds when
+// requesting more keys than Oracle's IN-list expression limit (1000).
+// This exercises the sequential chunking path introduced to fix
+// https://github.com/dapr/components-contrib/issues/4041.
+func testBulkGetChunkingExceedsLimit(t *testing.T, ods state.Store) {
+	const totalKeys = 1100
+
+	// Seed keys
+	setReqs := make([]state.SetRequest, totalKeys)
+	for i := range setReqs {
+		setReqs[i] = state.SetRequest{
+			Key:   randomKey(),
+			Value: &fakeItem{Color: fmt.Sprintf("color-%d", i)},
+		}
+	}
+
+	err := ods.BulkSet(t.Context(), setReqs, state.BulkStoreOpts{})
+	require.NoError(t, err)
+
+	// Build BulkGet request plus one key that doesn't exist
+	getReqs := make([]state.GetRequest, totalKeys+1)
+	for i := range totalKeys {
+		getReqs[i] = state.GetRequest{Key: setReqs[i].Key}
+	}
+	getReqs[totalKeys] = state.GetRequest{Key: randomKey()} // non-existent
+
+	responses, err := ods.BulkGet(t.Context(), getReqs, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, responses, totalKeys+1)
+
+	byKey := make(map[string]state.BulkGetResponse, len(responses))
+	for _, r := range responses {
+		byKey[r.Key] = r
+	}
+
+	// All seeded keys should be present with data
+	for i := range totalKeys {
+		expectedKey := setReqs[i].Key
+		r, ok := byKey[expectedKey]
+		require.True(t, ok, "expected bulk get response for key %s", expectedKey)
+		assert.Empty(t, r.Error, "key %s should not have error", expectedKey)
+		assert.NotNil(t, r.Data, "key %s should have data", expectedKey)
+		assert.NotNil(t, r.ETag, "key %s should have etag", expectedKey)
+	}
+
+	// Non-existent key should be present with no data
+	missingResp := byKey[getReqs[totalKeys].Key]
+	assert.Empty(t, missingResp.Error)
+	assert.Nil(t, missingResp.Data)
+	assert.Nil(t, missingResp.ETag)
+
+	// Clean up
+	deleteReqs := make([]state.DeleteRequest, totalKeys)
+	for i := range totalKeys {
+		deleteReqs[i] = state.DeleteRequest{Key: setReqs[i].Key}
+	}
+	err = ods.BulkDelete(t.Context(), deleteReqs, state.BulkStoreOpts{})
 	require.NoError(t, err)
 }
 

--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -39,6 +39,17 @@ const (
 	oracleWalletLocationKey    = "oracleWalletLocation"
 	errMissingConnectionString = "missing connection string"
 	defaultTableName           = "state"
+	// defaultBulkGetChunkSize is the default per-chunk size for BulkGet
+	// requests. Matches Oracle's documented IN-list expression limit so that
+	// requests with fewer keys than this default execute as a single query,
+	// preserving pre-chunking behavior.
+	// Invariant: defaultBulkGetChunkSize <= maxBulkGetChunkSize.
+	defaultBulkGetChunkSize = 1000
+	// maxBulkGetChunkSize is Oracle's hard limit on the number of
+	// expressions in a SQL IN list, per the Oracle SQL Language Reference.
+	// Values above this limit are rejected by Oracle with ORA-01795
+	// ("maximum number of expressions in a list is 1000").
+	maxBulkGetChunkSize = 1000
 )
 
 // oracleDatabaseAccess implements dbaccess.
@@ -53,6 +64,13 @@ type oracleDatabaseMetadata struct {
 	ConnectionString     string `json:"connectionString"`
 	OracleWalletLocation string `json:"oracleWalletLocation"`
 	TableName            string `json:"tableName"`
+	// BulkGetChunkSize controls the maximum number of keys included in each
+	// internal SQL query issued by BulkGet. When the number of requested
+	// keys exceeds this value, BulkGet issues multiple chunked queries
+	// sequentially (not in parallel) and merges the results. Values less
+	// than or equal to 0 default to 1000; values above 1000 are clamped.
+	// See normalizeBulkGetChunkSize.
+	BulkGetChunkSize int `json:"bulkGetChunkSize"`
 }
 
 // newOracleDatabaseAccess creates a new instance of oracleDatabaseAccess.
@@ -74,6 +92,21 @@ func parseMetadata(meta map[string]string) (oracleDatabaseMetadata, error) {
 	return m, err
 }
 
+// normalizeBulkGetChunkSize applies defaults and clamping to the configured
+// chunk size. Values <= 0 default to defaultBulkGetChunkSize; values above
+// Oracle's IN-list limit are clamped to maxBulkGetChunkSize with a warning.
+func normalizeBulkGetChunkSize(log logger.Logger, configured int) int {
+	if configured <= 0 {
+		return defaultBulkGetChunkSize
+	}
+	if configured > maxBulkGetChunkSize {
+		log.Warnf("bulkGetChunkSize %d exceeds Oracle's IN-list limit of %d; clamping to %d",
+			configured, maxBulkGetChunkSize, maxBulkGetChunkSize)
+		return maxBulkGetChunkSize
+	}
+	return configured
+}
+
 // Init sets up OracleDatabase connection and ensures that the state table exists.
 func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata) error {
 	meta, err := parseMetadata(metadata.Properties)
@@ -81,6 +114,7 @@ func (o *oracleDatabaseAccess) Init(ctx context.Context, metadata state.Metadata
 		return err
 	}
 
+	meta.BulkGetChunkSize = normalizeBulkGetChunkSize(o.logger, meta.BulkGetChunkSize)
 	o.metadata = meta
 
 	if o.metadata.ConnectionString == "" {
@@ -312,20 +346,74 @@ func (o *oracleDatabaseAccess) Get(ctx context.Context, req *state.GetRequest) (
 	}, nil
 }
 
+// BulkGet retrieves multiple keys. When the number of requested keys exceeds
+// the configured BulkGetChunkSize, BulkGet issues multiple chunked queries
+// sequentially (not in parallel) and merges the results. This avoids Oracle's
+// hard 1000-expression limit on IN lists and reduces index pressure for large
+// key sets.
+//
+// The default chunk size equals Oracle's IN-list limit (1000), so callers
+// with <= 1000 keys see identical behavior to the pre-chunking implementation.
 func (o *oracleDatabaseAccess) BulkGet(ctx context.Context, req []state.GetRequest) ([]state.BulkGetResponse, error) {
 	if len(req) == 0 {
 		return []state.BulkGetResponse{}, nil
 	}
 
+	// Validate all keys upfront — an empty key is a programmer bug, not a
+	// per-key data issue, so we fail fast before issuing any query.
+	for _, r := range req {
+		if r.Key == "" {
+			return nil, errors.New("missing key in bulk get operation")
+		}
+	}
+
+	chunkSize := o.metadata.BulkGetChunkSize
+
+	// Fast path: input fits in one chunk — no allocation overhead.
+	if len(req) <= chunkSize {
+		return o.bulkGetChunk(ctx, req)
+	}
+
+	// Chunked path: sequential chunks, results concatenated.
+	res := make([]state.BulkGetResponse, 0, len(req))
+	for start := 0; start < len(req); start += chunkSize {
+		// Check context between chunks so a cancelled context stops promptly
+		// instead of issuing wasted round-trips.
+		if err := ctx.Err(); err != nil {
+			for _, r := range req[start:] {
+				res = append(res, state.BulkGetResponse{
+					Key:   r.Key,
+					Error: err.Error(),
+				})
+			}
+			return res, nil
+		}
+
+		end := start + chunkSize
+		if end > len(req) {
+			end = len(req)
+		}
+
+		chunkRes, err := o.bulkGetChunk(ctx, req[start:end])
+		if err != nil {
+			// bulkGetChunk only returns a hard error for programming bugs
+			// (e.g. more rows than expected). Propagate it.
+			return nil, err
+		}
+		res = append(res, chunkRes...)
+	}
+	return res, nil
+}
+
+// bulkGetChunk executes a single IN-clause query for the given requests.
+// Pre-condition: req is non-empty and all keys are non-empty.
+func (o *oracleDatabaseAccess) bulkGetChunk(ctx context.Context, req []state.GetRequest) ([]state.BulkGetResponse, error) {
 	// Oracle supports the IN operator for bulk operations
 	// Build the IN clause with bind variables
 	// Oracle uses :1, :2, etc. for bind variables in the IN clause
 	params := make([]any, len(req))
 	bindVars := make([]string, len(req))
 	for i, r := range req {
-		if r.Key == "" {
-			return nil, errors.New("missing key in bulk get operation")
-		}
 		params[i] = r.Key
 		bindVars[i] = ":" + strconv.Itoa(i+1)
 	}

--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -41,7 +41,7 @@ const (
 	defaultTableName           = "state"
 	// defaultBulkGetChunkSize is the default per-chunk size for BulkGet
 	// requests. Matches Oracle's documented IN-list expression limit so that
-	// requests with fewer keys than this default execute as a single query,
+	// requests with this many keys or fewer execute as a single query,
 	// preserving pre-chunking behavior.
 	// Invariant: defaultBulkGetChunkSize <= maxBulkGetChunkSize.
 	defaultBulkGetChunkSize = 1000

--- a/state/oracledatabase/oracledatabaseaccess_test.go
+++ b/state/oracledatabase/oracledatabaseaccess_test.go
@@ -598,12 +598,12 @@ func TestNormalizeBulkGetChunkSize(t *testing.T) {
 		},
 		{
 			name:       "exact max boundary",
-			configured: 1000,
-			expected:   1000,
+			configured: maxBulkGetChunkSize,
+			expected:   maxBulkGetChunkSize,
 		},
 		{
 			name:       "above max clamped to max",
-			configured: 2000,
+			configured: maxBulkGetChunkSize + 1,
 			expected:   maxBulkGetChunkSize,
 		},
 		{

--- a/state/oracledatabase/oracledatabaseaccess_test.go
+++ b/state/oracledatabase/oracledatabaseaccess_test.go
@@ -16,9 +16,11 @@ limitations under the License.
 package oracledatabase
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -170,7 +172,7 @@ func TestBulkGetQueryFailure(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	mock.ExpectQuery("SELECT").WillReturnError(errors.New("connection refused"))
@@ -207,7 +209,7 @@ func TestBulkGetBinaryDecodeFailure(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	// First row: valid non-binary data
@@ -260,7 +262,7 @@ func TestBulkGetBinaryBase64DecodeFailure(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	// Value is valid JSON string but not valid base64
@@ -295,7 +297,7 @@ func TestBulkGetRowsErrFailure(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	// sqlmock's RowError(N, err) causes rows.Next() to return false (with the
@@ -356,7 +358,7 @@ func TestBulkGetRowsErrAfterAllRowsProcessed(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	// Return the one requested row successfully, then trigger rows.Err().
@@ -403,7 +405,7 @@ func TestBulkGetWithExpiration(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	expTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
@@ -432,7 +434,7 @@ func TestBulkGetEmpty(t *testing.T) {
 
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	res, err := o.BulkGet(t.Context(), []state.GetRequest{})
@@ -450,7 +452,7 @@ func TestBulkGetMissingKeys(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	// DB only returns key2; key1 and key3 are not in the database.
@@ -504,7 +506,7 @@ func TestBulkGetRowsScanFailure(t *testing.T) {
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
 		db:       db,
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	// To trigger a Scan error, pass a string for the expiration_time column.
@@ -549,7 +551,7 @@ func TestBulkGetEmptyKeyValidation(t *testing.T) {
 
 	o := &oracleDatabaseAccess{
 		logger:   logger.NewLogger("test"),
-		metadata: oracleDatabaseMetadata{TableName: "state"},
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: defaultBulkGetChunkSize},
 	}
 
 	req := []state.GetRequest{
@@ -562,4 +564,343 @@ func TestBulkGetEmptyKeyValidation(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, res)
 	assert.Equal(t, "missing key in bulk get operation", err.Error())
+}
+
+func TestNormalizeBulkGetChunkSize(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewLogger("test")
+
+	tests := []struct {
+		name       string
+		configured int
+		expected   int
+	}{
+		{
+			name:       "zero defaults to default",
+			configured: 0,
+			expected:   defaultBulkGetChunkSize,
+		},
+		{
+			name:       "negative defaults to default",
+			configured: -1,
+			expected:   defaultBulkGetChunkSize,
+		},
+		{
+			name:       "valid value 100",
+			configured: 100,
+			expected:   100,
+		},
+		{
+			name:       "valid value 500",
+			configured: 500,
+			expected:   500,
+		},
+		{
+			name:       "exact max boundary",
+			configured: 1000,
+			expected:   1000,
+		},
+		{
+			name:       "above max clamped to max",
+			configured: 2000,
+			expected:   maxBulkGetChunkSize,
+		},
+		{
+			name:       "one is valid minimum",
+			configured: 1,
+			expected:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeBulkGetChunkSize(log, tt.configured)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseMetadata_BulkGetChunkSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected int
+	}{
+		{
+			name:     "not set defaults to zero",
+			input:    map[string]string{"connectionString": "x"},
+			expected: 0,
+		},
+		{
+			name:     "explicit value decoded",
+			input:    map[string]string{"connectionString": "x", "bulkGetChunkSize": "200"},
+			expected: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := parseMetadata(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, m.BulkGetChunkSize)
+		})
+	}
+}
+
+func TestBulkGetChunking_MultipleChunks(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	chunkSize := 3
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: chunkSize},
+	}
+
+	// 7 keys → 3 chunks: [key1,key2,key3], [key4,key5,key6], [key7]
+	req := make([]state.GetRequest, 7)
+	for i := range req {
+		req[i] = state.GetRequest{Key: fmt.Sprintf("key%d", i+1)}
+	}
+
+	// Chunk 1: returns key1, key2, key3
+	rows1 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key1", `"v1"`, "N", "e1", nil).
+		AddRow("key2", `"v2"`, "N", "e2", nil).
+		AddRow("key3", `"v3"`, "N", "e3", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows1)
+
+	// Chunk 2: returns key4, key6 — key5 is missing
+	rows2 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key4", `"v4"`, "N", "e4", nil).
+		AddRow("key6", `"v6"`, "N", "e6", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows2)
+
+	// Chunk 3: returns key7
+	rows3 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("key7", `"v7"`, "N", "e7", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows3)
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 7)
+
+	// Build map for flexible assertion
+	byKey := make(map[string]state.BulkGetResponse, len(res))
+	for _, r := range res {
+		byKey[r.Key] = r
+	}
+
+	// All 7 keys present
+	for i := 1; i <= 7; i++ {
+		k := fmt.Sprintf("key%d", i)
+		_, ok := byKey[k]
+		assert.True(t, ok, "key %s should be in results", k)
+	}
+
+	// Found keys have data
+	for _, k := range []string{"key1", "key2", "key3", "key4", "key6", "key7"} {
+		r := byKey[k]
+		assert.Empty(t, r.Error, "key %s should not have error", k)
+		assert.NotNil(t, r.Data, "key %s should have data", k)
+		assert.NotNil(t, r.ETag, "key %s should have etag", k)
+	}
+
+	// Missing key5 has empty response
+	r5 := byKey["key5"]
+	assert.Empty(t, r5.Error)
+	assert.Nil(t, r5.Data)
+	assert.Nil(t, r5.ETag)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_ExactMultiple(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	chunkSize := 2
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: chunkSize},
+	}
+
+	// 4 keys → 2 chunks of exactly 2
+	req := []state.GetRequest{
+		{Key: "k1"}, {Key: "k2"}, {Key: "k3"}, {Key: "k4"},
+	}
+
+	rows1 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("k1", `"v1"`, "N", "e1", nil).
+		AddRow("k2", `"v2"`, "N", "e2", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows1)
+
+	rows2 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("k3", `"v3"`, "N", "e3", nil).
+		AddRow("k4", `"v4"`, "N", "e4", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows2)
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 4)
+
+	for _, r := range res {
+		assert.Empty(t, r.Error)
+		assert.NotNil(t, r.Data)
+		assert.NotNil(t, r.ETag)
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_MiddleChunkFails(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	chunkSize := 2
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: chunkSize},
+	}
+
+	// 6 keys → 3 chunks: [k1,k2], [k3,k4], [k5,k6]
+	req := []state.GetRequest{
+		{Key: "k1"},
+		{Key: "k2"},
+		{Key: "k3"},
+		{Key: "k4"},
+		{Key: "k5"},
+		{Key: "k6"},
+	}
+
+	// Chunk 1 succeeds
+	rows1 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("k1", `"v1"`, "N", "e1", nil).
+		AddRow("k2", `"v2"`, "N", "e2", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows1)
+
+	// Chunk 2 fails
+	mock.ExpectQuery("SELECT").WillReturnError(errors.New("connection reset"))
+
+	// Chunk 3 succeeds
+	rows3 := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("k5", `"v5"`, "N", "e5", nil).
+		AddRow("k6", `"v6"`, "N", "e6", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows3)
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 6)
+
+	byKey := make(map[string]state.BulkGetResponse, len(res))
+	for _, r := range res {
+		byKey[r.Key] = r
+	}
+
+	// Chunks 1 and 3 succeeded
+	for _, k := range []string{"k1", "k2", "k5", "k6"} {
+		r := byKey[k]
+		assert.Empty(t, r.Error, "key %s should not have error", k)
+		assert.NotNil(t, r.Data, "key %s should have data", k)
+	}
+
+	// Chunk 2 keys have per-key errors
+	for _, k := range []string{"k3", "k4"} {
+		r := byKey[k]
+		assert.NotEmpty(t, r.Error, "key %s should have error", k)
+		assert.Contains(t, r.Error, "bulk get query failed:")
+		assert.Contains(t, r.Error, "connection reset")
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	chunkSize := 2
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: chunkSize},
+	}
+
+	// 4 keys → chunked path (4 > chunkSize 2)
+	req := []state.GetRequest{
+		{Key: "k1"}, {Key: "k2"}, {Key: "k3"}, {Key: "k4"},
+	}
+
+	// Pre-cancel the context — the ctx.Err() check at the top of the chunk
+	// loop fires before any query is issued.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	res, err := o.BulkGet(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, res, 4)
+
+	for _, r := range res {
+		assert.NotEmpty(t, r.Error, "key %s should have ctx error", r.Key)
+		assert.Contains(t, r.Error, "context canceled")
+	}
+
+	// No queries should have been issued
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_SingleChunkFastPath(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	chunkSize := 10
+	o := &oracleDatabaseAccess{
+		logger:   logger.NewLogger("test"),
+		db:       db,
+		metadata: oracleDatabaseMetadata{TableName: "state", BulkGetChunkSize: chunkSize},
+	}
+
+	// 3 keys < chunkSize 10 → fast path, single query
+	req := []state.GetRequest{
+		{Key: "k1"}, {Key: "k2"}, {Key: "k3"},
+	}
+
+	rows := sqlmock.NewRows([]string{"key", "value", "binary_yn", "etag", "expiration_time"}).
+		AddRow("k1", `"v1"`, "N", "e1", nil).
+		AddRow("k2", `"v2"`, "N", "e2", nil).
+		AddRow("k3", `"v3"`, "N", "e3", nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	res, err := o.BulkGet(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	for _, r := range res {
+		assert.Empty(t, r.Error)
+		assert.NotNil(t, r.Data)
+	}
+
+	// Only one query issued
+	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
# Description
## Summary
- Add configurable `bulkGetChunkSize` metadata option to the Oracle state store, which splits large `BulkGet` requests into sequential chunked SQL queries to avoid Oracle's hard 1000-expression IN-list limit ([#4041](https://github.com/dapr/components-contrib/issues/4041))
- Default chunk size is 1000 (Oracle's cap), so existing users with ≤1000 keys see **zero behavior change** — only the previously-crashing >1000-key path now works
- Chunks execute sequentially (not in parallel) per issue guidance; failed chunks don't abort remaining chunks (partial-success semantics preserved)

## Changes

### Production code (`oracledatabaseaccess.go`)
- Added `BulkGetChunkSize` field to `oracleDatabaseMetadata` struct with `bulkGetChunkSize` metadata key
- Added `normalizeBulkGetChunkSize()` helper: defaults `<=0` to 1000, clamps `>1000` with a warning log
- Refactored `BulkGet` into an orchestrator (upfront key validation, fast-path single chunk, sequential chunking loop with `ctx.Err()` check between chunks) and `bulkGetChunk` (the existing single-query logic, extracted as-is)
- Called `normalizeBulkGetChunkSize` from `Init()` after metadata parsing

### Metadata (`metadata.yaml`)
- Added `bulkGetChunkSize` entry (type: number, default: 1000, range [1, 1000])
 
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #4041

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5122


**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
