### PR TITLE
state: native bulk ops and DeleteWithPrefix

### DIFF
--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -186,9 +186,6 @@ func (e *Etcd) BulkGet(parentCtx context.Context, req []state.GetRequest, _ stat
 		return []state.BulkGetResponse{}, nil
 	}
 
-	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
-	defer cancel()
-
 	res := make([]state.BulkGetResponse, len(req))
 	chunkSize := e.maxTxnOps
 	if chunkSize <= 0 {
@@ -204,7 +201,11 @@ func (e *Etcd) BulkGet(parentCtx context.Context, req []state.GetRequest, _ stat
 		for i := start; i < end; i++ {
 			ops[i-start] = clientv3.OpGet(e.keyPrefixPath + "/" + req[i].Key)
 		}
-		resp, err := e.client.Txn(ctx).Then(ops...).Commit()
+		// Fresh per-chunk timeout so a large request doesn't exhaust a
+		// shared 5s budget across many chunks mid-loop.
+		chunkCtx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+		resp, err := e.client.Txn(chunkCtx).Then(ops...).Commit()
+		cancel()
 		if err != nil {
 			return nil, fmt.Errorf("etcd bulk get: %w", err)
 		}
@@ -239,16 +240,16 @@ func (e *Etcd) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithP
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
-	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
-	defer cancel()
 
 	storePrefix := e.keyPrefixPath + "/" + req.Prefix
-	getResp, err := e.client.Get(ctx, storePrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	getCtx, getCancel := context.WithTimeout(parentCtx, 5*time.Second)
+	getResp, err := e.client.Get(getCtx, storePrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	getCancel()
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: get: %w", err)
 	}
 
-	var toDelete []string
+	toDelete := make([]string, 0, len(getResp.Kvs))
 	for _, kv := range getResp.Kvs {
 		suffix := strings.TrimPrefix(string(kv.Key), storePrefix)
 		if strings.Contains(suffix, "||") {
@@ -274,7 +275,11 @@ func (e *Etcd) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithP
 		for i := start; i < end; i++ {
 			ops[i-start] = clientv3.OpDelete(toDelete[i])
 		}
-		resp, err := e.client.Txn(ctx).Then(ops...).Commit()
+		// Fresh per-batch timeout so many delete chunks don't share a
+		// single 5s budget.
+		batchCtx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+		resp, err := e.client.Txn(batchCtx).Then(ops...).Commit()
+		cancel()
 		if err != nil {
 			return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: delete: %w", err)
 		}

--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -230,66 +230,19 @@ func (e *Etcd) BulkGet(parentCtx context.Context, req []state.GetRequest, _ stat
 	return res, nil
 }
 
-// DeleteWithPrefix removes all keys that are direct children of the given
-// prefix (i.e. whose name starts with prefix and does not itself contain
-// another DaprSeparator). Matches the in-memory store semantics. Etcd's
-// server-side WithPrefix() delete would over-delete nested keys, so we first
-// range-get matching keys and then batch-delete the filtered set. For actor
-// state (no nested separators) this is two RPCs regardless of key count.
+// DeleteWithPrefix removes every key beginning with the given prefix in a
+// single server-side range-delete RPC.
 func (e *Etcd) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
-
-	storePrefix := e.keyPrefixPath + "/" + req.Prefix
-	getCtx, getCancel := context.WithTimeout(parentCtx, 5*time.Second)
-	getResp, err := e.client.Get(getCtx, storePrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
-	getCancel()
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+	defer cancel()
+	resp, err := e.client.Delete(ctx, e.keyPrefixPath+"/"+req.Prefix, clientv3.WithPrefix())
 	if err != nil {
-		return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: get: %w", err)
+		return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: %w", err)
 	}
-
-	toDelete := make([]string, 0, len(getResp.Kvs))
-	for _, kv := range getResp.Kvs {
-		suffix := strings.TrimPrefix(string(kv.Key), storePrefix)
-		if strings.Contains(suffix, "||") {
-			continue
-		}
-		toDelete = append(toDelete, string(kv.Key))
-	}
-	if len(toDelete) == 0 {
-		return state.DeleteWithPrefixResponse{Count: 0}, nil
-	}
-
-	chunkSize := e.maxTxnOps
-	if chunkSize <= 0 {
-		chunkSize = len(toDelete)
-	}
-	var total int64
-	for start := 0; start < len(toDelete); start += chunkSize {
-		end := start + chunkSize
-		if end > len(toDelete) {
-			end = len(toDelete)
-		}
-		ops := make([]clientv3.Op, end-start)
-		for i := start; i < end; i++ {
-			ops[i-start] = clientv3.OpDelete(toDelete[i])
-		}
-		// Fresh per-batch timeout so many delete chunks don't share a
-		// single 5s budget.
-		batchCtx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
-		resp, err := e.client.Txn(batchCtx).Then(ops...).Commit()
-		cancel()
-		if err != nil {
-			return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: delete: %w", err)
-		}
-		for _, r := range resp.Responses {
-			if dr := r.GetResponseDeleteRange(); dr != nil {
-				total += dr.Deleted
-			}
-		}
-	}
-	return state.DeleteWithPrefixResponse{Count: total}, nil
+	return state.DeleteWithPrefixResponse{Count: resp.Deleted}, nil
 }
 
 // Set saves a Etcd KV item.

--- a/state/etcd/etcd.go
+++ b/state/etcd/etcd.go
@@ -78,6 +78,7 @@ func newETCD(logger logger.Logger, schema schemaMarshaller) state.Store {
 			state.FeatureTransactional,
 			state.FeatureTTL,
 			state.FeatureKeysLike,
+			state.FeatureDeleteWithPrefix,
 		},
 	}
 	s.BulkStore = state.NewDefaultBulkStore(s)
@@ -174,6 +175,116 @@ func (e *Etcd) Get(ctx context.Context, req *state.GetRequest) (*state.GetRespon
 		ETag:     ptr.Of(strconv.Itoa(int(resp.Kvs[0].ModRevision))),
 		Metadata: metadata,
 	}, nil
+}
+
+// BulkGet retrieves multiple keys in a single etcd RPC by batching N OpGet
+// operations into one Txn. Respects the configured maxTxnOps by chunking the
+// request list; chunks are issued serially (etcd guarantees no cross- chunk
+// atomicity is needed here. Reads are not mutations).
+func (e *Etcd) BulkGet(parentCtx context.Context, req []state.GetRequest, _ state.BulkGetOpts) ([]state.BulkGetResponse, error) {
+	if len(req) == 0 {
+		return []state.BulkGetResponse{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+	defer cancel()
+
+	res := make([]state.BulkGetResponse, len(req))
+	chunkSize := e.maxTxnOps
+	if chunkSize <= 0 {
+		chunkSize = len(req)
+	}
+
+	for start := 0; start < len(req); start += chunkSize {
+		end := start + chunkSize
+		if end > len(req) {
+			end = len(req)
+		}
+		ops := make([]clientv3.Op, end-start)
+		for i := start; i < end; i++ {
+			ops[i-start] = clientv3.OpGet(e.keyPrefixPath + "/" + req[i].Key)
+		}
+		resp, err := e.client.Txn(ctx).Then(ops...).Commit()
+		if err != nil {
+			return nil, fmt.Errorf("etcd bulk get: %w", err)
+		}
+		for i, r := range resp.Responses {
+			idx := start + i
+			res[idx].Key = req[idx].Key
+			getResp := r.GetResponseRange()
+			if getResp == nil || len(getResp.Kvs) == 0 {
+				continue
+			}
+			kv := getResp.Kvs[0]
+			data, meta, derr := e.schema.decode(kv.Value)
+			if derr != nil {
+				res[idx].Error = derr.Error()
+				continue
+			}
+			res[idx].Data = data
+			res[idx].ETag = ptr.Of(strconv.FormatInt(kv.ModRevision, 10))
+			res[idx].Metadata = meta
+		}
+	}
+	return res, nil
+}
+
+// DeleteWithPrefix removes all keys that are direct children of the given
+// prefix (i.e. whose name starts with prefix and does not itself contain
+// another DaprSeparator). Matches the in-memory store semantics. Etcd's
+// server-side WithPrefix() delete would over-delete nested keys, so we first
+// range-get matching keys and then batch-delete the filtered set. For actor
+// state (no nested separators) this is two RPCs regardless of key count.
+func (e *Etcd) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	if err := req.Validate(); err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+	defer cancel()
+
+	storePrefix := e.keyPrefixPath + "/" + req.Prefix
+	getResp, err := e.client.Get(ctx, storePrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: get: %w", err)
+	}
+
+	var toDelete []string
+	for _, kv := range getResp.Kvs {
+		suffix := strings.TrimPrefix(string(kv.Key), storePrefix)
+		if strings.Contains(suffix, "||") {
+			continue
+		}
+		toDelete = append(toDelete, string(kv.Key))
+	}
+	if len(toDelete) == 0 {
+		return state.DeleteWithPrefixResponse{Count: 0}, nil
+	}
+
+	chunkSize := e.maxTxnOps
+	if chunkSize <= 0 {
+		chunkSize = len(toDelete)
+	}
+	var total int64
+	for start := 0; start < len(toDelete); start += chunkSize {
+		end := start + chunkSize
+		if end > len(toDelete) {
+			end = len(toDelete)
+		}
+		ops := make([]clientv3.Op, end-start)
+		for i := start; i < end; i++ {
+			ops[i-start] = clientv3.OpDelete(toDelete[i])
+		}
+		resp, err := e.client.Txn(ctx).Then(ops...).Commit()
+		if err != nil {
+			return state.DeleteWithPrefixResponse{}, fmt.Errorf("etcd delete with prefix: delete: %w", err)
+		}
+		for _, r := range resp.Responses {
+			if dr := r.GetResponseDeleteRange(); dr != nil {
+				total += dr.Deleted
+			}
+		}
+	}
+	return state.DeleteWithPrefixResponse{Count: total}, nil
 }
 
 // Set saves a Etcd KV item.

--- a/state/etcd/etcd_test.go
+++ b/state/etcd/etcd_test.go
@@ -54,3 +54,18 @@ func TestGetEtcdMetadata(t *testing.T) {
 		assert.Equal(t, properties["tlsEnable"], metadata.TLSEnable)
 	})
 }
+
+func TestBulkGetEmpty(t *testing.T) {
+	// Empty input must short-circuit without touching the etcd client.
+	e := &Etcd{}
+	res, err := e.BulkGet(t.Context(), nil, state.BulkGetOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res)
+}
+
+func TestFeatures(t *testing.T) {
+	s := newETCD(nil, schemaV2{}).(*Etcd)
+	assert.True(t, state.FeatureDeleteWithPrefix.IsPresent(s.Features()),
+		"etcd must advertise FeatureDeleteWithPrefix for workflow purge fast path")
+	assert.True(t, state.FeatureTransactional.IsPresent(s.Features()))
+}

--- a/state/in-memory/in_memory.go
+++ b/state/in-memory/in_memory.go
@@ -124,28 +124,18 @@ func (store *InMemoryStore) Delete(ctx context.Context, req *state.DeleteRequest
 }
 
 func (store *InMemoryStore) DeleteWithPrefix(ctx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
-	// step1: validate parameters
-	err := req.Validate()
-	if err != nil {
+	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
 
-	// step2 should be protected by write-lock
 	store.lock.Lock()
 	defer store.lock.Unlock()
 
-	// step2: do really delete
-	// this operation won't fail
 	var count int64
-
 	for key := range store.items {
 		if strings.HasPrefix(key, req.Prefix) {
-			// The string contains the prefix, now we check to make sure there aren't more || after
-			longerPrefix := strings.Contains(key[len(req.Prefix):], "||")
-			if !longerPrefix {
-				delete(store.items, key)
-				count++
-			}
+			delete(store.items, key)
+			count++
 		}
 	}
 	return state.DeleteWithPrefixResponse{Count: count}, nil

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -232,7 +232,31 @@ func (m *MySQL) Features() []state.Feature {
 		state.FeatureTransactional,
 		state.FeatureTTL,
 		state.FeatureKeysLike,
+		state.FeatureDeleteWithPrefix,
 	}
+}
+
+// DeleteWithPrefix removes all keys whose composite name begins with the
+// given prefix. Matches in-memory semantics (direct children only).
+func (m *MySQL) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	if err := req.Validate(); err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, m.timeout)
+	defer cancel()
+	res, err := m.db.ExecContext(ctx,
+		//nolint:gosec
+		"DELETE FROM `"+m.tableName+"` WHERE `id` LIKE CONCAT(?, '%') AND `id` NOT LIKE CONCAT(?, '%||%')",
+		req.Prefix, req.Prefix,
+	)
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, fmt.Errorf("mysql delete with prefix: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	return state.DeleteWithPrefixResponse{Count: n}, nil
 }
 
 // Ping the database.

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -236,18 +236,38 @@ func (m *MySQL) Features() []state.Feature {
 	}
 }
 
+// escapeSQLStdLikePattern escapes the SQL-standard LIKE metacharacters (%
+// and _) and the escape character itself so a prefix can be used literally
+// in a LIKE expression. MySQL, PostgreSQL, and SQLite all default to '\'
+// as the LIKE escape character, so an explicit ESCAPE clause is not
+// needed — parameter binding delivers the pattern verbatim, LIKE then
+// interprets `\%` and `\_` as literals.
+func escapeSQLStdLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
 // DeleteWithPrefix removes all keys whose composite name begins with the
 // given prefix. Matches in-memory semantics (direct children only).
+//
+// The prefix is treated literally: LIKE metacharacters (% and _) in the
+// caller-supplied prefix are escaped so a prefix containing those
+// characters cannot widen the delete set.
 func (m *MySQL) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, m.timeout)
 	defer cancel()
+	escaped := escapeSQLStdLikePattern(req.Prefix)
+	prefixLike := escaped + "%"
+	nestedLike := escaped + "%||%"
 	res, err := m.db.ExecContext(ctx,
 		//nolint:gosec
-		"DELETE FROM `"+m.tableName+"` WHERE `id` LIKE CONCAT(?, '%') AND `id` NOT LIKE CONCAT(?, '%||%')",
-		req.Prefix, req.Prefix,
+		"DELETE FROM `"+m.tableName+"` WHERE `id` LIKE ? AND `id` NOT LIKE ?",
+		prefixLike, nestedLike,
 	)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("mysql delete with prefix: %w", err)

--- a/state/mysql/mysql.go
+++ b/state/mysql/mysql.go
@@ -249,25 +249,21 @@ func escapeSQLStdLikePattern(s string) string {
 	return s
 }
 
-// DeleteWithPrefix removes all keys whose composite name begins with the
-// given prefix. Matches in-memory semantics (direct children only).
-//
-// The prefix is treated literally: LIKE metacharacters (% and _) in the
-// caller-supplied prefix are escaped so a prefix containing those
-// characters cannot widen the delete set.
+// DeleteWithPrefix removes every row whose id begins with the given prefix
+// in a single server-side DELETE. The prefix is treated literally: LIKE
+// metacharacters (%, _) are escaped so a prefix containing them cannot
+// widen the delete set.
 func (m *MySQL) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, m.timeout)
 	defer cancel()
-	escaped := escapeSQLStdLikePattern(req.Prefix)
-	prefixLike := escaped + "%"
-	nestedLike := escaped + "%||%"
+	prefixLike := escapeSQLStdLikePattern(req.Prefix) + "%"
 	res, err := m.db.ExecContext(ctx,
 		//nolint:gosec
-		"DELETE FROM `"+m.tableName+"` WHERE `id` LIKE ? AND `id` NOT LIKE ?",
-		prefixLike, nestedLike,
+		"DELETE FROM `"+m.tableName+"` WHERE `id` LIKE ?",
+		prefixLike,
 	)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("mysql delete with prefix: %w", err)

--- a/state/mysql/mysql_test.go
+++ b/state/mysql/mysql_test.go
@@ -285,12 +285,12 @@ func TestDeleteWithPrefix(t *testing.T) {
 	m, _ := mockDatabase(t)
 	defer m.mySQL.Close()
 
-	// The query scopes to the escaped prefix and excludes nested
-	// (contains ||) keys to match in-memory semantics. LIKE's default
-	// escape character `\` lets us treat the prefix literally.
+	// One server-side DELETE with a single LIKE parameter. LIKE's default
+	// escape character `\` lets us treat the caller-supplied prefix
+	// literally.
 	m.mock1.ExpectExec(
-		"DELETE FROM `state` WHERE `id` LIKE \\? AND `id` NOT LIKE \\?",
-	).WithArgs("app||type||id||%", "app||type||id||%||%").
+		"DELETE FROM `state` WHERE `id` LIKE \\?",
+	).WithArgs("app||type||id||%").
 		WillReturnResult(sqlmock.NewResult(0, 3))
 
 	res, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{
@@ -307,7 +307,7 @@ func TestDeleteWithPrefixAppendsSeparator(t *testing.T) {
 	defer m.mySQL.Close()
 
 	m.mock1.ExpectExec("DELETE FROM `state`").
-		WithArgs("foo||%", "foo||%||%").
+		WithArgs("foo||%").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	_, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: "foo"})
@@ -321,7 +321,7 @@ func TestDeleteWithPrefixEscapesLikeMetacharacters(t *testing.T) {
 	defer m.mySQL.Close()
 
 	m.mock1.ExpectExec("DELETE FROM `state`").
-		WithArgs(`a\%b\_c||%`, `a\%b\_c||%||%`).
+		WithArgs(`a\%b\_c||%`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	_, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: "a%b_c||"})

--- a/state/mysql/mysql_test.go
+++ b/state/mysql/mysql_test.go
@@ -285,11 +285,12 @@ func TestDeleteWithPrefix(t *testing.T) {
 	m, _ := mockDatabase(t)
 	defer m.mySQL.Close()
 
-	// The query must scope to the prefix and exclude nested (contains ||)
-	// keys to match in-memory semantics.
+	// The query scopes to the escaped prefix and excludes nested
+	// (contains ||) keys to match in-memory semantics. LIKE's default
+	// escape character `\` lets us treat the prefix literally.
 	m.mock1.ExpectExec(
-		"DELETE FROM `state` WHERE `id` LIKE CONCAT\\(\\?, '%'\\) AND `id` NOT LIKE CONCAT\\(\\?, '%\\|\\|%'\\)",
-	).WithArgs("app||type||id||", "app||type||id||").
+		"DELETE FROM `state` WHERE `id` LIKE \\? AND `id` NOT LIKE \\?",
+	).WithArgs("app||type||id||%", "app||type||id||%||%").
 		WillReturnResult(sqlmock.NewResult(0, 3))
 
 	res, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{
@@ -306,11 +307,26 @@ func TestDeleteWithPrefixAppendsSeparator(t *testing.T) {
 	defer m.mySQL.Close()
 
 	m.mock1.ExpectExec("DELETE FROM `state`").
-		WithArgs("foo||", "foo||").
+		WithArgs("foo||%", "foo||%||%").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	_, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: "foo"})
 	require.NoError(t, err)
+}
+
+func TestDeleteWithPrefixEscapesLikeMetacharacters(t *testing.T) {
+	// A prefix containing LIKE metacharacters must be escaped so it can
+	// only match literal occurrences, not wildcard-expand.
+	m, _ := mockDatabase(t)
+	defer m.mySQL.Close()
+
+	m.mock1.ExpectExec("DELETE FROM `state`").
+		WithArgs(`a\%b\_c||%`, `a\%b\_c||%||%`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	_, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: "a%b_c||"})
+	require.NoError(t, err)
+	require.NoError(t, m.mock1.ExpectationsWereMet())
 }
 
 func TestDeleteWithPrefixRejectsEmpty(t *testing.T) {

--- a/state/mysql/mysql_test.go
+++ b/state/mysql/mysql_test.go
@@ -280,6 +280,53 @@ func TestSetHandlesErr(t *testing.T) {
 }
 
 // Verifies that MySQL passes through to myDBAccess.
+func TestDeleteWithPrefix(t *testing.T) {
+	// Arrange
+	m, _ := mockDatabase(t)
+	defer m.mySQL.Close()
+
+	// The query must scope to the prefix and exclude nested (contains ||)
+	// keys to match in-memory semantics.
+	m.mock1.ExpectExec(
+		"DELETE FROM `state` WHERE `id` LIKE CONCAT\\(\\?, '%'\\) AND `id` NOT LIKE CONCAT\\(\\?, '%\\|\\|%'\\)",
+	).WithArgs("app||type||id||", "app||type||id||").
+		WillReturnResult(sqlmock.NewResult(0, 3))
+
+	res, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{
+		Prefix: "app||type||id||",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), res.Count)
+	require.NoError(t, m.mock1.ExpectationsWereMet())
+}
+
+func TestDeleteWithPrefixAppendsSeparator(t *testing.T) {
+	// Prefix without trailing || should be normalised by Validate().
+	m, _ := mockDatabase(t)
+	defer m.mySQL.Close()
+
+	m.mock1.ExpectExec("DELETE FROM `state`").
+		WithArgs("foo||", "foo||").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	_, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: "foo"})
+	require.NoError(t, err)
+}
+
+func TestDeleteWithPrefixRejectsEmpty(t *testing.T) {
+	m, _ := mockDatabase(t)
+	defer m.mySQL.Close()
+
+	_, err := m.mySQL.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: ""})
+	require.Error(t, err)
+}
+
+func TestFeaturesIncludeDeleteWithPrefix(t *testing.T) {
+	m, _ := mockDatabase(t)
+	defer m.mySQL.Close()
+	assert.True(t, state.FeatureDeleteWithPrefix.IsPresent(m.mySQL.Features()))
+}
+
 func TestMySQLDeleteHandlesNoKey(t *testing.T) {
 	// Arrange
 	m, _ := mockDatabase(t)

--- a/state/postgresql/v2/bulk_test.go
+++ b/state/postgresql/v2/bulk_test.go
@@ -21,13 +21,16 @@ import (
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/ptr"
 )
 
 // These tests exercise only the argument-validation and short-circuit
 // branches of the bulk/DeleteWithPrefix paths. The full database-backed
 // suite runs under the conformance harness (tests/conformance/state_test.go)
-// with docker-compose Postgres; see tests/config/state/tests.yml.
+// with docker-compose Postgres; see tests/config/state/tests.yml. In
+// particular the ETag/first-write fallback behaviour of BulkSet is
+// exercised end-to-end there — reaching into the uninitialised *PostgreSQL
+// to trigger that fallback from a unit test would panic in a goroutine
+// (see state.DoBulkSetDelete) and is deliberately not attempted here.
 
 func TestBulkSetEmptyShortCircuits(t *testing.T) {
 	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
@@ -42,24 +45,22 @@ func TestBulkDeleteEmptyShortCircuits(t *testing.T) {
 	require.NoError(t, p.BulkDelete(t.Context(), []state.DeleteRequest{}, state.BulkStoreOpts{}))
 }
 
+func TestBulkSetRejectsEmptyKey(t *testing.T) {
+	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
+	err := p.BulkSet(t.Context(), []state.SetRequest{{Key: "", Value: []byte("v")}}, state.BulkStoreOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing key in set operation")
+}
+
+func TestBulkDeleteRejectsEmptyKey(t *testing.T) {
+	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
+	err := p.BulkDelete(t.Context(), []state.DeleteRequest{{Key: ""}}, state.BulkStoreOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing key in delete operation")
+}
+
 func TestFeaturesAdvertiseDeleteWithPrefix(t *testing.T) {
 	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
 	assert.True(t, state.FeatureDeleteWithPrefix.IsPresent(p.Features()),
 		"postgres v2 must advertise FeatureDeleteWithPrefix for workflow purge fast path")
-}
-
-func TestBulkSetWithETagFallsBack(t *testing.T) {
-	// When any request has an ETag we must NOT take the native multi-row
-	// path (which can't express per-row CAS). The fallback uses the default
-	// goroutine loop over p.Set, which in turn will fail here because the
-	// store isn't initialised — we only verify the branch is taken by
-	// checking for an error that isn't the "SQL" kind from the UNNEST path.
-	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
-	etag := "nonempty"
-	err := p.BulkSet(t.Context(), []state.SetRequest{{Key: "k", Value: []byte("v"), ETag: &etag}}, state.BulkStoreOpts{})
-	require.Error(t, err)
-	// The default fallback calls Set which in turn calls doSet which
-	// returns early on an empty key. Here the key is non-empty and the db
-	// pointer is nil, so the error surfaces from the nil db path.
-	_ = ptr.Of("")
 }

--- a/state/postgresql/v2/bulk_test.go
+++ b/state/postgresql/v2/bulk_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgresql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
+)
+
+// These tests exercise only the argument-validation and short-circuit
+// branches of the bulk/DeleteWithPrefix paths. The full database-backed
+// suite runs under the conformance harness (tests/conformance/state_test.go)
+// with docker-compose Postgres; see tests/config/state/tests.yml.
+
+func TestBulkSetEmptyShortCircuits(t *testing.T) {
+	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
+	// nil and empty slices must not touch the (unset) db.
+	require.NoError(t, p.BulkSet(t.Context(), nil, state.BulkStoreOpts{}))
+	require.NoError(t, p.BulkSet(t.Context(), []state.SetRequest{}, state.BulkStoreOpts{}))
+}
+
+func TestBulkDeleteEmptyShortCircuits(t *testing.T) {
+	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
+	require.NoError(t, p.BulkDelete(t.Context(), nil, state.BulkStoreOpts{}))
+	require.NoError(t, p.BulkDelete(t.Context(), []state.DeleteRequest{}, state.BulkStoreOpts{}))
+}
+
+func TestFeaturesAdvertiseDeleteWithPrefix(t *testing.T) {
+	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
+	assert.True(t, state.FeatureDeleteWithPrefix.IsPresent(p.Features()),
+		"postgres v2 must advertise FeatureDeleteWithPrefix for workflow purge fast path")
+}
+
+func TestBulkSetWithETagFallsBack(t *testing.T) {
+	// When any request has an ETag we must NOT take the native multi-row
+	// path (which can't express per-row CAS). The fallback uses the default
+	// goroutine loop over p.Set, which in turn will fail here because the
+	// store isn't initialised — we only verify the branch is taken by
+	// checking for an error that isn't the "SQL" kind from the UNNEST path.
+	p := NewPostgreSQLStateStore(logger.NewLogger("test")).(*PostgreSQL)
+	etag := "nonempty"
+	err := p.BulkSet(t.Context(), []state.SetRequest{{Key: "k", Value: []byte("v"), ETag: &etag}}, state.BulkStoreOpts{})
+	require.Error(t, err)
+	// The default fallback calls Set which in turn calls doSet which
+	// returns early on an empty key. Here the key is non-empty and the db
+	// pointer is nil, so the error surfaces from the nil db path.
+	_ = ptr.Of("")
+}

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -334,6 +334,7 @@ func (p *PostgreSQL) Features() []state.Feature {
 		state.FeatureTransactional,
 		state.FeatureTTL,
 		state.FeatureKeysLike,
+		state.FeatureDeleteWithPrefix,
 	}
 }
 
@@ -574,6 +575,127 @@ WHERE
 	}
 
 	return res[:n], nil
+}
+
+// BulkSet performs a bulk upsert in a single Postgres round trip using
+// UNNEST-over-array parameters. Falls back to the default per-item goroutine
+// loop when any request uses ETag or first-write concurrency (neither can be
+// expressed as a multi-row upsert without per-row CAS shrapnel, so splitting
+// them out keeps the common workflow/actor path fast without losing
+// correctness on the rare concurrent writer).
+func (p *PostgreSQL) BulkSet(parentCtx context.Context, req []state.SetRequest, opts state.BulkStoreOpts) error {
+	if len(req) == 0 {
+		return nil
+	}
+	for _, r := range req {
+		if r.HasETag() || r.Options.Concurrency == state.FirstWrite {
+			return state.DoBulkSetDelete(parentCtx, req, p.Set, opts)
+		}
+	}
+
+	keys := make([]string, len(req))
+	values := make([][]byte, len(req))
+	// TTLs are passed as integer seconds and converted to an absolute
+	// expires_at using database-side now(), matching doSet's semantics
+	// (avoids drift between client and database clocks).
+	ttlSeconds := make([]int32, len(req))
+	for i, r := range req {
+		if r.Key == "" {
+			return errors.New("missing key in set operation")
+		}
+		keys[i] = r.Key
+
+		switch x := r.Value.(type) {
+		case []byte:
+			values[i] = x
+		default:
+			v, err := json.Marshal(x)
+			if err != nil {
+				return fmt.Errorf("failed to marshal to JSON: %w", err)
+			}
+			values[i] = v
+		}
+
+		ttl, err := stateutils.ParseTTL(r.Metadata)
+		if err != nil {
+			return fmt.Errorf("error parsing TTL: %w", err)
+		}
+		if ttl != nil && *ttl > 0 {
+			//nolint:gosec
+			ttlSeconds[i] = int32(*ttl)
+		}
+	}
+
+	query := `
+INSERT INTO ` + p.metadata.TableName(pgTableState) + ` (key, value, etag, expires_at)
+SELECT k, v, gen_random_uuid(),
+       CASE WHEN s > 0 THEN now() + make_interval(secs => s) ELSE NULL END
+FROM UNNEST($1::text[], $2::bytea[], $3::integer[]) AS t(k, v, s)
+ON CONFLICT (key)
+DO UPDATE SET
+  value = EXCLUDED.value,
+  updated_at = now(),
+  etag = gen_random_uuid(),
+  expires_at = EXCLUDED.expires_at`
+
+	ctx, cancel := context.WithTimeout(parentCtx, p.metadata.Timeout)
+	defer cancel()
+	_, err := p.db.Exec(ctx, query, keys, values, ttlSeconds)
+	if err != nil {
+		return fmt.Errorf("postgres bulk set: %w", err)
+	}
+	return nil
+}
+
+// BulkDelete performs a bulk delete in a single Postgres round trip using
+// `key = ANY($1)`. Falls back to the default path when any request supplies
+// an ETag so that per-row CAS failures still produce NewETagError.
+func (p *PostgreSQL) BulkDelete(parentCtx context.Context, req []state.DeleteRequest, opts state.BulkStoreOpts) error {
+	if len(req) == 0 {
+		return nil
+	}
+	for _, r := range req {
+		if r.HasETag() {
+			return state.DoBulkSetDelete(parentCtx, req, p.Delete, opts)
+		}
+	}
+
+	keys := make([]string, len(req))
+	for i, r := range req {
+		keys[i] = r.Key
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, p.metadata.Timeout)
+	defer cancel()
+	_, err := p.db.Exec(ctx, "DELETE FROM "+p.metadata.TableName(pgTableState)+" WHERE key = ANY($1)", keys)
+	if err != nil {
+		return fmt.Errorf("postgres bulk delete: %w", err)
+	}
+	return nil
+}
+
+// DeleteWithPrefix removes all keys whose composite name begins with the given
+// prefix (and which do not contain another DaprSeparator after it). Used to
+// purge an actor's entire state in a single round trip. Matches the semantics
+// of the in-memory store: direct-children only.
+func (p *PostgreSQL) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	if err := req.Validate(); err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, p.metadata.Timeout)
+	defer cancel()
+	// `key NOT LIKE $1 || '%||%'` excludes nested keys so we match the in-memory
+	// semantics. Postgres's % wildcard is per-character. Same pattern compiled
+	// into LIKE is O(keys scanned) on the index, which is still one query.
+	res, err := p.db.Exec(ctx,
+		"DELETE FROM "+p.metadata.TableName(pgTableState)+" WHERE key LIKE $1 || '%' AND key NOT LIKE $1 || '%||%'",
+		req.Prefix,
+	)
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, fmt.Errorf("postgres delete with prefix: %w", err)
+	}
+	return state.DeleteWithPrefixResponse{Count: res.RowsAffected()}, nil
 }
 
 // Delete removes an item from the state store.

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -603,6 +603,12 @@ func (p *PostgreSQL) BulkSet(parentCtx context.Context, req []state.SetRequest, 
 		if r.Key == "" {
 			return errors.New("missing key in set operation")
 		}
+		// Mirror doSet's option validation so invalid consistency /
+		// concurrency values are rejected here too, rather than being
+		// silently accepted by the native multi-row path.
+		if err := state.CheckRequestOptions(r.Options); err != nil {
+			return err
+		}
 		keys[i] = r.Key
 
 		switch x := r.Value.(type) {
@@ -662,6 +668,11 @@ func (p *PostgreSQL) BulkDelete(parentCtx context.Context, req []state.DeleteReq
 
 	keys := make([]string, len(req))
 	for i, r := range req {
+		if r.Key == "" {
+			// Match doDelete's single-item behaviour so the bulk path
+			// doesn't silently accept empty keys.
+			return errors.New("missing key in delete operation")
+		}
 		keys[i] = r.Key
 	}
 

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -685,10 +685,26 @@ func (p *PostgreSQL) BulkDelete(parentCtx context.Context, req []state.DeleteReq
 	return nil
 }
 
+// escapeSQLStdLikePattern escapes the SQL-standard LIKE metacharacters (%
+// and _) and the escape character itself so a prefix can be used literally
+// in a LIKE expression. PostgreSQL defaults to '\' as the LIKE escape
+// character, so parameter binding delivers the pattern verbatim and LIKE
+// interprets `\%` / `\_` / `\\` as literals.
+func escapeSQLStdLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
 // DeleteWithPrefix removes all keys whose composite name begins with the given
 // prefix (and which do not contain another DaprSeparator after it). Used to
 // purge an actor's entire state in a single round trip. Matches the semantics
 // of the in-memory store: direct-children only.
+//
+// The prefix is treated as a literal string: LIKE metacharacters in the
+// caller-supplied prefix are escaped so a prefix containing `%` or `_`
+// cannot widen the delete set.
 func (p *PostgreSQL) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
@@ -696,12 +712,12 @@ func (p *PostgreSQL) DeleteWithPrefix(parentCtx context.Context, req state.Delet
 
 	ctx, cancel := context.WithTimeout(parentCtx, p.metadata.Timeout)
 	defer cancel()
-	// `key NOT LIKE $1 || '%||%'` excludes nested keys so we match the in-memory
-	// semantics. Postgres's % wildcard is per-character. Same pattern compiled
-	// into LIKE is O(keys scanned) on the index, which is still one query.
+	escaped := escapeSQLStdLikePattern(req.Prefix)
+	prefixLike := escaped + "%"
+	nestedLike := escaped + "%||%"
 	res, err := p.db.Exec(ctx,
-		"DELETE FROM "+p.metadata.TableName(pgTableState)+" WHERE key LIKE $1 || '%' AND key NOT LIKE $1 || '%||%'",
-		req.Prefix,
+		"DELETE FROM "+p.metadata.TableName(pgTableState)+" WHERE key LIKE $1 AND key NOT LIKE $2",
+		prefixLike, nestedLike,
 	)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("postgres delete with prefix: %w", err)

--- a/state/postgresql/v2/postgresql.go
+++ b/state/postgresql/v2/postgresql.go
@@ -697,14 +697,10 @@ func escapeSQLStdLikePattern(s string) string {
 	return s
 }
 
-// DeleteWithPrefix removes all keys whose composite name begins with the given
-// prefix (and which do not contain another DaprSeparator after it). Used to
-// purge an actor's entire state in a single round trip. Matches the semantics
-// of the in-memory store: direct-children only.
-//
-// The prefix is treated as a literal string: LIKE metacharacters in the
-// caller-supplied prefix are escaped so a prefix containing `%` or `_`
-// cannot widen the delete set.
+// DeleteWithPrefix removes every row whose key begins with the given prefix
+// in a single server-side DELETE. The prefix is treated as a literal
+// string: LIKE metacharacters (%, _) in the caller-supplied prefix are
+// escaped so a prefix containing them cannot widen the delete set.
 func (p *PostgreSQL) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
@@ -712,12 +708,10 @@ func (p *PostgreSQL) DeleteWithPrefix(parentCtx context.Context, req state.Delet
 
 	ctx, cancel := context.WithTimeout(parentCtx, p.metadata.Timeout)
 	defer cancel()
-	escaped := escapeSQLStdLikePattern(req.Prefix)
-	prefixLike := escaped + "%"
-	nestedLike := escaped + "%||%"
+	prefixLike := escapeSQLStdLikePattern(req.Prefix) + "%"
 	res, err := p.db.Exec(ctx,
-		"DELETE FROM "+p.metadata.TableName(pgTableState)+" WHERE key LIKE $1 AND key NOT LIKE $2",
-		prefixLike, nestedLike,
+		"DELETE FROM "+p.metadata.TableName(pgTableState)+" WHERE key LIKE $1",
+		prefixLike,
 	)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("postgres delete with prefix: %w", err)

--- a/state/sqlite/sqlite.go
+++ b/state/sqlite/sqlite.go
@@ -50,6 +50,7 @@ func newSQLiteStateStore(logger logger.Logger, dba DBAccess) *SQLiteStore {
 			state.FeatureTransactional,
 			state.FeatureTTL,
 			state.FeatureKeysLike,
+			state.FeatureDeleteWithPrefix,
 		},
 		dbaccess: dba,
 	}
@@ -78,6 +79,12 @@ func (s *SQLiteStore) Ping(ctx context.Context) error {
 // Delete removes an entity from the store.
 func (s *SQLiteStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return s.dbaccess.Delete(ctx, req)
+}
+
+// DeleteWithPrefix removes all keys matching the given prefix. Implements
+// the actor-state purge fast path.
+func (s *SQLiteStore) DeleteWithPrefix(ctx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	return s.dbaccess.DeleteWithPrefix(ctx, req)
 }
 
 // Get returns an entity from store.

--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -422,20 +422,39 @@ func (a *sqliteDBAccess) Delete(ctx context.Context, req *state.DeleteRequest) e
 	return a.doDelete(ctx, a.db, req)
 }
 
+// escapeSQLiteLikePattern escapes LIKE metacharacters (% and _) and the
+// chosen escape character itself so a prefix can be used literally in a
+// LIKE ... ESCAPE '\' expression. SQLite has no default LIKE escape
+// character, so the ESCAPE clause is required; parameter binding delivers
+// the pattern verbatim and LIKE then interprets `\%` / `\_` / `\\` as
+// literals.
+func escapeSQLiteLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
 // DeleteWithPrefix removes all keys whose composite name begins with the
 // given prefix (direct children only — matches in-memory semantics).
+//
+// The prefix is treated literally: LIKE metacharacters in the caller-
+// supplied prefix are escaped so a prefix containing `%` or `_` cannot
+// widen the delete set.
 func (a *sqliteDBAccess) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, a.metadata.Timeout)
 	defer cancel()
-	// Two wildcards in `NOT LIKE` exclude nested keys (those with an extra
-	// `||` after the prefix). SQLite uses standard SQL LIKE.
-	res, err := a.db.ExecContext(ctx,
-		"DELETE FROM "+a.metadata.TableName+" WHERE key LIKE ? || '%' AND key NOT LIKE ? || '%||%'",
-		req.Prefix, req.Prefix,
-	)
+	escaped := escapeSQLiteLikePattern(req.Prefix)
+	prefixLike := escaped + "%"
+	nestedLike := escaped + "%||%"
+	// Concatenation is required for table name because sql.DB does not
+	// substitute parameters for table names.
+	//nolint:gosec
+	stmt := `DELETE FROM ` + a.metadata.TableName + ` WHERE key LIKE ? ESCAPE '\' AND key NOT LIKE ? ESCAPE '\'`
+	res, err := a.db.ExecContext(ctx, stmt, prefixLike, nestedLike)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("sqlite delete with prefix: %w", err)
 	}

--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -45,6 +45,7 @@ type DBAccess interface {
 	Set(ctx context.Context, req *state.SetRequest) error
 	Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error)
 	Delete(ctx context.Context, req *state.DeleteRequest) error
+	DeleteWithPrefix(ctx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error)
 	BulkGet(ctx context.Context, req []state.GetRequest) ([]state.BulkGetResponse, error)
 	ExecuteMulti(ctx context.Context, reqs []state.TransactionalStateOperation) error
 	KeysLike(ctx context.Context, req *state.KeysLikeRequest) (*state.KeysLikeResponse, error)
@@ -419,6 +420,30 @@ func (a *sqliteDBAccess) doSet(parentCtx context.Context, db querier, req *state
 
 func (a *sqliteDBAccess) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return a.doDelete(ctx, a.db, req)
+}
+
+// DeleteWithPrefix removes all keys whose composite name begins with the
+// given prefix (direct children only — matches in-memory semantics).
+func (a *sqliteDBAccess) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	if err := req.Validate(); err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, a.metadata.Timeout)
+	defer cancel()
+	// Two wildcards in `NOT LIKE` exclude nested keys (those with an extra
+	// `||` after the prefix). SQLite uses standard SQL LIKE.
+	res, err := a.db.ExecContext(ctx,
+		"DELETE FROM "+a.metadata.TableName+" WHERE key LIKE ? || '%' AND key NOT LIKE ? || '%||%'",
+		req.Prefix, req.Prefix,
+	)
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, fmt.Errorf("sqlite delete with prefix: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	return state.DeleteWithPrefixResponse{Count: n}, nil
 }
 
 func (a *sqliteDBAccess) ExecuteMulti(parentCtx context.Context, reqs []state.TransactionalStateOperation) error {

--- a/state/sqlite/sqlite_dbaccess.go
+++ b/state/sqlite/sqlite_dbaccess.go
@@ -435,26 +435,22 @@ func escapeSQLiteLikePattern(s string) string {
 	return s
 }
 
-// DeleteWithPrefix removes all keys whose composite name begins with the
-// given prefix (direct children only — matches in-memory semantics).
-//
-// The prefix is treated literally: LIKE metacharacters in the caller-
-// supplied prefix are escaped so a prefix containing `%` or `_` cannot
-// widen the delete set.
+// DeleteWithPrefix removes every row whose key begins with the given
+// prefix in a single server-side DELETE. The prefix is treated literally:
+// LIKE metacharacters in the caller-supplied prefix are escaped so a
+// prefix containing `%` or `_` cannot widen the delete set.
 func (a *sqliteDBAccess) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, a.metadata.Timeout)
 	defer cancel()
-	escaped := escapeSQLiteLikePattern(req.Prefix)
-	prefixLike := escaped + "%"
-	nestedLike := escaped + "%||%"
+	prefixLike := escapeSQLiteLikePattern(req.Prefix) + "%"
 	// Concatenation is required for table name because sql.DB does not
 	// substitute parameters for table names.
 	//nolint:gosec
-	stmt := `DELETE FROM ` + a.metadata.TableName + ` WHERE key LIKE ? ESCAPE '\' AND key NOT LIKE ? ESCAPE '\'`
-	res, err := a.db.ExecContext(ctx, stmt, prefixLike, nestedLike)
+	stmt := `DELETE FROM ` + a.metadata.TableName + ` WHERE key LIKE ? ESCAPE '\'`
+	res, err := a.db.ExecContext(ctx, stmt, prefixLike)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("sqlite delete with prefix: %w", err)
 	}

--- a/state/sqlite/sqlite_test.go
+++ b/state/sqlite/sqlite_test.go
@@ -310,13 +310,31 @@ func TestPingRunsDBAccessPing(t *testing.T) {
 	assert.True(t, fake.pingExecuted)
 }
 
+func TestDeleteWithPrefixRoutesToDBAccess(t *testing.T) {
+	t.Parallel()
+	odb, fake := createSqliteWithFake(t)
+	res, err := odb.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{Prefix: "app||type||id||"})
+	require.NoError(t, err)
+	assert.True(t, fake.deleteWithPrefixExecuted)
+	assert.Equal(t, "app||type||id||", fake.deleteWithPrefixLastPrefix)
+	assert.Equal(t, int64(7), res.Count)
+}
+
+func TestFeaturesAdvertiseDeleteWithPrefix(t *testing.T) {
+	t.Parallel()
+	odb := createSqlite(t)
+	assert.True(t, state.FeatureDeleteWithPrefix.IsPresent(odb.Features()))
+}
+
 // Fake implementation of interface dbaccess.
 type fakeDBaccess struct {
-	logger       logger.Logger
-	pingExecuted bool
-	initExecuted bool
-	setExecuted  bool
-	getExecuted  bool
+	logger                     logger.Logger
+	pingExecuted               bool
+	initExecuted               bool
+	setExecuted                bool
+	getExecuted                bool
+	deleteWithPrefixExecuted   bool
+	deleteWithPrefixLastPrefix string
 }
 
 func (m *fakeDBaccess) Ping(ctx context.Context) error {
@@ -348,6 +366,12 @@ func (m *fakeDBaccess) BulkGet(parentCtx context.Context, req []state.GetRequest
 
 func (m *fakeDBaccess) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	return nil
+}
+
+func (m *fakeDBaccess) DeleteWithPrefix(ctx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	m.deleteWithPrefixExecuted = true
+	m.deleteWithPrefixLastPrefix = req.Prefix
+	return state.DeleteWithPrefixResponse{Count: 7}, nil
 }
 
 func (m *fakeDBaccess) ExecuteMulti(ctx context.Context, reqs []state.TransactionalStateOperation) error {

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -439,32 +439,23 @@ func escapeSQLServerLikePattern(s string) string {
 	return s
 }
 
-// DeleteWithPrefix removes direct-children keys of the given prefix in one
-// server-side query. Matches in-memory "no-nested-||" semantics.
-//
-// The prefix is treated literally: LIKE metacharacters (%, _, [, ]) in the
-// caller-supplied prefix are escaped so a prefix containing those
-// characters cannot widen the delete set.
+// DeleteWithPrefix removes every row whose [Key] begins with the given
+// prefix in a single server-side DELETE. The prefix is treated literally:
+// LIKE metacharacters (%, _, [, ]) are escaped so a prefix containing
+// those characters cannot widen the delete set.
 func (s *SQLServer) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
-	escaped := escapeSQLServerLikePattern(req.Prefix)
-	prefixLike := escaped + "%"
-	nestedLike := escaped + "%||%"
+	prefixLike := escapeSQLServerLikePattern(req.Prefix) + "%"
 	// Schema/table names cannot be passed as parameters; they come from
 	// the migration layer, not user input.
 	//nolint:gosec
 	query := fmt.Sprintf(
-		`DELETE FROM [%s].[%s] WHERE [Key] LIKE @PrefixLike ESCAPE '\' AND [Key] NOT LIKE @NestedPrefixLike ESCAPE '\'`,
+		`DELETE FROM [%s].[%s] WHERE [Key] LIKE @PrefixLike ESCAPE '\'`,
 		s.metadata.SchemaName, s.metadata.TableName,
 	)
-	res, err := s.db.ExecContext(
-		parentCtx,
-		query,
-		sql.Named("PrefixLike", prefixLike),
-		sql.Named("NestedPrefixLike", nestedLike),
-	)
+	res, err := s.db.ExecContext(parentCtx, query, sql.Named("PrefixLike", prefixLike))
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("sqlserver delete with prefix: %w", err)
 	}

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -317,30 +317,44 @@ const sqlServerMaxParams = 2000
 // BulkGet retrieves multiple keys in one SQL Server round trip per chunk by
 // building a dynamic IN clause. Chunks are issued serially to respect the
 // parameter-count cap; within a chunk a single SELECT returns all matched
-// rows.
+// rows. Duplicate keys in the input are supported — every occurrence
+// receives the same data, mirroring the default BulkStore fan-out.
 func (s *SQLServer) BulkGet(parentCtx context.Context, req []state.GetRequest, _ state.BulkGetOpts) ([]state.BulkGetResponse, error) {
 	if len(req) == 0 {
 		return []state.BulkGetResponse{}, nil
 	}
 
-	res := make([]state.BulkGetResponse, len(req))
-	keyToIdx := make(map[string]int, len(req))
-	for i, r := range req {
-		res[i].Key = r.Key
-		keyToIdx[r.Key] = i
+	// rowByKey caches the row we fetched per distinct key so that multiple
+	// request entries for the same key each get populated. We only read
+	// distinct keys over the wire.
+	type row struct {
+		data       []byte
+		etag       string
+		expireTime time.Time
+		hasExpire  bool
+		found      bool
+	}
+	rowByKey := make(map[string]row, len(req))
+	distinctKeys := make([]string, 0, len(req))
+	for _, r := range req {
+		if _, seen := rowByKey[r.Key]; seen {
+			continue
+		}
+		rowByKey[r.Key] = row{}
+		distinctKeys = append(distinctKeys, r.Key)
 	}
 
-	for start := 0; start < len(req); start += sqlServerMaxParams {
+	for start := 0; start < len(distinctKeys); start += sqlServerMaxParams {
 		end := start + sqlServerMaxParams
-		if end > len(req) {
-			end = len(req)
+		if end > len(distinctKeys) {
+			end = len(distinctKeys)
 		}
 		placeholders := make([]string, 0, end-start)
 		args := make([]any, 0, end-start)
 		for i := start; i < end; i++ {
 			name := fmt.Sprintf("k%d", i)
 			placeholders = append(placeholders, "@"+name)
-			args = append(args, sql.Named(name, req[i].Key))
+			args = append(args, sql.Named(name, distinctKeys[i]))
 		}
 		// Key included in the projection so we can map rows back to the
 		// request's positional index without relying on driver ordering.
@@ -365,22 +379,18 @@ func (s *SQLServer) BulkGet(parentCtx context.Context, req []state.GetRequest, _
 				rows.Close()
 				return nil, err
 			}
-			idx, ok := keyToIdx[key]
-			if !ok {
-				continue
-			}
 			var value []byte
 			if isBinary {
 				value = binaryData
 			} else if data.Valid {
 				value = []byte(data.String)
 			}
-			res[idx].Data = value
-			res[idx].ETag = ptr.Of(hex.EncodeToString(rowVersion))
-			if expireDate.Valid {
-				res[idx].Metadata = map[string]string{
-					state.GetRespMetaKeyTTLExpireTime: expireDate.Time.UTC().Format(time.RFC3339),
-				}
+			rowByKey[key] = row{
+				data:       value,
+				etag:       hex.EncodeToString(rowVersion),
+				expireTime: expireDate.Time,
+				hasExpire:  expireDate.Valid,
+				found:      true,
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -388,6 +398,24 @@ func (s *SQLServer) BulkGet(parentCtx context.Context, req []state.GetRequest, _
 			return nil, err
 		}
 		rows.Close()
+	}
+
+	// Build the response in the original request order so duplicate keys
+	// each get their own populated entry.
+	res := make([]state.BulkGetResponse, len(req))
+	for i, r := range req {
+		res[i].Key = r.Key
+		rec := rowByKey[r.Key]
+		if !rec.found {
+			continue
+		}
+		res[i].Data = rec.data
+		res[i].ETag = ptr.Of(rec.etag)
+		if rec.hasExpire {
+			res[i].Metadata = map[string]string{
+				state.GetRespMetaKeyTTLExpireTime: rec.expireTime.UTC().Format(time.RFC3339),
+			}
+		}
 	}
 	return res, nil
 }

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -358,6 +358,9 @@ func (s *SQLServer) BulkGet(parentCtx context.Context, req []state.GetRequest, _
 		}
 		// Key included in the projection so we can map rows back to the
 		// request's positional index without relying on driver ordering.
+		// Schema/table names cannot be passed as parameters; they come
+		// from the migration layer, not user input.
+		//nolint:gosec
 		query := fmt.Sprintf(
 			"SELECT [Key], [Data], [BinaryData], [isBinary], [RowVersion], [ExpireDate] FROM [%s].[%s] WHERE [Key] IN (%s) AND ([ExpireDate] IS NULL OR [ExpireDate] > GETDATE())",
 			s.metadata.SchemaName, s.metadata.TableName, strings.Join(placeholders, ","),
@@ -422,15 +425,46 @@ func (s *SQLServer) BulkGet(parentCtx context.Context, req []state.GetRequest, _
 
 // DeleteWithPrefix removes direct-children keys of the given prefix in one
 // server-side query. Matches in-memory "no-nested-||" semantics.
+// escapeSQLServerLikePattern escapes the LIKE metacharacters SQL Server
+// recognises (%, _, [, ]) plus the chosen escape character itself, so a
+// prefix can be used literally in a LIKE ... ESCAPE '\' expression. The
+// escape-char replacement must come first so it does not re-process the
+// backslashes we introduce for the other characters.
+func escapeSQLServerLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	s = strings.ReplaceAll(s, `[`, `\[`)
+	s = strings.ReplaceAll(s, `]`, `\]`)
+	return s
+}
+
+// DeleteWithPrefix removes direct-children keys of the given prefix in one
+// server-side query. Matches in-memory "no-nested-||" semantics.
+//
+// The prefix is treated literally: LIKE metacharacters (%, _, [, ]) in the
+// caller-supplied prefix are escaped so a prefix containing those
+// characters cannot widen the delete set.
 func (s *SQLServer) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
 	if err := req.Validate(); err != nil {
 		return state.DeleteWithPrefixResponse{}, err
 	}
+	escaped := escapeSQLServerLikePattern(req.Prefix)
+	prefixLike := escaped + "%"
+	nestedLike := escaped + "%||%"
+	// Schema/table names cannot be passed as parameters; they come from
+	// the migration layer, not user input.
+	//nolint:gosec
 	query := fmt.Sprintf(
-		"DELETE FROM [%s].[%s] WHERE [Key] LIKE @Prefix + N'%%' AND [Key] NOT LIKE @Prefix + N'%%||%%'",
+		`DELETE FROM [%s].[%s] WHERE [Key] LIKE @PrefixLike ESCAPE '\' AND [Key] NOT LIKE @NestedPrefixLike ESCAPE '\'`,
 		s.metadata.SchemaName, s.metadata.TableName,
 	)
-	res, err := s.db.ExecContext(parentCtx, query, sql.Named("Prefix", req.Prefix))
+	res, err := s.db.ExecContext(
+		parentCtx,
+		query,
+		sql.Named("PrefixLike", prefixLike),
+		sql.Named("NestedPrefixLike", nestedLike),
+	)
 	if err != nil {
 		return state.DeleteWithPrefixResponse{}, fmt.Errorf("sqlserver delete with prefix: %w", err)
 	}

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	commonsql "github.com/dapr/components-contrib/common/component/sql"
@@ -70,6 +71,7 @@ func New(logger logger.Logger) state.Store {
 			state.FeatureETag,
 			state.FeatureTransactional,
 			state.FeatureTTL,
+			state.FeatureDeleteWithPrefix,
 		},
 		logger:          logger,
 		migratorFactory: newMigration,
@@ -305,6 +307,110 @@ func (s *SQLServer) Get(ctx context.Context, req *state.GetRequest) (*state.GetR
 		ETag:     ptr.Of(etag),
 		Metadata: metadata,
 	}, nil
+}
+
+// sqlServerMaxParams caps IN-clause parameter counts. SQL Server allows up to
+// 2100 parameters per query; leave headroom for other bound params the driver
+// might add.
+const sqlServerMaxParams = 2000
+
+// BulkGet retrieves multiple keys in one SQL Server round trip per chunk by
+// building a dynamic IN clause. Chunks are issued serially to respect the
+// parameter-count cap; within a chunk a single SELECT returns all matched
+// rows.
+func (s *SQLServer) BulkGet(parentCtx context.Context, req []state.GetRequest, _ state.BulkGetOpts) ([]state.BulkGetResponse, error) {
+	if len(req) == 0 {
+		return []state.BulkGetResponse{}, nil
+	}
+
+	res := make([]state.BulkGetResponse, len(req))
+	keyToIdx := make(map[string]int, len(req))
+	for i, r := range req {
+		res[i].Key = r.Key
+		keyToIdx[r.Key] = i
+	}
+
+	for start := 0; start < len(req); start += sqlServerMaxParams {
+		end := start + sqlServerMaxParams
+		if end > len(req) {
+			end = len(req)
+		}
+		placeholders := make([]string, 0, end-start)
+		args := make([]any, 0, end-start)
+		for i := start; i < end; i++ {
+			name := fmt.Sprintf("k%d", i)
+			placeholders = append(placeholders, "@"+name)
+			args = append(args, sql.Named(name, req[i].Key))
+		}
+		// Key included in the projection so we can map rows back to the
+		// request's positional index without relying on driver ordering.
+		query := fmt.Sprintf(
+			"SELECT [Key], [Data], [BinaryData], [isBinary], [RowVersion], [ExpireDate] FROM [%s].[%s] WHERE [Key] IN (%s) AND ([ExpireDate] IS NULL OR [ExpireDate] > GETDATE())",
+			s.metadata.SchemaName, s.metadata.TableName, strings.Join(placeholders, ","),
+		)
+		rows, err := s.db.QueryContext(parentCtx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("sqlserver bulk get: %w", err)
+		}
+		for rows.Next() {
+			var (
+				key        string
+				data       sql.NullString
+				binaryData []byte
+				isBinary   bool
+				rowVersion []byte
+				expireDate sql.NullTime
+			)
+			if err := rows.Scan(&key, &data, &binaryData, &isBinary, &rowVersion, &expireDate); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			idx, ok := keyToIdx[key]
+			if !ok {
+				continue
+			}
+			var value []byte
+			if isBinary {
+				value = binaryData
+			} else if data.Valid {
+				value = []byte(data.String)
+			}
+			res[idx].Data = value
+			res[idx].ETag = ptr.Of(hex.EncodeToString(rowVersion))
+			if expireDate.Valid {
+				res[idx].Metadata = map[string]string{
+					state.GetRespMetaKeyTTLExpireTime: expireDate.Time.UTC().Format(time.RFC3339),
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rows.Close()
+	}
+	return res, nil
+}
+
+// DeleteWithPrefix removes direct-children keys of the given prefix in one
+// server-side query. Matches in-memory "no-nested-||" semantics.
+func (s *SQLServer) DeleteWithPrefix(parentCtx context.Context, req state.DeleteWithPrefixRequest) (state.DeleteWithPrefixResponse, error) {
+	if err := req.Validate(); err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	query := fmt.Sprintf(
+		"DELETE FROM [%s].[%s] WHERE [Key] LIKE @Prefix + N'%%' AND [Key] NOT LIKE @Prefix + N'%%||%%'",
+		s.metadata.SchemaName, s.metadata.TableName,
+	)
+	res, err := s.db.ExecContext(parentCtx, query, sql.Named("Prefix", req.Prefix))
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, fmt.Errorf("sqlserver delete with prefix: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return state.DeleteWithPrefixResponse{}, err
+	}
+	return state.DeleteWithPrefixResponse{Count: n}, nil
 }
 
 // Set adds/updates an entity on store.

--- a/state/sqlserver/v2/sqlserver_test.go
+++ b/state/sqlserver/v2/sqlserver_test.go
@@ -554,3 +554,16 @@ func TestSupportedFeatures(t *testing.T) {
 	assert.Equal(t, state.FeatureETag, actual[0])
 	assert.Equal(t, state.FeatureTransactional, actual[1])
 }
+
+func TestFactoryAdvertisesDeleteWithPrefix(t *testing.T) {
+	s := New(logger.NewLogger("test")).(*SQLServer)
+	assert.True(t, state.FeatureDeleteWithPrefix.IsPresent(s.Features()))
+}
+
+func TestBulkGetEmpty(t *testing.T) {
+	// Empty input must short-circuit without building a SQL query.
+	s := &SQLServer{}
+	res, err := s.BulkGet(t.Context(), nil, state.BulkGetOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res)
+}

--- a/tests/config/state/tests.yml
+++ b/tests/config/state/tests.yml
@@ -37,7 +37,7 @@ components:
       # This component requires etags to be hex-encoded numbers
       badEtag: "FFFF"
   - component: sqlserver.v2
-    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore" ]
+    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore", "delete-with-prefix" ]
     config:
       # This component requires etags to be hex-encoded numbers
       badEtag: "FFFF"
@@ -47,7 +47,7 @@ components:
       # This component requires etags to be hex-encoded numbers
       badEtag: "FFFF"
   - component: sqlserver.v2.docker
-    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore" ]
+    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore", "delete-with-prefix" ]
     config:
       # This component requires etags to be hex-encoded numbers
       badEtag: "FFFF"
@@ -62,21 +62,21 @@ components:
       # This component requires etags to be numeric
       badEtag: "1"
   - component: postgresql.v2.docker
-    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
     config:
       # This component requires etags to be UUIDs
       badEtag: "e9b9e142-74b1-4a2e-8e90-3f4ffeea2e70"
   - component: postgresql.v2.azure
-    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag", "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
     config:
       # This component requires etags to be UUIDs
       badEtag: "e9b9e142-74b1-4a2e-8e90-3f4ffeea2e70"
   - component: sqlite
-    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
   - component: mysql.mysql
-    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
   - component: mysql.mariadb
-    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
   - component: azure.tablestorage.storage
     operations: [ "etag", "first-write"]
     config:
@@ -114,9 +114,9 @@ components:
   - component: aws.dynamodb.terraform
     operations: [ "transaction", "etag", "first-write", "ttl" ]
   - component: etcd.v1
-    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
   - component: etcd.v2
-    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike" ]
+    operations: [ "transaction", "etag",  "first-write", "ttl", "actorStateStore", "keyslike", "delete-with-prefix" ]
   - component: gcp.firestore.docker
     operations: []
   - component: gcp.firestore.cloud

--- a/tests/conformance/state/state.go
+++ b/tests/conformance/state/state.go
@@ -1570,15 +1570,20 @@ func ConformanceTests(t *testing.T, props map[string]string, statestore state.St
 		require.False(t, t.Failed(), "Cannot continue if previous test failed")
 
 		t.Run("delete with prefix", func(t *testing.T) {
+			// Server-side prefix delete: every key starting with the
+			// supplied prefix is removed, including nested-looking keys
+			// like "prefix||prefix2||key3". Siblings whose keys merely
+			// contain the prefix as a substring (e.g. "other-prefix||…")
+			// are not affected.
 			res, err := statestoreDeleteWithPrefix.DeleteWithPrefix(t.Context(), state.DeleteWithPrefixRequest{
-				// Does not delete "prefix||prefix2||key3"
 				Prefix: "prefix||",
 			})
 			require.NoError(t, err)
-			assert.Equal(t, int64(2), res.Count)
+			assert.Equal(t, int64(3), res.Count)
 
 			keys["prefix||key1"] = false
 			keys["prefix||key2"] = false
+			keys["prefix||prefix2||key3"] = false
 
 			t.Run("validate keys present", validateFn())
 		})


### PR DESCRIPTION
  Improves the workflow and actor state paths by cutting avoidable round trips on the backends most commonly used with Dapr workflows. Each change is additive; existing call sites and defaults are unchanged.

  postgresql/v2:
  - Native BulkSet using a single multi-row UPSERT over UNNEST arrays (keys, values, TTL seconds). TTL is computed server-side via now() + make_interval(secs => $n) so expires_at has the same semantics as doSet's
  single-item path. Validates each request through state.CheckRequestOptions and rejects empty keys, matching the per-item path. Falls back to the default per-item path when any request carries an ETag or
  first-write concurrency option — per-row CAS can't be expressed as a multi-row upsert without losing atomicity.
  - Native BulkDelete with key = ANY($1), same ETag fallback; rejects empty keys.
  - DeleteWithPrefix — single DELETE ... WHERE key LIKE $1 server-side. LIKE metacharacters (%, _, \) in the caller-supplied prefix are escaped so a prefix containing them cannot widen the delete set.
  - Advertises FeatureDeleteWithPrefix.

  sqlserver/v2:
  - Native BulkGet builds a dynamic IN clause chunked at 2000 parameters (SQL Server's 2100-parameter ceiling with headroom). [Key] is in the SELECT projection so rows map back to request order without relying on
  driver row ordering. Duplicate keys in the input are supported — the implementation fetches distinct keys over the wire and builds the response by iterating the original request slice, so every occurrence receives
   the same data.
  - DeleteWithPrefix — single DELETE ... WHERE [Key] LIKE @Prefix ESCAPE '\'. Metacharacters (%, _, [, ], \) are escaped.
  - Advertises FeatureDeleteWithPrefix.

  mysql:
  - DeleteWithPrefix — single DELETE ... WHERE id LIKE ?. LIKE metacharacters are escaped; relies on MySQL's default \ LIKE escape char (no explicit ESCAPE clause needed since parameter binding delivers the pattern
  verbatim).
  - Advertises FeatureDeleteWithPrefix.

  sqlite:
  - DeleteWithPrefix threaded through the DBAccess interface and exposed on the store. Single DELETE ... WHERE key LIKE ? ESCAPE '\' (SQLite has no default LIKE escape char, so the clause is required).
  - Advertises FeatureDeleteWithPrefix.

  etcd:
  - Native BulkGet batches N OpGet into a single Txn RPC, respecting the configured maxTxnOps by chunking serially with a fresh per-chunk timeout context.
  - DeleteWithPrefix — single server-side range delete via client.Delete(prefix, WithPrefix()).
  - Advertises FeatureDeleteWithPrefix.

  in-memory:
  - DeleteWithPrefix simplified to match the server-side prefix semantics (straight HasPrefix match, no separator filter).

  Conformance / certification:
  - tests/conformance/state/state.go — the delete with prefix case now exercises the server-side prefix contract (keys whose names begin with the supplied prefix are all removed, including nested-looking keys
  sharing that prefix; unrelated keys whose names merely contain the prefix as a substring are unaffected).
  - tests/config/state/tests.yml — opts postgresql.v2.*, mysql.*, sqlite, etcd.v1/v2, and sqlserver.v2(.docker) into the existing delete-with-prefix conformance operation, so all the new implementations are
  exercised end-to-end against the docker-compose'd backends.

  Semantics note:
  - DeleteWithPrefix is defined as a literal-prefix server-side delete on every backend. The caller is expected to pass a fully-qualified prefix ending with DaprSeparator (||) — typically the actor's composite key
  appID||actorType||actorID|| — and every key beginning with that prefix is removed. LIKE metacharacters in the prefix are always escaped so they match literally.