### PR TITLE
feat(oracle): use TABLE(:bind_array) for bulk get chunks >= 900 keys

### DIFF
--- a/state/oracledatabase/oracledatabaseaccess.go
+++ b/state/oracledatabase/oracledatabaseaccess.go
@@ -408,22 +408,36 @@ func (o *oracleDatabaseAccess) BulkGet(ctx context.Context, req []state.GetReque
 // bulkGetChunk executes a single IN-clause query for the given requests.
 // Pre-condition: req is non-empty and all keys are non-empty.
 func (o *oracleDatabaseAccess) bulkGetChunk(ctx context.Context, req []state.GetRequest) ([]state.BulkGetResponse, error) {
-	// Oracle supports the IN operator for bulk operations
-	// Build the IN clause with bind variables
-	// Oracle uses :1, :2, etc. for bind variables in the IN clause
-	params := make([]any, len(req))
-	bindVars := make([]string, len(req))
+	keys := make([]string, len(req))
 	for i, r := range req {
-		params[i] = r.Key
-		bindVars[i] = ":" + strconv.Itoa(i+1)
+		keys[i] = r.Key
 	}
 
-	inClause := strings.Join(bindVars, ",")
-	// Concatenation is required for table name because sql.DB does not substitute parameters for table names.
-	//nolint:gosec
-	query := "SELECT key, value, binary_yn, etag, expiration_time FROM " + o.metadata.TableName + " WHERE key IN (" + inClause + ") AND (expiration_time IS NULL OR expiration_time > systimestamp)"
+	// Use TABLE(:bind_array) when keys approach Oracle's 1000-expression limit
+	// to avoid bind variable capacity issues with large IN lists.
+	useTableFunc := len(keys) >= 900
 
-	rows, err := o.db.QueryContext(ctx, query, params...)
+	var rows *sql.Rows
+	var err error
+
+	if useTableFunc {
+		// Oracle's TABLE(:bind_array) syntax binds a string array as an Oracle
+		// collection type, avoiding the 1000-expression IN-list limit.
+		query := "SELECT key, value, binary_yn, etag, expiration_time FROM " + o.metadata.TableName + " WHERE key IN (SELECT COLUMN_VALUE FROM TABLE(:1)) AND (expiration_time IS NULL OR expiration_time > systimestamp)"
+		rows, err = o.db.QueryContext(ctx, query, goora.StringArray(keys))
+	} else {
+		// Standard IN-list with individual bind variables for smaller sets.
+		bindVars := make([]string, len(req))
+		params := make([]any, len(req))
+		for i, k := range keys {
+			params[i] = k
+			bindVars[i] = ":" + strconv.Itoa(i+1)
+		}
+		inClause := strings.Join(bindVars, ",")
+		//nolint:gosec
+		query := "SELECT key, value, binary_yn, etag, expiration_time FROM " + o.metadata.TableName + " WHERE key IN (" + inClause + ") AND (expiration_time IS NULL OR expiration_time > systimestamp)"
+		rows, err = o.db.QueryContext(ctx, query, params...)
+	}
 	if err != nil {
 		// If the query fails, return per-key error entries instead of
 		// propagating the error, for consistency with other state stores


### PR DESCRIPTION
## Summary
Implements the optimization described in dapr/components-contrib#4041.

### What changed
In ulkGetChunk, when the number of keys is >= 900, the query now uses Oracle's TABLE(:bind_array) syntax instead of the standard IN (:1, :2, ...) syntax:

\\\sql
SELECT key, value, binary_yn, etag, expiration_time
FROM state_table
WHERE key IN (SELECT COLUMN_VALUE FROM TABLE(:1))
\\\

This passes goora.StringArray(keys) as a bind variable, leveraging the go_ora driver's native Oracle ARRAY support.

### Threshold
- **< 900 keys**: standard IN-list with individual bind variables (existing behavior)
- **>= 900 keys**: TABLE(:bind_array) with StringArray bind (new optimization)

The 900-key threshold leaves a safe margin below Oracle's 1000-expression hard limit.

### Testing
Existing unit tests cover chunking behavior and edge cases. The existing mock-based tests should continue to pass as the logic path is determined at runtime based on key count.

Closes #4041