### PR TITLE
Adds immediate bulk subscriptions to the Pulsar pubsub component

### DIFF
--- a/pubsub/feature.go
+++ b/pubsub/feature.go
@@ -23,6 +23,35 @@ const (
 	// FeatureSubscribeWildcards is the feature to allow subscribing to topics/queues using a wildcard.
 	FeatureSubscribeWildcards Feature = "SUBSCRIBE_WILDCARDS"
 	FeatureBulkPublish        Feature = "BULK_PUBSUB"
+	// FeatureBulkSubscribeImmediate signals that the default bulk
+	// subscriber should flush each delivery as soon as it arrives
+	// rather than buffer until MaxMessagesCount is reached or
+	// MaxAwaitDurationMs elapses.
+	//
+	// Concretely, the default bulk subscriber:
+	//
+	//   - Disables the MaxAwaitDurationMs timer entirely. There is
+	//     no per-batch waiting period.
+	//   - Still honours MaxMessagesCount as the upper bound on a
+	//     single flush, and still coalesces messages that happen to
+	//     arrive concurrently via a non-blocking channel drain. So
+	//     "immediate" describes *when* a flush fires, not the batch
+	//     size — bursts produce multi-entry batches up to
+	//     MaxMessagesCount; quiet periods produce single-entry
+	//     batches.
+	//
+	// Components should declare this feature when their delivery
+	// model cannot satisfy a buffered batching window — typically
+	// because the broker delivers serially and blocks on ack, so a
+	// second message will never land in the buffer while the first
+	// is pending. Without this feature such components produce
+	// unbounded unacked-message buildup waiting for a batch that
+	// can never form.
+	//
+	// This feature is only consulted by the default bulk-subscribe
+	// wrapper. Components that natively implement BulkSubscriber
+	// are unaffected — they own their own flushing policy.
+	FeatureBulkSubscribeImmediate Feature = "BULK_SUBSCRIBE_IMMEDIATE"
 )
 
 // Feature names a feature that can be implemented by PubSub components.

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -936,7 +936,30 @@ func (p *Pulsar) Close() error {
 }
 
 func (p *Pulsar) Features() []pubsub.Feature {
-	return nil
+	// FeatureBulkSubscribeImmediate is declared because Pulsar's
+	// delivery model does not fit the default bulk subscriber's
+	// count+timer batching window:
+	//
+	//   - processMode=sync: the consumer loop calls the message
+	//     handler serially and blocks on ack, so at most one
+	//     message is ever in flight per consumer. A batching
+	//     window can never accumulate, and waiting for one would
+	//     pile up unacked messages on the broker side
+	//     (dapr/dapr#9727).
+	//
+	//   - processMode=async (default): the consumer loop spawns a
+	//     goroutine per delivery, so multiple messages can arrive
+	//     in the bulk subscriber's channel concurrently. Bursts
+	//     are still coalesced opportunistically by the bulk
+	//     subscriber's drain step (so real multi-entry batches
+	//     still happen under load); the difference is that we no
+	//     longer wait for MaxAwaitDurationMs before flushing,
+	//     keeping acks flowing back to the broker without delay.
+	//
+	// Declaring the feature unconditionally avoids per-subscription
+	// dispatch divergence and matches what each mode can actually
+	// satisfy.
+	return []pubsub.Feature{pubsub.FeatureBulkSubscribeImmediate}
 }
 
 // formatTopic formats the topic into pulsar's structure with tenant and namespace.

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -2740,3 +2740,17 @@ func TestHandleMessageNonAvroSchemaPassthrough(t *testing.T) {
 	assert.True(t, consumer.acked)
 	assert.False(t, consumer.nacked)
 }
+
+// TestFeaturesDeclaresBulkSubscribeImmediate locks in that Pulsar
+// declares pubsub.FeatureBulkSubscribeImmediate, which routes Pulsar
+// subscriptions through Dapr's flush-on-arrival path in the default
+// bulk subscriber. Removing this declaration would re-introduce the
+// unacked-message buildup reported in dapr/dapr#9727 for sync
+// processMode subscriptions.
+func TestFeaturesDeclaresBulkSubscribeImmediate(t *testing.T) {
+	p := &Pulsar{}
+	require.True(t,
+		pubsub.FeatureBulkSubscribeImmediate.IsPresent(p.Features()),
+		"Pulsar must declare FeatureBulkSubscribeImmediate so the default bulk subscriber flushes per-message instead of buffering until MaxMessagesCount/MaxAwaitDurationMs",
+	)
+}


### PR DESCRIPTION
# Description

## Summary
- Add `pubsub.FeatureBulkSubscribeImmediate`, a new pubsub feature that signals the default bulk subscriber should flush every delivery on arrival rather than buffer until `MaxMessagesCount` or `MaxAwaitDurationMs`
- Declare the feature on the Pulsar component, since Pulsar's delivery model cannot satisfy the default bulk subscriber's count+timer batching window in either `processMode: sync` or `processMode: async`
- Add a unit test on Pulsar's `Features()` so the declaration cannot be silently removed

A follow up PR in dapr/dapr will be created to make use of this feature and deliver immediate messages.

## Problem
With Pulsar configured for bulk subscribe (`bulkSubscribe.enabled: true`) and `processMode: sync`, applications report a steadily growing unacked-message count on the broker side and per-message latency that scales with `MaxAwaitDurationMs`. See [dapr/dapr#9727](https://github.com/dapr/dapr/issues/9727).

The root cause is on the dapr side: dapr's default bulk subscriber (used when a component does not implement `BulkSubscriber` natively) buffers each delivery and flushes only when the count threshold is hit or the await-duration timer fires. Pulsar in sync mode delivers messages serially and blocks on ack — so only one message is ever in flight per consumer, the count threshold can never accumulate, and every message is held for the full `MaxAwaitDurationMs` while the broker piles up the rest of its prefetch buffer waiting for the ack.

In async mode the situation is less severe (multiple deliveries can arrive concurrently, so batches can form), but honouring the configured timer would still introduce latency that the broker's prefetch flow control was not designed for.

## Related issues / PRs

- **[dapr/dapr#9211](https://github.com/dapr/dapr/issues/9211)** — original bug: bulk subscribe await-duration timer not reset after a count-based flush. Reopened after subsequent regressions.
- **[dapr/dapr#9562](https://github.com/dapr/dapr/pull/9562)** — added `ticker.Reset()` after a count-based flush. Shipped in v1.17.1. Correct for async-delivering components, but did not address sync-mode delivery throughput.
- **[dapr/dapr#9727](https://github.com/dapr/dapr/issues/9727)** — the Pulsar `processMode: sync` issue this PR resolves.
- **[dapr/dapr#9792](https://github.com/dapr/dapr/pull/9792)** — replaced the count+timer logic with drain-and-flush on every arrival (master-only, never released). Fixed sync-mode but silently dropped the batching contract for every other component.
- **[dapr/dapr#9826](https://github.com/dapr/dapr/pull/9826)** — consumer of this PR. Restores the count+timer batching contract for components without this feature, and routes components that declare it through a flush-on-arrival path. Includes the unit tests that pin down the dispatch decision.

## Solution
Introduce a new pubsub feature so components can declare that the default bulk subscriber should treat them as flush-on-arrival rather than count/timer batched.

Pulsar declares the feature with the rationale documented in `pubsub/pulsar/pulsar.go`:

- `processMode: sync` — only one message is ever in flight per consumer; a batching window can never accumulate, and waiting for one piles up unacked messages on the broker side.
- `processMode: async` — multiple goroutines push to the bulk subscriber's channel, so bursts are still coalesced opportunistically by the drain step. The only loss is the timer wait, in exchange for keeping acks flowing back to the broker without delay.

Declaring the feature unconditionally avoids per-subscription dispatch divergence and matches what each Pulsar mode can actually satisfy.
