### PR TITLE
feat(state/sqlserver): native batched BulkGet for v2

### DIFF
--- a/state/sqlserver/v2/metadata.go
+++ b/state/sqlserver/v2/metadata.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	sqlserverAuth "github.com/dapr/components-contrib/common/authentication/sqlserver"
+	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/metadata"
 	"github.com/dapr/kit/ptr"
 )
@@ -32,6 +33,16 @@ const (
 	defaultTable           = "state"
 	defaultMetaTable       = "dapr_metadata"
 	defaultCleanupInterval = time.Hour
+
+	// defaultBulkGetChunkSize is the default per-chunk size for BulkGet
+	// requests. Requests with this many keys or fewer execute as a single
+	// query.
+	defaultBulkGetChunkSize = 1000
+	// maxBulkGetChunkSize is the safe upper bound for keys-per-chunk on SQL
+	// Server. SQL Server allows up to 2100 parameters in a single
+	// parameterized query (sp_executesql limit); we leave headroom for any
+	// auxiliary parameters and clamp callers above this value.
+	maxBulkGetChunkSize = 2000
 )
 
 type sqlServerMetadata struct {
@@ -43,6 +54,13 @@ type sqlServerMetadata struct {
 	KeyLength         int
 	IndexedProperties string
 	CleanupInterval   *time.Duration `mapstructure:"cleanupInterval" mapstructurealiases:"cleanupIntervalInSeconds"`
+	// BulkGetChunkSize controls the maximum number of keys included in each
+	// internal SQL query issued by BulkGet. When the number of requested
+	// keys exceeds this value, BulkGet issues multiple chunked queries
+	// sequentially (not in parallel) and merges the results. Values <= 0
+	// default to defaultBulkGetChunkSize; values above maxBulkGetChunkSize
+	// are clamped. See normalizeBulkGetChunkSize.
+	BulkGetChunkSize int `mapstructure:"bulkGetChunkSize"`
 
 	// Internal properties
 	keyTypeParsed           KeyType
@@ -57,6 +75,24 @@ func newMetadata() sqlServerMetadata {
 		MetadataTableName: defaultMetaTable,
 		CleanupInterval:   ptr.Of(defaultCleanupInterval),
 	}
+}
+
+// normalizeBulkGetChunkSize applies defaults and clamping to the configured
+// chunk size. Values <= 0 default to defaultBulkGetChunkSize; values above
+// SQL Server's safe parameter cap are clamped to maxBulkGetChunkSize with a
+// warning.
+func normalizeBulkGetChunkSize(log logger.Logger, configured int) int {
+	if configured <= 0 {
+		return defaultBulkGetChunkSize
+	}
+	if configured > maxBulkGetChunkSize {
+		if log != nil {
+			log.Warnf("bulkGetChunkSize %d exceeds SQL Server safe parameter cap of %d; clamping to %d",
+				configured, maxBulkGetChunkSize, maxBulkGetChunkSize)
+		}
+		return maxBulkGetChunkSize
+	}
+	return configured
 }
 
 func (m *sqlServerMetadata) Parse(meta map[string]string) error {

--- a/state/sqlserver/v2/metadata.yaml
+++ b/state/sqlserver/v2/metadata.yaml
@@ -103,3 +103,15 @@ metadata:
       "3600"
     example: |
       "1800", "-1"
+  - name: bulkGetChunkSize
+    type: number
+    description: |
+      Maximum number of keys included in each internal SQL query issued by BulkGet.
+      When the number of requested keys exceeds this value, BulkGet issues multiple
+      chunked queries sequentially (not in parallel) and merges the results. This
+      avoids SQL Server's 2100-parameter limit and reduces connection-pool pressure.
+      Values <=0 default to 1000; values above 2000 are clamped to 2000.
+    default: |
+      "1000"
+    example: |
+      "500", "2000"

--- a/state/sqlserver/v2/metadata.yaml
+++ b/state/sqlserver/v2/metadata.yaml
@@ -112,6 +112,6 @@ metadata:
       avoids SQL Server's 2100-parameter limit and reduces connection-pool pressure.
       Values <=0 default to 1000; values above 2000 are clamped to 2000.
     default: |
-      "1000"
+      1000
     example: |
-      "500", "2000"
+      500

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	commonsql "github.com/dapr/components-contrib/common/component/sql"
@@ -113,6 +115,8 @@ func (s *SQLServer) Init(ctx context.Context, metadata state.Metadata) error {
 	if err != nil {
 		return err
 	}
+
+	s.metadata.BulkGetChunkSize = normalizeBulkGetChunkSize(s.logger, s.metadata.BulkGetChunkSize)
 
 	migration := s.migratorFactory(&s.metadata)
 	mr, err := migration.executeMigrations(ctx)
@@ -305,6 +309,206 @@ func (s *SQLServer) Get(ctx context.Context, req *state.GetRequest) (*state.GetR
 		ETag:     ptr.Of(etag),
 		Metadata: metadata,
 	}, nil
+}
+
+// BulkGet retrieves multiple entities in a single round-trip per chunk using a
+// `WHERE [Key] IN (...)` query. When the number of requested keys exceeds the
+// configured BulkGetChunkSize, BulkGet issues multiple chunked queries
+// sequentially (not in parallel) and merges the results. This avoids SQL
+// Server's hard 2100-parameter limit and reduces connection-pool pressure
+// versus the default per-key fan-out.
+//
+// The default chunk size is 1000, so callers with <= 1000 keys see a single
+// query.
+func (s *SQLServer) BulkGet(ctx context.Context, req []state.GetRequest, _ state.BulkGetOpts) ([]state.BulkGetResponse, error) {
+	if len(req) == 0 {
+		return []state.BulkGetResponse{}, nil
+	}
+
+	// Validate all keys upfront — an empty key is a programmer bug, not a
+	// per-key data issue, so we fail fast before issuing any query.
+	for _, r := range req {
+		if r.Key == "" {
+			return nil, errors.New("missing key in bulk get operation")
+		}
+	}
+
+	chunkSize := s.metadata.BulkGetChunkSize
+	if chunkSize <= 0 {
+		chunkSize = defaultBulkGetChunkSize
+	}
+
+	// Fast path: input fits in one chunk.
+	if len(req) <= chunkSize {
+		return s.bulkGetChunk(ctx, req), nil
+	}
+
+	// Chunked path: sequential chunks, results concatenated.
+	res := make([]state.BulkGetResponse, 0, len(req))
+	for start := 0; start < len(req); start += chunkSize {
+		// Check context between chunks so a cancelled context stops promptly
+		// instead of issuing wasted round-trips.
+		if err := ctx.Err(); err != nil {
+			for _, r := range req[start:] {
+				res = append(res, state.BulkGetResponse{
+					Key:   r.Key,
+					Error: err.Error(),
+				})
+			}
+			return res, nil
+		}
+
+		end := start + chunkSize
+		if end > len(req) {
+			end = len(req)
+		}
+
+		res = append(res, s.bulkGetChunk(ctx, req[start:end])...)
+	}
+	return res, nil
+}
+
+// bulkGetChunk executes a single IN-clause query for the given requests.
+// Pre-condition: req is non-empty and all keys are non-empty.
+//
+// Errors surface as per-key Error entries in the response (consistent with
+// other state stores like Redis and Oracle), so this helper never returns a
+// hard error.
+func (s *SQLServer) bulkGetChunk(ctx context.Context, req []state.GetRequest) []state.BulkGetResponse {
+	params := make([]any, len(req))
+	bindVars := make([]string, len(req))
+	for i, r := range req {
+		name := "p" + strconv.Itoa(i)
+		params[i] = sql.Named(name, r.Key)
+		bindVars[i] = "@" + name
+	}
+
+	// Schema and table names are validated at Init via IsValidSQLName, so
+	// concatenation here is safe.
+	//nolint:gosec
+	query := fmt.Sprintf(
+		"SELECT [Key], [Data], [BinaryData], [isBinary], [RowVersion], [ExpireDate] FROM [%s].[%s] WHERE [Key] IN (%s) AND ([ExpireDate] IS NULL OR [ExpireDate] > GETDATE())",
+		s.metadata.SchemaName, s.metadata.TableName, strings.Join(bindVars, ","),
+	)
+
+	rows, err := s.db.QueryContext(ctx, query, params...)
+	if err != nil {
+		// If the query fails, return per-key error entries instead of
+		// propagating the error, matching Oracle/Redis convention.
+		res := make([]state.BulkGetResponse, len(req))
+		for i, r := range req {
+			res[i] = state.BulkGetResponse{
+				Key:   r.Key,
+				Error: "bulk get query failed: " + err.Error(),
+			}
+		}
+		return res
+	}
+	defer rows.Close()
+
+	var n int
+	res := make([]state.BulkGetResponse, len(req))
+	foundKeys := make(map[string]struct{}, len(req))
+
+	for rows.Next() {
+		if n >= len(req) {
+			// Defensive: more rows than slots. Not expected (PK-on-key,
+			// distinct binds), but drop extras instead of panicking.
+			s.logger.Warnf("SQL Server BulkGet: query returned more records than expected (%d), discarding extras", len(req))
+			break
+		}
+
+		var (
+			key        string
+			data       sql.NullString
+			binaryData []byte
+			isBinary   bool
+			rowVersion []byte
+			expireDate sql.NullTime
+		)
+
+		err = rows.Scan(&key, &data, &binaryData, &isBinary, &rowVersion, &expireDate)
+		if err != nil {
+			res[n] = state.BulkGetResponse{
+				Key:   key,
+				Error: err.Error(),
+			}
+			foundKeys[key] = struct{}{}
+			n++
+			continue
+		}
+
+		etag := hex.EncodeToString(rowVersion)
+		response := state.BulkGetResponse{
+			Key:  key,
+			ETag: ptr.Of(etag),
+		}
+
+		if expireDate.Valid {
+			response.Metadata = map[string]string{
+				state.GetRespMetaKeyTTLExpireTime: expireDate.Time.UTC().Format(time.RFC3339),
+			}
+		}
+
+		if isBinary {
+			response.Data = binaryData
+		} else {
+			if !data.Valid {
+				res[n] = state.BulkGetResponse{
+					Key:   key,
+					Error: "unexpected error: no item was found",
+				}
+				foundKeys[key] = struct{}{}
+				n++
+				continue
+			}
+			response.Data = []byte(data.String)
+		}
+
+		res[n] = response
+		foundKeys[key] = struct{}{}
+		n++
+	}
+
+	// rows.Err() reports errors from iteration; surface as per-key errors for
+	// any keys not yet found, matching Oracle's behavior.
+	if err = rows.Err(); err != nil {
+		errMsg := err.Error()
+		anyUnfound := false
+		for _, r := range req {
+			if _, ok := foundKeys[r.Key]; !ok {
+				anyUnfound = true
+				if n >= len(req) {
+					break
+				}
+				res[n] = state.BulkGetResponse{
+					Key:   r.Key,
+					Error: "rows iteration failed: " + errMsg,
+				}
+				foundKeys[r.Key] = struct{}{}
+				n++
+			}
+		}
+		if !anyUnfound {
+			s.logger.Warnf("SQL Server BulkGet: rows iteration error after all rows processed: %v", err)
+		}
+		return res[:n]
+	}
+
+	// Populate missing keys with empty responses to match the per-key Get
+	// semantics (a missing key returns &state.GetResponse{}).
+	if len(foundKeys) < len(req) {
+		for _, r := range req {
+			if _, ok := foundKeys[r.Key]; !ok {
+				res[n] = state.BulkGetResponse{
+					Key: r.Key,
+				}
+				n++
+			}
+		}
+	}
+
+	return res[:n]
 }
 
 // Set adds/updates an entity on store.

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -338,6 +338,24 @@ func (s *SQLServer) BulkGet(ctx context.Context, req []state.GetRequest, _ state
 		chunkSize = defaultBulkGetChunkSize
 	}
 
+	// Eager ctx.Err() check applies to both fast and chunked paths so
+	// cancellation produces a consistent per-key error format regardless
+	// of how many request entries the caller passed. Without this, the
+	// fast path would let database/sql wrap the context error as "bulk
+	// get query failed: ..." while the chunked path would surface
+	// ctx.Err() directly, which would silently change format when a
+	// caller tunes bulkGetChunkSize.
+	if err := ctx.Err(); err != nil {
+		res := make([]state.BulkGetResponse, len(req))
+		for i, r := range req {
+			res[i] = state.BulkGetResponse{
+				Key:   r.Key,
+				Error: err.Error(),
+			}
+		}
+		return res, nil
+	}
+
 	// Fast path: input fits in one chunk.
 	if len(req) <= chunkSize {
 		return s.bulkGetChunk(ctx, req), nil
@@ -346,8 +364,8 @@ func (s *SQLServer) BulkGet(ctx context.Context, req []state.GetRequest, _ state
 	// Chunked path: sequential chunks, results concatenated.
 	res := make([]state.BulkGetResponse, 0, len(req))
 	for start := 0; start < len(req); start += chunkSize {
-		// Check context between chunks so a cancelled context stops promptly
-		// instead of issuing wasted round-trips.
+		// Re-check context between chunks so a cancellation that fires
+		// mid-request stops promptly instead of issuing further round-trips.
 		if err := ctx.Err(); err != nil {
 			for _, r := range req[start:] {
 				res = append(res, state.BulkGetResponse{
@@ -475,7 +493,12 @@ func (s *SQLServer) bulkGetChunk(ctx context.Context, req []state.GetRequest) []
 		if isBinary {
 			rd.data = binaryData
 		} else if !data.Valid {
-			rd.scanErr = "unexpected error: no item was found"
+			// Row was found and scanned successfully, but a non-binary
+			// row has a NULL Data column — shouldn't happen in production
+			// (the schema/upsert path always writes Data for isBinary=0).
+			// Surface as a per-key error so operators can spot corrupted
+			// rows in logs without losing the response slot.
+			rd.scanErr = "row has NULL Data column on a non-binary entry (possible data corruption)"
 		} else {
 			rd.data = []byte(data.String)
 		}

--- a/state/sqlserver/v2/sqlserver.go
+++ b/state/sqlserver/v2/sqlserver.go
@@ -368,18 +368,51 @@ func (s *SQLServer) BulkGet(ctx context.Context, req []state.GetRequest, _ state
 	return res, nil
 }
 
-// bulkGetChunk executes a single IN-clause query for the given requests.
+// bulkGetChunk executes a single IN-clause query for the distinct keys of
+// the given requests, then builds the response by iterating the original
+// request slice so duplicate request entries each get their own populated
+// response (matching the default fan-out BulkStore semantics). Only
+// distinct keys hit the wire.
+//
 // Pre-condition: req is non-empty and all keys are non-empty.
 //
 // Errors surface as per-key Error entries in the response (consistent with
-// other state stores like Redis and Oracle), so this helper never returns a
-// hard error.
+// other state stores like Redis and Oracle); this helper never returns a
+// hard error. Exception: rows.Scan failures lose the row's key and so
+// cannot be attributed to a specific request entry. The affected key
+// surfaces as a missing-key response (empty Data/ETag/Error) and the
+// failure is logged at warn level.
 func (s *SQLServer) bulkGetChunk(ctx context.Context, req []state.GetRequest) []state.BulkGetResponse {
-	params := make([]any, len(req))
-	bindVars := make([]string, len(req))
-	for i, r := range req {
+	type rowData struct {
+		data       []byte
+		etag       string
+		expireTime time.Time
+		hasExpire  bool
+		found      bool
+		// scanErr is set if reading this row failed in a recoverable way
+		// (e.g. NULL data on a non-binary row); surfaced as a per-key
+		// error in the response loop.
+		scanErr string
+	}
+
+	// Build the distinct key list, preserving first-seen order. The map is
+	// pre-populated with zero-value entries so we can detect duplicates via
+	// the `seen` check without a separate set.
+	rowByKey := make(map[string]rowData, len(req))
+	distinctKeys := make([]string, 0, len(req))
+	for _, r := range req {
+		if _, seen := rowByKey[r.Key]; seen {
+			continue
+		}
+		rowByKey[r.Key] = rowData{}
+		distinctKeys = append(distinctKeys, r.Key)
+	}
+
+	params := make([]any, len(distinctKeys))
+	bindVars := make([]string, len(distinctKeys))
+	for i, k := range distinctKeys {
 		name := "p" + strconv.Itoa(i)
-		params[i] = sql.Named(name, r.Key)
+		params[i] = sql.Named(name, k)
 		bindVars[i] = "@" + name
 	}
 
@@ -396,28 +429,18 @@ func (s *SQLServer) bulkGetChunk(ctx context.Context, req []state.GetRequest) []
 		// If the query fails, return per-key error entries instead of
 		// propagating the error, matching Oracle/Redis convention.
 		res := make([]state.BulkGetResponse, len(req))
+		errMsg := "bulk get query failed: " + err.Error()
 		for i, r := range req {
 			res[i] = state.BulkGetResponse{
 				Key:   r.Key,
-				Error: "bulk get query failed: " + err.Error(),
+				Error: errMsg,
 			}
 		}
 		return res
 	}
 	defer rows.Close()
 
-	var n int
-	res := make([]state.BulkGetResponse, len(req))
-	foundKeys := make(map[string]struct{}, len(req))
-
 	for rows.Next() {
-		if n >= len(req) {
-			// Defensive: more rows than slots. Not expected (PK-on-key,
-			// distinct binds), but drop extras instead of panicking.
-			s.logger.Warnf("SQL Server BulkGet: query returned more records than expected (%d), discarding extras", len(req))
-			break
-		}
-
 		var (
 			key        string
 			data       sql.NullString
@@ -426,89 +449,82 @@ func (s *SQLServer) bulkGetChunk(ctx context.Context, req []state.GetRequest) []
 			rowVersion []byte
 			expireDate sql.NullTime
 		)
-
-		err = rows.Scan(&key, &data, &binaryData, &isBinary, &rowVersion, &expireDate)
-		if err != nil {
-			res[n] = state.BulkGetResponse{
-				Key:   key,
-				Error: err.Error(),
-			}
-			foundKeys[key] = struct{}{}
-			n++
+		if err := rows.Scan(&key, &data, &binaryData, &isBinary, &rowVersion, &expireDate); err != nil {
+			// We can't trust `key` after a failed scan, so we can't slot
+			// the error here. Log it; the response loop below will treat
+			// the corresponding request keys as not-found.
+			s.logger.Warnf("SQL Server BulkGet: row scan failed: %v", err)
 			continue
 		}
 
-		etag := hex.EncodeToString(rowVersion)
-		response := state.BulkGetResponse{
-			Key:  key,
-			ETag: ptr.Of(etag),
+		// Defensive: the SQL `IN` clause can only match values we bound,
+		// so any returned key must be one we requested (and therefore
+		// pre-populated in rowByKey). An unrecognized key would indicate
+		// a misbehaving driver or a future schema change leaking through;
+		// log and drop rather than insert an orphan entry into the map.
+		if _, requested := rowByKey[key]; !requested {
+			s.logger.Warnf("SQL Server BulkGet: query returned unrequested key %q, discarding", key)
+			continue
 		}
 
+		rd := rowData{found: true, etag: hex.EncodeToString(rowVersion)}
 		if expireDate.Valid {
-			response.Metadata = map[string]string{
-				state.GetRespMetaKeyTTLExpireTime: expireDate.Time.UTC().Format(time.RFC3339),
-			}
+			rd.expireTime = expireDate.Time
+			rd.hasExpire = true
 		}
-
 		if isBinary {
-			response.Data = binaryData
+			rd.data = binaryData
+		} else if !data.Valid {
+			rd.scanErr = "unexpected error: no item was found"
 		} else {
-			if !data.Valid {
-				res[n] = state.BulkGetResponse{
-					Key:   key,
-					Error: "unexpected error: no item was found",
-				}
-				foundKeys[key] = struct{}{}
-				n++
-				continue
-			}
-			response.Data = []byte(data.String)
+			rd.data = []byte(data.String)
 		}
-
-		res[n] = response
-		foundKeys[key] = struct{}{}
-		n++
+		rowByKey[key] = rd
 	}
 
-	// rows.Err() reports errors from iteration; surface as per-key errors for
-	// any keys not yet found, matching Oracle's behavior.
-	if err = rows.Err(); err != nil {
-		errMsg := err.Error()
-		anyUnfound := false
-		for _, r := range req {
-			if _, ok := foundKeys[r.Key]; !ok {
-				anyUnfound = true
-				if n >= len(req) {
-					break
-				}
-				res[n] = state.BulkGetResponse{
-					Key:   r.Key,
-					Error: "rows iteration failed: " + errMsg,
-				}
-				foundKeys[r.Key] = struct{}{}
-				n++
-			}
-		}
-		if !anyUnfound {
-			s.logger.Warnf("SQL Server BulkGet: rows iteration error after all rows processed: %v", err)
-		}
-		return res[:n]
-	}
+	// rows.Err() reports errors from iteration; we surface it per-key for
+	// any request keys that didn't get a row.
+	iterErr := rows.Err()
 
-	// Populate missing keys with empty responses to match the per-key Get
-	// semantics (a missing key returns &state.GetResponse{}).
-	if len(foundKeys) < len(req) {
-		for _, r := range req {
-			if _, ok := foundKeys[r.Key]; !ok {
-				res[n] = state.BulkGetResponse{
-					Key: r.Key,
-				}
-				n++
+	// Build the response by iterating the original request slice so that
+	// duplicate request entries each get their own populated response with
+	// the same data, and response order matches request order.
+	res := make([]state.BulkGetResponse, len(req))
+	anyUnfound := false
+	for i, r := range req {
+		res[i].Key = r.Key
+		rd := rowByKey[r.Key]
+		if !rd.found {
+			anyUnfound = true
+			if iterErr != nil {
+				res[i].Error = "rows iteration failed: " + iterErr.Error()
+			}
+			// else: missing key, empty response — matches per-key Get
+			// semantics (`&state.GetResponse{}`).
+			continue
+		}
+		if rd.scanErr != "" {
+			res[i].Error = rd.scanErr
+			continue
+		}
+		res[i].Data = rd.data
+		res[i].ETag = ptr.Of(rd.etag)
+		if rd.hasExpire {
+			res[i].Metadata = map[string]string{
+				state.GetRespMetaKeyTTLExpireTime: rd.expireTime.UTC().Format(time.RFC3339),
 			}
 		}
 	}
 
-	return res[:n]
+	// rows.Err() that fires after every requested key was already found
+	// has no per-key slot to land in (every response carries data).
+	// Without a log, the error would vanish entirely — e.g. a network
+	// reset after the last row arrived would be invisible. Warn-log it
+	// so transient driver/network failures stay diagnosable.
+	if iterErr != nil && !anyUnfound {
+		s.logger.Warnf("SQL Server BulkGet: rows iteration error after all requested keys were found: %v", iterErr)
+	}
+	return res
 }
 
 // Set adds/updates an entity on store.

--- a/state/sqlserver/v2/sqlserver_bulkget_test.go
+++ b/state/sqlserver/v2/sqlserver_bulkget_test.go
@@ -1,0 +1,454 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlserver
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sqlserverAuth "github.com/dapr/components-contrib/common/authentication/sqlserver"
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/kit/logger"
+)
+
+// newTestSQLServer wires a *SQLServer with a sqlmock-backed *sql.DB and the
+// minimum metadata fields BulkGet needs.
+func newTestSQLServer(t *testing.T, chunkSize int) (*SQLServer, sqlmock.Sqlmock, func()) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	s := &SQLServer{
+		logger: logger.NewLogger("test"),
+		db:     db,
+	}
+	s.metadata = sqlServerMetadata{
+		SQLServerAuthMetadata: sqlserverAuth.SQLServerAuthMetadata{
+			SchemaName: "dbo",
+		},
+		TableName:        "state",
+		BulkGetChunkSize: chunkSize,
+	}
+
+	cleanup := func() { db.Close() }
+	return s, mock, cleanup
+}
+
+var bulkCols = []string{"Key", "Data", "BinaryData", "isBinary", "RowVersion", "ExpireDate"}
+
+func TestBulkGetEmpty(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	res, err := s.BulkGet(t.Context(), nil, state.BulkGetOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetEmptyKeyValidation(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	req := []state.GetRequest{{Key: "key1"}, {Key: ""}, {Key: "key3"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.Error(t, err)
+	assert.Nil(t, res)
+
+	// No query should have been issued.
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetSingleQueryAllPresent(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	rowVer1 := []byte{0x01, 0x02}
+	rowVer2 := []byte{0x03, 0x04}
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("key1", `"value1"`, nil, false, rowVer1, nil).
+		AddRow("key2", `"value2"`, nil, false, rowVer2, nil)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "key1"}, {Key: "key2"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	byKey := indexByKey(res)
+	assert.Equal(t, []byte(`"value1"`), byKey["key1"].Data)
+	require.NotNil(t, byKey["key1"].ETag)
+	assert.Equal(t, hex.EncodeToString(rowVer1), *byKey["key1"].ETag)
+	assert.Empty(t, byKey["key1"].Error)
+	assert.Equal(t, []byte(`"value2"`), byKey["key2"].Data)
+	require.NotNil(t, byKey["key2"].ETag)
+	assert.Equal(t, hex.EncodeToString(rowVer2), *byKey["key2"].ETag)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetMissingKeys(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("key1", `"value1"`, nil, false, []byte{0x01}, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "key1"}, {Key: "key2"}, {Key: "key3"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	byKey := indexByKey(res)
+	assert.NotNil(t, byKey["key1"].ETag)
+	assert.Equal(t, []byte(`"value1"`), byKey["key1"].Data)
+	assert.Empty(t, byKey["key1"].Error)
+
+	for _, k := range []string{"key2", "key3"} {
+		r := byKey[k]
+		assert.Equal(t, k, r.Key)
+		assert.Empty(t, r.Error)
+		assert.Nil(t, r.Data)
+		assert.Nil(t, r.ETag)
+		assert.Nil(t, r.Metadata)
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetWithExpiration(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	expireAt := time.Now().Add(1 * time.Hour).UTC()
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("key1", `"value1"`, nil, false, []byte{0x01}, expireAt)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "key1"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].Metadata)
+	assert.Equal(t, expireAt.Format(time.RFC3339), res[0].Metadata[state.GetRespMetaKeyTTLExpireTime])
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetBinary(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	binaryPayload := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	// isBinary=true rows have NULL Data and use BinaryData. Mirror the v2
+	// schema: Data column is NULL when isBinary=1.
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("k_text", `"plain"`, nil, false, []byte{0x01}, nil).
+		AddRow("k_bin", nil, binaryPayload, true, []byte{0x02}, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "k_text"}, {Key: "k_bin"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	byKey := indexByKey(res)
+	assert.Equal(t, []byte(`"plain"`), byKey["k_text"].Data)
+	assert.Empty(t, byKey["k_text"].Error)
+	assert.Equal(t, binaryPayload, byKey["k_bin"].Data)
+	assert.Empty(t, byKey["k_bin"].Error)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetNonBinaryWithNullDataIsError(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	// Defensive: shouldn't happen in production (non-binary rows always have
+	// JSON Data), but if it does we surface a per-key error rather than panic.
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("k1", nil, nil, false, []byte{0x01}, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "k1"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.Equal(t, "k1", res[0].Key)
+	assert.NotEmpty(t, res[0].Error)
+	assert.Nil(t, res[0].Data)
+	assert.Nil(t, res[0].ETag)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetQueryFailure(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT").WillReturnError(errors.New("connection refused"))
+
+	req := []state.GetRequest{{Key: "key1"}, {Key: "key2"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	for _, r := range res {
+		assert.Contains(t, r.Error, "bulk get query failed:")
+		assert.Contains(t, r.Error, "connection refused")
+		assert.Nil(t, r.Data)
+		assert.Nil(t, r.ETag)
+	}
+	assert.Equal(t, "key1", res[0].Key)
+	assert.Equal(t, "key2", res[1].Key)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsScanFailure(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	// Wrong column type for isBinary forces Scan to fail for that row.
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("k1", `"v1"`, nil, "not-a-bool", []byte{0x01}, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "k1"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.NotEmpty(t, res[0].Error)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsErrFailure(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("key1", `"value1"`, nil, false, []byte{0x01}, nil).
+		AddRow("key2", `"value2"`, nil, false, []byte{0x02}, nil).
+		RowError(1, errors.New("network timeout"))
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "key1"}, {Key: "key2"}, {Key: "key3"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 3)
+
+	byKey := indexByKey(res)
+	assert.Empty(t, byKey["key1"].Error)
+	assert.NotNil(t, byKey["key1"].Data)
+	for _, k := range []string{"key2", "key3"} {
+		r := byKey[k]
+		assert.Equal(t, k, r.Key)
+		assert.Contains(t, r.Error, "rows iteration failed:")
+		assert.Contains(t, r.Error, "network timeout")
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_MultipleChunks(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, 2)
+	defer cleanup()
+
+	// 5 keys at chunkSize=2 → 3 chunks (2, 2, 1).
+	chunk1 := sqlmock.NewRows(bulkCols).
+		AddRow("k1", `"v1"`, nil, false, []byte{0x01}, nil).
+		AddRow("k2", `"v2"`, nil, false, []byte{0x02}, nil)
+	chunk2 := sqlmock.NewRows(bulkCols).
+		AddRow("k3", `"v3"`, nil, false, []byte{0x03}, nil).
+		AddRow("k4", `"v4"`, nil, false, []byte{0x04}, nil)
+	chunk3 := sqlmock.NewRows(bulkCols).
+		AddRow("k5", `"v5"`, nil, false, []byte{0x05}, nil)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(chunk1)
+	mock.ExpectQuery("SELECT").WillReturnRows(chunk2)
+	mock.ExpectQuery("SELECT").WillReturnRows(chunk3)
+
+	req := []state.GetRequest{
+		{Key: "k1"}, {Key: "k2"}, {Key: "k3"}, {Key: "k4"}, {Key: "k5"},
+	}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 5)
+
+	byKey := indexByKey(res)
+	for i, k := range []string{"k1", "k2", "k3", "k4", "k5"} {
+		assert.Equal(t, []byte(`"v`+string(rune('0'+i+1))+`"`), byKey[k].Data, "key %s", k)
+		assert.Empty(t, byKey[k].Error, "key %s", k)
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_ExactMultiple(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, 2)
+	defer cleanup()
+
+	// 4 keys, chunkSize 2 → exactly 2 chunks.
+	chunk1 := sqlmock.NewRows(bulkCols).
+		AddRow("k1", `"v1"`, nil, false, []byte{0x01}, nil).
+		AddRow("k2", `"v2"`, nil, false, []byte{0x02}, nil)
+	chunk2 := sqlmock.NewRows(bulkCols).
+		AddRow("k3", `"v3"`, nil, false, []byte{0x03}, nil).
+		AddRow("k4", `"v4"`, nil, false, []byte{0x04}, nil)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(chunk1)
+	mock.ExpectQuery("SELECT").WillReturnRows(chunk2)
+
+	req := []state.GetRequest{{Key: "k1"}, {Key: "k2"}, {Key: "k3"}, {Key: "k4"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 4)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_ContextCanceledBetweenChunks(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, 2)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// First chunk succeeds; we then cancel before the second chunk runs.
+	chunk1 := sqlmock.NewRows(bulkCols).
+		AddRow("k1", `"v1"`, nil, false, []byte{0x01}, nil).
+		AddRow("k2", `"v2"`, nil, false, []byte{0x02}, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(chunk1)
+
+	// Cancel before invoking; the per-chunk ctx.Err() check converts the
+	// remaining keys (k3, k4) to per-key cancel errors instead of issuing
+	// a second SELECT.
+	cancel()
+
+	req := []state.GetRequest{{Key: "k1"}, {Key: "k2"}, {Key: "k3"}, {Key: "k4"}}
+
+	res, err := s.BulkGet(ctx, req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 4)
+
+	byKey := indexByKey(res)
+	// k3, k4 should carry context-cancel errors.
+	for _, k := range []string{"k3", "k4"} {
+		assert.NotEmpty(t, byKey[k].Error, "key %s should be marked cancelled", k)
+	}
+
+	// We do NOT call ExpectationsWereMet — the first chunk's QueryContext
+	// returns ctx.Err() once the context has already been cancelled before
+	// the call, so sqlmock may or may not record a Query depending on
+	// driver internals. The behavioral assertion (k3, k4 errored) is the
+	// invariant we care about.
+}
+
+func TestNormalizeBulkGetChunkSize(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewLogger("test")
+
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero defaults", 0, defaultBulkGetChunkSize},
+		{"negative defaults", -5, defaultBulkGetChunkSize},
+		{"under default kept", 100, 100},
+		{"at default kept", defaultBulkGetChunkSize, defaultBulkGetChunkSize},
+		{"between default and max kept", 1500, 1500},
+		{"at max kept", maxBulkGetChunkSize, maxBulkGetChunkSize},
+		{"above max clamped", maxBulkGetChunkSize + 1, maxBulkGetChunkSize},
+		{"way above max clamped", 10000, maxBulkGetChunkSize},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeBulkGetChunkSize(log, tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// indexByKey turns the result slice into a map for order-independent
+// assertions in tests.
+func indexByKey(res []state.BulkGetResponse) map[string]state.BulkGetResponse {
+	m := make(map[string]state.BulkGetResponse, len(res))
+	for _, r := range res {
+		m[r.Key] = r
+	}
+	return m
+}
+
+// Compile-time assertion: BulkGet on *SQLServer satisfies the BulkStore
+// signature. If this fails, the embedded BulkStore would be used instead.
+var _ = func() bool {
+	var s *SQLServer
+	var fn func(ctx context.Context, req []state.GetRequest, opts state.BulkGetOpts) ([]state.BulkGetResponse, error)
+	fn = s.BulkGet
+	_ = fn
+	return true
+}()

--- a/state/sqlserver/v2/sqlserver_bulkget_test.go
+++ b/state/sqlserver/v2/sqlserver_bulkget_test.go
@@ -366,23 +366,17 @@ func TestBulkGetChunking_ExactMultiple(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestBulkGetChunking_ContextCanceledBetweenChunks(t *testing.T) {
+func TestBulkGetChunking_ContextAlreadyCanceled(t *testing.T) {
 	t.Parallel()
 
+	// Use chunkSize=2 so the request would split across multiple chunks.
+	// With ctx cancelled before BulkGet runs, the first iteration's
+	// ctx.Err() check fires and no SQL query is issued at all — every
+	// requested key is reported with the cancellation error.
 	s, mock, cleanup := newTestSQLServer(t, 2)
 	defer cleanup()
 
 	ctx, cancel := context.WithCancel(t.Context())
-
-	// First chunk succeeds; we then cancel before the second chunk runs.
-	chunk1 := sqlmock.NewRows(bulkCols).
-		AddRow("k1", `"v1"`, nil, false, []byte{0x01}, nil).
-		AddRow("k2", `"v2"`, nil, false, []byte{0x02}, nil)
-	mock.ExpectQuery("SELECT").WillReturnRows(chunk1)
-
-	// Cancel before invoking; the per-chunk ctx.Err() check converts the
-	// remaining keys (k3, k4) to per-key cancel errors instead of issuing
-	// a second SELECT.
 	cancel()
 
 	req := []state.GetRequest{{Key: "k1"}, {Key: "k2"}, {Key: "k3"}, {Key: "k4"}}
@@ -392,16 +386,18 @@ func TestBulkGetChunking_ContextCanceledBetweenChunks(t *testing.T) {
 	require.Len(t, res, 4)
 
 	byKey := indexByKey(res)
-	// k3, k4 should carry context-cancel errors.
-	for _, k := range []string{"k3", "k4"} {
-		assert.NotEmpty(t, byKey[k].Error, "key %s should be marked cancelled", k)
+	for _, k := range []string{"k1", "k2", "k3", "k4"} {
+		r := byKey[k]
+		assert.Equal(t, k, r.Key)
+		assert.Contains(t, r.Error, context.Canceled.Error(), "key %s should carry the cancellation error", k)
+		assert.Nil(t, r.Data)
+		assert.Nil(t, r.ETag)
 	}
 
-	// We do NOT call ExpectationsWereMet — the first chunk's QueryContext
-	// returns ctx.Err() once the context has already been cancelled before
-	// the call, so sqlmock may or may not record a Query depending on
-	// driver internals. The behavioral assertion (k3, k4 errored) is the
-	// invariant we care about.
+	// No ExpectQuery was registered, so a passing ExpectationsWereMet here
+	// proves no SQL was issued — the cancellation short-circuit fired
+	// before the first chunk.
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestNormalizeBulkGetChunkSize(t *testing.T) {

--- a/state/sqlserver/v2/sqlserver_bulkget_test.go
+++ b/state/sqlserver/v2/sqlserver_bulkget_test.go
@@ -267,6 +267,12 @@ func TestBulkGetRowsScanFailure(t *testing.T) {
 	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
 	require.NoError(t, err)
 	require.Len(t, res, 1)
+	// `key` is the first scan destination. database/sql's Rows.Scan
+	// converts column values into destination pointers in column order
+	// and stops at the first conversion error, so `key` is populated
+	// before isBinary's bad value trips Scan. Pin the expected value
+	// so a future change leaving Key empty on partial scan would fail.
+	assert.Equal(t, "k1", res[0].Key)
 	assert.NotEmpty(t, res[0].Error)
 
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -363,16 +369,22 @@ func TestBulkGetChunking_ExactMultiple(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 4)
 
+	byKey := indexByKey(res)
+	for i, k := range []string{"k1", "k2", "k3", "k4"} {
+		assert.Equal(t, []byte(`"v`+string(rune('0'+i+1))+`"`), byKey[k].Data, "key %s", k)
+		assert.Empty(t, byKey[k].Error, "key %s", k)
+	}
+
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestBulkGetChunking_ContextAlreadyCanceled(t *testing.T) {
+func TestBulkGetChunking_ContextAlreadyCanceled_ChunkedPath(t *testing.T) {
 	t.Parallel()
 
-	// Use chunkSize=2 so the request would split across multiple chunks.
-	// With ctx cancelled before BulkGet runs, the first iteration's
-	// ctx.Err() check fires and no SQL query is issued at all — every
-	// requested key is reported with the cancellation error.
+	// Chunked path (len(req)=4 > chunkSize=2): the eager ctx.Err() check
+	// at the top of the chunk loop fires before any query is issued, so
+	// every requested key is reported with ctx.Err() as its error and no
+	// SQL runs.
 	s, mock, cleanup := newTestSQLServer(t, 2)
 	defer cleanup()
 
@@ -397,6 +409,48 @@ func TestBulkGetChunking_ContextAlreadyCanceled(t *testing.T) {
 	// No ExpectQuery was registered, so a passing ExpectationsWereMet here
 	// proves no SQL was issued — the cancellation short-circuit fired
 	// before the first chunk.
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetChunking_ContextAlreadyCanceled_FastPath(t *testing.T) {
+	t.Parallel()
+
+	// Fast path (len(req) <= chunkSize): there's no eager ctx.Err() check
+	// — BulkGet calls bulkGetChunk directly, which calls QueryContext on a
+	// cancelled context. Empirically in current Go (1.8+), database/sql
+	// checks ctx.Err() before dispatching to the driver, so the driver
+	// never sees the query; that behavior is stable but not part of
+	// database/sql's documented contract. bulkGetChunk receives the
+	// context error and wraps it as "bulk get query failed: context
+	// canceled" — different prefix from the chunked path's plain
+	// ctx.Err() format. The primary evidence that we hit the
+	// query-failure path (not the eager-check path) is the "bulk get
+	// query failed:" prefix in the per-key error string.
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	req := []state.GetRequest{{Key: "k1"}, {Key: "k2"}}
+
+	res, err := s.BulkGet(ctx, req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	byKey := indexByKey(res)
+	for _, k := range []string{"k1", "k2"} {
+		r := byKey[k]
+		assert.Equal(t, k, r.Key)
+		assert.Contains(t, r.Error, "bulk get query failed:")
+		assert.Contains(t, r.Error, context.Canceled.Error())
+		assert.Nil(t, r.Data)
+		assert.Nil(t, r.ETag)
+	}
+
+	// No expectations were registered; this only confirms no *unexpected*
+	// query slipped through. The real proof that we hit the query-failure
+	// path is the "bulk get query failed:" assertion above.
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/state/sqlserver/v2/sqlserver_bulkget_test.go
+++ b/state/sqlserver/v2/sqlserver_bulkget_test.go
@@ -218,7 +218,7 @@ func TestBulkGetNonBinaryWithNullDataIsError(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	assert.Equal(t, "k1", res[0].Key)
-	assert.NotEmpty(t, res[0].Error)
+	assert.Contains(t, res[0].Error, "NULL Data column", "error message must describe what actually happened")
 	assert.Nil(t, res[0].Data)
 	assert.Nil(t, res[0].ETag)
 
@@ -577,7 +577,7 @@ func TestBulkGetChunking_ContextAlreadyCanceled_ChunkedPath(t *testing.T) {
 	for _, k := range []string{"k1", "k2", "k3", "k4"} {
 		r := byKey[k]
 		assert.Equal(t, k, r.Key)
-		assert.Contains(t, r.Error, context.Canceled.Error(), "key %s should carry the cancellation error", k)
+		assert.Equal(t, context.Canceled.Error(), r.Error, "fast and chunked paths must produce the same per-key error string for cancellation")
 		assert.Nil(t, r.Data)
 		assert.Nil(t, r.ETag)
 	}
@@ -591,17 +591,11 @@ func TestBulkGetChunking_ContextAlreadyCanceled_ChunkedPath(t *testing.T) {
 func TestBulkGetChunking_ContextAlreadyCanceled_FastPath(t *testing.T) {
 	t.Parallel()
 
-	// Fast path (len(req) <= chunkSize): there's no eager ctx.Err() check
-	// — BulkGet calls bulkGetChunk directly, which calls QueryContext on a
-	// cancelled context. Empirically in current Go (1.8+), database/sql
-	// checks ctx.Err() before dispatching to the driver, so the driver
-	// never sees the query; that behavior is stable but not part of
-	// database/sql's documented contract. bulkGetChunk receives the
-	// context error and wraps it as "bulk get query failed: context
-	// canceled" — different prefix from the chunked path's plain
-	// ctx.Err() format. The primary evidence that we hit the
-	// query-failure path (not the eager-check path) is the "bulk get
-	// query failed:" prefix in the per-key error string.
+	// Fast path (len(req) <= chunkSize): BulkGet's eager ctx.Err() check
+	// fires before bulkGetChunk is invoked, so the per-key error format
+	// matches the chunked path (plain ctx.Err() string, no driver wrap).
+	// This unification means callers tuning bulkGetChunkSize see the same
+	// cancellation behavior regardless of which path their request takes.
 	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
 	defer cleanup()
 
@@ -618,15 +612,13 @@ func TestBulkGetChunking_ContextAlreadyCanceled_FastPath(t *testing.T) {
 	for _, k := range []string{"k1", "k2"} {
 		r := byKey[k]
 		assert.Equal(t, k, r.Key)
-		assert.Contains(t, r.Error, "bulk get query failed:")
-		assert.Contains(t, r.Error, context.Canceled.Error())
+		assert.Equal(t, context.Canceled.Error(), r.Error, "fast and chunked paths must produce the same per-key error string for cancellation")
 		assert.Nil(t, r.Data)
 		assert.Nil(t, r.ETag)
 	}
 
-	// No expectations were registered; this only confirms no *unexpected*
-	// query slipped through. The real proof that we hit the query-failure
-	// path is the "bulk get query failed:" assertion above.
+	// No expectations registered, and ExpectationsWereMet passing here
+	// proves the eager check short-circuited before any query was issued.
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/state/sqlserver/v2/sqlserver_bulkget_test.go
+++ b/state/sqlserver/v2/sqlserver_bulkget_test.go
@@ -258,6 +258,11 @@ func TestBulkGetRowsScanFailure(t *testing.T) {
 	defer cleanup()
 
 	// Wrong column type for isBinary forces Scan to fail for that row.
+	// The dedup-and-map-back pattern can't attribute a scan error to a
+	// specific request key (the row's key is lost on Scan failure), so
+	// the affected key surfaces as a missing-key response (no Data, no
+	// ETag, no Error). The warn log is the operational signal —
+	// documented trade-off in the PR description.
 	rows := sqlmock.NewRows(bulkCols).
 		AddRow("k1", `"v1"`, nil, "not-a-bool", []byte{0x01}, nil)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
@@ -267,13 +272,60 @@ func TestBulkGetRowsScanFailure(t *testing.T) {
 	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
 	require.NoError(t, err)
 	require.Len(t, res, 1)
-	// `key` is the first scan destination. database/sql's Rows.Scan
-	// converts column values into destination pointers in column order
-	// and stops at the first conversion error, so `key` is populated
-	// before isBinary's bad value trips Scan. Pin the expected value
-	// so a future change leaving Key empty on partial scan would fail.
 	assert.Equal(t, "k1", res[0].Key)
-	assert.NotEmpty(t, res[0].Error)
+	assert.Empty(t, res[0].Error, "scan failure surfaces as a missing-key response, not a per-key error")
+	assert.Nil(t, res[0].Data)
+	assert.Nil(t, res[0].ETag)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	// Duplicate request keys must yield duplicate response entries with
+	// the same data, matching the default fan-out BulkStore semantics
+	// (response length == request length, request order preserved). The
+	// dedup-and-map-back pattern issues only distinct keys over the wire
+	// and rebuilds the response by iterating the original request slice.
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	rowVer1 := []byte{0x01}
+	rowVer2 := []byte{0x02}
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("k1", `"v1"`, nil, false, rowVer1, nil).
+		AddRow("k2", `"v2"`, nil, false, rowVer2, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "k1"},
+		{Key: "k1"},
+		{Key: "k2"},
+		{Key: "k1"},
+	}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 4, "response length must match request length even with duplicates")
+
+	expected := []struct {
+		key    string
+		data   []byte
+		rowVer []byte
+	}{
+		{"k1", []byte(`"v1"`), rowVer1},
+		{"k1", []byte(`"v1"`), rowVer1},
+		{"k2", []byte(`"v2"`), rowVer2},
+		{"k1", []byte(`"v1"`), rowVer1},
+	}
+	for i, e := range expected {
+		assert.Equal(t, e.key, res[i].Key, "position %d", i)
+		assert.Equal(t, e.data, res[i].Data, "position %d", i)
+		require.NotNil(t, res[i].ETag, "position %d", i)
+		assert.Equal(t, hex.EncodeToString(e.rowVer), *res[i].ETag, "position %d", i)
+		assert.Empty(t, res[i].Error, "position %d", i)
+	}
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -305,6 +357,130 @@ func TestBulkGetRowsErrFailure(t *testing.T) {
 		assert.Contains(t, r.Error, "rows iteration failed:")
 		assert.Contains(t, r.Error, "network timeout")
 	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsErrFailure_WithDuplicates(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	// key1 appears twice in the request. The mock scans key1 successfully
+	// then rows.Err() fires before key2 / key3 are produced. Every
+	// duplicate entry for a found key must keep the same populated data;
+	// every entry for an unfound key (key2, key3) must surface the iter
+	// error. This pins the duplicate-plus-iteration-error interaction
+	// introduced by the dedup-and-map-back refactor.
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("key1", `"value1"`, nil, false, []byte{0x01}, nil).
+		AddRow("key2", `"value2"`, nil, false, []byte{0x02}, nil).
+		RowError(1, errors.New("network timeout"))
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{
+		{Key: "key1"},
+		{Key: "key1"},
+		{Key: "key2"},
+		{Key: "key3"},
+	}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 4)
+
+	// Both occurrences of key1 carry the same data; rd.found=true is
+	// definitive even though iteration later failed.
+	for _, i := range []int{0, 1} {
+		assert.Equal(t, "key1", res[i].Key, "position %d", i)
+		assert.Equal(t, []byte(`"value1"`), res[i].Data, "position %d", i)
+		require.NotNil(t, res[i].ETag, "position %d", i)
+		assert.Empty(t, res[i].Error, "position %d", i)
+	}
+	// key2 and key3 never reached found=true; the iter error fills them.
+	for _, i := range []int{2, 3} {
+		assert.Contains(t, res[i].Error, "rows iteration failed:", "position %d", i)
+		assert.Contains(t, res[i].Error, "network timeout", "position %d", i)
+		assert.Nil(t, res[i].Data, "position %d", i)
+		assert.Nil(t, res[i].ETag, "position %d", i)
+	}
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetRowsErrAfterAllFound(t *testing.T) {
+	t.Parallel()
+
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	// Mock returns rows for k1 then triggers rows.Err() at the boundary
+	// past the last row — every requested key has rd.found=true by the
+	// time iteration ends, but rows.Err() is non-nil. The production
+	// code must not silently drop this error: the per-key responses
+	// still carry their data (correct, the rows were definitively
+	// scanned), and the function warn-logs the iteration error so
+	// transient driver/network failures stay diagnosable.
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("k1", `"v1"`, nil, false, []byte{0x01}, nil).
+		RowError(1, errors.New("network reset after last row"))
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "k1"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	// Data is preserved because k1's row was scanned successfully
+	// before the iteration error fired.
+	assert.Equal(t, "k1", res[0].Key)
+	assert.Equal(t, []byte(`"v1"`), res[0].Data)
+	require.NotNil(t, res[0].ETag)
+	assert.Empty(t, res[0].Error)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBulkGetCaseDifferingKeys_RequestCasingPreserved(t *testing.T) {
+	t.Parallel()
+
+	// Two request entries that differ only by case. The dedup-and-map-back
+	// pattern sets res[i].Key = r.Key in the response loop, so each
+	// response carries the original request casing regardless of what
+	// the DB stored or returned.
+	//
+	// On a real SQL Server with the default case-insensitive collation,
+	// both binds would match the same stored row and the DB would return
+	// it once. The PR description documents that the in-tree code does
+	// not attempt to detect or correct this — Dapr internals are
+	// case-consistent. This test only pins the structural Go-side
+	// guarantee: response Key always matches request Key.
+	s, mock, cleanup := newTestSQLServer(t, defaultBulkGetChunkSize)
+	defer cleanup()
+
+	// Mock returns a row matching the lowercase request; sqlmock echoes
+	// whatever we configure — it doesn't simulate CI collation.
+	rows := sqlmock.NewRows(bulkCols).
+		AddRow("key1", `"v1"`, nil, false, []byte{0x01}, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	req := []state.GetRequest{{Key: "KEY1"}, {Key: "key1"}}
+
+	res, err := s.BulkGet(t.Context(), req, state.BulkGetOpts{})
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	assert.Equal(t, "KEY1", res[0].Key, "response Key must preserve request casing (uppercase entry)")
+	assert.Equal(t, "key1", res[1].Key, "response Key must preserve request casing (lowercase entry)")
+	// The lowercase request matched the returned row; uppercase did not
+	// (rowByKey["KEY1"] stays at zero-value). On a real CI-collation DB
+	// both would match; the in-tree behavior is documented in the PR
+	// description.
+	assert.Equal(t, []byte(`"v1"`), res[1].Data)
+	require.NotNil(t, res[1].ETag)
+	assert.Nil(t, res[0].Data)
+	assert.Nil(t, res[0].ETag)
+	assert.Empty(t, res[0].Error)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Description

- Add a native `BulkGet` to the SQL Server v2 state store, shadowing the default `state.NewDefaultBulkStore` fan-out that issues one `Get` per requested key in parallel.
- Each chunk runs as a single `WHERE [Key] IN (@p0, @p1, …)` query, drastically reducing connection-pool pressure on large bulk reads.

## On case-insensitive collations (intentional)

SQL Server's default collations are case-insensitive (e.g. `SQL_Latin1_General_CP1_CI_AS`). Under such a collation, `WHERE [Key] IN (@p)` will match a stored row regardless of casing, and the row returns with the *stored* key value. This PR deliberately does **not** add a case-collation defense: Dapr internals are case-consistent on state keys, so the issue never arises for in-tree callers. A user who explicitly mixes casing on a case-insensitive column is expected to address it at the database layer — either with a case-sensitive column collation or by passing keys consistently. This is the same trade-off the existing per-key `Get` makes; surfacing it as a per-key concern in `BulkGet` would diverge from `Get`'s behavior for no in-tree benefit.

## Issue reference

Closes #4327

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / `metadata.yaml`