### PR TITLE
feat(pubsub/kafka): add PausableSubscriber + harden graceful shutdown

### DIFF
--- a/common/component/kafka/consumer.go
+++ b/common/component/kafka/consumer.go
@@ -91,14 +91,18 @@ func (consumer *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 					}, func() {
 						consumer.k.logger.Infof("Successfully processed Kafka message after it previously failed: %s/%d/%d [key=%s]", message.Topic, message.Partition, message.Offset, asBase64String(message.Key))
 					}); err != nil {
-						consumer.k.logger.Errorf("Too many failed attempts at processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
-						if errors.Is(session.Context().Err(), context.Canceled) {
-							// If the context is canceled, we should not attempt to consume any more messages. Exiting the loop.
-							// Otherwise, there is a race condition when this loop keeps processing messages from the claim.Messages() channel
-							// before the session.Context().Done() is closed. If there are other messages that can successfully be processed,
-							// they will be marked as processed and this failing message will be lost.
+						// When the session context is canceled (graceful
+						// shutdown / rebalance), the retry exits with the last
+						// observed error rather than a real "exhausted"
+						// outcome. The message is left unmarked and will be
+						// redelivered to whichever consumer takes over the
+						// partition, so this is not a processing failure —
+						// just shutdown noise. Demote the log accordingly.
+						if errors.Is(session.Context().Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+							consumer.k.logger.Debugf("Kafka message processing aborted due to shutdown; will be redelivered: %s/%d/%d [key=%s]", message.Topic, message.Partition, message.Offset, asBase64String(message.Key))
 							return nil
 						}
+						consumer.k.logger.Errorf("Too many failed attempts at processing Kafka message: %s/%d/%d [key=%s]. Error: %v.", message.Topic, message.Partition, message.Offset, asBase64String(message.Key), err)
 					}
 				} else {
 					err := consumer.doCallback(session, message)
@@ -124,7 +128,13 @@ func (consumer *consumer) flushBulkMessages(claim sarama.ConsumerGroupClaim,
 			}, func() {
 				consumer.k.logger.Infof("Successfully processed Kafka message after it previously failed: %s", claim.Topic())
 			}); err != nil {
-				consumer.k.logger.Errorf("Too many failed attempts at processing Kafka message: %s. Error: %v.", claim.Topic(), err)
+				// Same shutdown-vs-exhausted distinction as the singular
+				// path: demote when session ctx is canceled.
+				if errors.Is(session.Context().Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+					consumer.k.logger.Debugf("Kafka bulk message processing aborted due to shutdown; will be redelivered: %s", claim.Topic())
+				} else {
+					consumer.k.logger.Errorf("Too many failed attempts at processing Kafka message: %s. Error: %v.", claim.Topic(), err)
+				}
 			}
 		} else {
 			err := consumer.doBulkCallback(session, messages, handler, claim.Topic())

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -319,6 +319,32 @@ func (k *Kafka) ValidateAWS(metadata map[string]string) (awsAuth.Options, error)
 	}, nil
 }
 
+// Pause stops fetching new messages from the broker for all active
+// subscriptions on this component. The Sarama session and partition
+// assignments are preserved so messages already buffered in claim queues can
+// still be processed by handlers. Idempotent.
+func (k *Kafka) Pause(ctx context.Context) error {
+	k.subscribeLock.Lock()
+	defer k.subscribeLock.Unlock()
+	if k.clients != nil && k.clients.consumerGroup != nil {
+		k.logger.Debugf("Pausing all subscriptions")
+		k.clients.consumerGroup.PauseAll()
+	}
+	return nil
+}
+
+// Resume resumes fetching new messages from the broker for all active
+// subscriptions on this component. Idempotent.
+func (k *Kafka) Resume(ctx context.Context) error {
+	k.subscribeLock.Lock()
+	defer k.subscribeLock.Unlock()
+	if k.clients != nil && k.clients.consumerGroup != nil {
+		k.logger.Debugf("Resuming all subscriptions")
+		k.clients.consumerGroup.ResumeAll()
+	}
+	return nil
+}
+
 func (k *Kafka) Close() error {
 	defer k.wg.Wait()
 	defer k.consumerWG.Wait()

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -324,6 +324,9 @@ func (k *Kafka) ValidateAWS(metadata map[string]string) (awsAuth.Options, error)
 // assignments are preserved so messages already buffered in claim queues can
 // still be processed by handlers. Idempotent.
 func (k *Kafka) Pause(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	k.subscribeLock.Lock()
 	defer k.subscribeLock.Unlock()
 	if k.clients != nil && k.clients.consumerGroup != nil {
@@ -336,6 +339,9 @@ func (k *Kafka) Pause(ctx context.Context) error {
 // Resume resumes fetching new messages from the broker for all active
 // subscriptions on this component. Idempotent.
 func (k *Kafka) Resume(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	k.subscribeLock.Lock()
 	defer k.subscribeLock.Unlock()
 	if k.clients != nil && k.clients.consumerGroup != nil {

--- a/common/component/kafka/subscriber.go
+++ b/common/component/kafka/subscriber.go
@@ -70,8 +70,14 @@ func (k *Kafka) Subscribe(ctx context.Context, handlerConfig SubscriptionHandler
 
 		k.reloadConsumerGroup()
 
-		if isGraceful && k.clients != nil && k.clients.consumerGroup != nil {
-			k.logger.Debugf("Kafka component is closing. Closing consumer group.")
+		// Only the last subscription to exit closes the consumer group.
+		// Closing while sibling Subscribe goroutines still hold subscriptions
+		// on the same component would race with the new consume goroutine
+		// reloadConsumerGroup just started for the remaining topics, leaving
+		// it to error out with "tried to use a consumer group that was
+		// closed".
+		if isGraceful && len(k.subscribeTopics) == 0 && k.clients != nil && k.clients.consumerGroup != nil {
+			k.logger.Debugf("Last subscription closing; closing consumer group.")
 			if err := k.clients.consumerGroup.Close(); err != nil {
 				k.logger.Errorf("failed to close consumer group: %w", err)
 			}

--- a/common/component/kafka/subscriber.go
+++ b/common/component/kafka/subscriber.go
@@ -37,30 +37,30 @@ func (k *Kafka) Subscribe(ctx context.Context, handlerConfig SubscriptionHandler
 	k.wg.Add(1)
 	go func() {
 		defer k.wg.Done()
-		postAction := func() {}
+		isGraceful := false
 
 		select {
 		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if errors.Is(err, pubsub.ErrGracefulShutdown) {
+			if errors.Is(context.Cause(ctx), pubsub.ErrGracefulShutdown) {
+				isGraceful = true
 				k.logger.Debugf("Kafka component is closing. Context is done due to shutdown process.")
-				postAction = func() {
-					if k.clients != nil && k.clients.consumerGroup != nil {
-						k.logger.Debugf("Kafka component is closing. Closing consumer group.")
-						err := k.clients.consumerGroup.Close()
-						if err != nil {
-							k.logger.Errorf("failed to close consumer group: %w", err)
-						}
-					}
-				}
 			}
-
 		case <-k.closeCh:
 			k.logger.Debugf("Kafka component is closing. Channel is closed.")
 		}
 
 		k.subscribeLock.Lock()
 		defer k.subscribeLock.Unlock()
+
+		// On graceful shutdown, pause fetching from the broker before tearing
+		// down the consumer group. Pausing here stops Sarama from issuing
+		// further FetchRequests while the consume goroutine winds down,
+		// keeping the close path quieter and bounding any last-second
+		// claim-buffer growth between session cancel and LeaveGroup.
+		if isGraceful && k.clients != nil && k.clients.consumerGroup != nil {
+			k.logger.Debugf("Pausing all partitions before closing consumer group.")
+			k.clients.consumerGroup.PauseAll()
+		}
 
 		k.logger.Debugf("Unsubscribing to topic: %v", topics)
 
@@ -69,7 +69,13 @@ func (k *Kafka) Subscribe(ctx context.Context, handlerConfig SubscriptionHandler
 		}
 
 		k.reloadConsumerGroup()
-		postAction()
+
+		if isGraceful && k.clients != nil && k.clients.consumerGroup != nil {
+			k.logger.Debugf("Kafka component is closing. Closing consumer group.")
+			if err := k.clients.consumerGroup.Close(); err != nil {
+				k.logger.Errorf("failed to close consumer group: %w", err)
+			}
+		}
 	}()
 }
 

--- a/common/component/kafka/subscriber_test.go
+++ b/common/component/kafka/subscriber_test.go
@@ -277,6 +277,87 @@ func Test_reloadConsumerGroup(t *testing.T) {
 		assert.Equal(t, int64(1), closeCalled.Load())
 	})
 
+	t.Run("On graceful shutdown PauseAll is called before Close", func(t *testing.T) {
+		var pauseAllCalled atomic.Int64
+		var closeCalled atomic.Int64
+		var pauseAllAt atomic.Int64
+		var closeAt atomic.Int64
+		var seq atomic.Int64
+		waitCh := make(chan struct{})
+		cg := mocks.NewConsumerGroup().
+			WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+				<-ctx.Done()
+				return nil
+			}).
+			WithPauseAllFn(func() {
+				pauseAllCalled.Add(1)
+				pauseAllAt.Store(seq.Add(1))
+			}).
+			WithCloseFn(func() error {
+				closeCalled.Add(1)
+				closeAt.Store(seq.Add(1))
+				waitCh <- struct{}{}
+				return nil
+			})
+
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			mockConsumerGroup:    cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{"foo": {}},
+			consumeRetryInterval: time.Millisecond,
+		}
+		c, err := k.latestClients()
+		require.NoError(t, err)
+		k.clients = c
+
+		ctx, cancel := context.WithCancelCause(t.Context())
+		k.Subscribe(ctx, SubscriptionHandlerConfig{}, "foo")
+
+		cancel(pubsub.ErrGracefulShutdown)
+		<-waitCh
+
+		assert.Equal(t, int64(1), pauseAllCalled.Load(), "PauseAll should be called exactly once on graceful shutdown")
+		assert.Equal(t, int64(1), closeCalled.Load(), "Close should be called exactly once on graceful shutdown")
+		assert.Less(t, pauseAllAt.Load(), closeAt.Load(), "PauseAll should be called before Close")
+	})
+
+	t.Run("Non-graceful shutdown does not call PauseAll", func(t *testing.T) {
+		var pauseAllCalled atomic.Int64
+		var consumeCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().
+			WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+				consumeCalled.Add(1)
+				<-ctx.Done()
+				return nil
+			}).
+			WithPauseAllFn(func() {
+				pauseAllCalled.Add(1)
+			})
+
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			mockConsumerGroup:    cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{"foo": {}},
+			consumeRetryInterval: time.Millisecond,
+		}
+		c, err := k.latestClients()
+		require.NoError(t, err)
+		k.clients = c
+
+		ctx, cancel := context.WithCancelCause(t.Context())
+		k.Subscribe(ctx, SubscriptionHandlerConfig{}, "foo")
+		assert.Eventually(t, func() bool { return consumeCalled.Load() == 1 }, time.Second, time.Millisecond)
+
+		cancel(errors.New("non-graceful cancel"))
+		// Wait for the unsubscribe goroutine to finish.
+		k.wg.Wait()
+		assert.Equal(t, int64(0), pauseAllCalled.Load(), "PauseAll should not be called for non-graceful shutdown")
+	})
+
 	t.Run("Cancel context whit shutdown error closes consumer group with multiple subscriber", func(t *testing.T) {
 		var closeCalled atomic.Int64
 		waitCh := make(chan struct{})

--- a/common/component/kafka/subscriber_test.go
+++ b/common/component/kafka/subscriber_test.go
@@ -358,12 +358,10 @@ func Test_reloadConsumerGroup(t *testing.T) {
 		assert.Equal(t, int64(0), pauseAllCalled.Load(), "PauseAll should not be called for non-graceful shutdown")
 	})
 
-	t.Run("Cancel context whit shutdown error closes consumer group with multiple subscriber", func(t *testing.T) {
+	t.Run("Cancelling one of many subscribers does NOT close the consumer group", func(t *testing.T) {
 		var closeCalled atomic.Int64
-		waitCh := make(chan struct{})
 		cg := mocks.NewConsumerGroup().WithCloseFn(func() error {
 			closeCalled.Add(1)
-			waitCh <- struct{}{}
 			return nil
 		})
 
@@ -372,12 +370,11 @@ func Test_reloadConsumerGroup(t *testing.T) {
 			mockConsumerGroup:    cg,
 			consumerCancel:       nil,
 			closeCh:              make(chan struct{}),
-			subscribeTopics:      map[string]SubscriptionHandlerConfig{"foo": {}},
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{},
 			consumeRetryInterval: time.Millisecond,
 		}
 		c, err := k.latestClients()
 		require.NoError(t, err)
-
 		k.clients = c
 
 		cancelFns := make([]context.CancelCauseFunc, 0, 100)
@@ -386,9 +383,77 @@ func Test_reloadConsumerGroup(t *testing.T) {
 			cancelFns = append(cancelFns, cancel)
 			k.Subscribe(ctx, SubscriptionHandlerConfig{}, fmt.Sprintf("foo%d", i))
 		}
+
+		// Cancel one of the 100 subscribers with the graceful shutdown cause.
+		// The other 99 still hold subscriptions on the same consumer group, so
+		// Close MUST NOT fire — doing so would race with the new consume
+		// goroutine reloadConsumerGroup just started for the remaining topics.
 		cancelFns[0](pubsub.ErrGracefulShutdown)
-		<-waitCh
-		assert.Equal(t, int64(1), closeCalled.Load())
+
+		// Give the unsubscribe goroutine ample time to run.
+		assert.Never(t, func() bool { return closeCalled.Load() > 0 }, time.Second, time.Millisecond*10,
+			"consumer group must not be closed while other subscriptions are still active")
+	})
+
+	t.Run("Cancelling all subscribers with shutdown error closes the consumer group exactly once", func(t *testing.T) {
+		var closeCalled atomic.Int64
+		var consumeErrors atomic.Int64
+		closedFlag := atomic.Bool{}
+
+		cg := mocks.NewConsumerGroup().
+			WithConsumeFn(func(ctx context.Context, _ []string, _ sarama.ConsumerGroupHandler) error {
+				if closedFlag.Load() {
+					// Sarama would return this error if Consume is called on a
+					// closed group. Track it so we can assert no spurious
+					// "consumer group closed" errors leak through during
+					// the unsubscribe cascade.
+					consumeErrors.Add(1)
+					return errors.New("kafka: tried to use a consumer group that was closed")
+				}
+				<-ctx.Done()
+				return nil
+			}).
+			WithCloseFn(func() error {
+				closeCalled.Add(1)
+				closedFlag.Store(true)
+				return nil
+			})
+
+		k := &Kafka{
+			logger:               logger.NewLogger("test"),
+			mockConsumerGroup:    cg,
+			consumerCancel:       nil,
+			closeCh:              make(chan struct{}),
+			subscribeTopics:      map[string]SubscriptionHandlerConfig{},
+			consumeRetryInterval: time.Hour, // make sure retry sleep doesn't kick in during the test
+		}
+		c, err := k.latestClients()
+		require.NoError(t, err)
+		k.clients = c
+
+		const N = 100
+		cancelFns := make([]context.CancelCauseFunc, 0, N)
+		for i := range N {
+			ctx, cancel := context.WithCancelCause(t.Context())
+			cancelFns = append(cancelFns, cancel)
+			k.Subscribe(ctx, SubscriptionHandlerConfig{}, fmt.Sprintf("foo%d", i))
+		}
+
+		// Cancel all subscribers with the graceful-shutdown cause in parallel
+		// to exercise the race where multiple Subscribe goroutines race for
+		// the subscribe lock while siblings still hold subscriptions on the
+		// same shared consumer group.
+		for _, cancel := range cancelFns {
+			cancel(pubsub.ErrGracefulShutdown)
+		}
+
+		// Wait for all Subscribe goroutines to finish.
+		k.wg.Wait()
+
+		assert.Equal(t, int64(1), closeCalled.Load(),
+			"consumer group should be closed exactly once after the last subscription exits")
+		assert.Equal(t, int64(0), consumeErrors.Load(),
+			"no consume goroutine should see the consumer group closed during the unsubscribe cascade")
 	})
 
 	t.Run("Closing subscriptions with no error or no ErrGracefulShutdown does not close consumer group", func(t *testing.T) {

--- a/common/component/kafka/subscriber_test.go
+++ b/common/component/kafka/subscriber_test.go
@@ -428,6 +428,71 @@ func Test_reloadConsumerGroup(t *testing.T) {
 	})
 }
 
+func Test_PauseResume(t *testing.T) {
+	t.Run("Pause forwards to consumerGroup.PauseAll", func(t *testing.T) {
+		var pauseAllCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithPauseAllFn(func() {
+			pauseAllCalled.Add(1)
+		})
+		k := &Kafka{
+			logger:            logger.NewLogger("test"),
+			mockConsumerGroup: cg,
+			closeCh:           make(chan struct{}),
+		}
+		c, err := k.latestClients()
+		require.NoError(t, err)
+		k.clients = c
+
+		require.NoError(t, k.Pause(t.Context()))
+		assert.Equal(t, int64(1), pauseAllCalled.Load())
+
+		// Idempotent: calling again should still succeed.
+		require.NoError(t, k.Pause(t.Context()))
+		assert.Equal(t, int64(2), pauseAllCalled.Load())
+	})
+
+	t.Run("Resume forwards to consumerGroup.ResumeAll", func(t *testing.T) {
+		var resumeAllCalled atomic.Int64
+		cg := mocks.NewConsumerGroup().WithResumeAllFn(func() {
+			resumeAllCalled.Add(1)
+		})
+		k := &Kafka{
+			logger:            logger.NewLogger("test"),
+			mockConsumerGroup: cg,
+			closeCh:           make(chan struct{}),
+		}
+		c, err := k.latestClients()
+		require.NoError(t, err)
+		k.clients = c
+
+		require.NoError(t, k.Resume(t.Context()))
+		assert.Equal(t, int64(1), resumeAllCalled.Load())
+
+		// Idempotent: calling again should still succeed.
+		require.NoError(t, k.Resume(t.Context()))
+		assert.Equal(t, int64(2), resumeAllCalled.Load())
+	})
+
+	t.Run("Pause is a no-op when consumerGroup is nil", func(t *testing.T) {
+		k := &Kafka{
+			logger:  logger.NewLogger("test"),
+			closeCh: make(chan struct{}),
+			clients: &clients{}, // consumerGroup is nil
+		}
+		require.NoError(t, k.Pause(t.Context()))
+		require.NoError(t, k.Resume(t.Context()))
+	})
+
+	t.Run("Pause is a no-op when clients is nil", func(t *testing.T) {
+		k := &Kafka{
+			logger:  logger.NewLogger("test"),
+			closeCh: make(chan struct{}),
+		}
+		require.NoError(t, k.Pause(t.Context()))
+		require.NoError(t, k.Resume(t.Context()))
+	})
+}
+
 func Test_Subscribe(t *testing.T) {
 	t.Run("Calling subscribe with no topics should not consume", func(t *testing.T) {
 		var consumeCalled atomic.Int64

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -138,6 +138,24 @@ func (p *PubSub) Close() (err error) {
 	return p.kafka.Close()
 }
 
+// Pause implements pubsub.PausableSubscriber. It stops fetching new messages
+// from the broker for all active subscriptions; messages already buffered
+// can still be processed.
+func (p *PubSub) Pause(ctx context.Context) error {
+	if p.closed.Load() {
+		return errors.New("component is closed")
+	}
+	return p.kafka.Pause(ctx)
+}
+
+// Resume implements pubsub.PausableSubscriber.
+func (p *PubSub) Resume(ctx context.Context) error {
+	if p.closed.Load() {
+		return errors.New("component is closed")
+	}
+	return p.kafka.Resume(ctx)
+}
+
 func (p *PubSub) Features() []pubsub.Feature {
 	return []pubsub.Feature{pubsub.FeatureBulkPublish}
 }

--- a/pubsub/kafka/kafka_test.go
+++ b/pubsub/kafka/kafka_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"github.com/dapr/components-contrib/pubsub"
+)
+
+// Compile-time assertion that PubSub implements the optional
+// PausableSubscriber capability.
+var _ pubsub.PausableSubscriber = (*PubSub)(nil)

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -52,6 +52,27 @@ type BulkSubscriber interface {
 	BulkSubscribe(ctx context.Context, req SubscribeRequest, bulkHandler BulkHandler) error
 }
 
+// PausableSubscriber is an optional capability that lets the runtime pause
+// fetching new messages from the broker without tearing down active
+// subscriptions.
+//
+// While paused, the broker stops delivering new messages but the session,
+// connection, and partition assignments are preserved. Messages already
+// buffered locally can continue to be processed by handlers — this enables a
+// clean drain-during-shutdown pattern: pause, let the in-flight pipeline
+// drain, then close.
+//
+// Implementations must be safe to call concurrently with Subscribe and must
+// be idempotent.
+type PausableSubscriber interface {
+	// Pause stops fetching new messages from the broker for all active
+	// subscriptions on this component. Already-buffered messages can still
+	// be processed.
+	Pause(ctx context.Context) error
+	// Resume resumes fetching new messages from the broker.
+	Resume(ctx context.Context) error
+}
+
 // Handler is the handler used to invoke the app handler.
 type Handler func(ctx context.Context, msg *NewMessage) error
 


### PR DESCRIPTION
# Description

## Summary

- Adds an optional `PausableSubscriber` capability to the pubsub interface so the runtime can stop the broker from feeding new messages into the local buffer during graceful shutdown without tearing down the session.
- Implements the new capability for Kafka via Sarama's `PauseAll` / `ResumeAll`.
- Hardens Kafka's existing graceful-shutdown path — fixes a multi-subscription race that was causing `consumer group was closed` log spam, and demotes a misleading retry-exhausted log to debug when the cause is shutdown rather than real exhaustion.

## Changes

### New: `PausableSubscriber` interface (`pubsub/pubsub.go`)

Optional capability for pubsub components that can pause fetching from the broker without tearing down the session. While paused, the connection and partition assignments stay alive so messages already buffered locally can still be processed by handlers — this enables a clean drain-during-shutdown pattern in the runtime.

```go
type PausableSubscriber interface {
    Pause(ctx context.Context) error
    Resume(ctx context.Context) error
}
```

Detected by callers via interface assertion. Brokers that don't implement it fall back to existing behavior.

### Kafka implementation (`common/component/kafka/kafka.go`, `pubsub/kafka/kafka.go`)

`Kafka.Pause` / `Kafka.Resume` delegate to Sarama's `consumerGroup.PauseAll()` / `ResumeAll()`. The `pubsub/kafka.PubSub` wrapper exposes them through a closed-state guard. Compile-time interface assertion in `pubsub/kafka/kafka_test.go` ensures the wrapper stays in sync with the interface.

### `subscriber.go`: pause-before-close ordering on graceful shutdown

When the Subscribe context is cancelled with `pubsub.ErrGracefulShutdown` cause, the contrib's Subscribe goroutine now calls `consumerGroup.PauseAll()` before the existing `reloadConsumerGroup` + `Close` sequence. This stops Sarama from issuing further FetchRequests while the consume goroutine winds down — keeps the close path quieter and bounds any last-second claim-buffer growth.

### `subscriber.go`: only the last subscription closes the shared consumer group

When multiple Subscribe calls share a single Kafka pubsub component (one declarative Subscription per topic, all on the same component), graceful shutdown fires `sub.Stop(ErrGracefulShutdown)` for every Subscription in parallel. Each Subscribe goroutine then takes `subscribeLock` serially, deletes its own topic, calls `reloadConsumerGroup()`, and runs the postAction.

Before this fix, the postAction unconditionally called `consumerGroup.Close()` — so the FIRST goroutine to acquire the lock tore down the shared consumer group while sibling goroutines still held subscriptions. Each subsequent `reloadConsumerGroup` then started a fresh `Consume()` against the now-closed group, producing log spam like:

```
level=error msg="Error consuming [topic1 topic2 topic3]. Retrying...:
kafka: tried to use a consumer group that was closed"
```

Gate `consumerGroup.Close()` on `len(k.subscribeTopics) == 0` so only the LAST goroutine to exit closes the group. Earlier goroutines just delete their topic and let reload restart consume for the remaining topics on a still-alive group.

This race was pre-existing — introduced by #3907 (the original `postAction`) and only became visible when running a multi-topic Kafka graceful shutdown. The Pause-before-Close commit on this branch made it more visible (Pause runs before delete, so the broker is paused while Close is still racing with siblings) but did not introduce it.

### `consumer.go`: demote retry-exhausted log when shutdown is the cause

`retry.NotifyRecover`'s "exhausted" return value covers two cases:

1. **Real exhaustion** — a healthy session retried the configured number of times and the handler kept failing. Genuine processing failure worth `Errorf`.
2. **Session context canceled** — graceful shutdown or rebalance canceled the backoff context, so the retry returned with the last observed error. The message is left unmarked and will be redelivered to whoever takes over the partition. Shutdown noise, not a failure.

Distinguish by checking `session.Context().Err()` and the error itself for `context.Canceled`. If either matches, log `Debugf` with a clearer message ("aborted due to shutdown; will be redelivered"); otherwise keep the existing `Errorf` for true exhaustion. Same change applied to the bulk path.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
