### PR TITLE
feat: add AWS Kinesis Data Firehose output binding

### DIFF
--- a/bindings/aws/firehose/firehose.go
+++ b/bindings/aws/firehose/firehose.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package firehose
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/firehose"
+	"github.com/aws/aws-sdk-go-v2/service/firehose/types"
+
+	"github.com/dapr/components-contrib/bindings"
+	awsCommon "github.com/dapr/components-contrib/common/aws"
+	awsAuth "github.com/dapr/components-contrib/common/aws/auth"
+	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
+	kitmd "github.com/dapr/kit/metadata"
+)
+
+const (
+	// Default values.
+	defaultMaxBatchSize              = 500
+	defaultServiceUnavailableRetries = 10
+	defaultServiceUnavailableTimeout = 60 * time.Second
+	defaultRecordRetryLimit          = 100
+
+	// AWS Firehose hard limits.
+	maxRecordsPerBatch = 500
+
+	// OperationBatch is the operation name for batch writes via PutRecordBatch.
+	OperationBatch bindings.OperationKind = "batch"
+)
+
+// AWSFirehose is a Dapr output binding for AWS Kinesis Data Firehose.
+// It supports single-record writes (PutRecord) via the "create" operation
+// and batch writes (PutRecordBatch) via the "batch" operation, with automatic
+// retry for both service-level and record-level failures.
+type AWSFirehose struct {
+	client   firehoseClient
+	metadata *firehoseMetadata
+	logger   logger.Logger
+}
+
+// firehoseClient abstracts the AWS Firehose SDK calls for testability.
+type firehoseClient interface {
+	PutRecord(ctx context.Context, params *firehose.PutRecordInput, optFns ...func(*firehose.Options)) (*firehose.PutRecordOutput, error)
+	PutRecordBatch(ctx context.Context, params *firehose.PutRecordBatchInput, optFns ...func(*firehose.Options)) (*firehose.PutRecordBatchOutput, error)
+}
+
+type firehoseMetadata struct {
+	// Ignored by metadata parser because included in built-in authentication profile.
+	Region       string `json:"region" mapstructure:"region" mapstructurealiases:"awsRegion" mdignore:"true"`
+	AccessKey    string `json:"accessKey" mapstructure:"accessKey" mdignore:"true"`
+	SecretKey    string `json:"secretKey" mapstructure:"secretKey" mdignore:"true"`
+	SessionToken string `json:"sessionToken" mapstructure:"sessionToken" mdignore:"true"`
+	Endpoint     string `json:"endpoint" mapstructure:"endpoint"`
+
+	// DeliveryStreamName is the default Firehose delivery stream name.
+	// Can be overridden per-request via invoke metadata.
+	DeliveryStreamName string `json:"deliveryStreamName" mapstructure:"deliveryStreamName"`
+
+	// MaxBatchSize is the maximum number of records per PutRecordBatch call (max 500).
+	MaxBatchSize int `json:"maxBatchSize" mapstructure:"maxBatchSize"`
+
+	// ServiceUnavailableRetries is the number of retries on transient service errors.
+	ServiceUnavailableRetries int `json:"serviceUnavailableRetries" mapstructure:"serviceUnavailableRetries"`
+
+	// ServiceUnavailableTimeout is the wait duration between service-level retries.
+	ServiceUnavailableTimeout time.Duration `json:"serviceUnavailableTimeout" mapstructure:"serviceUnavailableTimeout"`
+
+	// RecordRetryLimit is the maximum number of rounds that failed records are re-batched and retried.
+	RecordRetryLimit int `json:"recordRetryLimit" mapstructure:"recordRetryLimit"`
+}
+
+// NewAWSFirehose creates a new AWSFirehose output binding instance.
+func NewAWSFirehose(logger logger.Logger) bindings.OutputBinding {
+	return &AWSFirehose{logger: logger}
+}
+
+// Init parses metadata and creates the AWS Firehose client.
+func (a *AWSFirehose) Init(ctx context.Context, md bindings.Metadata) error {
+	m, err := a.parseMetadata(md)
+	if err != nil {
+		return fmt.Errorf("firehose binding init: %w", err)
+	}
+	a.metadata = m
+
+	authOpts := awsAuth.Options{
+		Logger:       a.logger,
+		Properties:   md.Properties,
+		Region:       m.Region,
+		Endpoint:     m.Endpoint,
+		AccessKey:    m.AccessKey,
+		SecretKey:    m.SecretKey,
+		SessionToken: m.SessionToken,
+	}
+
+	awsCfg, err := awsCommon.NewConfig(ctx, authOpts)
+	if err != nil {
+		return fmt.Errorf("firehose binding: error getting AWS config: %w", err)
+	}
+
+	a.client = firehose.NewFromConfig(awsCfg)
+	return nil
+}
+
+// Operations returns the list of supported binding operations.
+func (a *AWSFirehose) Operations() []bindings.OperationKind {
+	return []bindings.OperationKind{
+		bindings.CreateOperation, // PutRecord — single record
+		OperationBatch,           // PutRecordBatch — multiple records with retry
+	}
+}
+
+// Invoke handles an invocation request.
+//
+// Operation "create":
+//
+//	req.Data is the raw record payload (bytes). Sent via PutRecord.
+//	Per-request metadata key "deliveryStreamName" overrides the component default.
+//
+// Operation "batch":
+//
+//	req.Data is a JSON array of records. Each element is either:
+//	  - An object with a "Data" string field (e.g. {"Data": "..."})
+//	  - A raw JSON value used verbatim as record bytes
+//	Records are batched (max 500), sent via PutRecordBatch, and failed records
+//	are automatically retried up to RecordRetryLimit times.
+func (a *AWSFirehose) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	deliveryStream := a.metadata.DeliveryStreamName
+	if v, ok := req.Metadata["deliveryStreamName"]; ok && v != "" {
+		deliveryStream = v
+	}
+	if deliveryStream == "" {
+		return nil, errors.New("firehose binding: deliveryStreamName is required (set in component metadata or per-request)")
+	}
+
+	switch req.Operation {
+	case bindings.CreateOperation:
+		return a.putRecord(ctx, deliveryStream, req.Data)
+	case OperationBatch:
+		return a.putRecordBatch(ctx, deliveryStream, req.Data)
+	default:
+		return nil, fmt.Errorf("firehose binding: unsupported operation %q", req.Operation)
+	}
+}
+
+// Close is a no-op; the AWS SDK client does not require explicit cleanup.
+func (a *AWSFirehose) Close() error {
+	return nil
+}
+
+// GetComponentMetadata returns metadata field information for documentation tooling.
+func (a *AWSFirehose) GetComponentMetadata() (metadataInfo metadata.MetadataMap) {
+	metadataStruct := firehoseMetadata{}
+	metadata.GetMetadataInfoFromStructType(reflect.TypeOf(metadataStruct), &metadataInfo, metadata.BindingType)
+	return
+}
+
+// ---------------------------------------------------------------------------
+// PutRecord — single record
+// ---------------------------------------------------------------------------
+
+func (a *AWSFirehose) putRecord(ctx context.Context, stream string, data []byte) (*bindings.InvokeResponse, error) {
+	if len(data) == 0 {
+		return nil, errors.New("firehose PutRecord: empty data")
+	}
+
+	input := &firehose.PutRecordInput{
+		DeliveryStreamName: aws.String(stream),
+		Record:             &types.Record{Data: data},
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= a.metadata.ServiceUnavailableRetries; attempt++ {
+		if attempt > 0 {
+			a.logger.Warnf("PutRecord retry %d/%d after error: %v", attempt, a.metadata.ServiceUnavailableRetries, lastErr)
+			if err := sleepContext(ctx, a.metadata.ServiceUnavailableTimeout); err != nil {
+				return nil, err
+			}
+		}
+
+		output, err := a.client.PutRecord(ctx, input)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		return &bindings.InvokeResponse{
+			Metadata: map[string]string{
+				"recordId": aws.ToString(output.RecordId),
+			},
+		}, nil
+	}
+
+	return nil, fmt.Errorf("firehose PutRecord failed after %d retries: %w",
+		a.metadata.ServiceUnavailableRetries, lastErr)
+}
+
+// ---------------------------------------------------------------------------
+// PutRecordBatch — multiple records with batching + record-level retry
+// ---------------------------------------------------------------------------
+
+func (a *AWSFirehose) putRecordBatch(ctx context.Context, stream string, data []byte) (*bindings.InvokeResponse, error) {
+	records, err := unmarshalBatchRecords(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return &bindings.InvokeResponse{}, nil
+	}
+
+	totalInputRecords := len(records)
+
+	// Split into batches of maxBatchSize.
+	pendingBatches := batchRecords(records, a.metadata.MaxBatchSize)
+	retryRound := 0
+
+	// Send each batch; collect failed records for retry.
+	for len(pendingBatches) > 0 {
+		var nextRoundBatches [][]types.Record
+
+		for _, batch := range pendingBatches {
+			retryRecords, batchErr := a.sendBatchWithServiceRetry(ctx, stream, batch)
+			if batchErr != nil {
+				return nil, batchErr
+			}
+			if len(retryRecords) > 0 {
+				retryRound++
+				if retryRound >= a.metadata.RecordRetryLimit {
+					return nil, fmt.Errorf("firehose batch: record retry limit (%d) reached, giving up",
+						a.metadata.RecordRetryLimit)
+				}
+				nextRoundBatches = append(nextRoundBatches, batchRecords(retryRecords, a.metadata.MaxBatchSize)...)
+			}
+		}
+
+		pendingBatches = nextRoundBatches
+	}
+
+	return &bindings.InvokeResponse{
+		Metadata: map[string]string{
+			"recordCount": strconv.Itoa(totalInputRecords),
+		},
+	}, nil
+}
+
+// sendBatchWithServiceRetry calls PutRecordBatch with service-level retry on transient errors.
+func (a *AWSFirehose) sendBatchWithServiceRetry(ctx context.Context, stream string, records []types.Record) ([]types.Record, error) {
+	input := &firehose.PutRecordBatchInput{
+		DeliveryStreamName: aws.String(stream),
+		Records:            records,
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= a.metadata.ServiceUnavailableRetries; attempt++ {
+		if attempt > 0 {
+			a.logger.Warnf("PutRecordBatch service retry %d/%d: %v",
+				attempt, a.metadata.ServiceUnavailableRetries, lastErr)
+			if err := sleepContext(ctx, a.metadata.ServiceUnavailableTimeout); err != nil {
+				return nil, err
+			}
+		}
+
+		output, err := a.client.PutRecordBatch(ctx, input)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		return getRecordsToRetry(output, records), nil
+	}
+
+	return nil, fmt.Errorf("firehose PutRecordBatch failed after %d retries: %w",
+		a.metadata.ServiceUnavailableRetries, lastErr)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// unmarshalBatchRecords parses a JSON array into Firehose Record objects.
+// Supports {"Data": "..."} format as well as raw JSON values.
+func unmarshalBatchRecords(data []byte) ([]types.Record, error) {
+	var rawRecords []json.RawMessage
+	if err := json.Unmarshal(data, &rawRecords); err != nil {
+		return nil, fmt.Errorf("firehose batch: data must be a JSON array of records: %w", err)
+	}
+
+	records := make([]types.Record, 0, len(rawRecords))
+	for _, raw := range rawRecords {
+		var wrapper struct {
+			Data string `json:"Data"`
+		}
+		if err := json.Unmarshal(raw, &wrapper); err == nil && wrapper.Data != "" {
+			records = append(records, types.Record{Data: []byte(wrapper.Data)})
+		} else {
+			records = append(records, types.Record{Data: raw})
+		}
+	}
+	return records, nil
+}
+
+// batchRecords splits a slice of records into sub-slices of at most maxSize.
+func batchRecords(records []types.Record, maxSize int) [][]types.Record {
+	if len(records) == 0 {
+		return nil
+	}
+	batches := make([][]types.Record, 0, (len(records)+maxSize-1)/maxSize)
+	for i := 0; i < len(records); i += maxSize {
+		end := i + maxSize
+		if end > len(records) {
+			end = len(records)
+		}
+		batch := make([]types.Record, end-i)
+		copy(batch, records[i:end])
+		batches = append(batches, batch)
+	}
+	return batches
+}
+
+// getRecordsToRetry extracts the records that failed from a PutRecordBatch response.
+func getRecordsToRetry(output *firehose.PutRecordBatchOutput, records []types.Record) []types.Record {
+	if output.FailedPutCount == nil || *output.FailedPutCount == 0 {
+		return nil
+	}
+
+	retry := make([]types.Record, 0, int(*output.FailedPutCount))
+	for i, resp := range output.RequestResponses {
+		if resp.ErrorCode != nil && *resp.ErrorCode != "" {
+			retry = append(retry, records[i])
+		}
+	}
+	return retry
+}
+
+// parseMetadata decodes and validates component metadata.
+func (a *AWSFirehose) parseMetadata(meta bindings.Metadata) (*firehoseMetadata, error) {
+	m := &firehoseMetadata{
+		MaxBatchSize:              defaultMaxBatchSize,
+		ServiceUnavailableRetries: defaultServiceUnavailableRetries,
+		ServiceUnavailableTimeout: defaultServiceUnavailableTimeout,
+		RecordRetryLimit:          defaultRecordRetryLimit,
+	}
+
+	if err := kitmd.DecodeMetadata(meta.Properties, m); err != nil {
+		return nil, err
+	}
+
+	if m.MaxBatchSize <= 0 || m.MaxBatchSize > maxRecordsPerBatch {
+		m.MaxBatchSize = defaultMaxBatchSize
+	}
+	if m.ServiceUnavailableRetries < 0 {
+		m.ServiceUnavailableRetries = defaultServiceUnavailableRetries
+	}
+	if m.RecordRetryLimit <= 0 {
+		m.RecordRetryLimit = defaultRecordRetryLimit
+	}
+
+	return m, nil
+}
+
+// sleepContext sleeps for d or returns early if ctx is cancelled.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}

--- a/bindings/aws/firehose/firehose_test.go
+++ b/bindings/aws/firehose/firehose_test.go
@@ -1,0 +1,543 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package firehose
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/firehose"
+	"github.com/aws/aws-sdk-go-v2/service/firehose/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/bindings"
+	contribMetadata "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
+)
+
+// ---------------------------------------------------------------------------
+// Mock clients
+// ---------------------------------------------------------------------------
+
+// mockGoodClient: all records succeed.
+type mockGoodClient struct {
+	putCount    atomic.Int64
+	batchCalls  atomic.Int64
+	singleCalls atomic.Int64
+}
+
+func (m *mockGoodClient) PutRecord(_ context.Context, _ *firehose.PutRecordInput, _ ...func(*firehose.Options)) (*firehose.PutRecordOutput, error) {
+	m.singleCalls.Add(1)
+	return &firehose.PutRecordOutput{RecordId: aws.String("r-1")}, nil
+}
+
+func (m *mockGoodClient) PutRecordBatch(_ context.Context, in *firehose.PutRecordBatchInput, _ ...func(*firehose.Options)) (*firehose.PutRecordBatchOutput, error) {
+	m.batchCalls.Add(1)
+	n := int64(len(in.Records))
+	m.putCount.Add(n)
+
+	responses := make([]types.PutRecordBatchResponseEntry, len(in.Records))
+	for i := range in.Records {
+		responses[i] = types.PutRecordBatchResponseEntry{
+			RecordId: aws.String(fmt.Sprintf("r-%d", i)),
+		}
+	}
+	return &firehose.PutRecordBatchOutput{
+		FailedPutCount:   aws.Int32(0),
+		RequestResponses: responses,
+	}, nil
+}
+
+// mockBadClient: every other record fails (odd indices).
+type mockBadClient struct {
+	putCount atomic.Int64
+}
+
+func (m *mockBadClient) PutRecord(_ context.Context, _ *firehose.PutRecordInput, _ ...func(*firehose.Options)) (*firehose.PutRecordOutput, error) {
+	return nil, errors.New("use batch")
+}
+
+func (m *mockBadClient) PutRecordBatch(_ context.Context, in *firehose.PutRecordBatchInput, _ ...func(*firehose.Options)) (*firehose.PutRecordBatchOutput, error) {
+	var failed int32
+	responses := make([]types.PutRecordBatchResponseEntry, len(in.Records))
+	for i := range in.Records {
+		if i%2 == 0 {
+			responses[i] = types.PutRecordBatchResponseEntry{
+				RecordId: aws.String(fmt.Sprintf("r-%d", i)),
+			}
+			m.putCount.Add(1)
+		} else {
+			failed++
+			responses[i] = types.PutRecordBatchResponseEntry{
+				ErrorCode:    aws.String("ServiceUnavailableException"),
+				ErrorMessage: aws.String("Error"),
+			}
+		}
+	}
+	return &firehose.PutRecordBatchOutput{
+		FailedPutCount:   aws.Int32(failed),
+		RequestResponses: responses,
+	}, nil
+}
+
+// mockReallyBadClient: every record fails, every time.
+type mockReallyBadClient struct{}
+
+func (m *mockReallyBadClient) PutRecord(_ context.Context, _ *firehose.PutRecordInput, _ ...func(*firehose.Options)) (*firehose.PutRecordOutput, error) {
+	return nil, errors.New("always fails")
+}
+
+func (m *mockReallyBadClient) PutRecordBatch(_ context.Context, in *firehose.PutRecordBatchInput, _ ...func(*firehose.Options)) (*firehose.PutRecordBatchOutput, error) {
+	responses := make([]types.PutRecordBatchResponseEntry, len(in.Records))
+	for i := range in.Records {
+		responses[i] = types.PutRecordBatchResponseEntry{
+			ErrorCode:    aws.String("InternalFailure"),
+			ErrorMessage: aws.String("Error"),
+		}
+	}
+	return &firehose.PutRecordBatchOutput{
+		FailedPutCount:   aws.Int32(int32(len(in.Records))), //nolint:gosec // test data: record count never exceeds int32
+		RequestResponses: responses,
+	}, nil
+}
+
+// mockExceptionClient: always returns a transport-level error.
+type mockExceptionClient struct {
+	attempts atomic.Int64
+}
+
+func (m *mockExceptionClient) PutRecord(_ context.Context, _ *firehose.PutRecordInput, _ ...func(*firehose.Options)) (*firehose.PutRecordOutput, error) {
+	m.attempts.Add(1)
+	return nil, errors.New("connection refused")
+}
+
+func (m *mockExceptionClient) PutRecordBatch(_ context.Context, _ *firehose.PutRecordBatchInput, _ ...func(*firehose.Options)) (*firehose.PutRecordBatchOutput, error) {
+	m.attempts.Add(1)
+	return nil, errors.New("connection refused")
+}
+
+// capturingClient wraps another client and captures the delivery stream name.
+type capturingClient struct {
+	inner         firehoseClient
+	captureStream *string
+}
+
+func (c *capturingClient) PutRecord(ctx context.Context, in *firehose.PutRecordInput, opts ...func(*firehose.Options)) (*firehose.PutRecordOutput, error) {
+	*c.captureStream = aws.ToString(in.DeliveryStreamName)
+	return c.inner.PutRecord(ctx, in, opts...)
+}
+
+func (c *capturingClient) PutRecordBatch(ctx context.Context, in *firehose.PutRecordBatchInput, opts ...func(*firehose.Options)) (*firehose.PutRecordBatchOutput, error) {
+	*c.captureStream = aws.ToString(in.DeliveryStreamName)
+	return c.inner.PutRecordBatch(ctx, in, opts...)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newTestBinding(client firehoseClient) *AWSFirehose {
+	return &AWSFirehose{
+		client: client,
+		metadata: &firehoseMetadata{
+			DeliveryStreamName:        "test-stream",
+			MaxBatchSize:              500,
+			ServiceUnavailableRetries: 10,
+			ServiceUnavailableTimeout: 0,
+			RecordRetryLimit:          100,
+		},
+		logger: logger.NewLogger("test"),
+	}
+}
+
+func makeRecordPayloads(n int) []map[string]string {
+	records := make([]map[string]string, n)
+	for i := range records {
+		records[i] = map[string]string{"Data": fmt.Sprintf("record-%d\n", i)}
+	}
+	return records
+}
+
+func marshalRecords(records []map[string]string) []byte {
+	b, _ := json.Marshal(records)
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// Tests: batchRecords
+// ---------------------------------------------------------------------------
+
+func TestBatchRecords_Empty(t *testing.T) {
+	batches := batchRecords(nil, 500)
+	assert.Nil(t, batches)
+}
+
+func TestBatchRecords_ExactlyMaxSize(t *testing.T) {
+	records := make([]types.Record, 500)
+	batches := batchRecords(records, 500)
+	require.Len(t, batches, 1)
+	assert.Len(t, batches[0], 500)
+}
+
+func TestBatchRecords_LessThanMaxSize(t *testing.T) {
+	records := make([]types.Record, 499)
+	batches := batchRecords(records, 500)
+	require.Len(t, batches, 1)
+	assert.Len(t, batches[0], 499)
+}
+
+func TestBatchRecords_MultipleWithRemainder(t *testing.T) {
+	records := make([]types.Record, 1010)
+	for i := range records {
+		records[i] = types.Record{Data: []byte(strconv.Itoa(i))}
+	}
+	batches := batchRecords(records, 500)
+	require.Len(t, batches, 3)
+	assert.Len(t, batches[0], 500)
+	assert.Len(t, batches[1], 500)
+	assert.Len(t, batches[2], 10)
+	assert.Equal(t, []byte("0"), batches[0][0].Data)
+	assert.Equal(t, []byte("500"), batches[1][0].Data)
+	assert.Equal(t, []byte("1000"), batches[2][0].Data)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: getRecordsToRetry
+// ---------------------------------------------------------------------------
+
+func TestGetRecordsToRetry_NoFailures(t *testing.T) {
+	records := []types.Record{{Data: []byte("a")}, {Data: []byte("b")}, {Data: []byte("c")}}
+	output := &firehose.PutRecordBatchOutput{
+		FailedPutCount: aws.Int32(0),
+		RequestResponses: []types.PutRecordBatchResponseEntry{
+			{RecordId: aws.String("0")},
+			{RecordId: aws.String("1")},
+			{RecordId: aws.String("2")},
+		},
+	}
+	retry := getRecordsToRetry(output, records)
+	assert.Empty(t, retry)
+}
+
+func TestGetRecordsToRetry_SomeFailures(t *testing.T) {
+	records := []types.Record{{Data: []byte("a")}, {Data: []byte("b")}, {Data: []byte("c")}}
+	output := &firehose.PutRecordBatchOutput{
+		FailedPutCount: aws.Int32(2),
+		RequestResponses: []types.PutRecordBatchResponseEntry{
+			{ErrorCode: aws.String("1"), ErrorMessage: aws.String("")},
+			{RecordId: aws.String("3")},
+			{ErrorCode: aws.String("2"), ErrorMessage: aws.String("")},
+		},
+	}
+	retry := getRecordsToRetry(output, records)
+	require.Len(t, retry, 2)
+	assert.Equal(t, []byte("a"), retry[0].Data)
+	assert.Equal(t, []byte("c"), retry[1].Data)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: PutRecord (create operation)
+// ---------------------------------------------------------------------------
+
+func TestPutRecord_Success(t *testing.T) {
+	mock := &mockGoodClient{}
+	b := newTestBinding(mock)
+
+	resp, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: bindings.CreateOperation,
+		Data:      []byte(`{"key":"value"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "r-1", resp.Metadata["recordId"])
+	assert.Equal(t, int64(1), mock.singleCalls.Load())
+}
+
+func TestPutRecord_EmptyData(t *testing.T) {
+	b := newTestBinding(&mockGoodClient{})
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: bindings.CreateOperation,
+		Data:      nil,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty data")
+}
+
+func TestPutRecord_ServiceRetry(t *testing.T) {
+	mock := &mockExceptionClient{}
+	b := newTestBinding(mock)
+	b.metadata.ServiceUnavailableRetries = 2
+	b.metadata.ServiceUnavailableTimeout = 0
+
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: bindings.CreateOperation,
+		Data:      []byte("test"),
+	})
+	require.Error(t, err)
+	assert.Equal(t, int64(3), mock.attempts.Load())
+	assert.Contains(t, err.Error(), "failed after 2 retries")
+}
+
+func TestPutRecord_PerRequestStreamOverride(t *testing.T) {
+	var captured string
+	mock := &mockGoodClient{}
+	b := newTestBinding(mock)
+	b.client = &capturingClient{
+		inner:         mock,
+		captureStream: &captured,
+	}
+
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: bindings.CreateOperation,
+		Data:      []byte("test"),
+		Metadata:  map[string]string{"deliveryStreamName": "override-stream"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "override-stream", captured)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: PutRecordBatch (batch operation)
+// ---------------------------------------------------------------------------
+
+func TestBatchInvoke_AllSuccess(t *testing.T) {
+	mock := &mockGoodClient{}
+	b := newTestBinding(mock)
+
+	records := makeRecordPayloads(1025)
+	resp, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: OperationBatch,
+		Data:      marshalRecords(records),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "1025", resp.Metadata["recordCount"])
+	assert.Equal(t, int64(3), mock.batchCalls.Load())
+	assert.Equal(t, int64(1025), mock.putCount.Load())
+}
+
+func TestBatchInvoke_PartialFailure_RetriesExhausted(t *testing.T) {
+	mock := &mockBadClient{}
+	b := newTestBinding(mock)
+	b.metadata.RecordRetryLimit = 3
+
+	records := makeRecordPayloads(1025)
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: OperationBatch,
+		Data:      marshalRecords(records),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "record retry limit")
+}
+
+func TestBatchInvoke_AllFail_RetriesExhausted(t *testing.T) {
+	mock := &mockReallyBadClient{}
+	b := newTestBinding(mock)
+	b.metadata.RecordRetryLimit = 5
+
+	records := makeRecordPayloads(10)
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: OperationBatch,
+		Data:      marshalRecords(records),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "record retry limit")
+}
+
+func TestBatchInvoke_ServiceException(t *testing.T) {
+	mock := &mockExceptionClient{}
+	b := newTestBinding(mock)
+	b.metadata.ServiceUnavailableRetries = 2
+	b.metadata.ServiceUnavailableTimeout = 0
+
+	records := makeRecordPayloads(3)
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: OperationBatch,
+		Data:      marshalRecords(records),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after 2 retries")
+}
+
+func TestBatchInvoke_Empty(t *testing.T) {
+	mock := &mockGoodClient{}
+	b := newTestBinding(mock)
+
+	resp, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: OperationBatch,
+		Data:      []byte("[]"),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, int64(0), mock.batchCalls.Load())
+}
+
+func TestBatchInvoke_InvalidJSON(t *testing.T) {
+	b := newTestBinding(&mockGoodClient{})
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: OperationBatch,
+		Data:      []byte("not json"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON array")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: unmarshalBatchRecords
+// ---------------------------------------------------------------------------
+
+func TestUnmarshalBatchRecords_DataObjectFormat(t *testing.T) {
+	input := `[{"Data": "line1\n"}, {"Data": "line2\n"}]`
+	records, err := unmarshalBatchRecords([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, []byte("line1\n"), records[0].Data)
+	assert.Equal(t, []byte("line2\n"), records[1].Data)
+}
+
+func TestUnmarshalBatchRecords_RawFormat(t *testing.T) {
+	input := `[42, "hello", {"nested": true}]`
+	records, err := unmarshalBatchRecords([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+	assert.Equal(t, []byte("42"), records[0].Data)
+	assert.Equal(t, []byte(`"hello"`), records[1].Data)
+	assert.Equal(t, []byte(`{"nested": true}`), records[2].Data)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Operations
+// ---------------------------------------------------------------------------
+
+func TestOperations(t *testing.T) {
+	b := newTestBinding(&mockGoodClient{})
+	ops := b.Operations()
+	assert.Contains(t, ops, bindings.CreateOperation)
+	assert.Contains(t, ops, OperationBatch)
+}
+
+func TestUnsupportedOperation(t *testing.T) {
+	b := newTestBinding(&mockGoodClient{})
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: "delete",
+		Data:      []byte("x"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported operation")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Metadata parsing
+// ---------------------------------------------------------------------------
+
+func TestParseMetadata_Defaults(t *testing.T) {
+	b := &AWSFirehose{logger: logger.NewLogger("test")}
+	m, err := b.parseMetadata(bindings.Metadata{
+		Base: contribMetadata.Base{
+			Properties: map[string]string{
+				"deliveryStreamName": "my-stream",
+				"region":             "us-east-1",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-stream", m.DeliveryStreamName)
+	assert.Equal(t, "us-east-1", m.Region)
+	assert.Equal(t, 500, m.MaxBatchSize)
+	assert.Equal(t, 10, m.ServiceUnavailableRetries)
+	assert.Equal(t, 60*time.Second, m.ServiceUnavailableTimeout)
+	assert.Equal(t, 100, m.RecordRetryLimit)
+}
+
+func TestParseMetadata_CustomValues(t *testing.T) {
+	b := &AWSFirehose{logger: logger.NewLogger("test")}
+	m, err := b.parseMetadata(bindings.Metadata{
+		Base: contribMetadata.Base{
+			Properties: map[string]string{
+				"deliveryStreamName":        "custom-stream",
+				"region":                    "eu-west-1",
+				"maxBatchSize":              "250",
+				"serviceUnavailableRetries": "5",
+				"serviceUnavailableTimeout": "30s",
+				"recordRetryLimit":          "50",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 250, m.MaxBatchSize)
+	assert.Equal(t, 5, m.ServiceUnavailableRetries)
+	assert.Equal(t, 30*time.Second, m.ServiceUnavailableTimeout)
+	assert.Equal(t, 50, m.RecordRetryLimit)
+}
+
+func TestParseMetadata_InvalidBatchSize_ClampedToDefault(t *testing.T) {
+	b := &AWSFirehose{logger: logger.NewLogger("test")}
+	m, err := b.parseMetadata(bindings.Metadata{
+		Base: contribMetadata.Base{
+			Properties: map[string]string{
+				"deliveryStreamName": "s",
+				"maxBatchSize":       "9999",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 500, m.MaxBatchSize)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: context cancellation during retry
+// ---------------------------------------------------------------------------
+
+func TestPutRecord_ContextCancelled(t *testing.T) {
+	mock := &mockExceptionClient{}
+	b := newTestBinding(mock)
+	b.metadata.ServiceUnavailableTimeout = 5 * time.Second
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := b.Invoke(ctx, &bindings.InvokeRequest{
+		Operation: bindings.CreateOperation,
+		Data:      []byte("test"),
+	})
+	require.Error(t, err)
+}
+
+func TestMissingDeliveryStream(t *testing.T) {
+	b := newTestBinding(&mockGoodClient{})
+	b.metadata.DeliveryStreamName = ""
+
+	_, err := b.Invoke(t.Context(), &bindings.InvokeRequest{
+		Operation: bindings.CreateOperation,
+		Data:      []byte("test"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deliveryStreamName is required")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GetComponentMetadata
+// ---------------------------------------------------------------------------
+
+func TestGetComponentMetadata(t *testing.T) {
+	b := &AWSFirehose{logger: logger.NewLogger("test")}
+	md := b.GetComponentMetadata()
+	assert.NotNil(t, md)
+}

--- a/bindings/aws/firehose/metadata.yaml
+++ b/bindings/aws/firehose/metadata.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=../../../component-metadata-schema.json
+schemaVersion: v1
+type: bindings
+name: aws.firehose
+version: v1
+status: alpha
+title: "AWS Kinesis Data Firehose"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-bindings/firehose/
+binding:
+  output: true
+  operations:
+    - name: create
+      description: "Send a single record to a Firehose delivery stream via PutRecord"
+    - name: batch
+      description: "Send multiple records to a Firehose delivery stream via PutRecordBatch with automatic batching and retry"
+capabilities: []
+builtinAuthenticationProfiles:
+  - name: "aws"
+metadata:
+  - name: deliveryStreamName
+    required: true
+    description: |
+      The Firehose delivery stream name. Can be overridden per-request via invoke metadata.
+    example: '"my-delivery-stream"'
+    type: string
+  - name: endpoint
+    required: false
+    description: |
+      AWS endpoint for the component to use, to connect to Firehose-compatible
+      services or emulators. Do not use this when running against production AWS.
+    example: '"http://localhost:4566"'
+    type: string
+  - name: maxBatchSize
+    required: false
+    description: |
+      Maximum number of records per PutRecordBatch call. AWS hard limit is 500.
+    example: '"500"'
+    default: '"500"'
+    type: number
+  - name: serviceUnavailableRetries
+    required: false
+    description: |
+      Number of retry attempts when the Firehose service returns a transient error.
+    example: '"10"'
+    default: '"10"'
+    type: number
+  - name: serviceUnavailableTimeout
+    required: false
+    description: |
+      Wait duration between service-level retries.
+    example: '"60s"'
+    default: '"60s"'
+    type: string
+  - name: recordRetryLimit
+    required: false
+    description: |
+      Maximum number of rounds that failed records from PutRecordBatch are re-batched and retried.
+    example: '"100"'
+    default: '"100"'
+    type: number

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/apache/pulsar-client-go v0.18.0
 	github.com/apache/rocketmq-client-go/v2 v2.1.2-0.20230412142645-25003f6f083d
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.1-0.20241125194140-078c08b8574a
-	github.com/aws/aws-sdk-go-v2 v1.41.1
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.9
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.3
@@ -47,6 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.4
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.24.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.4
+	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.15
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.42.10
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.8
@@ -56,7 +57,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.60.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
-	github.com/aws/smithy-go v1.24.0
+	github.com/aws/smithy-go v1.25.1
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/camunda/zeebe/clients/go/v8 v8.5.25
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -203,8 +204,8 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.9.0/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
-github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
-github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4/go.mod h1:IOAPF6oT9KCsceNTvvYMNHy0+kMF8akOjeDvPENWxp4=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
@@ -283,10 +283,10 @@ github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.3.10 h1:z6fAXB4HSuYjrE/P8RU3NdC
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.3.10/go.mod h1:PoPjOi7j+/DtKIGC58HRfcdWKBPYYXwdKnRG+po+hzo=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.4 h1:X2X1hn9CQk9G8Nis/xBs3YWJaNJCpQYpxcGWpl5Kgg4=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.4/go.mod h1:Vg7AqclrUJtnnahELZ8ZFWMDHoUHvEwArxrE7rpri58=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 h1:xOLELNKGp2vsiteLsvLPwxC+mYmO6OZ8PYgiuPJzF8U=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17/go.mod h1:5M5CI3D12dNOtH3/mk6minaRwI2/37ifCURZISxA/IQ=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 h1:WWLqlh79iO48yLkj1v3ISRNiv+3KdQoZ6JWyfcsyQik=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17/go.mod h1:EhG22vHRrvF8oXSTYStZhJc1aUgKtnJe+aOiFEV90cM=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.2.4/go.mod h1:ZcBrrI3zBKlhGFNYWvju0I3TR93I7YIgAfy82Fh4lcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
@@ -299,6 +299,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.4 h1:Rv6o9v2AfdEIKoAa7pQpJ5c
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.4/go.mod h1:mWB0GE1bqcVSvpW7OtFA0sKuHk52+IqtnsYU2jUfYAs=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.6 h1:QHaS/SHXfyNycuu4GiWb+AfW5T3bput6X5E3Ai/Q31M=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.6/go.mod h1:He/RikglWUczbkV+fkdpcV/3GdL/rTRNVy7VaUiezMo=
+github.com/aws/aws-sdk-go-v2/service/firehose v1.42.15 h1:1iP6od4yr0pV2rUo9LXg9rKJa10za+mmbBPu2lv+VPk=
+github.com/aws/aws-sdk-go-v2/service/firehose v1.42.15/go.mod h1:8atLs+8lOWcDaxiD+suvyvt63IuwLbT8zlU6Ti9qZiY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4/go.mod h1:HQ4qwNZh32C3CBeO6iJLQlgtMzqeG17ziAA/3KDJFow=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 h1:Z5EiPIzXKewUQK0QTMkutjiaPVeVYXX7KIqhXu/0fXs=
@@ -338,8 +340,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/pJ1jOWYlFDJTjRQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
-github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
-github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20211222152315-953b66f67407 h1:p8Ubi4GEgfRc1xFn/WtGNkVG8RXxGHOsKiwGptufIo8=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20211222152315-953b66f67407/go.mod h1:0Qr1uMHFmHsIYMcG4T7BJ9yrJtWadhOmpABCX69dwuc=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=


### PR DESCRIPTION
# PR: Add AWS Kinesis Data Firehose output binding

## Description

This PR adds a new output binding for **AWS Kinesis Data Firehose** (`aws.firehose`), enabling Dapr applications to send records to Firehose delivery streams using the standard bindings API.

### What this does

- **`create` operation** — Sends a single record via `PutRecord`
- **`batch` operation** — Sends multiple records via `PutRecordBatch` with automatic batching (max 500 records per call) and record-level retry for partial failures

### Key features

| Feature | Detail |
|---|---|
| AWS SDK v2 | Uses `aws-sdk-go-v2/service/firehose` — consistent with recent SDK v2 upgrades across components-contrib |
| Built-in AWS auth | Uses `common/aws` auth provider (static credentials, IAM roles, IRSA, X.509) via `builtinAuthenticationProfiles: aws` |
| Automatic batching | Records exceeding `maxBatchSize` (default 500, AWS hard limit) are split into sub-batches automatically |
| Record-level retry | Failed records from `PutRecordBatch` responses are collected and re-sent up to `recordRetryLimit` rounds |
| Service-level retry | Transient AWS service errors trigger up to `serviceUnavailableRetries` retries with configurable backoff |
| Per-request stream override | Invoke metadata key `deliveryStreamName` overrides the component-level default |
| Custom endpoint | Supports `endpoint` for LocalStack / testing |

### Files

```
bindings/aws/firehose/
├── firehose.go         # Binding implementation
├── firehose_test.go    # Unit tests (mock clients, batching, retry, metadata parsing)
└── metadata.yaml       # Component metadata schema
```

### Component metadata

| Field | Required | Default | Description |
|---|---|---|---|
| `deliveryStreamName` | Yes | — | Firehose delivery stream name |
| `endpoint` | No | — | Custom AWS endpoint (for LocalStack) |
| `maxBatchSize` | No | `500` | Max records per PutRecordBatch call |
| `serviceUnavailableRetries` | No | `10` | Service-level retry count |
| `serviceUnavailableTimeout` | No | `60s` | Wait between service retries |
| `recordRetryLimit` | No | `100` | Max rounds of record-level retry |

Plus standard AWS auth fields via `builtinAuthenticationProfiles: aws`.

### Example component YAML

```yaml
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: firehose
spec:
  type: bindings.aws.firehose
  version: v1
  metadata:
    - name: deliveryStreamName
      value: "my-delivery-stream"
    - name: region
      value: "us-east-1"
    - name: accessKey
      value: "AKIAIOSFODNN7EXAMPLE"
    - name: secretKey
      value: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
```

### Usage examples

**Single record (create):**
```bash
curl -X POST http://localhost:3500/v1.0/bindings/firehose \
  -H "Content-Type: application/json" \
  -d '{
    "operation": "create",
    "data": "{\"tvid\":\"abc123\",\"app_name\":\"myapp\"}\n"
  }'
```

**Batch records:**
```bash
curl -X POST http://localhost:3500/v1.0/bindings/firehose \
  -H "Content-Type: application/json" \
  -d '{
    "operation": "batch",
    "data": [
      {"Data": "{\"tvid\":\"rec1\"}\n"},
      {"Data": "{\"tvid\":\"rec2\"}\n"}
    ]
  }'
```

**Per-request stream override:**
```bash
curl -X POST http://localhost:3500/v1.0/bindings/firehose \
  -H "Content-Type: application/json" \
  -d '{
    "operation": "create",
    "data": "{\"tvid\":\"abc123\"}\n",
    "metadata": {
      "deliveryStreamName": "another-stream"
    }
  }'
```

### Testing

All tests use mock AWS clients — no AWS credentials required:

```bash
cd bindings/aws/firehose
go test -v ./...
```

### Related

- Follows the same patterns as `bindings/aws/kinesis`, `bindings/aws/sns`, `bindings/aws/sqs`
- Uses AWS SDK v2 consistent with recent migration (#4231, #4169, #4170)
- **Companion PR**: [dapr/dapr#XXXX](https://github.com/dapr/dapr/pull/XXXX) — registers `aws.firehose` in the Dapr runtime (will be submitted after this PR is merged)

### Checklist

- [x] Uses `common/aws` auth provider (not raw SDK credential setup)
- [x] `GetComponentMetadata()` implemented for documentation tooling
- [x] `metadata.yaml` with `builtinAuthenticationProfiles: aws`
- [x] Unit tests with mock clients
- [x] `Close()` implemented (no-op — SDK client needs no cleanup)
- [x] Apache 2.0 license headers

---
Closes https://github.com/dapr/components-contrib/issues/4368