### PR TITLE
feat(kafka): add support for OIDC Workload Identity authentication

### DIFF
--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -193,6 +193,58 @@ authenticationProfiles:
         description: |
           The JWT key ID (kid) to use for the client assertion.
         example: '"1234567890"'
+  - title: "OIDC Workload Identity Authentication"
+    description: |
+      Authenticate using a projected Kubernetes service account token (e.g., Azure Workload Identity).
+      The component reads a short-lived token from the pod filesystem and exchanges it with the
+      identity provider for an access token using the client_assertion grant.
+      When running on AKS with the Azure Workload Identity webhook, clientID, tokenEndpoint,
+      and tokenFilePath are automatically resolved from injected environment variables.
+    metadata:
+      - name: authType
+        type: string
+        required: true
+        description: |
+          Authentication type.
+          This must be set to "oidc_workload_identity" for this authentication profile.
+        example: '"oidc_workload_identity"'
+        allowedValues:
+          - "oidc_workload_identity"
+      - name: oidcTokenEndpoint
+        type: string
+        required: false
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+          If not set, automatically derived from AZURE_AUTHORITY_HOST and AZURE_TENANT_ID environment variables.
+        example: '"https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"'
+      - name: oidcClientID
+        description: |
+          The OAuth2 client ID (application ID) registered in the identity provider.
+          If not set, automatically read from the AZURE_CLIENT_ID environment variable.
+        example: '"my-client-id"'
+        type: string
+        required: false
+      - name: oidcTokenFilePath
+        type: string
+        required: false
+        description: |
+          Path to the projected service account token file.
+          If not set, read from AZURE_FEDERATED_TOKEN_FILE environment variable,
+          or defaults to /var/run/secrets/azure/tokens/azure-identity-token.
+        example: '"/var/run/secrets/azure/tokens/azure-identity-token"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          If not set, defaults to "api://<clientID>/.default".
+        example: '"api://my-client-id/.default"'
+      - name: oidcExtensions
+        description: |
+          String containing a JSON-encoded dictionary of OAuth2/OIDC extensions to request with the access token.
+        example: |
+          {"cluster":"kafka","poolid":"kafkapool"}
+        type: string
   - title: "SASL Authentication"
     description: |
       Authenticate using SASL.

--- a/common/component/kafka/auth.go
+++ b/common/component/kafka/auth.go
@@ -105,3 +105,20 @@ func updateOidcPrivateKeyJWTAuthInfo(config *sarama.Config, metadata *KafkaMetad
 
 	return nil
 }
+
+func updateOidcWorkloadIdentityAuthInfo(config *sarama.Config, metadata *KafkaMetadata) error {
+	tokenProvider := metadata.getOAuthTokenSourceWorkloadIdentity()
+
+	if metadata.TLSCaCert != "" {
+		err := tokenProvider.addCa(metadata.TLSCaCert)
+		if err != nil {
+			return fmt.Errorf("kafka: error setting oauth client trusted CA: %w", err)
+		}
+	}
+
+	config.Net.SASL.Enable = true
+	config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
+	config.Net.SASL.TokenProvider = tokenProvider
+
+	return nil
+}

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -191,6 +191,12 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 		if err != nil {
 			return err
 		}
+	case oidcWorkloadIdentityAuthType:
+		k.logger.Info("Configuring SASL OAuth2/OIDC authentication with workload identity")
+		err = updateOidcWorkloadIdentityAuthInfo(config, meta)
+		if err != nil {
+			return err
+		}
 	case passwordAuthType:
 		k.logger.Info("Configuring SASL Password authentication")
 		k.saslUsername = meta.SaslUsername

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -44,6 +44,7 @@ const (
 	passwordAuthType                         = "password"
 	oidcAuthType                             = "oidc"
 	oidcPrivateKeyJWTAuthType                = "oidc_private_key_jwt"
+	oidcWorkloadIdentityAuthType             = "oidc_workload_identity"
 	mtlsAuthType                             = "mtls"
 	awsIAMAuthType                           = "awsiam"
 	noAuthType                               = "none"
@@ -88,6 +89,7 @@ type KafkaMetadata struct {
 	OidcResource            string              `mapstructure:"oidcResource"`
 	OidcAudience            string              `mapstructure:"oidcAudience"`
 	OidcKid                 string              `mapstructure:"oidcKid"`
+	OidcTokenFilePath       string              `mapstructure:"oidcTokenFilePath"`
 	internalOidcScopes      []string            `mapstructure:"-"`
 	TLSDisable              bool                `mapstructure:"disableTls"`
 	TLSSkipVerify           bool                `mapstructure:"skipVerify"`
@@ -284,6 +286,17 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 			}
 		}
 		k.logger.Debug("Configuring SASL token authentication via OIDC with private_key_jwt.")
+	case oidcWorkloadIdentityAuthType:
+		if m.OidcScopes != "" {
+			m.internalOidcScopes = strings.Split(m.OidcScopes, ",")
+		}
+		if m.OidcExtensions != "" {
+			err = json.Unmarshal([]byte(m.OidcExtensions), &m.internalOidcExtensions)
+			if err != nil || len(m.internalOidcExtensions) < 1 {
+				return nil, errors.New("kafka error: improper OIDC Extensions format for authType 'oidc_workload_identity'")
+			}
+		}
+		k.logger.Debug("Configuring SASL token authentication via OIDC with workload identity.")
 	case mtlsAuthType:
 		if m.TLSClientCert != "" {
 			if !isValidPEM(m.TLSClientCert) {

--- a/common/component/kafka/sasl_oauthbearer_workload_identity.go
+++ b/common/component/kafka/sasl_oauthbearer_workload_identity.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	ctx "context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/dapr/kit/crypto/pem"
+
+	"github.com/IBM/sarama"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// Default path where Azure Workload Identity projects the SA token.
+	defaultAzureFederatedTokenFile = "/var/run/secrets/azure/tokens/azure-identity-token"
+
+	// Environment variable names injected by the Azure Workload Identity webhook.
+	envAzureClientID            = "AZURE_CLIENT_ID"
+	envAzureTenantID            = "AZURE_TENANT_ID"
+	envAzureFederatedTokenFile  = "AZURE_FEDERATED_TOKEN_FILE"
+	envAzureAuthorityHost       = "AZURE_AUTHORITY_HOST"
+)
+
+// OAuthTokenSourceWorkloadIdentity implements sarama.AccessTokenProvider using
+// Azure Workload Identity (or similar projected SA token) for SASL/OAUTHBEARER.
+//
+// It reads a short-lived service account token from the filesystem,
+// then exchanges it with the IdP (e.g., Entra ID) for an access token
+// using the client_credentials grant with a client_assertion.
+type OAuthTokenSourceWorkloadIdentity struct {
+	CachedToken   oauth2.Token
+	Extensions    map[string]string
+	TokenEndpoint string
+	ClientID      string
+	TokenFilePath string
+	Scopes        []string
+	httpClient    *http.Client
+	trustedCas    []*x509.Certificate
+	skipCaVerify  bool
+}
+
+func (m KafkaMetadata) getOAuthTokenSourceWorkloadIdentity() *OAuthTokenSourceWorkloadIdentity {
+	tokenEndpoint := m.OidcTokenEndpoint
+	clientID := m.OidcClientID
+	tokenFilePath := m.OidcTokenFilePath
+	scopes := m.internalOidcScopes
+
+	// Fall back to Azure Workload Identity environment variables.
+	if clientID == "" {
+		clientID = os.Getenv(envAzureClientID)
+	}
+	if tokenFilePath == "" {
+		tokenFilePath = os.Getenv(envAzureFederatedTokenFile)
+	}
+	if tokenFilePath == "" {
+		tokenFilePath = defaultAzureFederatedTokenFile
+	}
+	if tokenEndpoint == "" {
+		authorityHost := os.Getenv(envAzureAuthorityHost)
+		tenantID := os.Getenv(envAzureTenantID)
+		if authorityHost != "" && tenantID != "" {
+			tokenEndpoint = strings.TrimRight(authorityHost, "/") + "/" + tenantID + "/oauth2/v2.0/token"
+		}
+	}
+
+	// Default scope: api://<clientID>/.default (Azure convention).
+	if len(scopes) == 0 && clientID != "" {
+		scopes = []string{"api://" + clientID + "/.default"}
+	}
+
+	return &OAuthTokenSourceWorkloadIdentity{
+		TokenEndpoint: tokenEndpoint,
+		ClientID:      clientID,
+		TokenFilePath: tokenFilePath,
+		Scopes:        scopes,
+		Extensions:    m.internalOidcExtensions,
+		skipCaVerify:  m.TLSSkipVerify,
+	}
+}
+
+func (ts *OAuthTokenSourceWorkloadIdentity) addCa(caPem string) error {
+	pemBytes := []byte(caPem)
+
+	caCerts, err := pem.DecodePEMCertificates(pemBytes)
+	if err != nil {
+		return fmt.Errorf("error parsing PEM certificate: %w", err)
+	}
+	if len(caCerts) > 1 {
+		return fmt.Errorf("expected 1 certificate, got %d", len(caCerts))
+	}
+
+	if ts.trustedCas == nil {
+		ts.trustedCas = make([]*x509.Certificate, 0)
+	}
+	ts.trustedCas = append(ts.trustedCas, caCerts[0])
+
+	return nil
+}
+
+func (ts *OAuthTokenSourceWorkloadIdentity) configureClient() {
+	if ts.httpClient != nil {
+		return
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: ts.skipCaVerify, //nolint:gosec
+	}
+
+	if ts.trustedCas != nil {
+		caPool, err := x509.SystemCertPool()
+		if err != nil {
+			caPool = x509.NewCertPool()
+		}
+
+		for _, c := range ts.trustedCas {
+			caPool.AddCert(c)
+		}
+		tlsConfig.RootCAs = caPool
+	}
+
+	ts.httpClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// Token implements sarama.AccessTokenProvider. It reads the projected SA token
+// from the file system and exchanges it with the IdP for an access token.
+func (ts *OAuthTokenSourceWorkloadIdentity) Token() (*sarama.AccessToken, error) {
+	if ts.CachedToken.Valid() {
+		return ts.asSaramaToken(), nil
+	}
+
+	if ts.TokenEndpoint == "" || ts.ClientID == "" {
+		return nil, errors.New("kafka: oidc_workload_identity not fully configured: tokenEndpoint and clientID are required")
+	}
+
+	if ts.TokenFilePath == "" {
+		return nil, errors.New("kafka: oidc_workload_identity: token file path is empty")
+	}
+
+	// Read the projected service account token (re-read each time since it rotates).
+	assertionBytes, err := os.ReadFile(ts.TokenFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("kafka: failed to read federated token file %q: %w", ts.TokenFilePath, err)
+	}
+	assertion := strings.TrimSpace(string(assertionBytes))
+	if assertion == "" {
+		return nil, fmt.Errorf("kafka: federated token file %q is empty", ts.TokenFilePath)
+	}
+
+	// Exchange the SA token for an access token.
+	urlValues := &url.Values{}
+	urlValues.Set("grant_type", "client_credentials")
+	urlValues.Set("client_id", ts.ClientID)
+	urlValues.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	urlValues.Set("client_assertion", assertion)
+	if len(ts.Scopes) > 0 {
+		urlValues.Set("scope", strings.Join(ts.Scopes, " "))
+	}
+
+	timeoutCtx, cancel := ctx.WithTimeout(ctx.TODO(), 30*time.Second)
+	defer cancel()
+
+	ts.configureClient()
+	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodPost, ts.TokenEndpoint, strings.NewReader(urlValues.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("kafka: failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := ts.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("kafka: token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("kafka: token endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("kafka: failed to decode token response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return nil, errors.New("kafka: no access_token in token response")
+	}
+
+	ts.CachedToken = oauth2.Token{
+		AccessToken: tr.AccessToken,
+		Expiry:      time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second),
+	}
+
+	return ts.asSaramaToken(), nil
+}
+
+func (ts *OAuthTokenSourceWorkloadIdentity) asSaramaToken() *sarama.AccessToken {
+	return &sarama.AccessToken{Token: ts.CachedToken.AccessToken, Extensions: ts.Extensions}
+}

--- a/common/component/kafka/sasl_oauthbearer_workload_identity_test.go
+++ b/common/component/kafka/sasl_oauthbearer_workload_identity_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkloadIdentityTokenSource(t *testing.T) {
+	t.Run("successful token exchange", func(t *testing.T) {
+		// Set up a mock token endpoint.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.NoError(t, r.ParseForm())
+
+			require.Equal(t, "client_credentials", r.FormValue("grant_type"))
+			require.Equal(t, "test-client-id", r.FormValue("client_id"))
+			require.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", r.FormValue("client_assertion_type"))
+			require.Equal(t, "fake-sa-token", r.FormValue("client_assertion"))
+			require.Equal(t, "api://test-client-id/.default", r.FormValue("scope"))
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "exchanged-access-token",
+				"expires_in":   3600,
+			})
+		}))
+		defer server.Close()
+
+		// Write a fake SA token file.
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("fake-sa-token"), 0o600))
+
+		ts := &OAuthTokenSourceWorkloadIdentity{
+			TokenEndpoint: server.URL,
+			ClientID:      "test-client-id",
+			TokenFilePath: tokenFile,
+			Scopes:        []string{"api://test-client-id/.default"},
+		}
+
+		token, err := ts.Token()
+		require.NoError(t, err)
+		require.Equal(t, "exchanged-access-token", token.Token)
+	})
+
+	t.Run("caches token on subsequent calls", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "cached-token",
+				"expires_in":   3600,
+			})
+		}))
+		defer server.Close()
+
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("sa-token"), 0o600))
+
+		ts := &OAuthTokenSourceWorkloadIdentity{
+			TokenEndpoint: server.URL,
+			ClientID:      "test-client",
+			TokenFilePath: tokenFile,
+			Scopes:        []string{"api://test/.default"},
+		}
+
+		token1, err := ts.Token()
+		require.NoError(t, err)
+		require.Equal(t, "cached-token", token1.Token)
+
+		token2, err := ts.Token()
+		require.NoError(t, err)
+		require.Equal(t, "cached-token", token2.Token)
+
+		require.Equal(t, 1, callCount, "token endpoint should only be called once")
+	})
+
+	t.Run("error when token file does not exist", func(t *testing.T) {
+		ts := &OAuthTokenSourceWorkloadIdentity{
+			TokenEndpoint: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+			ClientID:      "test-client",
+			TokenFilePath: "/nonexistent/path/token",
+		}
+
+		_, err := ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read federated token file")
+	})
+
+	t.Run("error when token file is empty", func(t *testing.T) {
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte(""), 0o600))
+
+		ts := &OAuthTokenSourceWorkloadIdentity{
+			TokenEndpoint: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+			ClientID:      "test-client",
+			TokenFilePath: tokenFile,
+		}
+
+		_, err := ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
+	})
+
+	t.Run("error when not configured", func(t *testing.T) {
+		ts := &OAuthTokenSourceWorkloadIdentity{}
+
+		_, err := ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not fully configured")
+	})
+
+	t.Run("error on non-200 response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("sa-token"), 0o600))
+
+		ts := &OAuthTokenSourceWorkloadIdentity{
+			TokenEndpoint: server.URL,
+			ClientID:      "test-client",
+			TokenFilePath: tokenFile,
+		}
+
+		_, err := ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "HTTP 401")
+	})
+
+	t.Run("passes extensions to sarama token", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "token-with-ext",
+				"expires_in":   3600,
+			})
+		}))
+		defer server.Close()
+
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("sa-token"), 0o600))
+
+		ts := &OAuthTokenSourceWorkloadIdentity{
+			TokenEndpoint: server.URL,
+			ClientID:      "test-client",
+			TokenFilePath: tokenFile,
+			Extensions: map[string]string{
+				"Identity Pool Id": "pool-ABC",
+				"Logical Cluster":  "lkc-123",
+			},
+		}
+
+		token, err := ts.Token()
+		require.NoError(t, err)
+		require.Equal(t, "token-with-ext", token.Token)
+		require.Equal(t, "pool-ABC", token.Extensions["Identity Pool Id"])
+		require.Equal(t, "lkc-123", token.Extensions["Logical Cluster"])
+	})
+}
+
+func TestWorkloadIdentityMetadataDefaults(t *testing.T) {
+	t.Run("uses explicit metadata values", func(t *testing.T) {
+		meta := KafkaMetadata{
+			OidcTokenEndpoint: "https://custom-endpoint/token",
+			OidcClientID:      "explicit-client",
+			OidcTokenFilePath: "/custom/path/token",
+			internalOidcScopes: []string{"custom-scope"},
+		}
+
+		ts := meta.getOAuthTokenSourceWorkloadIdentity()
+		require.Equal(t, "https://custom-endpoint/token", ts.TokenEndpoint)
+		require.Equal(t, "explicit-client", ts.ClientID)
+		require.Equal(t, "/custom/path/token", ts.TokenFilePath)
+		require.Equal(t, []string{"custom-scope"}, ts.Scopes)
+	})
+
+	t.Run("falls back to env vars", func(t *testing.T) {
+		t.Setenv("AZURE_CLIENT_ID", "env-client-id")
+		t.Setenv("AZURE_TENANT_ID", "env-tenant-id")
+		t.Setenv("AZURE_AUTHORITY_HOST", "https://login.microsoftonline.com/")
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+
+		meta := KafkaMetadata{}
+
+		ts := meta.getOAuthTokenSourceWorkloadIdentity()
+		require.Equal(t, "env-client-id", ts.ClientID)
+		require.Equal(t, "https://login.microsoftonline.com/env-tenant-id/oauth2/v2.0/token", ts.TokenEndpoint)
+		require.Equal(t, "/var/run/secrets/azure/tokens/azure-identity-token", ts.TokenFilePath)
+		require.Equal(t, []string{"api://env-client-id/.default"}, ts.Scopes)
+	})
+
+	t.Run("auto-derives scope from clientID", func(t *testing.T) {
+		meta := KafkaMetadata{
+			OidcClientID: "my-app-id",
+		}
+
+		ts := meta.getOAuthTokenSourceWorkloadIdentity()
+		require.Equal(t, []string{"api://my-app-id/.default"}, ts.Scopes)
+	})
+
+	t.Run("defaults token file path when env not set", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+
+		meta := KafkaMetadata{}
+
+		ts := meta.getOAuthTokenSourceWorkloadIdentity()
+		require.Equal(t, defaultAzureFederatedTokenFile, ts.TokenFilePath)
+	})
+}

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -187,6 +187,58 @@ authenticationProfiles:
         description: |
           The JWT key ID (kid) to use for the client assertion.
         example: '"1234567890"'
+  - title: "OIDC Workload Identity Authentication"
+    description: |
+      Authenticate using a projected Kubernetes service account token (e.g., Azure Workload Identity).
+      The component reads a short-lived token from the pod filesystem and exchanges it with the
+      identity provider for an access token using the client_assertion grant.
+      When running on AKS with the Azure Workload Identity webhook, clientID, tokenEndpoint,
+      and tokenFilePath are automatically resolved from injected environment variables.
+    metadata:
+      - name: authType
+        type: string
+        required: true
+        description: |
+          Authentication type.
+          This must be set to "oidc_workload_identity" for this authentication profile.
+        example: '"oidc_workload_identity"'
+        allowedValues:
+          - "oidc_workload_identity"
+      - name: oidcTokenEndpoint
+        type: string
+        required: false
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+          If not set, automatically derived from AZURE_AUTHORITY_HOST and AZURE_TENANT_ID environment variables.
+        example: '"https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"'
+      - name: oidcClientID
+        description: |
+          The OAuth2 client ID (application ID) registered in the identity provider.
+          If not set, automatically read from the AZURE_CLIENT_ID environment variable.
+        example: '"my-client-id"'
+        type: string
+        required: false
+      - name: oidcTokenFilePath
+        type: string
+        required: false
+        description: |
+          Path to the projected service account token file.
+          If not set, read from AZURE_FEDERATED_TOKEN_FILE environment variable,
+          or defaults to /var/run/secrets/azure/tokens/azure-identity-token.
+        example: '"/var/run/secrets/azure/tokens/azure-identity-token"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          If not set, defaults to "api://<clientID>/.default".
+        example: '"api://my-client-id/.default"'
+      - name: oidcExtensions
+        description: |
+          String containing a JSON-encoded dictionary of OAuth2/OIDC extensions to request with the access token.
+        example: |
+          {"cluster":"kafka","poolid":"kafkapool"}
+        type: string
   - title: "SASL Authentication"
     description: |
       Authenticate using SASL.


### PR DESCRIPTION
# Description

Add a new `oidc_workload_identity` auth type to the Kafka component (pubsub and bindings) that enables SASL/OAUTHBEARER authentication using Azure Workload Identity — without any secrets or certificates.

The component reads a projected service account token from the pod filesystem (injected by the Azure Workload Identity webhook) and exchanges it with Entra ID for an access token using the `client_assertion` grant. All configuration (clientID, tokenEndpoint, tokenFilePath, scopes) is auto-resolved from injected environment variables (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_HOST`, `AZURE_FEDERATED_TOKEN_FILE`).

Works with both Azure App Registrations and User-Assigned Managed Identities with Federated Identity Credentials. Also supports Confluent Cloud `oidcExtensions` for Identity Pool routing.

### Changes

- `common/component/kafka/sasl_oauthbearer_workload_identity.go` — new token source that reads projected SA token and performs token exchange
- `common/component/kafka/sasl_oauthbearer_workload_identity_test.go` — unit tests
- `common/component/kafka/metadata.go` — new `oidc_workload_identity` auth type constant, `OidcTokenFilePath` metadata field, validation case
- `common/component/kafka/auth.go` — new `updateOidcWorkloadIdentityAuthInfo` function
- `common/component/kafka/kafka.go` — new case in auth type switch
- `pubsub/kafka/metadata.yaml` — documentation for new auth profile
- `bindings/kafka/metadata.yaml` — documentation for new auth profile

## Issue reference

Closes #4375

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [ ] Created the dapr/docs PR: _TODO — will open once implementation PR is reviewed_

## Note

This implementation was vibe coded with AI assistance. All code compiles cleanly, and passes unit tests.
