### PR TITLE
fix(tests): scope influxdb to v2.9

### DIFF
--- a/.github/infrastructure/docker-compose-influxdb.yml
+++ b/.github/infrastructure/docker-compose-influxdb.yml
@@ -1,7 +1,6 @@
-version: '2'
 services:
   standalone:
-    image: influxdb:latest
+    image: influxdb:2
     container_name: influxdb
     ports:
       - "8086:8086"
@@ -12,3 +11,22 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=dapr-conf-test
       - DOCKER_INFLUXDB_INIT_BUCKET=dapr-conf-test-bucket
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_TOKEN}
+      # The default config.yml shipped in the influxdb:2.9 image is missing the
+      # http-bind-address / tls-cert / tls-key keys, which causes the entrypoint's
+      # dasel pipeline to fail with `map key not found` and prevents the container
+      # from starting. Point INFLUXD_CONFIG_PATH at the inline config below, which
+      # defines those keys explicitly. The path is outside /etc/influxdb2 so the
+      # entrypoint's chown of that volume does not fail on the read-only file.
+      - INFLUXD_CONFIG_PATH=/etc/influxdb2-fix/config.yml
+    configs:
+      - source: influxdb_config
+        target: /etc/influxdb2-fix/config.yml
+
+configs:
+  influxdb_config:
+    content: |
+      bolt-path: /var/lib/influxdb2/influxd.bolt
+      engine-path: /var/lib/influxdb2/engine
+      http-bind-address: :8086
+      tls-cert: ""
+      tls-key: ""


### PR DESCRIPTION
# Description

Explicitly scope influxdb (binding) to v2.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
