### PR TITLE
feat(pulsar): support listenerName metadata for advertisedListeners

### DIFF
--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -23,6 +23,7 @@ import (
 
 type pulsarMetadata struct {
 	Host                             string                    `mapstructure:"host"`
+	ListenerName                     string                    `mapstructure:"listenerName"`
 	ConsumerID                       string                    `mapstructure:"consumerID"`
 	EnableTLS                        bool                      `mapstructure:"enableTLS"`
 	DisableBatching                  bool                      `mapstructure:"disableBatching"`

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -68,6 +68,16 @@ metadata:
     description: "Address of the Pulsar broker."
     example: |
       "localhost:6650", "http://pulsar-pj54qwwdpz4b-pulsar.ap-sg.public.pulsar.com:8080"
+  - name: listenerName
+    type: string
+    description: |
+      Configures the listener name the Pulsar client sends to the broker for connection redirects.
+      Brokers with `advertisedListeners` resolve the redirect target using the matching named listener,
+      enabling cross-network topologies (multi-cluster, internal/external endpoints) without a Pulsar proxy.
+    example: '"external"'
+    url:
+      title: "Pulsar Multiple Advertised Listeners"
+      url: "https://pulsar.apache.org/docs/3.0.x/concepts-multiple-advertised-listeners/"
   - name: consumerID
     type: string
     description: "Used to set the subscription name or consumer ID."

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -300,6 +300,7 @@ func (p *Pulsar) Init(ctx context.Context, metadata pubsub.Metadata) error {
 		OperationTimeout:           30 * time.Second,
 		ConnectionTimeout:          30 * time.Second,
 		TLSAllowInsecureConnection: !m.EnableTLS,
+		ListenerName:               m.ListenerName,
 	}
 
 	switch {

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -2771,9 +2771,6 @@ func TestInitPropagatesListenerName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var capturedOpts pulsar.ClientOptions
 			p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
-			t.Cleanup(func() {
-				p.newClientFn = pulsar.NewClient
-			})
 			p.newClientFn = func(opts pulsar.ClientOptions) (pulsar.Client, error) {
 				capturedOpts = opts
 				return nil, nil

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -82,6 +82,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 		"batchingMaxSize":         "100",
 		"batchingMaxMessages":     "200",
 		"maxConcurrentHandlers":   "333",
+		"listenerName":            "external",
 	}
 	meta, err := parsePulsarMetadata(m)
 
@@ -95,6 +96,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 	assert.Equal(t, uint(100), meta.BatchingMaxSize)
 	assert.Equal(t, uint(200), meta.BatchingMaxMessages)
 	assert.Equal(t, uint(333), meta.MaxConcurrentHandlers)
+	assert.Equal(t, "external", meta.ListenerName)
 	assert.Empty(t, meta.internalTopicSchemas)
 	assert.Equal(t, "shared", meta.SubscriptionType)
 }
@@ -2753,4 +2755,38 @@ func TestFeaturesDeclaresBulkSubscribeImmediate(t *testing.T) {
 		pubsub.FeatureBulkSubscribeImmediate.IsPresent(p.Features()),
 		"Pulsar must declare FeatureBulkSubscribeImmediate so the default bulk subscriber flushes per-message instead of buffering until MaxMessagesCount/MaxAwaitDurationMs",
 	)
+}
+
+func TestInitPropagatesListenerName(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{name: "set", value: "external", expected: "external"},
+		{name: "omitted", value: "", expected: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedOpts pulsar.ClientOptions
+			p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
+			t.Cleanup(func() {
+				p.newClientFn = pulsar.NewClient
+			})
+			p.newClientFn = func(opts pulsar.ClientOptions) (pulsar.Client, error) {
+				capturedOpts = opts
+				return nil, nil
+			}
+
+			md := pubsub.Metadata{}
+			md.Properties = map[string]string{"host": "localhost:6650"}
+			if tc.value != "" {
+				md.Properties["listenerName"] = tc.value
+			}
+
+			require.NoError(t, p.Init(t.Context(), md))
+			assert.Equal(t, tc.expected, capturedOpts.ListenerName)
+		})
+	}
 }


### PR DESCRIPTION
## Description

Expose `pulsar-client-go` `ClientOptions.ListenerName` as a new `listenerName` metadata field on the Pulsar pubsub component. When configured, the value is passed verbatim to the underlying client, so brokers configured with `advertisedListeners` resolve redirect targets using the matching named listener.

This unblocks cross-network and multi-cluster Pulsar topologies for Dapr (sidecars in a separate VPC/cluster from the broker) without forcing a Pulsar proxy as a workaround. The Java, Python, Go, and C++ Pulsar clients already expose this option.

When the field is unset (the default), behavior is unchanged.

Example:

```yaml
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: pulsar-pubsub
spec:
  type: pubsub.pulsar
  version: v1
  metadata:
    - name: host
      value: "pulsar://broker.example.com:6650"
    - name: listenerName
      value: "external"
```

## Issue reference

Closes #4383

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests pass with `-race`
- [x] Extended `metadata.yaml` (new optional `listenerName` field)
- [ ] Extended the documentation (docs PR to follow in `dapr/docs`)

## Release Note

```
RELEASE NOTE: **ADD** listenerName metadata field to Pulsar pubsub component for advertisedListeners support.
```