### PR TITLE
add retriable/terminal error classification for pubsub publish

### DIFF
--- a/pubsub/aws/snssqs/snssqs.go
+++ b/pubsub/aws/snssqs/snssqs.go
@@ -859,7 +859,7 @@ func (s *snsSqs) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 
 func (s *snsSqs) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if s.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	topicArn, _, err := s.getOrCreateTopic(ctx, req.Topic)
@@ -882,7 +882,7 @@ func (s *snsSqs) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 		wrappedErr := fmt.Errorf("error publishing to topic: %s with topic ARN %s: %w", req.Topic, topicArn, err)
 		s.logger.Error(wrappedErr)
 
-		return wrappedErr
+		return pubsub.NewRetriableError(wrappedErr)
 	}
 
 	return nil

--- a/pubsub/aws/snssqs/snssqs_test.go
+++ b/pubsub/aws/snssqs/snssqs_test.go
@@ -14,10 +14,13 @@ limitations under the License.
 package snssqs
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
@@ -27,6 +30,21 @@ import (
 type testUnitFixture struct {
 	metadata pubsub.Metadata
 	name     string
+}
+
+// Publishing while the component is closed is a lifecycle error and must be
+// classified as terminal (codes.FailedPrecondition) so the runtime stops retrying.
+func Test_Publish_closed_isTerminal(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	s := &snsSqs{logger: logger.NewLogger("test")}
+	s.closed.Store(true)
+
+	err := s.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+	r.Error(err)
+	st, ok := status.FromError(err)
+	r.True(ok)
+	r.Equal(codes.FailedPrecondition, st.Code())
 }
 
 func Test_parseTopicArn(t *testing.T) {

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -54,7 +54,7 @@ func (aeh *AzureEventHubs) Features() []pubsub.Feature {
 // Publish sends a message to Azure Event Hubs.
 func (aeh *AzureEventHubs) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if req.Topic == "" {
-		return errors.New("parameter 'topic' is required")
+		return pubsub.NewTerminalError(errors.New("parameter 'topic' is required"))
 	}
 
 	// Get the partition key and create the batch of messages
@@ -70,7 +70,7 @@ func (aeh *AzureEventHubs) Publish(ctx context.Context, req *pubsub.PublishReque
 	}
 
 	// Publish the message
-	return aeh.AzureEventHubs.Publish(ctx, req.Topic, messages, batchOpts)
+	return pubsub.NewRetriableError(aeh.AzureEventHubs.Publish(ctx, req.Topic, messages, batchOpts))
 }
 
 // BulkPublish sends data to Azure Event Hubs in bulk.
@@ -79,7 +79,7 @@ func (aeh *AzureEventHubs) BulkPublish(ctx context.Context, req *pubsub.BulkPubl
 
 	if req.Topic == "" {
 		err = errors.New("parameter 'topic' is required")
-		return pubsub.NewBulkPublishResponse(req.Entries, err), err
+		return pubsub.NewBulkPublishResponse(req.Entries, err), pubsub.NewTerminalError(err)
 	}
 
 	// Batch options
@@ -104,7 +104,7 @@ func (aeh *AzureEventHubs) BulkPublish(ctx context.Context, req *pubsub.BulkPubl
 		if val := entry.Metadata["partitionKey"]; val != "" {
 			if batchOpts.PartitionKey != nil && *batchOpts.PartitionKey != val {
 				err = errors.New("cannot send messages to different partitions")
-				return pubsub.NewBulkPublishResponse(req.Entries, err), err
+				return pubsub.NewBulkPublishResponse(req.Entries, err), pubsub.NewTerminalError(err)
 			}
 			batchOpts.PartitionKey = &val
 		}
@@ -115,7 +115,7 @@ func (aeh *AzureEventHubs) BulkPublish(ctx context.Context, req *pubsub.BulkPubl
 	if err != nil {
 		// Partial success is not supported by Azure Event Hubs.
 		// If an error occurs, all events are considered failed.
-		return pubsub.NewBulkPublishResponse(req.Entries, err), err
+		return pubsub.NewBulkPublishResponse(req.Entries, err), pubsub.NewRetriableError(err)
 	}
 
 	return pubsub.BulkPublishResponse{}, nil

--- a/pubsub/azure/eventhubs/eventhubs.go
+++ b/pubsub/azure/eventhubs/eventhubs.go
@@ -78,8 +78,8 @@ func (aeh *AzureEventHubs) BulkPublish(ctx context.Context, req *pubsub.BulkPubl
 	var err error
 
 	if req.Topic == "" {
-		err = errors.New("parameter 'topic' is required")
-		return pubsub.NewBulkPublishResponse(req.Entries, err), pubsub.NewTerminalError(err)
+		err = pubsub.NewTerminalError(errors.New("parameter 'topic' is required"))
+		return pubsub.NewBulkPublishResponse(req.Entries, err), err
 	}
 
 	// Batch options
@@ -103,8 +103,8 @@ func (aeh *AzureEventHubs) BulkPublish(ctx context.Context, req *pubsub.BulkPubl
 		}
 		if val := entry.Metadata["partitionKey"]; val != "" {
 			if batchOpts.PartitionKey != nil && *batchOpts.PartitionKey != val {
-				err = errors.New("cannot send messages to different partitions")
-				return pubsub.NewBulkPublishResponse(req.Entries, err), pubsub.NewTerminalError(err)
+				err = pubsub.NewTerminalError(errors.New("cannot send messages to different partitions"))
+				return pubsub.NewBulkPublishResponse(req.Entries, err), err
 			}
 			batchOpts.PartitionKey = &val
 		}
@@ -115,7 +115,8 @@ func (aeh *AzureEventHubs) BulkPublish(ctx context.Context, req *pubsub.BulkPubl
 	if err != nil {
 		// Partial success is not supported by Azure Event Hubs.
 		// If an error occurs, all events are considered failed.
-		return pubsub.NewBulkPublishResponse(req.Entries, err), pubsub.NewRetriableError(err)
+		err = pubsub.NewRetriableError(err)
+		return pubsub.NewBulkPublishResponse(req.Entries, err), err
 	}
 
 	return pubsub.BulkPublishResponse{}, nil

--- a/pubsub/azure/eventhubs/eventhubs_test.go
+++ b/pubsub/azure/eventhubs/eventhubs_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventhubs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/components-contrib/pubsub"
+)
+
+// A missing topic is a request-validation error and must be classified as
+// terminal (codes.FailedPrecondition) so the runtime stops retrying. This path
+// returns before any broker interaction, so no live Event Hubs is required.
+func TestPublishMissingTopicIsTerminal(t *testing.T) {
+	aeh := &AzureEventHubs{}
+
+	err := aeh.Publish(context.Background(), &pubsub.PublishRequest{Topic: ""})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestBulkPublishMissingTopicIsTerminal(t *testing.T) {
+	aeh := &AzureEventHubs{}
+
+	_, err := aeh.BulkPublish(context.Background(), &pubsub.BulkPublishRequest{Topic: ""})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}

--- a/pubsub/azure/servicebus/queues/servicebus.go
+++ b/pubsub/azure/servicebus/queues/servicebus.go
@@ -67,18 +67,19 @@ func (a *azureServiceBus) Init(_ context.Context, metadata pubsub.Metadata) (err
 
 func (a *azureServiceBus) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if a.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
-	return a.client.PublishPubSub(ctx, req, a.client.EnsureQueue, a.logger)
+	return pubsub.NewRetriableError(a.client.PublishPubSub(ctx, req, a.client.EnsureQueue, a.logger))
 }
 
 func (a *azureServiceBus) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
 	if a.closed.Load() {
-		return pubsub.BulkPublishResponse{}, errors.New("component is closed")
+		return pubsub.BulkPublishResponse{}, pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
-	return a.client.PublishPubSubBulk(ctx, req, a.client.EnsureQueue, a.logger)
+	res, err := a.client.PublishPubSubBulk(ctx, req, a.client.EnsureQueue, a.logger)
+	return res, pubsub.NewRetriableError(err)
 }
 
 func (a *azureServiceBus) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {

--- a/pubsub/azure/servicebus/queues/servicebus_test.go
+++ b/pubsub/azure/servicebus/queues/servicebus_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/kit/logger"
+)
+
+// Publishing while the component is closed is a lifecycle error and must be
+// classified as terminal (codes.FailedPrecondition) so the runtime stops retrying.
+func TestPublishClosedIsTerminal(t *testing.T) {
+	a := &azureServiceBus{logger: logger.NewLogger("test")}
+	a.closed.Store(true)
+
+	err := a.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	_, berr := a.BulkPublish(context.Background(), &pubsub.BulkPublishRequest{Topic: "topic"})
+	require.Error(t, berr)
+	bst, bok := status.FromError(berr)
+	require.True(t, bok)
+	require.Equal(t, codes.FailedPrecondition, bst.Code())
+}

--- a/pubsub/azure/servicebus/topics/servicebus.go
+++ b/pubsub/azure/servicebus/topics/servicebus.go
@@ -68,16 +68,17 @@ func (a *azureServiceBus) Init(_ context.Context, metadata pubsub.Metadata) (err
 
 func (a *azureServiceBus) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if a.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
-	return a.client.PublishPubSub(ctx, req, a.client.EnsureTopic, a.logger)
+	return pubsub.NewRetriableError(a.client.PublishPubSub(ctx, req, a.client.EnsureTopic, a.logger))
 }
 
 func (a *azureServiceBus) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
 	if a.closed.Load() {
-		return pubsub.BulkPublishResponse{}, errors.New("component is closed")
+		return pubsub.BulkPublishResponse{}, pubsub.NewTerminalError(errors.New("component is closed"))
 	}
-	return a.client.PublishPubSubBulk(ctx, req, a.client.EnsureTopic, a.logger)
+	res, err := a.client.PublishPubSubBulk(ctx, req, a.client.EnsureTopic, a.logger)
+	return res, pubsub.NewRetriableError(err)
 }
 
 func (a *azureServiceBus) Subscribe(subscribeCtx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {

--- a/pubsub/azure/servicebus/topics/servicebus_test.go
+++ b/pubsub/azure/servicebus/topics/servicebus_test.go
@@ -26,11 +26,33 @@ import (
 	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	impl "github.com/dapr/components-contrib/common/component/azure/servicebus"
+	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/ptr"
 )
+
+// Publishing while the component is closed is a lifecycle error and must be
+// classified as terminal (codes.FailedPrecondition) so the runtime stops retrying.
+func TestPublishClosedIsTerminal(t *testing.T) {
+	a := &azureServiceBus{logger: logger.NewLogger("test")}
+	a.closed.Store(true)
+
+	err := a.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	_, berr := a.BulkPublish(context.Background(), &pubsub.BulkPublishRequest{Topic: "topic"})
+	require.Error(t, berr)
+	bst, bok := status.FromError(berr)
+	require.True(t, bok)
+	require.Equal(t, codes.FailedPrecondition, bst.Code())
+}
 
 type mockReceiver struct {
 	messages     []*azservicebus.ReceivedMessage

--- a/pubsub/errors.go
+++ b/pubsub/errors.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// CodeError wraps a Publish/BulkPublish error with a gRPC status code so the Dapr
+// runtime's resiliency layer can classify it for retry matching. It implements
+// GRPCStatus() (so status.FromError reads the code) and Unwrap() (so errors.Is/As
+// reach the underlying broker error).
+type CodeError struct {
+	code codes.Code
+	err  error
+}
+
+// Error implements the error interface, returning the wrapped error's message.
+func (e *CodeError) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns the wrapped error so errors.Is/errors.As work through a CodeError.
+func (e *CodeError) Unwrap() error {
+	return e.err
+}
+
+// GRPCStatus returns the gRPC status carrying the classification code. This is what
+// status.FromError (used by the runtime) reads to obtain the code.
+func (e *CodeError) GRPCStatus() *status.Status {
+	return status.New(e.code, e.err.Error())
+}
+
+// Code returns the gRPC status code assigned to this error.
+func (e *CodeError) Code() codes.Code {
+	return e.code
+}
+
+// withCode attaches code to err, unless err already carries a gRPC status —
+// in which case the precise existing code is preserved rather than overridden.
+func withCode(code codes.Code, err error) error {
+	if err == nil {
+		return nil
+	}
+	// err already implements a gRPC status
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	return &CodeError{code: code, err: err}
+}
+
+// NewRetriableError marks a publish error as transient (codes.Unavailable) unless it
+// already carries a gRPC status, in which case that code is preserved. Returns nil if
+// err is nil. With no retry `matching` configured the runtime retries every error
+// regardless of code, so this is behavior-preserving until a user configures `matching`.
+func NewRetriableError(err error) error {
+	return withCode(codes.Unavailable, err)
+}
+
+// NewTerminalError marks a publish error as non-retriable (codes.FailedPrecondition)
+// unless it already carries a gRPC status, in which case that code is preserved. A user
+// can exclude the code from retry `matching` to stop retries. Returns nil if err is nil.
+func NewTerminalError(err error) error {
+	return withCode(codes.FailedPrecondition, err)
+}

--- a/pubsub/errors_test.go
+++ b/pubsub/errors_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewRetriableError(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.NoError(t, NewRetriableError(nil))
+	})
+
+	t.Run("carries codes.Unavailable and is readable via status.FromError", func(t *testing.T) {
+		base := errors.New("broker is down")
+		err := NewRetriableError(base)
+
+		require.Error(t, err)
+		assert.Equal(t, "broker is down", err.Error())
+
+		st, ok := status.FromError(err)
+		require.True(t, ok, "status.FromError must extract the gRPC status")
+		assert.Equal(t, codes.Unavailable, st.Code())
+		assert.Equal(t, "broker is down", st.Message())
+	})
+
+	t.Run("Unwrap preserves the underlying error for errors.Is", func(t *testing.T) {
+		base := errors.New("broker is down")
+		err := NewRetriableError(fmt.Errorf("publish failed: %w", base))
+
+		assert.ErrorIs(t, err, base)
+	})
+}
+
+func TestNewTerminalError(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.NoError(t, NewTerminalError(nil))
+	})
+
+	t.Run("carries codes.FailedPrecondition and is readable via status.FromError", func(t *testing.T) {
+		base := errors.New("invalid topic")
+		err := NewTerminalError(base)
+
+		require.Error(t, err)
+		assert.Equal(t, "invalid topic", err.Error())
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("Unwrap preserves the underlying error for errors.As", func(t *testing.T) {
+		base := &customError{msg: "bad request"}
+		err := NewTerminalError(fmt.Errorf("publish failed: %w", base))
+
+		var target *customError
+		require.ErrorAs(t, err, &target)
+		assert.Equal(t, "bad request", target.msg)
+	})
+}
+
+func TestHelpersPreserveExistingStatus(t *testing.T) {
+	// An error that already carries a gRPC status (as gRPC-native SDKs like GCP return)
+	// must keep its precise code rather than being overridden with the helper's code.
+	t.Run("retriable preserves existing code", func(t *testing.T) {
+		orig := status.Error(codes.PermissionDenied, "denied")
+
+		err := NewRetriableError(orig)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code(), "must not override the existing code with Unavailable")
+	})
+
+	t.Run("terminal preserves existing code", func(t *testing.T) {
+		orig := status.Error(codes.Unavailable, "try later")
+
+		err := NewTerminalError(orig)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code(), "must not override the existing code with FailedPrecondition")
+	})
+
+	t.Run("existing code is found through a wrap", func(t *testing.T) {
+		orig := status.Error(codes.NotFound, "missing")
+
+		err := NewRetriableError(fmt.Errorf("publish failed: %w", orig))
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+}
+
+func TestCodeErrorCode(t *testing.T) {
+	var ce *CodeError
+	require.ErrorAs(t, NewRetriableError(errors.New("x")), &ce)
+	assert.Equal(t, codes.Unavailable, ce.Code())
+
+	require.ErrorAs(t, NewTerminalError(errors.New("y")), &ce)
+	assert.Equal(t, codes.FailedPrecondition, ce.Code())
+}
+
+type customError struct {
+	msg string
+}
+
+func (e *customError) Error() string {
+	return e.msg
+}

--- a/pubsub/gcp/pubsub/pubsub.go
+++ b/pubsub/gcp/pubsub/pubsub.go
@@ -221,7 +221,7 @@ func (g *GCPPubSub) getPubSubClient(ctx context.Context, metadata *metadata) (*g
 // Publish the topic to GCP Pubsub.
 func (g *GCPPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if g.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 	g.lock.RLock()
 	_, topicExists := g.topicCache[req.Topic]
@@ -232,6 +232,8 @@ func (g *GCPPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) err
 	if !g.metadata.DisableEntityManagement && !topicExists {
 		err := g.ensureTopic(ctx, req.Topic)
 		if err != nil {
+			// GCP's client returns gRPC-status errors, so the runtime reads the real
+			// code (e.g. PermissionDenied vs Unavailable) directly - don't override it.
 			return fmt.Errorf("%s could not get valid topic %s: %w", errorMessagePrefix, req.Topic, err)
 		}
 		g.lock.Lock()
@@ -261,6 +263,7 @@ func (g *GCPPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) err
 	}
 	_, err := topic.Publish(ctx, msg).Get(ctx)
 
+	// GCP returns gRPC-status errors - let the runtime read the native code.
 	return err
 }
 

--- a/pubsub/gcp/pubsub/pubsub_test.go
+++ b/pubsub/gcp/pubsub/pubsub_test.go
@@ -14,11 +14,14 @@ limitations under the License.
 package pubsub
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/pubsub"
 )
@@ -26,6 +29,19 @@ import (
 const (
 	invalidNumber = "invalid_number"
 )
+
+// Publishing while the component is closed is a lifecycle error and must be
+// classified as terminal (codes.FailedPrecondition) so the runtime stops retrying.
+func TestPublishClosedIsTerminal(t *testing.T) {
+	g := &GCPPubSub{}
+	g.closed.Store(true)
+
+	err := g.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}
 
 func TestInit(t *testing.T) {
 	t.Run("metadata is correct with explicit creds", func(t *testing.T) {

--- a/pubsub/in-memory/in-memory.go
+++ b/pubsub/in-memory/in-memory.go
@@ -60,7 +60,7 @@ func (a *bus) Init(_ context.Context, metadata pubsub.Metadata) error {
 
 func (a *bus) Publish(_ context.Context, req *pubsub.PublishRequest) error {
 	if a.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	a.bus.Publish(req.Topic, req.Data, req.Metadata)

--- a/pubsub/in-memory/in-memory_test.go
+++ b/pubsub/in-memory/in-memory_test.go
@@ -18,10 +18,28 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 )
+
+// TestPublishAfterCloseIsTerminal verifies that publishing to a closed bus
+// returns a terminal (codes.FailedPrecondition) error.
+func TestPublishAfterCloseIsTerminal(t *testing.T) {
+	bus := New(logger.NewLogger("test"))
+	bus.Init(t.Context(), pubsub.Metadata{})
+	require.NoError(t, bus.Close())
+
+	err := bus.Publish(t.Context(), &pubsub.PublishRequest{Data: []byte("x"), Topic: "demo"})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
 
 func TestNewInMemoryBus(t *testing.T) {
 	bus := New(logger.NewLogger("test"))

--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -114,7 +114,7 @@ func (js *jetstreamPubSub) Features() []pubsub.Feature {
 
 func (js *jetstreamPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if js.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	var opts []nats.PubOpt
@@ -137,8 +137,11 @@ func (js *jetstreamPubSub) Publish(ctx context.Context, req *pubsub.PublishReque
 
 	js.l.Debugf("Publishing to topic %v id: %s", req.Topic, msgID)
 	_, err = js.jsc.Publish(req.Topic, req.Data, opts...)
+	if err != nil {
+		return pubsub.NewRetriableError(err)
+	}
 
-	return err
+	return nil
 }
 
 func (js *jetstreamPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {

--- a/pubsub/jetstream/jetstream_test.go
+++ b/pubsub/jetstream/jetstream_test.go
@@ -22,11 +22,29 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	mdata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 )
+
+// TestJetStream_Publish_ClosedIsTerminal asserts the cheaply-reachable
+// closed-component guard in Publish is classified as terminal
+// (codes.FailedPrecondition) so the runtime can stop retrying it.
+func TestJetStream_Publish_ClosedIsTerminal(t *testing.T) {
+	js := &jetstreamPubSub{
+		l: logger.NewLogger("test"),
+	}
+	js.closed.Store(true)
+
+	err := js.Publish(t.Context(), &pubsub.PublishRequest{Topic: "test", Data: []byte("hi")})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
 
 func setupServerAndStream(t *testing.T) (*server.Server, *nats.Conn) {
 	// Create a new server with JetStream enabled.

--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -115,19 +115,26 @@ func NewKafka(logger logger.Logger) pubsub.PubSub {
 // Publish message to Kafka cluster.
 func (p *PubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if p.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
-	return p.kafka.Publish(ctx, req.Topic, req.Data, req.Metadata)
+	if err := p.kafka.Publish(ctx, req.Topic, req.Data, req.Metadata); err != nil {
+		return pubsub.NewRetriableError(err)
+	}
+	return nil
 }
 
 // BatchPublish messages to Kafka cluster.
 func (p *PubSub) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
 	if p.closed.Load() {
-		return pubsub.BulkPublishResponse{}, errors.New("component is closed")
+		return pubsub.BulkPublishResponse{}, pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
-	return p.kafka.BulkPublish(ctx, req.Topic, req.Entries, req.Metadata)
+	res, err := p.kafka.BulkPublish(ctx, req.Topic, req.Entries, req.Metadata)
+	if err != nil {
+		return res, pubsub.NewRetriableError(err)
+	}
+	return res, nil
 }
 
 func (p *PubSub) Close() (err error) {

--- a/pubsub/kafka/kafka_test.go
+++ b/pubsub/kafka/kafka_test.go
@@ -14,9 +14,41 @@ limitations under the License.
 package kafka
 
 import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/dapr/components-contrib/pubsub"
 )
 
 // Compile-time assertion that PubSub implements the optional
 // PausableSubscriber capability.
 var _ pubsub.PausableSubscriber = (*PubSub)(nil)
+
+// TestPublishWhenClosedIsTerminal verifies that publishing through a closed
+// component returns a terminal (codes.FailedPrecondition) error so the runtime
+// does not retry it.
+func TestPublishWhenClosedIsTerminal(t *testing.T) {
+	p := &PubSub{closeCh: make(chan struct{})}
+	p.closed.Store(true)
+
+	t.Run("Publish", func(t *testing.T) {
+		err := p.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, s.Code())
+	})
+
+	t.Run("BulkPublish", func(t *testing.T) {
+		_, err := p.BulkPublish(context.Background(), &pubsub.BulkPublishRequest{Topic: "topic"})
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, s.Code())
+	})
+}

--- a/pubsub/kubemq/kubemq_events.go
+++ b/pubsub/kubemq/kubemq_events.go
@@ -102,16 +102,16 @@ func (k *kubeMQEvents) setPublishStream() error {
 
 func (k *kubeMQEvents) Publish(req *pubsub.PublishRequest) error {
 	if err := k.init(); err != nil {
-		return err
+		return pubsub.NewRetriableError(err)
 	}
 	if req.Topic == "" {
-		return errors.New("kubemq pub/sub error: topic is required")
+		return pubsub.NewTerminalError(errors.New("kubemq pub/sub error: topic is required"))
 	}
 	metadata := ""
 	if req.Metadata != nil {
 		data, err := json.Marshal(req.Metadata)
 		if err != nil {
-			return fmt.Errorf("kubemq pub/sub error: failed to marshal metadata: %s", err.Error())
+			return pubsub.NewTerminalError(fmt.Errorf("kubemq pub/sub error: failed to marshal metadata: %s", err.Error()))
 		}
 		metadata = string(data)
 	}
@@ -132,7 +132,7 @@ func (k *kubeMQEvents) Publish(req *pubsub.PublishRequest) error {
 	}
 	if err := k.publishFunc(event); err != nil {
 		k.logger.Errorf("kubemq pub/sub error: publishing to %s failed with error: %s", req.Topic, err.Error())
-		return err
+		return pubsub.NewRetriableError(err)
 	}
 	return nil
 }

--- a/pubsub/kubemq/kubemq_events_test.go
+++ b/pubsub/kubemq/kubemq_events_test.go
@@ -163,19 +163,20 @@ func Test_kubeMQEvents_Publish(t *testing.T) {
 	}
 }
 
-func newInitializedEventsClient(client kubemqEventsClient) *kubeMQEvents {
+func newInitializedEventsClient(t *testing.T, client kubemqEventsClient) *kubeMQEvents {
+	t.Helper()
 	k := newkubeMQEvents(logger.NewLogger("kubemq-test"))
 	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
 	k.isInitialized = true
 	k.metadata = &kubemqMetadata{ClientID: "some-client-id"}
 	k.client = client
-	_ = k.setPublishStream()
+	require.NoError(t, k.setPublishStream())
 	return k
 }
 
 func Test_kubeMQEvents_Publish_ErrorClassification(t *testing.T) {
 	t.Run("empty topic is terminal", func(t *testing.T) {
-		k := newInitializedEventsClient(newKubemqEventsMock())
+		k := newInitializedEventsClient(t, newKubemqEventsMock())
 		defer k.Close()
 
 		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: ""})
@@ -188,7 +189,7 @@ func Test_kubeMQEvents_Publish_ErrorClassification(t *testing.T) {
 
 	t.Run("broker publish failure is retriable", func(t *testing.T) {
 		client := newKubemqEventsMock().setPublishError(errors.New("broker boom"))
-		k := newInitializedEventsClient(client)
+		k := newInitializedEventsClient(t, client)
 		defer k.Close()
 
 		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})

--- a/pubsub/kubemq/kubemq_events_test.go
+++ b/pubsub/kubemq/kubemq_events_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubemq
 
 import (
@@ -7,7 +20,10 @@ import (
 	"time"
 
 	"github.com/kubemq-io/kubemq-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
@@ -145,6 +161,43 @@ func Test_kubeMQEvents_Publish(t *testing.T) {
 		_ = k.Features()
 		_ = k.Close()
 	}
+}
+
+func newInitializedEventsClient(client kubemqEventsClient) *kubeMQEvents {
+	k := newkubeMQEvents(logger.NewLogger("kubemq-test"))
+	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
+	k.isInitialized = true
+	k.metadata = &kubemqMetadata{ClientID: "some-client-id"}
+	k.client = client
+	_ = k.setPublishStream()
+	return k
+}
+
+func Test_kubeMQEvents_Publish_ErrorClassification(t *testing.T) {
+	t.Run("empty topic is terminal", func(t *testing.T) {
+		k := newInitializedEventsClient(newKubemqEventsMock())
+		defer k.Close()
+
+		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: ""})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("broker publish failure is retriable", func(t *testing.T) {
+		client := newKubemqEventsMock().setPublishError(errors.New("broker boom"))
+		k := newInitializedEventsClient(client)
+		defer k.Close()
+
+		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+	})
 }
 
 func Test_kubeMQEvents_Subscribe(t *testing.T) {

--- a/pubsub/kubemq/kubemq_eventstore.go
+++ b/pubsub/kubemq/kubemq_eventstore.go
@@ -106,17 +106,17 @@ func (k *kubeMQEventStore) setPublishStream() error {
 
 func (k *kubeMQEventStore) Publish(req *pubsub.PublishRequest) error {
 	if err := k.init(); err != nil {
-		return err
+		return pubsub.NewRetriableError(err)
 	}
 	if req.Topic == "" {
-		return errors.New("kubemq pub/sub error: topic is required")
+		return pubsub.NewTerminalError(errors.New("kubemq pub/sub error: topic is required"))
 	}
 	k.logger.Debugf("kubemq pub/sub: publishing message to %s", req.Topic)
 	metadata := ""
 	if req.Metadata != nil {
 		data, err := json.Marshal(req.Metadata)
 		if err != nil {
-			return fmt.Errorf("kubemq pub/sub error: failed to marshal metadata: %s", err.Error())
+			return pubsub.NewTerminalError(fmt.Errorf("kubemq pub/sub error: failed to marshal metadata: %s", err.Error()))
 		}
 		metadata = string(data)
 	}
@@ -136,15 +136,15 @@ func (k *kubeMQEventStore) Publish(req *pubsub.PublishRequest) error {
 	}
 	if err := k.publishFunc(event); err != nil {
 		k.logger.Errorf("kubemq pub/sub error: publishing to %s failed with error: %s", req.Topic, err.Error())
-		return err
+		return pubsub.NewRetriableError(err)
 	}
 	select {
 	case res := <-k.resultChan:
 		if res != nil && res.Err != nil {
-			return res.Err
+			return pubsub.NewRetriableError(res.Err)
 		}
 	case <-time.After(k.waitForResultTimeout):
-		return errors.New("kubemq pub/sub error: timeout waiting for response")
+		return pubsub.NewRetriableError(errors.New("kubemq pub/sub error: timeout waiting for response"))
 	}
 	return nil
 }

--- a/pubsub/kubemq/kubemq_eventstore_test.go
+++ b/pubsub/kubemq/kubemq_eventstore_test.go
@@ -186,7 +186,8 @@ func Test_kubeMQEventsStore_Publish(t *testing.T) {
 	}
 }
 
-func newInitializedEventsStoreClient(client kubemqEventsStoreClient, resultTimeout time.Duration) *kubeMQEventStore {
+func newInitializedEventsStoreClient(t *testing.T, client kubemqEventsStoreClient, resultTimeout time.Duration) *kubeMQEventStore {
+	t.Helper()
 	k := newKubeMQEventsStore(logger.NewLogger("kubemq-test"))
 	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
 	k.isInitialized = true
@@ -195,13 +196,13 @@ func newInitializedEventsStoreClient(client kubemqEventsStoreClient, resultTimeo
 		k.waitForResultTimeout = resultTimeout
 	}
 	k.client = client
-	_ = k.setPublishStream()
+	require.NoError(t, k.setPublishStream())
 	return k
 }
 
 func Test_kubeMQEventsStore_Publish_ErrorClassification(t *testing.T) {
 	t.Run("empty topic is terminal", func(t *testing.T) {
-		k := newInitializedEventsStoreClient(newKubemqEventsStoreMock(), 0)
+		k := newInitializedEventsStoreClient(t, newKubemqEventsStoreMock(), 0)
 		defer k.Close()
 
 		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: ""})
@@ -214,7 +215,7 @@ func Test_kubeMQEventsStore_Publish_ErrorClassification(t *testing.T) {
 
 	t.Run("broker publish failure is retriable", func(t *testing.T) {
 		client := newKubemqEventsStoreMock().setPublishError(errors.New("broker boom"))
-		k := newInitializedEventsStoreClient(client, 0)
+		k := newInitializedEventsStoreClient(t, client, 0)
 		defer k.Close()
 
 		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})
@@ -227,7 +228,7 @@ func Test_kubeMQEventsStore_Publish_ErrorClassification(t *testing.T) {
 
 	t.Run("broker result error is retriable", func(t *testing.T) {
 		client := newKubemqEventsStoreMock().setResultError(errors.New("broker rejected"))
-		k := newInitializedEventsStoreClient(client, 0)
+		k := newInitializedEventsStoreClient(t, client, 0)
 		defer k.Close()
 
 		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})
@@ -240,7 +241,7 @@ func Test_kubeMQEventsStore_Publish_ErrorClassification(t *testing.T) {
 
 	t.Run("result timeout is retriable", func(t *testing.T) {
 		client := newKubemqEventsStoreMock().setPublishTimeout(3 * time.Second)
-		k := newInitializedEventsStoreClient(client, 1*time.Second)
+		k := newInitializedEventsStoreClient(t, client, 1*time.Second)
 		defer k.Close()
 
 		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})

--- a/pubsub/kubemq/kubemq_eventstore_test.go
+++ b/pubsub/kubemq/kubemq_eventstore_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubemq
 
 import (
@@ -7,7 +20,10 @@ import (
 	"time"
 
 	"github.com/kubemq-io/kubemq-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
@@ -168,6 +184,72 @@ func Test_kubeMQEventsStore_Publish(t *testing.T) {
 		_ = k.Features()
 		_ = k.Close()
 	}
+}
+
+func newInitializedEventsStoreClient(client kubemqEventsStoreClient, resultTimeout time.Duration) *kubeMQEventStore {
+	k := newKubeMQEventsStore(logger.NewLogger("kubemq-test"))
+	k.ctx, k.ctxCancel = context.WithCancel(context.Background())
+	k.isInitialized = true
+	k.metadata = &kubemqMetadata{ClientID: "some-client-id", IsStore: true}
+	if resultTimeout > 0 {
+		k.waitForResultTimeout = resultTimeout
+	}
+	k.client = client
+	_ = k.setPublishStream()
+	return k
+}
+
+func Test_kubeMQEventsStore_Publish_ErrorClassification(t *testing.T) {
+	t.Run("empty topic is terminal", func(t *testing.T) {
+		k := newInitializedEventsStoreClient(newKubemqEventsStoreMock(), 0)
+		defer k.Close()
+
+		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: ""})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("broker publish failure is retriable", func(t *testing.T) {
+		client := newKubemqEventsStoreMock().setPublishError(errors.New("broker boom"))
+		k := newInitializedEventsStoreClient(client, 0)
+		defer k.Close()
+
+		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+	})
+
+	t.Run("broker result error is retriable", func(t *testing.T) {
+		client := newKubemqEventsStoreMock().setResultError(errors.New("broker rejected"))
+		k := newInitializedEventsStoreClient(client, 0)
+		defer k.Close()
+
+		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+	})
+
+	t.Run("result timeout is retriable", func(t *testing.T) {
+		client := newKubemqEventsStoreMock().setPublishTimeout(3 * time.Second)
+		k := newInitializedEventsStoreClient(client, 1*time.Second)
+		defer k.Close()
+
+		err := k.Publish(&pubsub.PublishRequest{Data: []byte("data"), Topic: "some-topic"})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+	})
 }
 
 func Test_kubeMQkubeMQEventsStore_Subscribe(t *testing.T) {

--- a/pubsub/mqtt3/mqtt.go
+++ b/pubsub/mqtt3/mqtt.go
@@ -90,11 +90,11 @@ func (m *mqttPubSub) Init(ctx context.Context, metadata pubsub.Metadata) error {
 // Publish the topic to mqtt pub sub.
 func (m *mqttPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) (err error) {
 	if m.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	if req.Topic == "" {
-		return errors.New("topic name is empty")
+		return pubsub.NewTerminalError(errors.New("topic name is empty"))
 	}
 
 	// Note this can contain PII
@@ -105,7 +105,7 @@ func (m *mqttPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) (e
 	if val, ok := req.Metadata[mqttRetain]; ok && val != "" {
 		retain, err = strconv.ParseBool(val)
 		if err != nil {
-			return fmt.Errorf("mqtt invalid retain %s, %s", val, err)
+			return pubsub.NewTerminalError(fmt.Errorf("mqtt invalid retain %s, %s", val, err))
 		}
 	}
 
@@ -122,7 +122,7 @@ func (m *mqttPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) (e
 		err = ctx.Err()
 	}
 	if err != nil {
-		return fmt.Errorf("failed to publish: %w", err)
+		return pubsub.NewRetriableError(fmt.Errorf("failed to publish: %w", err))
 	}
 
 	return nil

--- a/pubsub/mqtt3/mqtt_test.go
+++ b/pubsub/mqtt3/mqtt_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	mdata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
@@ -711,4 +713,36 @@ func Test_mqttPubSub_Publish(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_mqttPubSub_Publish_terminalErrors asserts that cheaply-reachable
+// validation/lifecycle error paths in Publish are classified as terminal
+// (codes.FailedPrecondition) so the runtime can stop retrying them.
+func Test_mqttPubSub_Publish_terminalErrors(t *testing.T) {
+	t.Run("component closed is terminal", func(t *testing.T) {
+		m := &mqttPubSub{
+			logger:   logger.NewLogger("mqtt-test"),
+			metadata: &mqttMetadata{},
+		}
+		m.closed.Store(true)
+
+		err := m.Publish(t.Context(), &pubsub.PublishRequest{Topic: "test"})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("empty topic is terminal", func(t *testing.T) {
+		m := &mqttPubSub{
+			logger:   logger.NewLogger("mqtt-test"),
+			metadata: &mqttMetadata{},
+		}
+
+		err := m.Publish(t.Context(), &pubsub.PublishRequest{Topic: ""})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
 }

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -367,7 +367,7 @@ func (p *Pulsar) useConsumerEncryption() bool {
 
 func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if p.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	var (
@@ -411,7 +411,7 @@ func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 
 		producer, err = p.client.CreateProducer(opts)
 		if err != nil {
-			return err
+			return pubsub.NewRetriableError(err)
 		}
 
 		p.cache.Add(topic, producer)
@@ -419,11 +419,11 @@ func (p *Pulsar) Publish(ctx context.Context, req *pubsub.PublishRequest) error 
 
 	msg, err = parsePublishMetadata(req, sm)
 	if err != nil {
-		return err
+		return pubsub.NewTerminalError(err)
 	}
 
 	if _, err = producer.Send(ctx, msg); err != nil {
-		return err
+		return pubsub.NewRetriableError(err)
 	}
 
 	return nil

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -28,6 +28,8 @@ import (
 	goavro "github.com/linkedin/goavro/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
@@ -2784,4 +2786,21 @@ func TestInitPropagatesListenerName(t *testing.T) {
 			assert.Equal(t, tc.expected, capturedOpts.ListenerName)
 		})
 	}
+}
+
+// TestPublishErrorClassification verifies that publish errors are wrapped with a gRPC
+// status code so the Dapr runtime's resiliency layer can classify them. The reachable
+// non-broker path here is the closed-component guard, which must be terminal.
+func TestPublishErrorClassification(t *testing.T) {
+	t.Run("publish on a closed component returns a terminal error", func(t *testing.T) {
+		p := &Pulsar{}
+		p.closed.Store(true)
+
+		err := p.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok, "publish error must carry a gRPC status")
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
 }

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -287,7 +287,7 @@ func (r *rabbitMQ) publishSync(ctx context.Context, req *pubsub.PublishRequest) 
 
 func (r *rabbitMQ) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if r.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	r.logger.Debugf("%s publishing message to %s", logMessagePrefix, req.Topic)
@@ -301,7 +301,7 @@ func (r *rabbitMQ) Publish(ctx context.Context, req *pubsub.PublishRequest) erro
 		}
 		if attempt >= publishMaxRetries {
 			r.logger.Errorf("%s publishing failed: %v", logMessagePrefix, err)
-			return err
+			return pubsub.NewRetriableError(err)
 		}
 		if mustReconnect(channel, err) {
 			r.logger.Warnf("%s publisher is reconnecting in %s ...", logMessagePrefix, r.metadata.ReconnectWait.String())

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -24,11 +24,30 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	mdata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 )
+
+// TestPublishWhenClosedIsTerminal verifies that publishing through a closed
+// component returns a terminal (codes.FailedPrecondition) error so the runtime
+// does not retry it.
+func TestPublishWhenClosedIsTerminal(t *testing.T) {
+	r := &rabbitMQ{
+		logger:  logger.NewLogger("test"),
+		closeCh: make(chan struct{}),
+	}
+	r.closed.Store(true)
+
+	err := r.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, s.Code())
+}
 
 func newBroker() *rabbitMQInMemoryBroker {
 	return &rabbitMQInMemoryBroker{

--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -104,7 +104,7 @@ func (r *redisStreams) Init(ctx context.Context, metadata pubsub.Metadata) error
 
 func (r *redisStreams) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if r.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	redisPayload := map[string]interface{}{"data": req.Data}
@@ -112,14 +112,14 @@ func (r *redisStreams) Publish(ctx context.Context, req *pubsub.PublishRequest) 
 	if req.Metadata != nil {
 		serializedMetadata, err := json.Marshal(req.Metadata)
 		if err != nil {
-			return err
+			return pubsub.NewTerminalError(err)
 		}
 		redisPayload["metadata"] = serializedMetadata
 	}
 
 	_, err := r.client.XAdd(ctx, req.Topic, r.clientSettings.MaxLenApprox, r.clientSettings.GetMinID(time.Now()), redisPayload)
 	if err != nil {
-		return fmt.Errorf("redis streams: error from publish: %s", err)
+		return pubsub.NewRetriableError(fmt.Errorf("redis streams: error from publish: %s", err))
 	}
 
 	return nil

--- a/pubsub/redis/redis_test.go
+++ b/pubsub/redis/redis_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	commonredis "github.com/dapr/components-contrib/common/component/redis"
 	mdata "github.com/dapr/components-contrib/metadata"
@@ -30,6 +32,20 @@ import (
 	"github.com/dapr/kit/logger"
 	kitmd "github.com/dapr/kit/metadata"
 )
+
+// TestPublishWhenClosedIsTerminal verifies that publishing through a closed
+// component returns a terminal (codes.FailedPrecondition) error so the runtime
+// does not retry it.
+func TestPublishWhenClosedIsTerminal(t *testing.T) {
+	rs := &redisStreams{closeCh: make(chan struct{})}
+	rs.closed.Store(true)
+
+	err := rs.Publish(context.Background(), &pubsub.PublishRequest{Topic: "topic"})
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, s.Code())
+}
 
 func getFakeProperties() map[string]string {
 	return map[string]string{

--- a/pubsub/rocketmq/rocketmq.go
+++ b/pubsub/rocketmq/rocketmq.go
@@ -344,7 +344,7 @@ func (r *rocketMQ) resetProducer() {
 
 func (r *rocketMQ) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	if r.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	r.logger.Debugf("rocketmq publish topic:%s with data:%v", req.Topic, req.Data)
@@ -363,14 +363,14 @@ func (r *rocketMQ) Publish(ctx context.Context, req *pubsub.PublishRequest) erro
 	}
 	producer, e := r.getProducer()
 	if e != nil {
-		return fmt.Errorf("rocketmq message send fail because producer failed to initialize: %v", e)
+		return pubsub.NewRetriableError(fmt.Errorf("rocketmq message send fail because producer failed to initialize: %v", e))
 	}
 	result, e := producer.SendSync(ctx, msg)
 	if e != nil {
 		r.resetProducer()
 		m := fmt.Sprintf("rocketmq message send fail, topic[%s]: %v", req.Topic, e)
 		r.logger.Error(m)
-		return errors.New(m)
+		return pubsub.NewRetriableError(errors.New(m))
 	}
 	r.logger.Debugf("rocketmq message send result: topic[%s], tag[%s], status[%v]", req.Topic, msg.GetTags(), result.Status)
 	return nil

--- a/pubsub/rocketmq/rocketmq_test.go
+++ b/pubsub/rocketmq/rocketmq_test.go
@@ -18,12 +18,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	mdata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/kit/logger"
 )
+
+// TestRocketMQ_Publish_ClosedIsTerminal asserts the cheaply-reachable
+// closed-component guard in Publish is classified as terminal
+// (codes.FailedPrecondition) so the runtime can stop retrying it.
+func TestRocketMQ_Publish_ClosedIsTerminal(t *testing.T) {
+	r := &rocketMQ{
+		logger: logger.NewLogger("test"),
+	}
+	r.closed.Store(true)
+
+	err := r.Publish(t.Context(), &pubsub.PublishRequest{Topic: "test", Data: []byte("hi")})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
 
 func getTestMetadata() map[string]string {
 	return map[string]string{

--- a/pubsub/solace/amqp/amqp.go
+++ b/pubsub/solace/amqp/amqp.go
@@ -99,13 +99,13 @@ func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) er
 	defer a.publishLock.Unlock()
 
 	if a.closed.Load() {
-		return errors.New("component is closed")
+		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
 	a.publishRetryCount = 0
 
 	if req.Topic == "" {
-		return errors.New("topic name is empty")
+		return pubsub.NewTerminalError(errors.New("topic name is empty"))
 	}
 
 	m := amqp.NewMessage(req.Data)
@@ -151,7 +151,7 @@ func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) er
 		}
 	}
 
-	return err
+	return pubsub.NewRetriableError(err)
 }
 
 func (a *amqpPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, handler pubsub.Handler) error {

--- a/pubsub/solace/amqp/amqp_test.go
+++ b/pubsub/solace/amqp/amqp_test.go
@@ -14,10 +14,14 @@ limitations under the License.
 package amqp
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	mdata "github.com/dapr/components-contrib/metadata"
 
@@ -36,6 +40,33 @@ func getFakeProperties() map[string]string {
 		username:     "default",
 		password:     "default",
 	}
+}
+
+// TestPublishErrorClassification verifies that terminal Publish error paths
+// reachable without a live broker are classified as codes.FailedPrecondition.
+func TestPublishErrorClassification(t *testing.T) {
+	t.Run("closed component is terminal", func(t *testing.T) {
+		a := NewAMQPPubsub(logger.NewLogger("test")).(*amqpPubSub)
+		a.closed.Store(true)
+
+		err := a.Publish(context.Background(), &pubsub.PublishRequest{Topic: "some-topic"})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("empty topic is terminal", func(t *testing.T) {
+		a := NewAMQPPubsub(logger.NewLogger("test")).(*amqpPubSub)
+
+		err := a.Publish(context.Background(), &pubsub.PublishRequest{Topic: ""})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
 }
 
 func TestParseMetadata(t *testing.T) {

--- a/tests/e2e/pubsub/jetstream/go.mod
+++ b/tests/e2e/pubsub/jetstream/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
+	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apimachinery v0.33.0 // indirect

--- a/tests/e2e/pubsub/jetstream/go.sum
+++ b/tests/e2e/pubsub/jetstream/go.sum
@@ -16,6 +16,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -84,6 +86,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -94,6 +98,8 @@ golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
 golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -104,6 +110,10 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 h1:H86B94AW+VfJWDqFeEbBPhEtHzJwJfTbgE2lZa54ZAQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
+google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=
+google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpWvW7U=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=


### PR DESCRIPTION
Pubsub components return plain Go errors from `Publish`/`BulkPublish` (the raw broker SDK error or a `fmt.Errorf` wrap). These carry no status code, so Dapr's resiliency layer cannot distinguish a transient failure (broker unavailable timeout) from a terminal one (invalid topic, component closed) & it retries every publish error up to `maxRetries` and silently ignores any configured retry `matching` (httpStatusCodes / gRPCStatusCodes).
  
This PR adds a shared helper so components can classify their publish errors, which the runtime then reads via `status.FromError`