### PR TITLE
feat(redis): add OIDC private_key_jwt authentication

### DIFF
--- a/bindings/redis/metadata.yaml
+++ b/bindings/redis/metadata.yaml
@@ -153,9 +153,11 @@ authenticationProfiles:
         required: false
         description: |
           Username to pass to the Redis AUTH command together with the access token.
-          Defaults to "default" when using OIDC authentication.
-        example: '"default"'
-        default: '"default"'
+          When omitted, the token is sent using the 1-argument AUTH <token> form
+          (authenticating as the default user), accepted by the widest range of
+          RESP-compatible auth layers. Set a username to use the 2-argument
+          AUTH <username> <token> (ACL) form.
+        example: '"my-user"'
 metadata:
   - name: redisHost
     required: true

--- a/bindings/redis/metadata.yaml
+++ b/bindings/redis/metadata.yaml
@@ -66,6 +66,96 @@ authenticationProfiles:
         url:
           title: "Redis Sentinel authentication documentation"
           url: "https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#configuring-sentinel-instances-with-authentication"
+  - title: "OIDC private_key_jwt"
+    description: |
+      Authenticate using OpenID Connect with the private_key_jwt client authentication
+      method (RFC 7523). An OAuth2 access token is obtained from the identity provider
+      using a signed JWT client assertion and used as the password for the Redis AUTH
+      command. The token is refreshed in the background before it expires.
+    metadata:
+      - name: useOIDC
+        type: bool
+        required: false
+        description: |
+          If set to true, enables OIDC private_key_jwt authentication.
+          Must not be combined with "redisPassword" or "useEntraID".
+        example: '"true"'
+        default: '"false"'
+      - name: oidcTokenEndpoint
+        type: string
+        required: true
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+        example: '"https://identity.example.com/v1/token"'
+      - name: oidcClientID
+        type: string
+        required: true
+        description: |
+          The OAuth2 client ID that has been provisioned in the identity provider.
+        example: '"my-client-id"'
+      - name: oidcClientAssertionCert
+        type: string
+        required: true
+        description: |
+          PEM-encoded X.509 certificate paired with the client assertion signing key.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: oidcClientAssertionKey
+        type: string
+        required: true
+        sensitive: true
+        description: |
+          PEM-encoded RSA private key used to sign the client assertion.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN PRIVATE KEY-----\n...
+      - name: oidcResource
+        type: string
+        required: false
+        description: |
+          Optional OAuth2 resource parameter to include in the token request when
+          required by the identity provider.
+        example: '"URI:RS-12345-API"'
+      - name: oidcAudience
+        type: string
+        required: false
+        description: |
+          Overrides the JWT client assertion audience (aud). Defaults to the token
+          endpoint URL.
+        example: '"https://identity.example.com/realms/local"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          Although not required, this field is recommended.
+        example: '"openid,redis-prod"'
+        default: '"openid"'
+      - name: oidcKid
+        type: string
+        required: false
+        description: |
+          The JWT key ID (kid) header to use for the client assertion, when required by
+          the identity provider (for example, the thumbprint of the client certificate).
+        example: '"1234567890"'
+      - name: oidcCACert
+        type: string
+        required: false
+        description: |
+          PEM-encoded CA certificate used to verify the TLS connection to the token
+          endpoint. This is distinct from the TLS configuration of the Redis
+          connection itself.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username to pass to the Redis AUTH command together with the access token.
+          Defaults to "default" when using OIDC authentication.
+        example: '"default"'
+        default: '"default"'
 metadata:
   - name: redisHost
     required: true

--- a/common/component/redis/oauth2_private_key_jwt.go
+++ b/common/component/redis/oauth2_private_key_jwt.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"golang.org/x/oauth2"
+
+	"github.com/dapr/kit/crypto/pem"
+)
+
+// OAuthTokenSourcePrivateKeyJWT obtains OAuth2 access tokens using the
+// client_credentials grant with the private_key_jwt client authentication
+// method (RFC 7523), where the client authenticates to the token endpoint
+// with a signed JWT assertion instead of a client secret.
+// It is a port of the Kafka component's implementation in
+// common/component/kafka/sasl_oauthbearer_private_key_jwt.go, without the
+// Sarama-specific wrapping.
+type OAuthTokenSourcePrivateKeyJWT struct {
+	TokenEndpoint       oauth2.Endpoint
+	ClientID            string
+	Scopes              []string
+	ClientAssertionCert string
+	ClientAssertionKey  string
+	Resource            string
+	Audience            string
+	Kid                 string
+
+	lock         sync.Mutex
+	cachedToken  oauth2.Token
+	httpClient   *http.Client
+	trustedCas   []*x509.Certificate
+	skipCaVerify bool
+}
+
+type oidcTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
+}
+
+func (ts *OAuthTokenSourcePrivateKeyJWT) addCa(caPem string) error {
+	pemBytes := []byte(caPem)
+
+	caCerts, err := pem.DecodePEMCertificates(pemBytes)
+	if err != nil {
+		return fmt.Errorf("error parsing PEM certificate: %w", err)
+	}
+	if len(caCerts) > 1 {
+		return fmt.Errorf("expected 1 certificate, got %d", len(caCerts))
+	}
+
+	if ts.trustedCas == nil {
+		ts.trustedCas = make([]*x509.Certificate, 0)
+	}
+	ts.trustedCas = append(ts.trustedCas, caCerts[0])
+
+	return nil
+}
+
+func (ts *OAuthTokenSourcePrivateKeyJWT) configureClient() {
+	if ts.httpClient != nil {
+		return
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: ts.skipCaVerify, //nolint:gosec
+	}
+
+	if ts.trustedCas != nil {
+		caPool, err := x509.SystemCertPool()
+		if err != nil {
+			caPool = x509.NewCertPool()
+		}
+
+		for _, c := range ts.trustedCas {
+			caPool.AddCert(c)
+		}
+		tlsConfig.RootCAs = caPool
+	}
+
+	ts.httpClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// Token returns the cached access token if it is still valid, otherwise it
+// fetches a new one from the token endpoint.
+func (ts *OAuthTokenSourcePrivateKeyJWT) Token(ctx context.Context) (*oauth2.Token, error) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	return ts.token(ctx)
+}
+
+// ForceToken discards any cached token and fetches a fresh one. It is used by
+// the refresh routine, which runs before the cached token expires and would
+// otherwise be handed the still-valid cached token back.
+func (ts *OAuthTokenSourcePrivateKeyJWT) ForceToken(ctx context.Context) (*oauth2.Token, error) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	ts.cachedToken = oauth2.Token{}
+	return ts.token(ctx)
+}
+
+// token must be called with ts.lock held.
+// At the time of writing this, the oauth2 package does not support the client assertion authentication method.
+// Ref: https://github.com/golang/oauth2/issues/744
+func (ts *OAuthTokenSourcePrivateKeyJWT) token(ctx context.Context) (*oauth2.Token, error) {
+	if ts.cachedToken.Valid() {
+		tok := ts.cachedToken
+		return &tok, nil
+	}
+
+	if ts.TokenEndpoint.TokenURL == "" || ts.ClientID == "" {
+		return nil, errors.New("cannot generate token, OAuthTokenSourcePrivateKeyJWT not fully configured")
+	}
+
+	if ts.ClientAssertionCert == "" || ts.ClientAssertionKey == "" {
+		return nil, errors.New("private_key_jwt requires client assertion cert and key")
+	}
+
+	pk, err := pem.DecodePEMPrivateKey([]byte(ts.ClientAssertionKey))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse private key: %w", err)
+	}
+	rsaKey, ok := pk.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private_key_jwt requires RSA private key")
+	}
+
+	now := time.Now()
+
+	audClaim := ts.TokenEndpoint.TokenURL
+	if ts.Audience != "" {
+		audClaim = ts.Audience
+	}
+
+	assertionToken, err := jwt.NewBuilder().
+		Issuer(ts.ClientID).
+		Subject(ts.ClientID).
+		Audience([]string{audClaim}).
+		IssuedAt(now).
+		Expiration(now.Add(1 * time.Minute)).
+		JwtID(uuid.New().String()).
+		NotBefore(now).
+		Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build token: %w", err)
+	}
+
+	// Some IdPs require the audience to be set as a single string
+	assertionToken.Options().Enable(jwt.FlattenAudience)
+
+	var signOptions []jwt.Option
+	if ts.Kid != "" {
+		headers := jws.NewHeaders()
+		if err = headers.Set("kid", ts.Kid); err != nil {
+			return nil, fmt.Errorf("error setting JWT kid header: %w", err)
+		}
+		signOptions = append(signOptions, jws.WithProtectedHeaders(headers))
+	}
+	assertion, err := jwt.Sign(assertionToken, jwt.WithKey(jwa.RS256, rsaKey, signOptions...))
+	if err != nil {
+		return nil, fmt.Errorf("error signing client assertion: %w", err)
+	}
+
+	urlValues := &url.Values{}
+	urlValues.Set("grant_type", "client_credentials")
+	urlValues.Set("client_id", ts.ClientID)
+	urlValues.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	urlValues.Set("client_assertion", string(assertion))
+	if ts.Audience != "" {
+		urlValues.Set("audience", ts.Audience)
+	}
+	if ts.Resource != "" {
+		urlValues.Set("resource", ts.Resource)
+	}
+	if len(ts.Scopes) > 0 {
+		urlValues.Set("scope", strings.Join(ts.Scopes, " "))
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	ts.configureClient()
+	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodPost, ts.TokenEndpoint.TokenURL, strings.NewReader(urlValues.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// The token endpoint URL comes from trusted component metadata configured by the operator, not from untrusted input.
+	resp, err := ts.httpClient.Do(req) //nolint:gosec,nolintlint
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("token endpoint returned %d", resp.StatusCode)
+	}
+	var tr oidcTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, err
+	}
+	if tr.AccessToken == "" {
+		return nil, errors.New("no access_token in response")
+	}
+	ts.cachedToken = oauth2.Token{AccessToken: tr.AccessToken, Expiry: time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)}
+	tok := ts.cachedToken
+	return &tok, nil
+}

--- a/common/component/redis/oauth2_private_key_jwt.go
+++ b/common/component/redis/oauth2_private_key_jwt.go
@@ -104,10 +104,13 @@ func (ts *OAuthTokenSourcePrivateKeyJWT) configureClient() {
 		tlsConfig.RootCAs = caPool
 	}
 
+	// Clone http.DefaultTransport so we keep its defaults (ProxyFromEnvironment,
+	// connection pooling, timeouts) and only override the TLS configuration.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
 	ts.httpClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		Transport: transport,
 	}
 }
 

--- a/common/component/redis/oauth2_private_key_jwt.go
+++ b/common/component/redis/oauth2_private_key_jwt.go
@@ -53,11 +53,10 @@ type OAuthTokenSourcePrivateKeyJWT struct {
 	Audience            string
 	Kid                 string
 
-	lock         sync.Mutex
-	cachedToken  oauth2.Token
-	httpClient   *http.Client
-	trustedCas   []*x509.Certificate
-	skipCaVerify bool
+	lock        sync.Mutex
+	cachedToken oauth2.Token
+	httpClient  *http.Client
+	trustedCas  []*x509.Certificate
 }
 
 type oidcTokenResponse struct {
@@ -90,8 +89,7 @@ func (ts *OAuthTokenSourcePrivateKeyJWT) configureClient() {
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: ts.skipCaVerify, //nolint:gosec
+		MinVersion: tls.VersionTLS12,
 	}
 
 	if ts.trustedCas != nil {
@@ -157,6 +155,25 @@ func (ts *OAuthTokenSourcePrivateKeyJWT) token(ctx context.Context) (*oauth2.Tok
 	rsaKey, ok := pk.(*rsa.PrivateKey)
 	if !ok {
 		return nil, errors.New("private_key_jwt requires RSA private key")
+	}
+
+	// Verify the supplied certificate matches the private key. The certificate
+	// itself is not sent in the assertion (the IdP identifies the key via the
+	// kid header), but validating the pair here surfaces misconfiguration at
+	// init instead of as an opaque token-endpoint rejection.
+	certs, err := pem.DecodePEMCertificates([]byte(ts.ClientAssertionCert))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse client assertion certificate: %w", err)
+	}
+	if len(certs) == 0 {
+		return nil, errors.New("client assertion certificate is empty")
+	}
+	certPubKey, ok := certs[0].PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("client assertion certificate must use an RSA public key")
+	}
+	if !certPubKey.Equal(&rsaKey.PublicKey) {
+		return nil, errors.New("client assertion certificate public key does not match the private key")
 	}
 
 	now := time.Now()

--- a/common/component/redis/oauth2_private_key_jwt_test.go
+++ b/common/component/redis/oauth2_private_key_jwt_test.go
@@ -440,7 +440,7 @@ func TestGetOIDCTokenSourceAndSetInitialTokenAsPassword(t *testing.T) {
 		}
 	})
 
-	t.Run("happy path sets the token as password and defaults the username", func(t *testing.T) {
+	t.Run("happy path sets the token as password and leaves the username empty", func(t *testing.T) {
 		var hits atomic.Int32
 		var form sync.Map
 		server := newTokenEndpointStub(t, &hits, &form)
@@ -452,7 +452,9 @@ func TestGetOIDCTokenSourceAndSetInitialTokenAsPassword(t *testing.T) {
 		require.NotNil(t, tokenSource)
 		require.True(t, expiry.After(time.Now()))
 		require.Equal(t, "test-token", s.Password)
-		require.Equal(t, "default", s.Username)
+		// No explicit username: kept empty so the client uses the 1-argument
+		// AUTH <token> form for maximum RESP compatibility.
+		require.Empty(t, s.Username)
 		// no scopes specified: defaults to openid only
 		require.Equal(t, []string{"openid"}, s.internalOidcScopes)
 		require.Equal(t, "openid", formValue(t, &form, "scope"))

--- a/common/component/redis/oauth2_private_key_jwt_test.go
+++ b/common/component/redis/oauth2_private_key_jwt_test.go
@@ -106,6 +106,9 @@ func decodeJWTPart(t *testing.T, jwtPart string) map[string]interface{} {
 
 func TestOAuthTokenSourcePrivateKeyJWT(t *testing.T) {
 	certPEM, keyPEM := createTestCertAndKey(t)
+	// A certificate from an unrelated key pair, used to exercise the cert/key
+	// mismatch validation.
+	otherCertPEM, _ := createTestCertAndKey(t)
 
 	t.Run("happy path sends a signed client assertion and returns the token", func(t *testing.T) {
 		var hits atomic.Int32
@@ -275,6 +278,16 @@ func TestOAuthTokenSourcePrivateKeyJWT(t *testing.T) {
 					ClientAssertionKey:  "not a key",
 				},
 				err: "unable to parse private key",
+			},
+			{
+				name: "certificate does not match private key",
+				ts: &OAuthTokenSourcePrivateKeyJWT{
+					TokenEndpoint:       oauth2.Endpoint{TokenURL: "https://idp.example.com/token"},
+					ClientID:            "test-client",
+					ClientAssertionCert: string(otherCertPEM),
+					ClientAssertionKey:  string(keyPEM),
+				},
+				err: "does not match the private key",
 			},
 		}
 		for _, tt := range tests {

--- a/common/component/redis/oauth2_private_key_jwt_test.go
+++ b/common/component/redis/oauth2_private_key_jwt_test.go
@@ -1,0 +1,474 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	kitlogger "github.com/dapr/kit/logger"
+)
+
+// createTestCertAndKey returns a self-signed certificate and its RSA private
+// key, both PEM-encoded.
+// This helper with modifications comes from https://github.com/madflojo/testcerts/blob/main/testcerts.go
+// Copyright 2019 Benjamin Cane, MIT License
+func createTestCertAndKey(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+
+	ca := &x509.Certificate{
+		Subject: pkix.Name{
+			Organization: []string{"Dapr Development Only Organization"},
+		},
+		SerialNumber:          big.NewInt(123),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	keypair, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	cert, err := x509.CreateCertificate(rand.Reader, ca, ca, &keypair.PublicKey, keypair)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(keypair)})
+	return certPEM, keyPEM
+}
+
+func newTokenEndpointStub(t *testing.T, hits *atomic.Int32, lastForm *sync.Map) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		require.NoError(t, r.ParseForm())
+		for k, v := range r.Form {
+			lastForm.Store(k, v[0])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+		})
+	}))
+}
+
+func formValue(t *testing.T, form *sync.Map, key string) string {
+	t.Helper()
+	v, ok := form.Load(key)
+	if !ok {
+		return ""
+	}
+	return v.(string)
+}
+
+func decodeJWTPart(t *testing.T, jwtPart string) map[string]interface{} {
+	t.Helper()
+	decoded, err := base64.RawURLEncoding.DecodeString(jwtPart)
+	require.NoError(t, err)
+	var out map[string]interface{}
+	require.NoError(t, json.Unmarshal(decoded, &out))
+	return out
+}
+
+func TestOAuthTokenSourcePrivateKeyJWT(t *testing.T) {
+	certPEM, keyPEM := createTestCertAndKey(t)
+
+	t.Run("happy path sends a signed client assertion and returns the token", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+			Scopes:              []string{"openid", "redis-prod"},
+			Resource:            "URI:RS-12345-API",
+			Kid:                 "test-kid",
+		}
+
+		token, err := ts.Token(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "test-token", token.AccessToken)
+		require.True(t, token.Expiry.After(time.Now()))
+
+		require.Equal(t, "client_credentials", formValue(t, &form, "grant_type"))
+		require.Equal(t, "test-client", formValue(t, &form, "client_id"))
+		require.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", formValue(t, &form, "client_assertion_type"))
+		require.Equal(t, "URI:RS-12345-API", formValue(t, &form, "resource"))
+		require.Equal(t, "openid redis-prod", formValue(t, &form, "scope"))
+		require.Empty(t, formValue(t, &form, "audience"))
+
+		assertion := formValue(t, &form, "client_assertion")
+		require.NotEmpty(t, assertion)
+		parts := strings.Split(assertion, ".")
+		require.Len(t, parts, 3, "JWT should have 3 parts")
+
+		header := decodeJWTPart(t, parts[0])
+		require.Equal(t, "test-kid", header["kid"])
+		require.Equal(t, "RS256", header["alg"])
+
+		claims := decodeJWTPart(t, parts[1])
+		require.Equal(t, "test-client", claims["iss"])
+		require.Equal(t, "test-client", claims["sub"])
+		// Some IdPs require the audience to be a single JSON string, not an array
+		require.IsType(t, "", claims["aud"])
+		require.Equal(t, server.URL, claims["aud"])
+		require.NotEmpty(t, claims["jti"])
+	})
+
+	t.Run("audience overrides the aud claim and is sent as form parameter", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+			Audience:            "https://idp.example.com/realms/local",
+		}
+
+		_, err := ts.Token(context.Background())
+		require.NoError(t, err)
+
+		require.Equal(t, "https://idp.example.com/realms/local", formValue(t, &form, "audience"))
+		parts := strings.Split(formValue(t, &form, "client_assertion"), ".")
+		claims := decodeJWTPart(t, parts[1])
+		require.Equal(t, "https://idp.example.com/realms/local", claims["aud"])
+	})
+
+	t.Run("valid cached token short-circuits the endpoint", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+		ts.cachedToken = oauth2.Token{AccessToken: "cached-token", Expiry: time.Now().Add(1 * time.Hour)}
+
+		token, err := ts.Token(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "cached-token", token.AccessToken)
+		require.Equal(t, int32(0), hits.Load())
+	})
+
+	t.Run("ForceToken bypasses a valid cached token", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+		ts.cachedToken = oauth2.Token{AccessToken: "cached-token", Expiry: time.Now().Add(1 * time.Hour)}
+
+		token, err := ts.ForceToken(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "test-token", token.AccessToken)
+		require.Equal(t, int32(1), hits.Load())
+	})
+
+	t.Run("concurrent calls fetch only once", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+
+		var wg sync.WaitGroup
+		for range 5 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := ts.Token(context.Background())
+				require.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+		require.Equal(t, int32(1), hits.Load())
+	})
+
+	t.Run("missing configuration errors", func(t *testing.T) {
+		tests := []struct {
+			name string
+			ts   *OAuthTokenSourcePrivateKeyJWT
+			err  string
+		}{
+			{
+				name: "missing token endpoint",
+				ts:   &OAuthTokenSourcePrivateKeyJWT{ClientID: "test-client"},
+				err:  "not fully configured",
+			},
+			{
+				name: "missing client ID",
+				ts:   &OAuthTokenSourcePrivateKeyJWT{TokenEndpoint: oauth2.Endpoint{TokenURL: "https://idp.example.com/token"}},
+				err:  "not fully configured",
+			},
+			{
+				name: "missing client assertion cert and key",
+				ts: &OAuthTokenSourcePrivateKeyJWT{
+					TokenEndpoint: oauth2.Endpoint{TokenURL: "https://idp.example.com/token"},
+					ClientID:      "test-client",
+				},
+				err: "requires client assertion cert and key",
+			},
+			{
+				name: "invalid private key",
+				ts: &OAuthTokenSourcePrivateKeyJWT{
+					TokenEndpoint:       oauth2.Endpoint{TokenURL: "https://idp.example.com/token"},
+					ClientID:            "test-client",
+					ClientAssertionCert: string(certPEM),
+					ClientAssertionKey:  "not a key",
+				},
+				err: "unable to parse private key",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := tt.ts.Token(context.Background())
+				require.ErrorContains(t, err, tt.err)
+			})
+		}
+	})
+
+	t.Run("non-2xx response errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+
+		_, err := ts.Token(context.Background())
+		require.ErrorContains(t, err, "token endpoint returned 401")
+	})
+
+	t.Run("empty access_token in response errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"expires_in": 3600}`)
+		}))
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+
+		_, err := ts.Token(context.Background())
+		require.ErrorContains(t, err, "no access_token in response")
+	})
+
+	t.Run("custom CA verifies the token endpoint TLS connection", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"access_token": "tls-token", "expires_in": 3600}`)
+		}))
+		defer server.Close()
+
+		serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+		require.NoError(t, ts.addCa(string(serverCertPEM)))
+
+		token, err := ts.Token(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "tls-token", token.AccessToken)
+	})
+
+	t.Run("without the custom CA the TLS connection fails", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"access_token": "tls-token", "expires_in": 3600}`)
+		}))
+		defer server.Close()
+
+		ts := &OAuthTokenSourcePrivateKeyJWT{
+			TokenEndpoint:       oauth2.Endpoint{TokenURL: server.URL},
+			ClientID:            "test-client",
+			ClientAssertionCert: string(certPEM),
+			ClientAssertionKey:  string(keyPEM),
+		}
+
+		_, err := ts.Token(context.Background())
+		require.Error(t, err)
+	})
+}
+
+func TestGetOIDCTokenSourceAndSetInitialTokenAsPassword(t *testing.T) {
+	certPEM, keyPEM := createTestCertAndKey(t)
+	logger := kitlogger.NewLogger("test")
+
+	validSettings := func(tokenURL string) *Settings {
+		return &Settings{
+			UseOIDC:                 true,
+			OidcTokenEndpoint:       tokenURL,
+			OidcClientID:            "test-client",
+			OidcClientAssertionCert: string(certPEM),
+			OidcClientAssertionKey:  string(keyPEM),
+		}
+	}
+
+	t.Run("validation errors", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			modify func(s *Settings)
+			err    string
+		}{
+			{
+				name:   "useEntraID and useOIDC are mutually exclusive",
+				modify: func(s *Settings) { s.UseEntraID = true },
+				err:    "useEntraID and useOIDC must not be enabled at the same time",
+			},
+			{
+				name:   "password must not be set",
+				modify: func(s *Settings) { s.Password = "secret" },
+				err:    "password must not be specified when using OIDC authentication",
+			},
+			{
+				name:   "missing token endpoint",
+				modify: func(s *Settings) { s.OidcTokenEndpoint = "" },
+				err:    "missing oidcTokenEndpoint",
+			},
+			{
+				name:   "missing client ID",
+				modify: func(s *Settings) { s.OidcClientID = "" },
+				err:    "missing oidcClientID",
+			},
+			{
+				name:   "missing client assertion cert",
+				modify: func(s *Settings) { s.OidcClientAssertionCert = "" },
+				err:    "missing oidcClientAssertionCert",
+			},
+			{
+				name:   "missing client assertion key",
+				modify: func(s *Settings) { s.OidcClientAssertionKey = "" },
+				err:    "missing oidcClientAssertionKey",
+			},
+			{
+				name:   "invalid CA cert",
+				modify: func(s *Settings) { s.OidcCACert = "not a cert" },
+				err:    "error parsing PEM certificate",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				s := validSettings("https://idp.example.com/token")
+				tt.modify(s)
+				_, _, err := s.GetOIDCTokenSourceAndSetInitialTokenAsPassword(context.Background(), &logger)
+				require.ErrorContains(t, err, tt.err)
+			})
+		}
+	})
+
+	t.Run("happy path sets the token as password and defaults the username", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		s := validSettings(server.URL)
+		tokenSource, expiry, err := s.GetOIDCTokenSourceAndSetInitialTokenAsPassword(context.Background(), &logger)
+		require.NoError(t, err)
+		require.NotNil(t, tokenSource)
+		require.True(t, expiry.After(time.Now()))
+		require.Equal(t, "test-token", s.Password)
+		require.Equal(t, "default", s.Username)
+		// no scopes specified: defaults to openid only
+		require.Equal(t, []string{"openid"}, s.internalOidcScopes)
+		require.Equal(t, "openid", formValue(t, &form, "scope"))
+	})
+
+	t.Run("explicit username and scopes are preserved", func(t *testing.T) {
+		var hits atomic.Int32
+		var form sync.Map
+		server := newTokenEndpointStub(t, &hits, &form)
+		defer server.Close()
+
+		s := validSettings(server.URL)
+		s.Username = "my-user"
+		s.OidcScopes = "openid,redis-prod"
+		_, _, err := s.GetOIDCTokenSourceAndSetInitialTokenAsPassword(context.Background(), &logger)
+		require.NoError(t, err)
+		require.Equal(t, "my-user", s.Username)
+		require.Equal(t, []string{"openid", "redis-prod"}, s.internalOidcScopes)
+		require.Equal(t, "openid redis-prod", formValue(t, &form, "scope"))
+	})
+
+	t.Run("token endpoint failure surfaces as configuration error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		s := validSettings(server.URL)
+		_, _, err := s.GetOIDCTokenSourceAndSetInitialTokenAsPassword(context.Background(), &logger)
+		require.ErrorContains(t, err, "redis client configuration error")
+	})
+}

--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -283,7 +283,7 @@ func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username stri
 				backoffManager = backoffConfig.NewBackOffWithContext(ctx)
 				authErr := kitretry.NotifyRecover(
 					func() error {
-						var innerAuthErr = client.AuthACL(ctx, username, token.Token)
+						innerAuthErr := client.AuthACL(ctx, username, token.Token)
 						return innerAuthErr
 					},
 					backoffManager,
@@ -312,7 +312,8 @@ func StartEntraIDTokenRefreshBackgroundRoutine(client RedisClient, username stri
 func (s *Settings) GetEntraIDCredentialAndSetInitialTokenAsPassword(ctx context.Context, properties *map[string]string) (*time.Time, *azcore.TokenCredential, error) {
 	if len(s.Password) > 0 || len(s.Username) > 0 {
 		return nil, nil, errors.New(
-			"redis client configuration error: username or password must not be specified when using Entra ID authentication")
+			"redis client configuration error: username or password must not be specified when using Entra ID authentication",
+		)
 	}
 	envSettings, err := azure.NewEnvironmentSettings(*properties)
 	if err != nil {
@@ -377,9 +378,14 @@ func (s *Settings) GetOIDCTokenSourceAndSetInitialTokenAsPassword(ctx context.Co
 		s.Username = "default"
 	}
 
-	if s.OidcScopes != "" {
-		s.internalOidcScopes = strings.Split(s.OidcScopes, ",")
-	} else {
+	// Parse the comma-delimited scopes, trimming whitespace and dropping empty entries.
+	s.internalOidcScopes = nil
+	for _, scope := range strings.Split(s.OidcScopes, ",") {
+		if scope = strings.TrimSpace(scope); scope != "" {
+			s.internalOidcScopes = append(s.internalOidcScopes, scope)
+		}
+	}
+	if len(s.internalOidcScopes) == 0 {
 		(*logger).Warn("redis client: no OIDC scopes specified, using default 'openid' scope only. This is a security risk for token reuse.")
 		s.internalOidcScopes = []string{"openid"}
 	}
@@ -393,7 +399,6 @@ func (s *Settings) GetOIDCTokenSourceAndSetInitialTokenAsPassword(ctx context.Co
 		Resource:            s.OidcResource,
 		Audience:            s.OidcAudience,
 		Kid:                 s.OidcKid,
-		skipCaVerify:        s.InsecureSkipTLSVerify,
 	}
 	if s.OidcCACert != "" {
 		if err := tokenSource.addCa(s.OidcCACert); err != nil {

--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"golang.org/x/mod/semver"
+	"golang.org/x/oauth2"
 
 	"github.com/dapr/components-contrib/common/authentication/azure"
 	"github.com/dapr/components-contrib/configuration"
@@ -165,6 +166,15 @@ func ParseClientFromProperties(properties map[string]string, componentType metad
 			// if there was an error we would try to interpret it as a duration string, which was already done in Decode()
 		}
 	}
+	var oidcTokenSource *OAuthTokenSourcePrivateKeyJWT
+	var oidcTokenExpiry time.Time
+	if settings.UseOIDC {
+		oidcTokenSource, oidcTokenExpiry, err = settings.GetOIDCTokenSourceAndSetInitialTokenAsPassword(ctx, logger)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	var tokenExpires *time.Time
 	var tokenCredential *azcore.TokenCredential
 	if settings.UseEntraID {
@@ -215,6 +225,9 @@ func ParseClientFromProperties(properties map[string]string, componentType metad
 
 	if settings.UseEntraID {
 		StartEntraIDTokenRefreshBackgroundRoutine(c, settings.Username, *tokenExpires, tokenCredential, logger)
+	}
+	if settings.UseOIDC {
+		StartOIDCTokenRefreshBackgroundRoutine(c, settings.Username, oidcTokenExpiry, oidcTokenSource, logger)
 	}
 	return c, &settings, nil
 }
@@ -332,6 +345,159 @@ func (s *Settings) GetEntraIDCredentialAndSetInitialTokenAsPassword(ctx context.
 		return nil, nil, errors.New("redis client configuration error: could not parse object ID from Auth token")
 	}
 	return &token.ExpiresOn, &cred, nil
+}
+
+// GetOIDCTokenSourceAndSetInitialTokenAsPassword validates the OIDC private_key_jwt
+// settings, builds the token source, fetches the initial access token and sets it as
+// the password for the Redis connection. It returns the token source and the expiry
+// of the initial token so a refresh routine can be scheduled.
+func (s *Settings) GetOIDCTokenSourceAndSetInitialTokenAsPassword(ctx context.Context, logger *kitlogger.Logger) (*OAuthTokenSourcePrivateKeyJWT, time.Time, error) {
+	if s.UseEntraID {
+		return nil, time.Time{}, errors.New("redis client configuration error: useEntraID and useOIDC must not be enabled at the same time")
+	}
+	if len(s.Password) > 0 {
+		return nil, time.Time{}, errors.New("redis client configuration error: password must not be specified when using OIDC authentication")
+	}
+	if s.OidcTokenEndpoint == "" {
+		return nil, time.Time{}, errors.New("redis client configuration error: missing oidcTokenEndpoint for OIDC authentication")
+	}
+	if s.OidcClientID == "" {
+		return nil, time.Time{}, errors.New("redis client configuration error: missing oidcClientID for OIDC authentication")
+	}
+	if s.OidcClientAssertionCert == "" {
+		return nil, time.Time{}, errors.New("redis client configuration error: missing oidcClientAssertionCert for OIDC authentication")
+	}
+	if s.OidcClientAssertionKey == "" {
+		return nil, time.Time{}, errors.New("redis client configuration error: missing oidcClientAssertionKey for OIDC authentication")
+	}
+
+	if s.Username == "" {
+		// With no explicit username we authenticate as the default user,
+		// which is equivalent to the plain AUTH <token> command.
+		s.Username = "default"
+	}
+
+	if s.OidcScopes != "" {
+		s.internalOidcScopes = strings.Split(s.OidcScopes, ",")
+	} else {
+		(*logger).Warn("redis client: no OIDC scopes specified, using default 'openid' scope only. This is a security risk for token reuse.")
+		s.internalOidcScopes = []string{"openid"}
+	}
+
+	tokenSource := &OAuthTokenSourcePrivateKeyJWT{
+		TokenEndpoint:       oauth2.Endpoint{TokenURL: s.OidcTokenEndpoint},
+		ClientID:            s.OidcClientID,
+		Scopes:              s.internalOidcScopes,
+		ClientAssertionCert: s.OidcClientAssertionCert,
+		ClientAssertionKey:  s.OidcClientAssertionKey,
+		Resource:            s.OidcResource,
+		Audience:            s.OidcAudience,
+		Kid:                 s.OidcKid,
+		skipCaVerify:        s.InsecureSkipTLSVerify,
+	}
+	if s.OidcCACert != "" {
+		if err := tokenSource.addCa(s.OidcCACert); err != nil {
+			return nil, time.Time{}, fmt.Errorf("redis client configuration error: %w", err)
+		}
+	}
+
+	token, err := tokenSource.Token(ctx)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("redis client configuration error: %w", err)
+	}
+	s.Password = token.AccessToken
+
+	return tokenSource, token.Expiry, nil
+}
+
+// StartOIDCTokenRefreshBackgroundRoutine refreshes the OIDC access token before it
+// expires and re-authenticates the live Redis connection pool with it.
+func StartOIDCTokenRefreshBackgroundRoutine(client RedisClient, username string, nextExpiration time.Time, tokenSource *OAuthTokenSourcePrivateKeyJWT, logger *kitlogger.Logger) {
+	go runTokenRefreshLoop(client, username, nextExpiration, logger, "OIDC", func(ctx context.Context) (string, time.Time, error) {
+		token, err := tokenSource.ForceToken(ctx)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		return token.AccessToken, token.Expiry, nil
+	})
+}
+
+// runTokenRefreshLoop periodically refreshes an authentication token before it
+// expires and re-authenticates the existing Redis connection pool via the AUTH
+// command. fetch must return a fresh token and its expiry. On definitive failure
+// (after retries) the client is closed and the process is terminated, mirroring
+// the behavior of the EntraID token refresh routine.
+func runTokenRefreshLoop(client RedisClient, username string, nextExpiration time.Time, logger *kitlogger.Logger, label string, fetch func(ctx context.Context) (string, time.Time, error)) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backoffConfig := kitretry.DefaultConfig()
+	backoffConfig.MaxRetries = 3
+	backoffConfig.Policy = kitretry.PolicyExponential
+
+	var backoffManager backoff.BackOff
+	const refreshGracePeriod = 5 * time.Minute
+	tokenRefreshDuration := time.Until(nextExpiration.Add(-refreshGracePeriod))
+
+	(*logger).Debugf("redis client: starting %s token refresh loop", label)
+
+	for {
+		(*logger).Debugf("redis client: next %s token refresh: %v", label, tokenRefreshDuration)
+		select {
+		case <-ctx.Done():
+			(*logger).Infof("redis client: %s token refresh stopped due to context cancellation", label)
+			return
+		case <-time.After(tokenRefreshDuration):
+			(*logger).Debugf("redis client: refreshing %s token", label)
+			// Get a new access token
+			var newToken string
+			var newExpiry time.Time
+			backoffManager = backoffConfig.NewBackOffWithContext(ctx)
+			tokenErr := kitretry.NotifyRecover(
+				func() error {
+					var innerTokenErr error
+					newToken, newExpiry, innerTokenErr = fetch(ctx)
+					return innerTokenErr
+				},
+				backoffManager,
+				func(err error, _ time.Duration) {
+					(*logger).Debugf("redis client: %s token acquisition failed with error: %v. Retrying...", label, err)
+				},
+				func() {
+					(*logger).Debugf("redis client: %s token acquisition succeeded after error", label)
+				},
+			)
+			if tokenErr != nil {
+				_ = client.Close()
+				(*logger).Fatalf("redis client: %s token acquisition failed: %v", label, tokenErr)
+				return
+			}
+
+			// Use the new access token via the Redis AUTH command
+			backoffManager = backoffConfig.NewBackOffWithContext(ctx)
+			authErr := kitretry.NotifyRecover(
+				func() error {
+					return client.AuthACL(ctx, username, newToken)
+				},
+				backoffManager,
+				func(err error, _ time.Duration) {
+					(*logger).Debugf("redis client: %s auth failed with error: %v. Retrying...", label, err)
+				},
+				func() {
+					(*logger).Debugf("redis client: %s auth succeeded after error", label)
+				},
+			)
+			if authErr != nil {
+				_ = client.Close()
+				(*logger).Fatalf("redis client: %s auth failed: %v", label, authErr)
+				return
+			}
+
+			(*logger).Debugf("redis client: %s auth token successfully refreshed with the server", label)
+
+			// Schedule the next refresh based on the new token's expiry
+			tokenRefreshDuration = time.Until(newExpiry.Add(-refreshGracePeriod))
+		}
+	}
 }
 
 func ClientHasJSONSupport(c RedisClient) bool {

--- a/common/component/redis/redis.go
+++ b/common/component/redis/redis.go
@@ -372,11 +372,10 @@ func (s *Settings) GetOIDCTokenSourceAndSetInitialTokenAsPassword(ctx context.Co
 		return nil, time.Time{}, errors.New("redis client configuration error: missing oidcClientAssertionKey for OIDC authentication")
 	}
 
-	if s.Username == "" {
-		// With no explicit username we authenticate as the default user,
-		// which is equivalent to the plain AUTH <token> command.
-		s.Username = "default"
-	}
+	// Leave Username empty unless the operator set one explicitly. An empty
+	// username makes the client send the 1-argument AUTH <token> form, which the
+	// widest range of RESP-compatible auth layers accept; a configured username
+	// switches to the 2-argument AUTH <username> <token> (ACL) form.
 
 	// Parse the comma-delimited scopes, trimming whitespace and dropping empty entries.
 	s.internalOidcScopes = nil
@@ -441,7 +440,17 @@ func runTokenRefreshLoop(client RedisClient, username string, nextExpiration tim
 
 	var backoffManager backoff.BackOff
 	const refreshGracePeriod = 5 * time.Minute
-	tokenRefreshDuration := time.Until(nextExpiration.Add(-refreshGracePeriod))
+	// minTokenRefreshInterval floors the wait between refreshes so a short-lived
+	// or near-expiry token (remaining lifetime <= refreshGracePeriod) cannot
+	// drive the loop into a tight refresh+AUTH spin against the IdP and Redis.
+	const minTokenRefreshInterval = 5 * time.Second
+	nextRefresh := func(expiry time.Time) time.Duration {
+		if d := time.Until(expiry.Add(-refreshGracePeriod)); d > minTokenRefreshInterval {
+			return d
+		}
+		return minTokenRefreshInterval
+	}
+	tokenRefreshDuration := nextRefresh(nextExpiration)
 
 	(*logger).Debugf("redis client: starting %s token refresh loop", label)
 
@@ -477,11 +486,17 @@ func runTokenRefreshLoop(client RedisClient, username string, nextExpiration tim
 				return
 			}
 
-			// Use the new access token via the Redis AUTH command
+			// Re-authenticate the connection with the new token via the Redis AUTH
+			// command. DoWrite executes the command immediately (unlike AuthACL,
+			// which enqueues on a pipeline). With no username we send the
+			// 1-argument AUTH <token> form; with one we send AUTH <username> <token>.
 			backoffManager = backoffConfig.NewBackOffWithContext(ctx)
 			authErr := kitretry.NotifyRecover(
 				func() error {
-					return client.AuthACL(ctx, username, newToken)
+					if username == "" {
+						return client.DoWrite(ctx, "AUTH", newToken)
+					}
+					return client.DoWrite(ctx, "AUTH", username, newToken)
 				},
 				backoffManager,
 				func(err error, _ time.Duration) {
@@ -500,7 +515,7 @@ func runTokenRefreshLoop(client RedisClient, username string, nextExpiration tim
 			(*logger).Debugf("redis client: %s auth token successfully refreshed with the server", label)
 
 			// Schedule the next refresh based on the new token's expiry
-			tokenRefreshDuration = time.Until(newExpiry.Add(-refreshGracePeriod))
+			tokenRefreshDuration = nextRefresh(newExpiry)
 		}
 	}
 }

--- a/common/component/redis/refresh_test.go
+++ b/common/component/redis/refresh_test.go
@@ -26,20 +26,16 @@ import (
 	kitlogger "github.com/dapr/kit/logger"
 )
 
-type authACLCall struct {
-	username string
-	password string
-}
-
-// fakeRedisClient records AuthACL calls. The embedded RedisClient interface
-// satisfies the remaining methods (they panic if called, which no test does).
+// fakeRedisClient records the AUTH command issued via DoWrite. The embedded
+// RedisClient interface satisfies the remaining methods (they panic if called,
+// which no test does).
 type fakeRedisClient struct {
 	RedisClient
-	authCalls chan authACLCall
+	doWriteCalls chan []interface{}
 }
 
-func (f *fakeRedisClient) AuthACL(_ context.Context, username, password string) error {
-	f.authCalls <- authACLCall{username: username, password: password}
+func (f *fakeRedisClient) DoWrite(_ context.Context, args ...interface{}) error {
+	f.doWriteCalls <- args
 	return nil
 }
 
@@ -48,33 +44,55 @@ func (f *fakeRedisClient) Close() error {
 }
 
 func TestRunTokenRefreshLoop(t *testing.T) {
-	logger := kitlogger.NewLogger("test")
-	fake := &fakeRedisClient{authCalls: make(chan authACLCall, 10)}
-
 	// The loop refreshes 5 minutes before expiry; make the first refresh fire
 	// almost immediately, and schedule all subsequent refreshes far in the
 	// future so the goroutine goes dormant after the assertions.
 	const refreshGracePeriod = 5 * time.Minute
-	firstExpiry := time.Now().Add(refreshGracePeriod + 50*time.Millisecond)
 
-	var fetchCount atomic.Int32
-	fetch := func(ctx context.Context) (string, time.Time, error) {
-		n := fetchCount.Add(1)
-		if n == 1 {
-			// Transient failure: exercises the retry path
-			return "", time.Time{}, errors.New("transient token error")
-		}
-		return fmt.Sprintf("token-%d", n), time.Now().Add(refreshGracePeriod + 24*time.Hour), nil
+	tests := []struct {
+		name         string
+		username     string
+		expectedAuth []interface{}
+	}{
+		{
+			// No username: the connection must re-AUTH with the 1-argument form.
+			name:         "default user uses 1-argument AUTH",
+			username:     "",
+			expectedAuth: []interface{}{"AUTH", "token-2"},
+		},
+		{
+			// Explicit username: the connection re-AUTHs with the ACL 2-arg form.
+			name:         "explicit user uses 2-argument AUTH",
+			username:     "alice",
+			expectedAuth: []interface{}{"AUTH", "alice", "token-2"},
+		},
 	}
 
-	go runTokenRefreshLoop(fake, "default", firstExpiry, &logger, "test", fetch)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := kitlogger.NewLogger("test")
+			fake := &fakeRedisClient{doWriteCalls: make(chan []interface{}, 10)}
+			firstExpiry := time.Now().Add(refreshGracePeriod + 50*time.Millisecond)
 
-	select {
-	case call := <-fake.authCalls:
-		require.Equal(t, "default", call.username)
-		require.Equal(t, "token-2", call.password)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for AuthACL after token refresh")
+			var fetchCount atomic.Int32
+			fetch := func(ctx context.Context) (string, time.Time, error) {
+				n := fetchCount.Add(1)
+				if n == 1 {
+					// Transient failure: exercises the retry path
+					return "", time.Time{}, errors.New("transient token error")
+				}
+				return fmt.Sprintf("token-%d", n), time.Now().Add(refreshGracePeriod + 24*time.Hour), nil
+			}
+
+			go runTokenRefreshLoop(fake, tc.username, firstExpiry, &logger, "test", fetch)
+
+			select {
+			case call := <-fake.doWriteCalls:
+				require.Equal(t, tc.expectedAuth, call)
+			case <-time.After(10 * time.Second):
+				t.Fatal("timed out waiting for AUTH after token refresh")
+			}
+			require.Equal(t, int32(2), fetchCount.Load(), "expected one failed and one successful fetch")
+		})
 	}
-	require.Equal(t, int32(2), fetchCount.Load(), "expected one failed and one successful fetch")
 }

--- a/common/component/redis/refresh_test.go
+++ b/common/component/redis/refresh_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kitlogger "github.com/dapr/kit/logger"
+)
+
+type authACLCall struct {
+	username string
+	password string
+}
+
+// fakeRedisClient records AuthACL calls. The embedded RedisClient interface
+// satisfies the remaining methods (they panic if called, which no test does).
+type fakeRedisClient struct {
+	RedisClient
+	authCalls chan authACLCall
+}
+
+func (f *fakeRedisClient) AuthACL(_ context.Context, username, password string) error {
+	f.authCalls <- authACLCall{username: username, password: password}
+	return nil
+}
+
+func (f *fakeRedisClient) Close() error {
+	return nil
+}
+
+func TestRunTokenRefreshLoop(t *testing.T) {
+	logger := kitlogger.NewLogger("test")
+	fake := &fakeRedisClient{authCalls: make(chan authACLCall, 10)}
+
+	// The loop refreshes 5 minutes before expiry; make the first refresh fire
+	// almost immediately, and schedule all subsequent refreshes far in the
+	// future so the goroutine goes dormant after the assertions.
+	const refreshGracePeriod = 5 * time.Minute
+	firstExpiry := time.Now().Add(refreshGracePeriod + 50*time.Millisecond)
+
+	var fetchCount atomic.Int32
+	fetch := func(ctx context.Context) (string, time.Time, error) {
+		n := fetchCount.Add(1)
+		if n == 1 {
+			// Transient failure: exercises the retry path
+			return "", time.Time{}, errors.New("transient token error")
+		}
+		return fmt.Sprintf("token-%d", n), time.Now().Add(refreshGracePeriod + 24*time.Hour), nil
+	}
+
+	go runTokenRefreshLoop(fake, "default", firstExpiry, &logger, "test", fetch)
+
+	select {
+	case call := <-fake.authCalls:
+		require.Equal(t, "default", call.username)
+		require.Equal(t, "token-2", call.password)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for AuthACL after token refresh")
+	}
+	require.Equal(t, int32(2), fetchCount.Load(), "expected one failed and one successful fetch")
+}

--- a/common/component/redis/settings.go
+++ b/common/component/redis/settings.go
@@ -123,6 +123,32 @@ type Settings struct {
 	// EntraID / AzureAD Authentication based on the shared code which essentially uses the DefaultAzureCredential
 	// from the official Azure Identity SDK for Go
 	UseEntraID bool `mapstructure:"useEntraID" mapstructurealiases:"useAzureAD"`
+
+	// OIDC private_key_jwt (RFC 7523) authentication: an OAuth2 access token is
+	// obtained from the identity provider using a signed JWT client assertion,
+	// and used as the password for the Redis AUTH command. The token is
+	// refreshed in the background before it expires.
+	UseOIDC bool `mapstructure:"useOIDC"`
+	// URL of the OAuth2 identity provider access token endpoint
+	OidcTokenEndpoint string `mapstructure:"oidcTokenEndpoint"`
+	// The OAuth2 client ID that has been provisioned in the identity provider
+	OidcClientID string `mapstructure:"oidcClientID"`
+	// PEM-encoded X.509 certificate paired with the client assertion signing key
+	OidcClientAssertionCert string `mapstructure:"oidcClientAssertionCert"`
+	// PEM-encoded RSA private key used to sign the client assertion
+	OidcClientAssertionKey string `mapstructure:"oidcClientAssertionKey"`
+	// Optional OAuth2 resource parameter to include in the token request
+	OidcResource string `mapstructure:"oidcResource"`
+	// Optional override for the JWT client assertion audience (aud); defaults to the token endpoint URL
+	OidcAudience string `mapstructure:"oidcAudience"`
+	// Optional JWT key ID (kid) header for the client assertion
+	OidcKid string `mapstructure:"oidcKid"`
+	// Comma-delimited list of OAuth2/OIDC scopes to request with the access token; defaults to "openid"
+	OidcScopes string `mapstructure:"oidcScopes"`
+	// Optional PEM-encoded CA certificate used to verify the TLS connection to the token endpoint
+	OidcCACert string `mapstructure:"oidcCACert"`
+
+	internalOidcScopes []string `mapstructure:"-"`
 }
 
 func (s *Settings) Decode(in interface{}) error {

--- a/common/component/redis/v8client.go
+++ b/common/component/redis/v8client.go
@@ -318,9 +318,12 @@ func (c v8Client) TTLResult(ctx context.Context, key string) (time.Duration, err
 }
 
 func (c v8Client) AuthACL(ctx context.Context, username, password string) error {
+	// AuthACL is only exposed on the Pipeliner, so we queue it on a pipeline and
+	// Exec it. Without the Exec the command is never sent, making AUTH a no-op.
 	pipeline := c.client.Pipeline()
-	statusCmd := pipeline.AuthACL(ctx, username, password)
-	return statusCmd.Err()
+	pipeline.AuthACL(ctx, username, password)
+	_, err := pipeline.Exec(ctx)
+	return err
 }
 
 func newV8FailoverClient(s *Settings) (RedisClient, error) {

--- a/common/component/redis/v9client.go
+++ b/common/component/redis/v9client.go
@@ -318,9 +318,12 @@ func (c v9Client) TTLResult(ctx context.Context, key string) (time.Duration, err
 }
 
 func (c v9Client) AuthACL(ctx context.Context, username, password string) error {
+	// AuthACL is only exposed on the Pipeliner, so we queue it on a pipeline and
+	// Exec it. Without the Exec the command is never sent, making AUTH a no-op.
 	pipeline := c.client.Pipeline()
-	statusCmd := pipeline.AuthACL(ctx, username, password)
-	return statusCmd.Err()
+	pipeline.AuthACL(ctx, username, password)
+	_, err := pipeline.Exec(ctx)
+	return err
 }
 
 func newV9FailoverClient(s *Settings) (RedisClient, error) {

--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -141,9 +141,11 @@ authenticationProfiles:
         required: false
         description: |
           Username to pass to the Redis AUTH command together with the access token.
-          Defaults to "default" when using OIDC authentication.
-        example: '"default"'
-        default: '"default"'
+          When omitted, the token is sent using the 1-argument AUTH <token> form
+          (authenticating as the default user), accepted by the widest range of
+          RESP-compatible auth layers. Set a username to use the 2-argument
+          AUTH <username> <token> (ACL) form.
+        example: '"my-user"'
 metadata:
   - name: redisHost
     required: true

--- a/configuration/redis/metadata.yaml
+++ b/configuration/redis/metadata.yaml
@@ -54,6 +54,96 @@ authenticationProfiles:
         url:
           title: "Redis Sentinel authentication documentation"
           url: "https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#configuring-sentinel-instances-with-authentication"
+  - title: "OIDC private_key_jwt"
+    description: |
+      Authenticate using OpenID Connect with the private_key_jwt client authentication
+      method (RFC 7523). An OAuth2 access token is obtained from the identity provider
+      using a signed JWT client assertion and used as the password for the Redis AUTH
+      command. The token is refreshed in the background before it expires.
+    metadata:
+      - name: useOIDC
+        type: bool
+        required: false
+        description: |
+          If set to true, enables OIDC private_key_jwt authentication.
+          Must not be combined with "redisPassword" or "useEntraID".
+        example: '"true"'
+        default: '"false"'
+      - name: oidcTokenEndpoint
+        type: string
+        required: true
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+        example: '"https://identity.example.com/v1/token"'
+      - name: oidcClientID
+        type: string
+        required: true
+        description: |
+          The OAuth2 client ID that has been provisioned in the identity provider.
+        example: '"my-client-id"'
+      - name: oidcClientAssertionCert
+        type: string
+        required: true
+        description: |
+          PEM-encoded X.509 certificate paired with the client assertion signing key.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: oidcClientAssertionKey
+        type: string
+        required: true
+        sensitive: true
+        description: |
+          PEM-encoded RSA private key used to sign the client assertion.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN PRIVATE KEY-----\n...
+      - name: oidcResource
+        type: string
+        required: false
+        description: |
+          Optional OAuth2 resource parameter to include in the token request when
+          required by the identity provider.
+        example: '"URI:RS-12345-API"'
+      - name: oidcAudience
+        type: string
+        required: false
+        description: |
+          Overrides the JWT client assertion audience (aud). Defaults to the token
+          endpoint URL.
+        example: '"https://identity.example.com/realms/local"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          Although not required, this field is recommended.
+        example: '"openid,redis-prod"'
+        default: '"openid"'
+      - name: oidcKid
+        type: string
+        required: false
+        description: |
+          The JWT key ID (kid) header to use for the client assertion, when required by
+          the identity provider (for example, the thumbprint of the client certificate).
+        example: '"1234567890"'
+      - name: oidcCACert
+        type: string
+        required: false
+        description: |
+          PEM-encoded CA certificate used to verify the TLS connection to the token
+          endpoint. This is distinct from the TLS configuration of the Redis
+          connection itself.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username to pass to the Redis AUTH command together with the access token.
+          Defaults to "default" when using OIDC authentication.
+        example: '"default"'
+        default: '"default"'
 metadata:
   - name: redisHost
     required: true

--- a/lock/redis/metadata.yaml
+++ b/lock/redis/metadata.yaml
@@ -142,9 +142,11 @@ authenticationProfiles:
         required: false
         description: |
           Username to pass to the Redis AUTH command together with the access token.
-          Defaults to "default" when using OIDC authentication.
-        example: '"default"'
-        default: '"default"'
+          When omitted, the token is sent using the 1-argument AUTH <token> form
+          (authenticating as the default user), accepted by the widest range of
+          RESP-compatible auth layers. Set a username to use the 2-argument
+          AUTH <username> <token> (ACL) form.
+        example: '"my-user"'
 metadata:
   - name: redisHost
     required: true

--- a/lock/redis/metadata.yaml
+++ b/lock/redis/metadata.yaml
@@ -55,6 +55,96 @@ authenticationProfiles:
         sensitive: true
         description: "The Redis client key"
         example: '"-----BEGIN PRIVATE KEY-----\nXXX..."'
+  - title: "OIDC private_key_jwt"
+    description: |
+      Authenticate using OpenID Connect with the private_key_jwt client authentication
+      method (RFC 7523). An OAuth2 access token is obtained from the identity provider
+      using a signed JWT client assertion and used as the password for the Redis AUTH
+      command. The token is refreshed in the background before it expires.
+    metadata:
+      - name: useOIDC
+        type: bool
+        required: false
+        description: |
+          If set to true, enables OIDC private_key_jwt authentication.
+          Must not be combined with "redisPassword" or "useEntraID".
+        example: '"true"'
+        default: '"false"'
+      - name: oidcTokenEndpoint
+        type: string
+        required: true
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+        example: '"https://identity.example.com/v1/token"'
+      - name: oidcClientID
+        type: string
+        required: true
+        description: |
+          The OAuth2 client ID that has been provisioned in the identity provider.
+        example: '"my-client-id"'
+      - name: oidcClientAssertionCert
+        type: string
+        required: true
+        description: |
+          PEM-encoded X.509 certificate paired with the client assertion signing key.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: oidcClientAssertionKey
+        type: string
+        required: true
+        sensitive: true
+        description: |
+          PEM-encoded RSA private key used to sign the client assertion.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN PRIVATE KEY-----\n...
+      - name: oidcResource
+        type: string
+        required: false
+        description: |
+          Optional OAuth2 resource parameter to include in the token request when
+          required by the identity provider.
+        example: '"URI:RS-12345-API"'
+      - name: oidcAudience
+        type: string
+        required: false
+        description: |
+          Overrides the JWT client assertion audience (aud). Defaults to the token
+          endpoint URL.
+        example: '"https://identity.example.com/realms/local"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          Although not required, this field is recommended.
+        example: '"openid,redis-prod"'
+        default: '"openid"'
+      - name: oidcKid
+        type: string
+        required: false
+        description: |
+          The JWT key ID (kid) header to use for the client assertion, when required by
+          the identity provider (for example, the thumbprint of the client certificate).
+        example: '"1234567890"'
+      - name: oidcCACert
+        type: string
+        required: false
+        description: |
+          PEM-encoded CA certificate used to verify the TLS connection to the token
+          endpoint. This is distinct from the TLS configuration of the Redis
+          connection itself.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username to pass to the Redis AUTH command together with the access token.
+          Defaults to "default" when using OIDC authentication.
+        example: '"default"'
+        default: '"default"'
 metadata:
   - name: redisHost
     required: true

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -142,9 +142,11 @@ authenticationProfiles:
         required: false
         description: |
           Username to pass to the Redis AUTH command together with the access token.
-          Defaults to "default" when using OIDC authentication.
-        example: '"default"'
-        default: '"default"'
+          When omitted, the token is sent using the 1-argument AUTH <token> form
+          (authenticating as the default user), accepted by the widest range of
+          RESP-compatible auth layers. Set a username to use the 2-argument
+          AUTH <username> <token> (ACL) form.
+        example: '"my-user"'
 metadata:
   - name: redisHost
     required: true

--- a/pubsub/redis/metadata.yaml
+++ b/pubsub/redis/metadata.yaml
@@ -55,6 +55,96 @@ authenticationProfiles:
         url:
           title: "Redis Sentinel authentication documentation"
           url: "https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#configuring-sentinel-instances-with-authentication"
+  - title: "OIDC private_key_jwt"
+    description: |
+      Authenticate using OpenID Connect with the private_key_jwt client authentication
+      method (RFC 7523). An OAuth2 access token is obtained from the identity provider
+      using a signed JWT client assertion and used as the password for the Redis AUTH
+      command. The token is refreshed in the background before it expires.
+    metadata:
+      - name: useOIDC
+        type: bool
+        required: false
+        description: |
+          If set to true, enables OIDC private_key_jwt authentication.
+          Must not be combined with "redisPassword" or "useEntraID".
+        example: '"true"'
+        default: '"false"'
+      - name: oidcTokenEndpoint
+        type: string
+        required: true
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+        example: '"https://identity.example.com/v1/token"'
+      - name: oidcClientID
+        type: string
+        required: true
+        description: |
+          The OAuth2 client ID that has been provisioned in the identity provider.
+        example: '"my-client-id"'
+      - name: oidcClientAssertionCert
+        type: string
+        required: true
+        description: |
+          PEM-encoded X.509 certificate paired with the client assertion signing key.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: oidcClientAssertionKey
+        type: string
+        required: true
+        sensitive: true
+        description: |
+          PEM-encoded RSA private key used to sign the client assertion.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN PRIVATE KEY-----\n...
+      - name: oidcResource
+        type: string
+        required: false
+        description: |
+          Optional OAuth2 resource parameter to include in the token request when
+          required by the identity provider.
+        example: '"URI:RS-12345-API"'
+      - name: oidcAudience
+        type: string
+        required: false
+        description: |
+          Overrides the JWT client assertion audience (aud). Defaults to the token
+          endpoint URL.
+        example: '"https://identity.example.com/realms/local"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          Although not required, this field is recommended.
+        example: '"openid,redis-prod"'
+        default: '"openid"'
+      - name: oidcKid
+        type: string
+        required: false
+        description: |
+          The JWT key ID (kid) header to use for the client assertion, when required by
+          the identity provider (for example, the thumbprint of the client certificate).
+        example: '"1234567890"'
+      - name: oidcCACert
+        type: string
+        required: false
+        description: |
+          PEM-encoded CA certificate used to verify the TLS connection to the token
+          endpoint. This is distinct from the TLS configuration of the Redis
+          connection itself.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username to pass to the Redis AUTH command together with the access token.
+          Defaults to "default" when using OIDC authentication.
+        example: '"default"'
+        default: '"default"'
 metadata:
   - name: redisHost
     required: true

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -147,9 +147,11 @@ authenticationProfiles:
         required: false
         description: |
           Username to pass to the Redis AUTH command together with the access token.
-          Defaults to "default" when using OIDC authentication.
-        example: '"default"'
-        default: '"default"'
+          When omitted, the token is sent using the 1-argument AUTH <token> form
+          (authenticating as the default user), accepted by the widest range of
+          RESP-compatible auth layers. Set a username to use the 2-argument
+          AUTH <username> <token> (ACL) form.
+        example: '"my-user"'
 metadata:
   - name: redisHost
     required: true

--- a/state/redis/metadata.yaml
+++ b/state/redis/metadata.yaml
@@ -60,6 +60,96 @@ authenticationProfiles:
         url:
           title: "Redis Sentinel authentication documentation"
           url: "https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#configuring-sentinel-instances-with-authentication"
+  - title: "OIDC private_key_jwt"
+    description: |
+      Authenticate using OpenID Connect with the private_key_jwt client authentication
+      method (RFC 7523). An OAuth2 access token is obtained from the identity provider
+      using a signed JWT client assertion and used as the password for the Redis AUTH
+      command. The token is refreshed in the background before it expires.
+    metadata:
+      - name: useOIDC
+        type: bool
+        required: false
+        description: |
+          If set to true, enables OIDC private_key_jwt authentication.
+          Must not be combined with "redisPassword" or "useEntraID".
+        example: '"true"'
+        default: '"false"'
+      - name: oidcTokenEndpoint
+        type: string
+        required: true
+        description: |
+          URL of the OAuth2 identity provider access token endpoint.
+        example: '"https://identity.example.com/v1/token"'
+      - name: oidcClientID
+        type: string
+        required: true
+        description: |
+          The OAuth2 client ID that has been provisioned in the identity provider.
+        example: '"my-client-id"'
+      - name: oidcClientAssertionCert
+        type: string
+        required: true
+        description: |
+          PEM-encoded X.509 certificate paired with the client assertion signing key.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: oidcClientAssertionKey
+        type: string
+        required: true
+        sensitive: true
+        description: |
+          PEM-encoded RSA private key used to sign the client assertion.
+          Use secretKeyRef for secret reference.
+        example: |
+          -----BEGIN PRIVATE KEY-----\n...
+      - name: oidcResource
+        type: string
+        required: false
+        description: |
+          Optional OAuth2 resource parameter to include in the token request when
+          required by the identity provider.
+        example: '"URI:RS-12345-API"'
+      - name: oidcAudience
+        type: string
+        required: false
+        description: |
+          Overrides the JWT client assertion audience (aud). Defaults to the token
+          endpoint URL.
+        example: '"https://identity.example.com/realms/local"'
+      - name: oidcScopes
+        type: string
+        required: false
+        description: |
+          Comma-delimited list of OAuth2/OIDC scopes to request with the access token.
+          Although not required, this field is recommended.
+        example: '"openid,redis-prod"'
+        default: '"openid"'
+      - name: oidcKid
+        type: string
+        required: false
+        description: |
+          The JWT key ID (kid) header to use for the client assertion, when required by
+          the identity provider (for example, the thumbprint of the client certificate).
+        example: '"1234567890"'
+      - name: oidcCACert
+        type: string
+        required: false
+        description: |
+          PEM-encoded CA certificate used to verify the TLS connection to the token
+          endpoint. This is distinct from the TLS configuration of the Redis
+          connection itself.
+        example: |
+          -----BEGIN CERTIFICATE-----\n...
+      - name: redisUsername
+        type: string
+        required: false
+        description: |
+          Username to pass to the Redis AUTH command together with the access token.
+          Defaults to "default" when using OIDC authentication.
+        example: '"default"'
+        default: '"default"'
 metadata:
   - name: redisHost
     required: true

--- a/tests/certification/state/redis/README.md
+++ b/tests/certification/state/redis/README.md
@@ -33,3 +33,11 @@ Upsert in Multi function, using 3 keys with updating values and TTL for 2 of the
 
 ## enableTLS set to true & enableTLS not integer:
 Testing by creating component with ignoreErrors: true and then trying to use it, by trying to save, which should error out as state store never got configured successfully. 
+
+## OIDC private_key_jwt authentication (`useOIDC`):
+Redis cannot validate JWTs itself, so the test runs a mock OAuth2 token endpoint that cryptographically verifies the client assertion (RS256 signature against the client certificate, `kid` header, `aud` as a JSON string, `resource` and `scope` form parameters) before issuing tokens, and configures the Redis ACL to require those tokens as the `AUTH` password:
+1. Unauthenticated access is rejected after the ACL is applied.
+2. CRUD operations succeed authenticated with the initial access token.
+3. The identity provider rotates to a second token; the background refresh fetches it and re-authenticates the connection pool (verified by continued CRUD operations and the second token request).
+4. The client assertion wire format is asserted on the identity provider side.
+5. A component configured with both `useOIDC` and `redisPassword` fails to initialize.

--- a/tests/certification/state/redis/components/docker/oidc/localsecrets.yaml
+++ b/tests/certification/state/redis/components/docker/oidc/localsecrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: envvar-secret-store
+spec:
+  type: secretstores.local.env
+  version: v1
+  metadata:

--- a/tests/certification/state/redis/components/docker/oidc/statestore.yaml
+++ b/tests/certification/state/redis/components/docker/oidc/statestore.yaml
@@ -1,0 +1,37 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  initTimeout: 1m
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: useOIDC
+    value: "true"
+  - name: oidcTokenEndpoint
+    secretKeyRef:
+      name: OIDC_TOKEN_ENDPOINT
+      key: OIDC_TOKEN_ENDPOINT
+  - name: oidcClientID
+    value: "dapr-redis-client-jwt"
+  - name: oidcClientAssertionCert
+    secretKeyRef:
+      name: OIDC_CLIENT_ASSERTION_CERT
+      key: OIDC_CLIENT_ASSERTION_CERT
+  - name: oidcClientAssertionKey
+    secretKeyRef:
+      name: OIDC_CLIENT_ASSERTION_KEY
+      key: OIDC_CLIENT_ASSERTION_KEY
+  - name: oidcKid
+    secretKeyRef:
+      name: OIDC_CLIENT_KID
+      key: OIDC_CLIENT_KID
+  - name: oidcScopes
+    value: "openid,redis-cert"
+  - name: oidcResource
+    value: "URI:RS-redis-cert-test"
+auth:
+  secretStore: envvar-secret-store

--- a/tests/certification/state/redis/components/docker/oidcConflict/statestore.yaml
+++ b/tests/certification/state/redis/components/docker/oidcConflict/statestore.yaml
@@ -1,0 +1,19 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  ignoreErrors: true
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: "some-static-password"
+  - name: useOIDC
+    value: "true"
+  - name: oidcTokenEndpoint
+    value: "http://localhost:1/token"
+  - name: oidcClientID
+    value: "conflict-client"

--- a/tests/certification/state/redis/redis_oidc_test.go
+++ b/tests/certification/state/redis/redis_oidc_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis_test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/secretstores"
+	secretstore_env "github.com/dapr/components-contrib/secretstores/local/env"
+	"github.com/dapr/components-contrib/state"
+	state_redis "github.com/dapr/components-contrib/state/redis"
+	"github.com/dapr/components-contrib/tests/certification/embedded"
+	"github.com/dapr/components-contrib/tests/certification/flow"
+	"github.com/dapr/components-contrib/tests/certification/flow/dockercompose"
+	"github.com/dapr/components-contrib/tests/certification/flow/retry"
+	"github.com/dapr/components-contrib/tests/certification/flow/sidecar"
+	secretstores_loader "github.com/dapr/dapr/pkg/components/secretstores"
+	state_loader "github.com/dapr/dapr/pkg/components/state"
+	dapr_testing "github.com/dapr/dapr/pkg/testing"
+	"github.com/dapr/go-sdk/client"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	oidcClientID          = "dapr-redis-client-jwt"
+	oidcKid               = "redis-cert-test-kid"
+	oidcTokenOne          = "dapr-redis-oidc-token-1"
+	oidcTokenTwo          = "dapr-redis-oidc-token-2"
+	oidcClientAssertation = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+)
+
+type tokenRequestRecord struct {
+	form        url.Values
+	assertion   string
+	issuedToken string
+}
+
+// mockIdentityProvider is an OAuth2 token endpoint that verifies the
+// private_key_jwt client assertion (RS256 signature against the client
+// certificate's public key) before issuing the configured access token.
+// Redis cannot validate JWTs itself, so the certification of the wire format
+// happens here, and Redis is configured (via ACL) to accept the issued tokens
+// as AUTH passwords.
+type mockIdentityProvider struct {
+	publicKey *rsa.PublicKey
+
+	lock      sync.Mutex
+	token     string
+	expiresIn int
+	requests  []tokenRequestRecord
+}
+
+func (m *mockIdentityProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	assertion := r.FormValue("client_assertion")
+	if err := verifyRS256(assertion, m.publicKey); err != nil {
+		http.Error(w, "invalid client assertion: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	m.lock.Lock()
+	token, expiresIn := m.token, m.expiresIn
+	m.requests = append(m.requests, tokenRequestRecord{form: r.Form, assertion: assertion, issuedToken: token})
+	m.lock.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token": token,
+		"expires_in":   expiresIn,
+	})
+}
+
+func (m *mockIdentityProvider) setToken(token string, expiresIn int) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.token = token
+	m.expiresIn = expiresIn
+}
+
+func (m *mockIdentityProvider) requestCount() int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return len(m.requests)
+}
+
+func (m *mockIdentityProvider) request(i int) tokenRequestRecord {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.requests[i]
+}
+
+func (m *mockIdentityProvider) lastIssuedToken() string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if len(m.requests) == 0 {
+		return ""
+	}
+	return m.requests[len(m.requests)-1].issuedToken
+}
+
+// verifyRS256 checks the JWT signature against the given RSA public key.
+func verifyRS256(token string, pub *rsa.PublicKey) error {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return errors.New("JWT must have 3 parts")
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return fmt.Errorf("invalid signature encoding: %w", err)
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	return rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], sig)
+}
+
+func decodeJWTSegment(t *testing.T, segment string) map[string]interface{} {
+	t.Helper()
+	decoded, err := base64.RawURLEncoding.DecodeString(segment)
+	require.NoError(t, err)
+	var out map[string]interface{}
+	require.NoError(t, json.Unmarshal(decoded, &out))
+	return out
+}
+
+func TestRedisOIDC(t *testing.T) {
+	t.Setenv("DAPR_CLIENT_TIMEOUT_SECONDS", "10")
+
+	log := logger.NewLogger("dapr.components")
+
+	// Generate a private key and certificate for the OIDC client assertion.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Dapr"},
+		},
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	// The initial token expires in 310s: the background refresh runs 5 minutes
+	// before expiry, so the first refresh fires ~10s after init.
+	idp := &mockIdentityProvider{publicKey: &key.PublicKey, token: oidcTokenOne, expiresIn: 310}
+	idpServer := httptest.NewServer(idp)
+	defer idpServer.Close()
+
+	t.Setenv("OIDC_TOKEN_ENDPOINT", idpServer.URL)
+	t.Setenv("OIDC_CLIENT_ASSERTION_CERT", string(certPEM))
+	t.Setenv("OIDC_CLIENT_ASSERTION_KEY", string(keyPEM))
+	t.Setenv("OIDC_CLIENT_KID", oidcKid)
+
+	ports, err := dapr_testing.GetFreePorts(2)
+	require.NoError(t, err)
+	currentGrpcPort := ports[0]
+	currentHTTPPort := ports[1]
+
+	newRegistries := func() (*state_loader.Registry, *secretstores_loader.Registry) {
+		stateRegistry := state_loader.NewRegistry()
+		stateRegistry.Logger = log
+		stateRegistry.RegisterComponent(func(l logger.Logger) state.Store {
+			return state_redis.NewRedisStateStore(l)
+		}, "redis")
+
+		secretstoreRegistry := secretstores_loader.NewRegistry()
+		secretstoreRegistry.Logger = log
+		secretstoreRegistry.RegisterComponent(func(l logger.Logger) secretstores.SecretStore {
+			return secretstore_env.NewEnvSecretStore(l)
+		}, "local.env")
+
+		return stateRegistry, secretstoreRegistry
+	}
+
+	checkRedisConnection := func(ctx flow.Context) error {
+		rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer rdb.Close()
+		return rdb.Ping(ctx).Err()
+	}
+
+	// Require a password for the default user and accept both tokens, so the
+	// rotation from token-1 to token-2 is race-free: connections authenticated
+	// with either token remain valid.
+	setupRedisACL := func(ctx flow.Context) error {
+		rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer rdb.Close()
+		err := rdb.Do(ctx, "ACL", "SETUSER", "default", "on", "resetpass",
+			">"+oidcTokenOne, ">"+oidcTokenTwo, "allkeys", "allchannels", "+@all").Err()
+		if err != nil {
+			// Redis < 6.2 has no channel permissions
+			err = rdb.Do(ctx, "ACL", "SETUSER", "default", "on", "resetpass",
+				">"+oidcTokenOne, ">"+oidcTokenTwo, "allkeys", "+@all").Err()
+		}
+		if err != nil {
+			return fmt.Errorf("failed to configure Redis ACL: %w", err)
+		}
+		return nil
+	}
+
+	verifyNoAuthFails := func(ctx flow.Context) error {
+		rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer rdb.Close()
+		if err := rdb.Ping(ctx).Err(); err == nil {
+			return errors.New("expected unauthenticated PING to fail after ACL setup")
+		}
+		return nil
+	}
+
+	basicTest := func(keySuffix string) flow.Runnable {
+		return func(ctx flow.Context) error {
+			client, err := client.NewClientWithPort(fmt.Sprint(currentGrpcPort))
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			stateKey := certificationTestPrefix + "oidc-" + keySuffix
+			err = client.SaveState(ctx, stateStoreName, stateKey, []byte("redisOIDCCert"), nil)
+			require.NoError(t, err)
+
+			item, err := client.GetState(ctx, stateStoreName, stateKey, nil)
+			require.NoError(t, err)
+			require.Equal(t, "redisOIDCCert", string(item.Value))
+
+			return client.DeleteState(ctx, stateStoreName, stateKey, nil)
+		}
+	}
+
+	// Switch the identity provider to the second token. The long expiry pushes
+	// the refresh after the next one ~2h out, so the refresh loop is dormant by
+	// the time the sidecar stops (the loop terminates the process if it cannot
+	// re-authenticate, e.g. against a closed client).
+	rotateToken := func(ctx flow.Context) error {
+		idp.setToken(oidcTokenTwo, 7200)
+		return nil
+	}
+
+	waitForTokenRefresh := func(ctx flow.Context) error {
+		deadline := time.Now().Add(90 * time.Second)
+		for time.Now().Before(deadline) {
+			if idp.lastIssuedToken() == oidcTokenTwo {
+				// Give the AuthACL re-authentication a moment to complete
+				time.Sleep(2 * time.Second)
+				return nil
+			}
+			time.Sleep(time.Second)
+		}
+		return errors.New("timed out waiting for the background token refresh")
+	}
+
+	assertWireFormat := func(ctx flow.Context) error {
+		require.GreaterOrEqual(t, idp.requestCount(), 2, "expected the initial token request and at least one refresh")
+		req := idp.request(0)
+
+		require.Equal(t, "client_credentials", req.form.Get("grant_type"))
+		require.Equal(t, oidcClientID, req.form.Get("client_id"))
+		require.Equal(t, oidcClientAssertation, req.form.Get("client_assertion_type"))
+		require.Equal(t, "openid redis-cert", req.form.Get("scope"))
+		require.Equal(t, "URI:RS-redis-cert-test", req.form.Get("resource"))
+
+		parts := strings.Split(req.assertion, ".")
+		require.Len(t, parts, 3, "client assertion must be a JWT")
+
+		header := decodeJWTSegment(t, parts[0])
+		require.Equal(t, "RS256", header["alg"])
+		require.Equal(t, oidcKid, header["kid"])
+
+		claims := decodeJWTSegment(t, parts[1])
+		require.Equal(t, oidcClientID, claims["iss"])
+		require.Equal(t, oidcClientID, claims["sub"])
+		// Some IdPs require the audience to be a single JSON string, not an array
+		require.IsType(t, "", claims["aud"])
+		require.Equal(t, idpServer.URL, claims["aud"])
+		require.NotEmpty(t, claims["jti"])
+
+		return nil
+	}
+
+	stateRegistry, secretstoreRegistry := newRegistries()
+
+	flow.New(t, "redis state store with OIDC private_key_jwt authentication").
+		Step(dockercompose.Run("redisoidc", dockerComposeYAML)).
+		Step("Waiting for Redis readiness", retry.Do(time.Second*3, 10, checkRedisConnection)).
+		Step("Configure Redis ACL to accept the OIDC tokens as passwords", setupRedisACL).
+		Step("Verify unauthenticated access is rejected", verifyNoAuthFails).
+		Step(sidecar.Run(sidecarNamePrefix+"oidc",
+			embedded.WithoutApp(),
+			embedded.WithDaprGRPCPort(strconv.Itoa(currentGrpcPort)),
+			embedded.WithDaprHTTPPort(strconv.Itoa(currentHTTPPort)),
+			embedded.WithComponentsPath("components/docker/oidc"),
+			embedded.WithStates(stateRegistry),
+			embedded.WithSecretStores(secretstoreRegistry),
+		)).
+		Step("Run basic test authenticated with the initial token", basicTest("initial")).
+		Step("Rotate the identity provider token", rotateToken).
+		Step("Wait for the background token refresh", waitForTokenRefresh).
+		Step("Run basic test after the token refresh", basicTest("refreshed")).
+		Step("Assert the private_key_jwt wire format", assertWireFormat).
+		Step("stop dapr", sidecar.Stop(sidecarNamePrefix+"oidc")).
+		Run()
+
+	conflictStateRegistry, conflictSecretstoreRegistry := newRegistries()
+
+	testForStateStoreNotConfigured := func(ctx flow.Context) error {
+		client, err := client.NewClientWithPort(fmt.Sprint(currentGrpcPort))
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		err = client.SaveState(ctx, stateStoreName, certificationTestPrefix+"oidc-conflict", []byte("redisOIDCCert"), nil)
+		require.EqualError(t, err, stateStoreNoConfigError)
+
+		return nil
+	}
+
+	flow.New(t, "redis state store with conflicting useOIDC and redisPassword fails to initialize").
+		Step(dockercompose.Run("redisoidc", dockerComposeYAML)).
+		Step("Waiting for Redis readiness", retry.Do(time.Second*3, 10, checkRedisConnection)).
+		Step(sidecar.Run(sidecarNamePrefix+"oidc-conflict",
+			embedded.WithoutApp(),
+			embedded.WithDaprGRPCPort(strconv.Itoa(currentGrpcPort)),
+			embedded.WithDaprHTTPPort(strconv.Itoa(currentHTTPPort)),
+			embedded.WithComponentsPath("components/docker/oidcConflict"),
+			embedded.WithStates(conflictStateRegistry),
+			embedded.WithSecretStores(conflictSecretstoreRegistry),
+		)).
+		Step("Verify the state store is not configured", testForStateStoreNotConfigured).
+		Step("stop dapr", sidecar.Stop(sidecarNamePrefix+"oidc-conflict")).
+		Run()
+}

--- a/tests/certification/state/redis/redis_oidc_test.go
+++ b/tests/certification/state/redis/redis_oidc_test.go
@@ -55,11 +55,11 @@ import (
 )
 
 const (
-	oidcClientID          = "dapr-redis-client-jwt"
-	oidcKid               = "redis-cert-test-kid"
-	oidcTokenOne          = "dapr-redis-oidc-token-1"
-	oidcTokenTwo          = "dapr-redis-oidc-token-2"
-	oidcClientAssertation = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+	oidcClientID        = "dapr-redis-client-jwt"
+	oidcKid             = "redis-cert-test-kid"
+	oidcTokenOne        = "dapr-redis-oidc-token-1"
+	oidcTokenTwo        = "dapr-redis-oidc-token-2"
+	oidcClientAssertion = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 )
 
 type tokenRequestRecord struct {
@@ -291,7 +291,7 @@ func TestRedisOIDC(t *testing.T) {
 
 		require.Equal(t, "client_credentials", req.form.Get("grant_type"))
 		require.Equal(t, oidcClientID, req.form.Get("client_id"))
-		require.Equal(t, oidcClientAssertation, req.form.Get("client_assertion_type"))
+		require.Equal(t, oidcClientAssertion, req.form.Get("client_assertion_type"))
 		require.Equal(t, "openid redis-cert", req.form.Get("scope"))
 		require.Equal(t, "URI:RS-redis-cert-test", req.form.Get("resource"))
 
@@ -320,7 +320,8 @@ func TestRedisOIDC(t *testing.T) {
 		Step("Waiting for Redis readiness", retry.Do(time.Second*3, 10, checkRedisConnection)).
 		Step("Configure Redis ACL to accept the OIDC tokens as passwords", setupRedisACL).
 		Step("Verify unauthenticated access is rejected", verifyNoAuthFails).
-		Step(sidecar.Run(sidecarNamePrefix+"oidc",
+		Step(sidecar.Run(
+			sidecarNamePrefix+"oidc",
 			embedded.WithoutApp(),
 			embedded.WithDaprGRPCPort(strconv.Itoa(currentGrpcPort)),
 			embedded.WithDaprHTTPPort(strconv.Itoa(currentHTTPPort)),
@@ -354,7 +355,8 @@ func TestRedisOIDC(t *testing.T) {
 	flow.New(t, "redis state store with conflicting useOIDC and redisPassword fails to initialize").
 		Step(dockercompose.Run("redisoidc", dockerComposeYAML)).
 		Step("Waiting for Redis readiness", retry.Do(time.Second*3, 10, checkRedisConnection)).
-		Step(sidecar.Run(sidecarNamePrefix+"oidc-conflict",
+		Step(sidecar.Run(
+			sidecarNamePrefix+"oidc-conflict",
 			embedded.WithoutApp(),
 			embedded.WithDaprGRPCPort(strconv.Itoa(currentGrpcPort)),
 			embedded.WithDaprHTTPPort(strconv.Itoa(currentHTTPPort)),


### PR DESCRIPTION
# Description

Adds support for the OAuth2 `client_credentials` grant with the **private_key_jwt** client authentication method ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)) to all Redis-based components (state, pubsub, lock, bindings, configuration), enabled via a new `useOIDC` metadata flag.

## How it works

1. The component authenticates to the identity provider's token endpoint with a signed JWT client assertion (RS256, optional `kid` header, flattened `aud` claim for IdPs that require a JSON string).
2. The resulting access token is used as the password for the Redis `AUTH` command (username defaults to `default`, equivalent to plain `AUTH <token>`; an explicit `redisUsername` is honored).
3. A background routine refreshes the token 5 minutes before expiry and re-authenticates the live connection pool via `AuthACL`, mirroring the existing `useEntraID` flow.

This works against Redis, Valkey, and any other RESP-compatible server fronted by an auth layer that accepts a bearer token as the AUTH password.

## Implementation notes

- **Token acquisition is a port of the Kafka component's existing `oidc_private_key_jwt` implementation** (`common/component/kafka/sasl_oauthbearer_private_key_jwt.go`, from #4057 and #4099) with the Sarama-specific wrapping removed, plus a mutex on the cached token and a `ForceToken` used by the refresh routine.
- **The existing EntraID flow is untouched.** The new refresh routine shares the same loop semantics (5-min grace period, exponential backoff ×3, close + fatal on definitive failure) via a generic `runTokenRefreshLoop`; the EntraID routine is intentionally not modified to keep this diff low-risk.
- New metadata fields (mirroring the Kafka names): `useOIDC`, `oidcTokenEndpoint`, `oidcClientID`, `oidcClientAssertionCert`, `oidcClientAssertionKey`, `oidcResource`, `oidcAudience`, `oidcKid`, `oidcScopes`, `oidcCACert` (CA for the token endpoint TLS, distinct from the Redis connection TLS). Declared in the `authenticationProfiles` of all 5 Redis component metadata.yaml files.
- `useOIDC` is mutually exclusive with `useEntraID` and `redisPassword`.

## Testing

- Unit tests for the token source against an `httptest` IdP stub: form parameters, JWT assertion claims (`iss`/`sub`/`aud`-as-string/`jti`), `kid` header, token caching, `ForceToken`, custom CA TLS verification, error paths, and concurrency.
- Unit tests for settings validation (required fields, mutual exclusivity, username defaulting, scope parsing).
- Unit test for the refresh loop (retry on transient failure, `AuthACL` re-authentication) against a fake client.
- Certification test (`tests/certification/state/redis/redis_oidc_test.go`). Redis cannot validate JWTs itself, so the test certifies both ends of the contract: a mock OAuth2 token endpoint cryptographically verifies the client assertion (RS256 signature against the client certificate, `kid` header, `aud` as a JSON string, `resource`/`scope` parameters) before issuing tokens, and the Redis ACL requires those tokens as the `AUTH` password. Covers: unauthenticated access rejected, CRUD with the initial token, token rotation picked up by the background refresh (verified by the second token request and continued CRUD), wire-format assertions, and failed initialization when `useOIDC` is combined with `redisPassword`.

RELEASE NOTE: ADD OIDC private_key_jwt authentication support for Redis-based components

## Issue reference

Please reference the issue this PR will close: #4107

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5211



