### PR TITLE
Add topicsPattern regex subscriptions to Pulsar pub/sub

### DIFF
--- a/pubsub/pulsar/metadata.go
+++ b/pubsub/pulsar/metadata.go
@@ -45,6 +45,8 @@ type pulsarMetadata struct {
 	SubscriptionInitialPosition      string                    `mapstructure:"subscribeInitialPosition"`
 	ReplicateSubscriptionState       bool                      `mapstructure:"replicateSubscriptionState"`
 	SubscriptionMode                 string                    `mapstructure:"subscribeMode"`
+	TopicsPattern                    string                    `mapstructure:"topicsPattern"`
+	AutoDiscoveryPeriod              time.Duration             `mapstructure:"autoDiscoveryPeriod"`
 	Token                            string                    `mapstructure:"token"`
 	CompressionType                  string                    `mapstructure:"compressionType"`
 	CompressionLevel                 string                    `mapstructure:"compressionLevel"`

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -308,8 +308,8 @@ metadata:
     type: duration
     description: |
       When topicsPattern is set, controls how often Pulsar re-evaluates the pattern to pick up newly
-      created (or removed) matching topics. A value of "0" lets the Pulsar client use its own default
-      interval. Has no effect unless topicsPattern is set. Can be overridden per subscription via
-      subscription metadata.
-    default: '"1m"'
+      created (or removed) matching topics. The component default is "0", which lets the Pulsar client
+      use its own default interval (currently 1m). Has no effect unless topicsPattern is set. Can be
+      overridden per subscription via subscription metadata.
+    default: '"0"'
     example: '"30s", "5m"'

--- a/pubsub/pulsar/metadata.yaml
+++ b/pubsub/pulsar/metadata.yaml
@@ -284,9 +284,32 @@ metadata:
   - name: subscribeMode
     type: string
     description: |
-      Subscription mode indicates the cursor belongs to "durable" type or "non_durable" type, durable subscription retains messages and persists the current position. 
+      Subscription mode indicates the cursor belongs to "durable" type or "non_durable" type, durable subscription retains messages and persists the current position.
     default: '"durable"'
     example: '"durable"'
-    url: 
+    url:
       title: "Pulsar SubscriptionMode"
       url: "https://pkg.go.dev/github.com/apache/pulsar-client-go/pulsar#SubscriptionMode"
+  - name: topicsPattern
+    type: string
+    description: |
+      A regular expression used to subscribe to all topics whose name matches the pattern within the
+      configured tenant and namespace, instead of a single explicit topic. When set, it takes precedence
+      over the subscription's topic, and Pulsar auto-discovers new matching topics over time
+      (see autoDiscoveryPeriod). The expression is matched against the local topic name within the
+      resolved persistent/non-persistent tenant/namespace scope. Can be set on the component (applies to
+      all subscriptions) or overridden per subscription via subscription metadata. Messages are delivered
+      to the application tagged with the concrete topic they arrived on, not the pattern.
+    example: '"orders-.*", "event-.+-v2"'
+    url:
+      title: "Pulsar Pattern Subscriptions"
+      url: "https://pulsar.apache.org/docs/3.0.x/client-libraries-go/#use-regular-expressions"
+  - name: autoDiscoveryPeriod
+    type: duration
+    description: |
+      When topicsPattern is set, controls how often Pulsar re-evaluates the pattern to pick up newly
+      created (or removed) matching topics. A value of "0" lets the Pulsar client use its own default
+      interval. Has no effect unless topicsPattern is set. Can be overridden per subscription via
+      subscription metadata.
+    default: '"1m"'
+    example: '"30s", "5m"'

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -109,6 +110,14 @@ const (
 
 	subscribeModeDurable    = "durable"
 	subscribeModeNonDurable = "non_durable"
+
+	// topicsPatternKey is the subscription/component metadata key holding a
+	// regular expression that selects multiple topics within a single
+	// tenant/namespace. When set it takes precedence over the explicit topic.
+	topicsPatternKey = "topicsPattern"
+	// autoDiscoveryPeriodKey controls how often Pulsar re-evaluates the
+	// topicsPattern to pick up newly created (or removed) matching topics.
+	autoDiscoveryPeriodKey = "autoDiscoveryPeriod"
 
 	compressionTypeKey  = "compressionType"
 	compressionLevelKey = "compressionLevel"
@@ -239,6 +248,23 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 	// workers would block the dispatch loop immediately.
 	if m.MaxConcurrentHandlers == 0 {
 		m.MaxConcurrentHandlers = defaultConcurrency
+	}
+
+	// Validate the topics regex pattern up-front so misconfiguration surfaces at
+	// Init rather than as an opaque error on the first Subscribe call. The
+	// pattern is matched by Pulsar against the local topic name within the
+	// resolved tenant/namespace (Subscribe scopes it via formatTopic), so we
+	// compile only the user-supplied expression here.
+	if m.TopicsPattern != "" {
+		if _, err := regexp.Compile(m.TopicsPattern); err != nil {
+			return nil, fmt.Errorf("invalid topicsPattern %q: %w", m.TopicsPattern, err)
+		}
+	}
+
+	// A negative auto-discovery period is meaningless; zero is allowed and lets
+	// the Pulsar client fall back to its own default interval.
+	if m.AutoDiscoveryPeriod < 0 {
+		return nil, fmt.Errorf("invalid autoDiscoveryPeriod %q: must not be negative", m.AutoDiscoveryPeriod)
 	}
 
 	// First pass: collect per-topic rawSchema flags.
@@ -713,15 +739,30 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 
 	channel := make(chan pulsar.ConsumerMessage, p.metadata.MaxConcurrentHandlers)
 
-	topic := p.formatTopic(req.Topic)
-
 	subscribeType := p.metadata.SubscriptionType
 	if s, exists := req.Metadata[subscribeTypeKey]; exists {
 		subscribeType = s
 	}
 
+	// Resolve the topics pattern. It may be set on the component (applies to
+	// every subscription) or overridden per-subscription via metadata. When a
+	// pattern is present the consumer subscribes by regex instead of to a single
+	// explicit topic, and Pulsar auto-discovers matching topics over time.
+	topicsPattern := p.resolveTopicsPattern(req)
+	patternMode := topicsPattern != ""
+
+	autoDiscoveryPeriod := p.metadata.AutoDiscoveryPeriod
+	if v, ok := req.Metadata[autoDiscoveryPeriodKey]; ok && v != "" {
+		d, derr := time.ParseDuration(v)
+		if derr != nil || d < 0 {
+			return fmt.Errorf("invalid %s %q in subscription metadata: must be a non-negative Go duration", autoDiscoveryPeriodKey, v)
+		}
+		autoDiscoveryPeriod = d
+	}
+
+	topic := p.formatTopic(req.Topic)
+
 	options := pulsar.ConsumerOptions{
-		Topic:                       topic,
 		SubscriptionName:            p.metadata.ConsumerID,
 		Type:                        getSubscribeType(subscribeType),
 		SubscriptionInitialPosition: getSubscribePosition(p.metadata.SubscriptionInitialPosition),
@@ -730,6 +771,17 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 		NackRedeliveryDelay:         p.metadata.RedeliveryDelay,
 		ReceiverQueueSize:           p.metadata.ReceiverQueueSize,
 		ReplicateSubscriptionState:  p.metadata.ReplicateSubscriptionState,
+	}
+
+	if patternMode {
+		// Reuse formatTopic so the regex is scoped to the configured
+		// tenant/namespace, e.g. "persistent://public/default/orders-.*".
+		// Pulsar derives the namespace to scan from this prefix and matches the
+		// regex against topics within it.
+		options.TopicsPattern = p.formatTopic(topicsPattern)
+		options.AutoDiscoveryPeriod = autoDiscoveryPeriod
+	} else {
+		options.Topic = topic
 	}
 
 	// Handle KeySharedPolicy for key_shared subscription type
@@ -752,15 +804,28 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 		}
 	}
 
-	if sm, ok := p.metadata.internalTopicSchemas[req.Topic]; ok {
-		options.Schema = getRegistrationSchema(sm)
+	// Per-topic schema registration only applies to an explicit single topic.
+	// A regex subscription can span many topics whose schemas are not known in
+	// advance, so schema enforcement is skipped in pattern mode.
+	if !patternMode {
+		if sm, ok := p.metadata.internalTopicSchemas[req.Topic]; ok {
+			options.Schema = getRegistrationSchema(sm)
+		}
 	}
 	consumer, err := p.client.Subscribe(options)
 	if err != nil {
-		p.logger.Debugf("Could not subscribe to %s, full topic name in pulsar is %s", req.Topic, topic)
+		if patternMode {
+			p.logger.Debugf("Could not subscribe with topics pattern %q (full pattern in pulsar is %s)", topicsPattern, options.TopicsPattern)
+		} else {
+			p.logger.Debugf("Could not subscribe to %s, full topic name in pulsar is %s", req.Topic, topic)
+		}
 		return err
 	}
-	p.logger.Debugf("Subscribed to '%s'(%s) with type '%s'", req.Topic, topic, subscribeType)
+	if patternMode {
+		p.logger.Debugf("Subscribed to topics pattern %q(%s) with type '%s'", topicsPattern, options.TopicsPattern, subscribeType)
+	} else {
+		p.logger.Debugf("Subscribed to '%s'(%s) with type '%s'", req.Topic, topic, subscribeType)
+	}
 
 	p.wg.Add(2)
 	listenCtx, cancel := context.WithCancel(ctx)
@@ -781,8 +846,24 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 	return nil
 }
 
+// resolveTopicsPattern returns the effective topics regex for a subscription:
+// the per-subscription override if present, otherwise the component default.
+// An empty result means the subscription targets a single explicit topic.
+func (p *Pulsar) resolveTopicsPattern(req pubsub.SubscribeRequest) string {
+	if v, ok := req.Metadata[topicsPatternKey]; ok {
+		return v
+	}
+	return p.metadata.TopicsPattern
+}
+
 func (p *Pulsar) listenMessage(ctx context.Context, req pubsub.SubscribeRequest, consumer pulsar.Consumer, handler pubsub.Handler) {
 	defer consumer.Close()
+
+	// In pattern mode a single consumer spans many topics, so each message must
+	// be delivered tagged with the concrete topic it arrived on rather than the
+	// regex. Outside pattern mode we keep using the subscription's declared
+	// topic, preserving existing behavior (and the per-topic Avro schema path).
+	patternMode := p.resolveTopicsPattern(req) != ""
 
 	// Resolve effective process mode: component metadata is already normalized
 	// to lowercase in parsePulsarMetadata; subscription metadata may override.
@@ -806,21 +887,21 @@ func (p *Pulsar) listenMessage(ctx context.Context, req pubsub.SubscribeRequest,
 	originTopic := req.Topic
 
 	if mode == processModeSync {
-		p.listenMessageSync(ctx, originTopic, consumer, handler)
+		p.listenMessageSync(ctx, originTopic, patternMode, consumer, handler)
 	} else {
-		p.listenMessageAsync(ctx, originTopic, consumer, handler)
+		p.listenMessageAsync(ctx, originTopic, patternMode, consumer, handler)
 	}
 }
 
 // listenMessageSync processes messages sequentially on the calling goroutine.
-func (p *Pulsar) listenMessageSync(ctx context.Context, originTopic string, consumer pulsar.Consumer, handler pubsub.Handler) {
+func (p *Pulsar) listenMessageSync(ctx context.Context, originTopic string, patternMode bool, consumer pulsar.Consumer, handler pubsub.Handler) {
 	for {
 		select {
 		case msg, ok := <-consumer.Chan():
 			if !ok {
 				return
 			}
-			if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
+			if err := p.handleMessage(ctx, originTopic, patternMode, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
 				p.logger.Errorf("Error sync processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
 			}
 		case <-ctx.Done():
@@ -836,7 +917,7 @@ func (p *Pulsar) listenMessageSync(ctx context.Context, originTopic string, cons
 // and the SDK stops requesting more messages from the broker. There is no
 // intermediate work channel, so MaxConcurrentHandlers bounds both the number
 // of concurrent handlers and the consumer channel buffer (set in Subscribe).
-func (p *Pulsar) listenMessageAsync(ctx context.Context, originTopic string, consumer pulsar.Consumer, handler pubsub.Handler) {
+func (p *Pulsar) listenMessageAsync(ctx context.Context, originTopic string, patternMode bool, consumer pulsar.Consumer, handler pubsub.Handler) {
 	// Use a local WaitGroup for workers so that we can wait for in-flight
 	// handlers to finish their Ack/Nack calls before returning. The caller
 	// defers consumer.Close(), so returning early would close the consumer
@@ -854,7 +935,7 @@ func (p *Pulsar) listenMessageAsync(ctx context.Context, originTopic string, con
 					if !ok {
 						return
 					}
-					if err := p.handleMessage(ctx, originTopic, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
+					if err := p.handleMessage(ctx, originTopic, patternMode, msg, handler); err != nil && !errors.Is(err, context.Canceled) {
 						p.logger.Errorf("Error async processing message: %s/%#v [key=%s]: %v", msg.Topic(), msg.ID(), msg.Key(), err)
 					}
 				case <-ctx.Done():
@@ -873,15 +954,27 @@ func (p *Pulsar) listenMessageAsync(ctx context.Context, originTopic string, con
 	workerWg.Wait()
 }
 
-func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, msg pulsar.ConsumerMessage, handler pubsub.Handler) error {
+func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, patternMode bool, msg pulsar.ConsumerMessage, handler pubsub.Handler) error {
 	data := msg.Payload()
+
+	// The topic surfaced to the Dapr runtime. For an explicit single-topic
+	// subscription this is the declared topic. For a pattern subscription the
+	// declared "topic" is a regex, so we instead report the concrete topic the
+	// message arrived on (shortened to the local name, matching the short names
+	// used elsewhere) so routing and observability see the real topic.
+	deliveredTopic := originTopic
+	if patternMode {
+		deliveredTopic = p.shortTopicName(msg.Topic())
+	}
 
 	// If an Avro schema is registered for this topic, decode the Avro binary
 	// payload to JSON before passing it to the Dapr runtime. The Pulsar Go
 	// client does not automatically decode msg.Payload() when using Chan(),
 	// so we must do it explicitly here.
 	// The goavro codec was compiled once at init in parsePulsarMetadata.
-	if sm, ok := p.metadata.internalTopicSchemas[originTopic]; ok && sm.protocol == avroProtocol {
+	// Keyed on the delivered (concrete) topic so it resolves correctly for both
+	// explicit and pattern subscriptions.
+	if sm, ok := p.metadata.internalTopicSchemas[deliveredTopic]; ok && sm.protocol == avroProtocol {
 		// Use the CE envelope codec when available (matches the schema registered
 		// with the producer/consumer), otherwise fall back to the inner codec.
 		codec := sm.ceCodec
@@ -891,19 +984,19 @@ func (p *Pulsar) handleMessage(ctx context.Context, originTopic string, msg puls
 		native, _, decodeErr := codec.NativeFromBinary(data)
 		if decodeErr != nil {
 			msg.Nack(msg.Message)
-			return fmt.Errorf("avro decode failed for topic %q: %w", originTopic, decodeErr)
+			return fmt.Errorf("avro decode failed for topic %q: %w", deliveredTopic, decodeErr)
 		}
 		jsonBytes, encodeErr := codec.TextualFromNative(nil, native)
 		if encodeErr != nil {
 			msg.Nack(msg.Message)
-			return fmt.Errorf("avro to json conversion failed for topic %q: %w", originTopic, encodeErr)
+			return fmt.Errorf("avro to json conversion failed for topic %q: %w", deliveredTopic, encodeErr)
 		}
 		data = jsonBytes
 	}
 
 	pubsubMsg := pubsub.NewMessage{
 		Data:     data,
-		Topic:    originTopic,
+		Topic:    deliveredTopic,
 		Metadata: msg.Properties(),
 	}
 
@@ -970,6 +1063,26 @@ func (p *Pulsar) formatTopic(topic string) string {
 		persist = nonPersistentStr
 	}
 	return fmt.Sprintf(topicFormat, persist, p.metadata.Tenant, p.metadata.Namespace, topic)
+}
+
+// shortTopicName reduces a topic name to its local part. The Pulsar client
+// reports fully-qualified names (e.g. "persistent://public/default/orders-eu");
+// for pattern subscriptions we deliver the trailing local name ("orders-eu") so
+// it matches the short topic names used by explicit subscriptions. Names that do
+// not carry the expected prefix are returned unchanged.
+func (p *Pulsar) shortTopicName(topic string) string {
+	// Drop the "{persistent|non-persistent}://" domain prefix, then keep the
+	// segment after the last "/", which is the local topic name within
+	// tenant/namespace. Partitioned topics keep their "-partition-N" suffix,
+	// which is part of the local name.
+	name := topic
+	if idx := strings.Index(name, "://"); idx >= 0 {
+		name = name[idx+len("://"):]
+	}
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
 }
 
 // GetComponentMetadata returns the metadata of the component.

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -751,6 +751,16 @@ func (p *Pulsar) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, han
 	topicsPattern := p.resolveTopicsPattern(req)
 	patternMode := topicsPattern != ""
 
+	// The component-level pattern is validated once at Init in
+	// parsePulsarMetadata, but a per-subscription override bypasses that path, so
+	// validate it here too. This keeps a malformed regex surfacing as a clear
+	// error rather than an opaque failure from the Pulsar client.
+	if v, ok := req.Metadata[topicsPatternKey]; ok && v != "" {
+		if _, err := regexp.Compile(v); err != nil {
+			return fmt.Errorf("invalid %s %q in subscription metadata: %w", topicsPatternKey, v, err)
+		}
+	}
+
 	autoDiscoveryPeriod := p.metadata.AutoDiscoveryPeriod
 	if v, ok := req.Metadata[autoDiscoveryPeriodKey]; ok && v != "" {
 		d, derr := time.ParseDuration(v)

--- a/pubsub/pulsar/pulsar.go
+++ b/pubsub/pulsar/pulsar.go
@@ -264,7 +264,7 @@ func parsePulsarMetadata(meta pubsub.Metadata) (*pulsarMetadata, error) {
 	// A negative auto-discovery period is meaningless; zero is allowed and lets
 	// the Pulsar client fall back to its own default interval.
 	if m.AutoDiscoveryPeriod < 0 {
-		return nil, fmt.Errorf("invalid autoDiscoveryPeriod %q: must not be negative", m.AutoDiscoveryPeriod)
+		return nil, fmt.Errorf("invalid autoDiscoveryPeriod %s: must not be negative", m.AutoDiscoveryPeriod)
 	}
 
 	// First pass: collect per-topic rawSchema flags.

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -2502,7 +2502,7 @@ func TestHandleMessageAvroDecodeRoundTrip(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(t.Context(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.NoError(t, err)
 	assert.True(t, consumer.acked, "message should be acked on success")
 	assert.False(t, consumer.nacked, "message should not be nacked on success")
@@ -2568,7 +2568,7 @@ func TestHandleMessageAvroCEEnvelopeDecodeRoundTrip(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(t.Context(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.NoError(t, err)
 	assert.True(t, consumer.acked)
 
@@ -2609,7 +2609,7 @@ func TestHandleMessageAvroDecodeError(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(t.Context(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "avro decode failed")
 	assert.True(t, consumer.nacked, "message should be nacked on decode error")
@@ -2638,7 +2638,7 @@ func TestHandleMessageNoAvroSchema(t *testing.T) {
 		return nil
 	}
 
-	err := p.handleMessage(t.Context(), topic, cm, handler)
+	err := p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(rawJSON), string(receivedData))
 	assert.True(t, consumer.acked)
@@ -2665,7 +2665,7 @@ func TestHandleMessageHandlerErrorNacks(t *testing.T) {
 		return handlerErr
 	}
 
-	err := p.handleMessage(t.Context(), topic, cm, handler)
+	err := p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.Error(t, err)
 	assert.Equal(t, handlerErr, err)
 	assert.True(t, consumer.nacked, "message must be nacked when handler returns error")
@@ -2706,7 +2706,7 @@ func TestHandleMessageAvroPropertiesPreserved(t *testing.T) {
 		return nil
 	}
 
-	err = p.handleMessage(t.Context(), topic, cm, handler)
+	err = p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.NoError(t, err)
 	assert.Equal(t, props, receivedMetadata, "properties must be preserved through the Avro decode path")
 }
@@ -2736,7 +2736,7 @@ func TestHandleMessageNonAvroSchemaPassthrough(t *testing.T) {
 		return nil
 	}
 
-	err := p.handleMessage(t.Context(), topic, cm, handler)
+	err := p.handleMessage(t.Context(), topic, false, cm, handler)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(rawJSON), string(receivedData), "non-Avro schema topics must pass raw bytes through")
 	assert.True(t, consumer.acked)
@@ -2803,4 +2803,276 @@ func TestPublishErrorClassification(t *testing.T) {
 		require.True(t, ok, "publish error must carry a gRPC status")
 		assert.Equal(t, codes.FailedPrecondition, st.Code())
 	})
+}
+
+// --- topicsPattern (regex / wildcard multi-topic subscriptions) ---
+
+func TestParsePulsarMetadataTopicsPattern(t *testing.T) {
+	tests := []struct {
+		name                string
+		properties          map[string]string
+		expectErr           bool
+		expectPattern       string
+		expectAutoDiscovery time.Duration
+	}{
+		{
+			name:          "valid pattern",
+			properties:    map[string]string{"host": "localhost:6650", "topicsPattern": "orders-.*"},
+			expectPattern: "orders-.*",
+		},
+		{
+			name:                "valid pattern with auto discovery period",
+			properties:          map[string]string{"host": "localhost:6650", "topicsPattern": "events-.+", "autoDiscoveryPeriod": "30s"},
+			expectPattern:       "events-.+",
+			expectAutoDiscovery: 30 * time.Second,
+		},
+		{
+			name:          "no pattern leaves field empty",
+			properties:    map[string]string{"host": "localhost:6650"},
+			expectPattern: "",
+		},
+		{
+			name:       "invalid regex is rejected",
+			properties: map[string]string{"host": "localhost:6650", "topicsPattern": "orders-[a-"},
+			expectErr:  true,
+		},
+		{
+			name:       "negative auto discovery period is rejected",
+			properties: map[string]string{"host": "localhost:6650", "topicsPattern": "orders-.*", "autoDiscoveryPeriod": "-5s"},
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta, err := parsePulsarMetadata(pubsub.Metadata{Base: metadata.Base{Properties: tc.properties}})
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectPattern, meta.TopicsPattern)
+			assert.Equal(t, tc.expectAutoDiscovery, meta.AutoDiscoveryPeriod)
+		})
+	}
+}
+
+// TestSubscribe_TopicsPatternFromComponent verifies that a component-level
+// topicsPattern causes Subscribe to set ConsumerOptions.TopicsPattern (scoped to
+// the tenant/namespace) and leave the single Topic field empty.
+func TestSubscribe_TopicsPatternFromComponent(t *testing.T) {
+	p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
+
+	md := pubsub.Metadata{
+		Base: metadata.Base{Properties: map[string]string{
+			"host":                "localhost:6650",
+			"consumerID":          "pattern-consumer",
+			"tenant":              "public",
+			"namespace":           "default",
+			"topicsPattern":       "orders-.*",
+			"autoDiscoveryPeriod": "45s",
+		}},
+	}
+
+	var capturedOptions pulsar.ConsumerOptions
+	p.client = &MockPulsarClient{
+		SubscribeFn: func(options pulsar.ConsumerOptions) (pulsar.Consumer, error) {
+			capturedOptions = options
+			return &MockPulsarConsumer{Ch: make(chan pulsar.ConsumerMessage)}, nil
+		},
+	}
+
+	parsedMeta, err := parsePulsarMetadata(md)
+	require.NoError(t, err)
+	p.metadata = *parsedMeta
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// req.Topic is ignored when a pattern is active, but the runtime still
+	// supplies one; ensure it does not leak into ConsumerOptions.Topic.
+	req := pubsub.SubscribeRequest{Topic: "ignored-topic", Metadata: md.Properties}
+	err = p.Subscribe(ctx, req, func(ctx context.Context, msg *pubsub.NewMessage) error { return nil })
+	require.NoError(t, err)
+
+	assert.Empty(t, capturedOptions.Topic, "pattern mode must not set a single Topic")
+	assert.Equal(t, "persistent://public/default/orders-.*", capturedOptions.TopicsPattern,
+		"pattern must be scoped to the configured tenant/namespace")
+	assert.Equal(t, 45*time.Second, capturedOptions.AutoDiscoveryPeriod)
+}
+
+// TestSubscribe_TopicsPatternPerSubscriptionOverride verifies that subscription
+// metadata can enable (or change) a pattern even when the component default is a
+// single topic, and that the per-subscription auto-discovery period is applied.
+func TestSubscribe_TopicsPatternPerSubscriptionOverride(t *testing.T) {
+	p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
+
+	componentMeta := pubsub.Metadata{
+		Base: metadata.Base{Properties: map[string]string{
+			"host":       "localhost:6650",
+			"consumerID": "pattern-consumer",
+		}},
+	}
+	parsedMeta, err := parsePulsarMetadata(componentMeta)
+	require.NoError(t, err)
+	p.metadata = *parsedMeta
+
+	var capturedOptions pulsar.ConsumerOptions
+	p.client = &MockPulsarClient{
+		SubscribeFn: func(options pulsar.ConsumerOptions) (pulsar.Consumer, error) {
+			capturedOptions = options
+			return &MockPulsarConsumer{Ch: make(chan pulsar.ConsumerMessage)}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{
+		Topic: "single-topic",
+		Metadata: map[string]string{
+			"topicsPattern":       "events-.+",
+			"autoDiscoveryPeriod": "10s",
+		},
+	}
+	err = p.Subscribe(ctx, req, func(ctx context.Context, msg *pubsub.NewMessage) error { return nil })
+	require.NoError(t, err)
+
+	assert.Empty(t, capturedOptions.Topic)
+	assert.Equal(t, "persistent://public/default/events-.+", capturedOptions.TopicsPattern)
+	assert.Equal(t, 10*time.Second, capturedOptions.AutoDiscoveryPeriod)
+}
+
+// TestSubscribe_InvalidAutoDiscoveryPeriodOverride verifies that a malformed
+// per-subscription autoDiscoveryPeriod is rejected at Subscribe time.
+func TestSubscribe_InvalidAutoDiscoveryPeriodOverride(t *testing.T) {
+	p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
+	p.client = &MockPulsarClient{
+		SubscribeFn: func(options pulsar.ConsumerOptions) (pulsar.Consumer, error) {
+			return &MockPulsarConsumer{Ch: make(chan pulsar.ConsumerMessage)}, nil
+		},
+	}
+
+	parsedMeta, err := parsePulsarMetadata(pubsub.Metadata{Base: metadata.Base{Properties: map[string]string{"host": "localhost:6650"}}})
+	require.NoError(t, err)
+	p.metadata = *parsedMeta
+
+	req := pubsub.SubscribeRequest{
+		Topic: "t",
+		Metadata: map[string]string{
+			"topicsPattern":       "orders-.*",
+			"autoDiscoveryPeriod": "not-a-duration",
+		},
+	}
+	err = p.Subscribe(t.Context(), req, func(ctx context.Context, msg *pubsub.NewMessage) error { return nil })
+	require.Error(t, err)
+}
+
+// TestSubscribe_NoPatternUsesSingleTopic verifies the default (non-pattern) path
+// still sets ConsumerOptions.Topic and leaves TopicsPattern empty.
+func TestSubscribe_NoPatternUsesSingleTopic(t *testing.T) {
+	p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
+
+	md := pubsub.Metadata{Base: metadata.Base{Properties: map[string]string{
+		"host":       "localhost:6650",
+		"consumerID": "c1",
+	}}}
+	parsedMeta, err := parsePulsarMetadata(md)
+	require.NoError(t, err)
+	p.metadata = *parsedMeta
+
+	var capturedOptions pulsar.ConsumerOptions
+	p.client = &MockPulsarClient{
+		SubscribeFn: func(options pulsar.ConsumerOptions) (pulsar.Consumer, error) {
+			capturedOptions = options
+			return &MockPulsarConsumer{Ch: make(chan pulsar.ConsumerMessage)}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := pubsub.SubscribeRequest{Topic: "my-topic"}
+	err = p.Subscribe(ctx, req, func(ctx context.Context, msg *pubsub.NewMessage) error { return nil })
+	require.NoError(t, err)
+
+	assert.Equal(t, "persistent://public/default/my-topic", capturedOptions.Topic)
+	assert.Empty(t, capturedOptions.TopicsPattern)
+}
+
+func TestShortTopicName(t *testing.T) {
+	p := &Pulsar{}
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"persistent://public/default/orders-eu", "orders-eu"},
+		{"non-persistent://my-tenant/my-ns/events-1", "events-1"},
+		{"persistent://public/default/orders-eu-partition-3", "orders-eu-partition-3"},
+		{"orders-eu", "orders-eu"}, // already short
+		{"", ""},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, p.shortTopicName(tc.in), "input %q", tc.in)
+	}
+}
+
+// TestHandleMessage_PatternModeDeliversConcreteTopic verifies that in pattern
+// mode the message is delivered tagged with the concrete (short) topic it
+// arrived on, not the regex pattern.
+func TestHandleMessage_PatternModeDeliversConcreteTopic(t *testing.T) {
+	p := &Pulsar{
+		logger:   logger.NewLogger("test"),
+		metadata: pulsarMetadata{internalTopicSchemas: map[string]schemaMetadata{}},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{
+		payload:    []byte(`{"hello":"world"}`),
+		properties: map[string]string{},
+		topic:      "persistent://public/default/orders-eu",
+	}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedTopic string
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedTopic = m.Topic
+		return nil
+	}
+
+	// originTopic is the regex pattern; patternMode=true must override it with
+	// the concrete topic from the message.
+	err := p.handleMessage(t.Context(), "orders-.*", true, cm, handler)
+	require.NoError(t, err)
+	assert.True(t, consumer.acked)
+	assert.Equal(t, "orders-eu", receivedTopic,
+		"pattern subscriptions must deliver the concrete topic, not the regex")
+}
+
+// TestHandleMessage_NonPatternKeepsDeclaredTopic verifies the explicit-topic path
+// still delivers the subscription's declared topic regardless of the broker's
+// fully-qualified name.
+func TestHandleMessage_NonPatternKeepsDeclaredTopic(t *testing.T) {
+	p := &Pulsar{
+		logger:   logger.NewLogger("test"),
+		metadata: pulsarMetadata{internalTopicSchemas: map[string]schemaMetadata{}},
+	}
+
+	consumer := &mockAckConsumer{}
+	msg := &mockPulsarMessage{
+		payload:    []byte(`{"hello":"world"}`),
+		properties: map[string]string{},
+		topic:      "persistent://public/default/my-topic",
+	}
+	cm := makeConsumerMessage(msg, consumer)
+
+	var receivedTopic string
+	handler := func(ctx context.Context, m *pubsub.NewMessage) error {
+		receivedTopic = m.Topic
+		return nil
+	}
+
+	err := p.handleMessage(t.Context(), "my-topic", false, cm, handler)
+	require.NoError(t, err)
+	assert.Equal(t, "my-topic", receivedTopic)
 }

--- a/pubsub/pulsar/pulsar_test.go
+++ b/pubsub/pulsar/pulsar_test.go
@@ -2968,6 +2968,35 @@ func TestSubscribe_InvalidAutoDiscoveryPeriodOverride(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestSubscribe_InvalidTopicsPatternOverride verifies that a malformed
+// per-subscription topicsPattern is rejected at Subscribe time with a clear
+// error, rather than being passed through to the Pulsar client. The
+// component-level pattern is validated at Init, so this covers the override path.
+func TestSubscribe_InvalidTopicsPatternOverride(t *testing.T) {
+	p := NewPulsar(logger.NewLogger("test")).(*Pulsar)
+
+	subscribeCalled := false
+	p.client = &MockPulsarClient{
+		SubscribeFn: func(options pulsar.ConsumerOptions) (pulsar.Consumer, error) {
+			subscribeCalled = true
+			return &MockPulsarConsumer{Ch: make(chan pulsar.ConsumerMessage)}, nil
+		},
+	}
+
+	parsedMeta, err := parsePulsarMetadata(pubsub.Metadata{Base: metadata.Base{Properties: map[string]string{"host": "localhost:6650"}}})
+	require.NoError(t, err)
+	p.metadata = *parsedMeta
+
+	req := pubsub.SubscribeRequest{
+		Topic:    "t",
+		Metadata: map[string]string{"topicsPattern": "orders-[a-"},
+	}
+	err = p.Subscribe(t.Context(), req, func(ctx context.Context, msg *pubsub.NewMessage) error { return nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "topicsPattern")
+	assert.False(t, subscribeCalled, "client.Subscribe must not be called with an invalid pattern")
+}
+
 // TestSubscribe_NoPatternUsesSingleTopic verifies the default (non-pattern) path
 // still sets ConsumerOptions.Topic and leaves TopicsPattern empty.
 func TestSubscribe_NoPatternUsesSingleTopic(t *testing.T) {


### PR DESCRIPTION
# Description

Adds support for **regex topic-pattern subscriptions** to the Apache Pulsar pub/sub component.

Previously a Dapr subscription mapped to a single explicit Pulsar topic. This adds an opt-in `topicsPattern` metadata field that subscribes a consumer to all topics matching a regular expression within the configured tenant/namespace, via the pulsar-client-go `ConsumerOptions.TopicsPattern`. An optional `autoDiscoveryPeriod` field maps to `ConsumerOptions.AutoDiscoveryPeriod`, making Pulsar's auto-discovery of newly created matching topics configurable.

Key points:
- Both fields can be set at the component level (applies to all subscriptions) or overridden per subscription via subscription metadata.
- In pattern mode, each message is delivered tagged with the **concrete topic it arrived on** (shortened to the local name) rather than the regex, so runtime route matching and observability see the real topic name.
- Per-topic schema validation (`<topic>.avroschema` / `.jsonschema`) is skipped in pattern mode, since the matching topic set is not known in advance.
- **Fully backward-compatible**: with `topicsPattern` unset, behavior is byte-for-byte unchanged. No runtime or CRD changes are required.

Invalid configuration (malformed regex, negative `autoDiscoveryPeriod`) is rejected at `Init` (component) and `Subscribe` (per-subscription override).

## Issue reference

Fixes #2566

(See the [comment on #2566](https://github.com/dapr/components-contrib/issues/2566#issuecomment-4802644223) describing why this component-local, no-runtime-change approach addresses the earlier maintainer concern.)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: dapr/docs#5226
