### PR TITLE
docs(rabbitmq): list all supported exchangeKind values in metadata

### DIFF
--- a/pubsub/rabbitmq/metadata.yaml
+++ b/pubsub/rabbitmq/metadata.yaml
@@ -145,7 +145,9 @@ metadata:
     allowedValues:
       - "fanout"
       - "topic"
-    example: '"fanout","topic"'
+      - "direct"
+      - "headers"
+    example: '"fanout","topic","direct","headers"'
   - name: deliveryMode
     type: number
     description: |


### PR DESCRIPTION
## Description

`exchangeKindValid` in `pubsub/rabbitmq/metadata.go` accepts four exchange kinds — `fanout`, `topic`, `direct`, and `headers` — but `pubsub/rabbitmq/metadata.yaml` only documented `fanout` and `topic`. This brings the metadata (which drives generated reference docs) in line with the actual validation logic by adding `direct` and `headers` to `allowedValues` and the example.

No behavior change — documentation/metadata only.
