### PR TITLE
auto open issue on ci failure during release

### DIFF
--- a/.github/workflows/generate-component-metadata-for-tag.yml
+++ b/.github/workflows/generate-component-metadata-for-tag.yml
@@ -42,3 +42,18 @@ jobs:
           tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: component-metadata-bundle.json
+
+  # Opens (or comments on) a tracking issue when the release upload fails.
+  notify-on-failure:
+    needs: [upload-bundle]
+    if: failure() && (startsWith(github.ref, 'refs/tags/') || inputs.tag != '')
+    permissions:
+      issues: write
+      actions: read
+    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@main
+    with:
+      title: "Release publish failed: ${{ github.workflow }} (${{ inputs.tag || github.ref_name }})"
+      labels: "release,ci/publish-failure"
+      mention: "@dapr/maintainers-components-contrib @dapr/approvers-components-contrib"
+    secrets:
+      dapr_bot_token: ${{ secrets.DAPR_BOT_TOKEN }}

--- a/.github/workflows/generate-component-metadata-for-tag.yml
+++ b/.github/workflows/generate-component-metadata-for-tag.yml
@@ -43,17 +43,16 @@ jobs:
           generate_release_notes: true
           files: component-metadata-bundle.json
 
-  # Opens (or comments on) a tracking issue when the release upload fails.
+  # Opens (or comments on) a tracking issue only when the upload-bundle job
+  # (release asset upload) itself fails; any other outcome won't open an issue.
   notify-on-failure:
     needs: [upload-bundle]
-    if: failure() && (startsWith(github.ref, 'refs/tags/') || inputs.tag != '')
+    if: always() && (startsWith(github.ref, 'refs/tags/') || inputs.tag != '') && needs['upload-bundle'].result == 'failure'
     permissions:
       issues: write
       actions: read
     uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@main
     with:
-      title: "Release publish failed: ${{ github.workflow }} (${{ inputs.tag || github.ref_name }})"
-      labels: "release,ci/publish-failure"
+      title: "Release workflow failed: ${{ github.workflow }} (${{ inputs.tag || github.ref_name }})"
+      labels: "release,ci/release-failure"
       mention: "@dapr/maintainers-components-contrib @dapr/approvers-components-contrib"
-    secrets:
-      dapr_bot_token: ${{ secrets.DAPR_BOT_TOKEN }}


### PR DESCRIPTION
Reusable workflow_call that opens (or comments on) a tracking issue in the caller repo when a release/publish job fails, with links to the failed jobs and a maintainer @-mention.

[Needs this PR merged first.](https://github.com/dapr/.github/pull/14)