### PR TITLE
fix(pubsub/rabbitmq): skip NACK on context cancellation in handleMessage

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -638,7 +638,9 @@ func (r *rabbitMQ) listenMessages(ctx context.Context, channel rabbitMQChannelBr
 				go func(d amqp.Delivery) {
 					defer r.wg.Done()
 					if err := r.handleMessage(ctx, d, topic, handler); err != nil {
-						r.logger.Errorf("%s error handling message: %v", logMessagePrefix, err)
+						if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+							r.logger.Errorf("%s error handling message: %v", logMessagePrefix, err)
+						}
 					}
 				}(d)
 			}

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -660,6 +660,11 @@ func (r *rabbitMQ) handleMessage(ctx context.Context, d amqp.Delivery, topic str
 	err := handler(ctx, pubsubMsg)
 
 	if err != nil {
+		if ctx.Err() != nil {
+			r.logger.Debugf("%s context done while handling message from topic '%s'; skipping ack/nack to allow redelivery", logMessagePrefix, topic)
+			return err
+		}
+
 		r.logger.Errorf("%s handling message from topic '%s', %s", errorMessagePrefix, topic, err)
 
 		if !r.metadata.AutoAck {

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -508,9 +508,9 @@ func TestHandleMessageSkipsNACKOnContextCanceled(t *testing.T) {
 		metadata: &rabbitmqMetadata{AutoAck: false},
 	}
 
-	t.Run("context canceled: no NACK and no ACK", func(t *testing.T) {
+	t.Run("context canceled: no NACK, no ACK, context error returned", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // already cancelled — simulates subscription context cancelled during shutdown
+		cancel() // already cancelled; simulates subscription context cancelled during shutdown
 
 		ack := &mockAcknowledger{}
 		d := amqp.Delivery{Acknowledger: ack, Body: []byte("test payload")}
@@ -520,8 +520,8 @@ func TestHandleMessageSkipsNACKOnContextCanceled(t *testing.T) {
 		}
 
 		err := r.handleMessage(ctx, d, "topic", handler)
-		require.Error(t, err)
-		assert.False(t, ack.nackCalled.Load(), "NACK must not be called when context is canceled — message should be redelivered, not DLQ'd")
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, ack.nackCalled.Load(), "NACK must not be called when context is canceled; message should be redelivered, not DLQ'd")
 		assert.False(t, ack.ackCalled.Load(), "ACK must not be called when context is canceled")
 	})
 

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -475,6 +475,86 @@ func TestSubscribeReconnect(t *testing.T) {
 	assert.Equal(t, int32(4), broker.closeCount.Load())   // two counts for each connection closure - one for connection, one for channel
 }
 
+// mockAcknowledger tracks Ack/Nack calls on an amqp.Delivery for unit tests.
+type mockAcknowledger struct {
+	nackCalled atomic.Bool
+	ackCalled  atomic.Bool
+}
+
+func (m *mockAcknowledger) Ack(_ uint64, _ bool) error {
+	m.ackCalled.Store(true)
+	return nil
+}
+
+func (m *mockAcknowledger) Nack(_ uint64, _ bool, _ bool) error {
+	m.nackCalled.Store(true)
+	return nil
+}
+
+func (m *mockAcknowledger) Reject(_ uint64, _ bool) error {
+	return nil
+}
+
+// TestHandleMessageSkipsNACKOnContextCanceled verifies that handleMessage does
+// not NACK the delivery when the handler returns because the context was
+// cancelled (e.g. during graceful shutdown). Leaving the message unacknowledged
+// lets RabbitMQ redeliver it to another consumer when the connection closes,
+// rather than routing it to the dead-letter queue.
+//
+// Regression test for https://github.com/dapr/components-contrib/issues/4449
+func TestHandleMessageSkipsNACKOnContextCanceled(t *testing.T) {
+	r := &rabbitMQ{
+		logger:   logger.NewLogger("test"),
+		metadata: &rabbitmqMetadata{AutoAck: false},
+	}
+
+	t.Run("context canceled: no NACK and no ACK", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled — simulates subscription context cancelled during shutdown
+
+		ack := &mockAcknowledger{}
+		d := amqp.Delivery{Acknowledger: ack, Body: []byte("test payload")}
+
+		handler := func(ctx context.Context, _ *pubsub.NewMessage) error {
+			return ctx.Err() // returns context.Canceled
+		}
+
+		err := r.handleMessage(ctx, d, "topic", handler)
+		require.Error(t, err)
+		assert.False(t, ack.nackCalled.Load(), "NACK must not be called when context is canceled — message should be redelivered, not DLQ'd")
+		assert.False(t, ack.ackCalled.Load(), "ACK must not be called when context is canceled")
+	})
+
+	t.Run("handler error with live context: NACK is called", func(t *testing.T) {
+		ack := &mockAcknowledger{}
+		d := amqp.Delivery{Acknowledger: ack, Body: []byte("test payload")}
+
+		handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+			return errors.New("processing error")
+		}
+
+		// handleMessage re-assigns err = d.Nack(...); our mock returns nil so the
+		// function itself returns nil — what matters is that Nack was invoked.
+		_ = r.handleMessage(context.Background(), d, "topic", handler)
+		assert.True(t, ack.nackCalled.Load(), "NACK must be called on real handler error when context is alive")
+		assert.False(t, ack.ackCalled.Load())
+	})
+
+	t.Run("no error: ACK is called, no NACK", func(t *testing.T) {
+		ack := &mockAcknowledger{}
+		d := amqp.Delivery{Acknowledger: ack, Body: []byte("test payload")}
+
+		handler := func(_ context.Context, _ *pubsub.NewMessage) error {
+			return nil
+		}
+
+		err := r.handleMessage(context.Background(), d, "topic", handler)
+		require.NoError(t, err)
+		assert.True(t, ack.ackCalled.Load(), "ACK must be called on success")
+		assert.False(t, ack.nackCalled.Load(), "NACK must not be called on success")
+	})
+}
+
 func createAMQPMessage(body []byte) amqp.Delivery {
 	return amqp.Delivery{Body: body}
 }


### PR DESCRIPTION
## Description

Fixes #4449 (re-filing of #4281, closed as stale).

When the subscription handler returns an error because its context was cancelled
(e.g. during Dapr graceful shutdown), `handleMessage` was unconditionally calling
`d.Nack()`. With `enableDeadLetter: true` and `requeueInFailure: false` (the
defaults), this routes the message to the dead-letter queue instead of letting
RabbitMQ redeliver it to another consumer when the AMQP connection closes.

### Root Cause

```go
// before — no context check before NACK
if err != nil {
    r.logger.Errorf(...)
    if !r.metadata.AutoAck {
        d.Nack(false, r.metadata.RequeueInFailure)  // fires on context.Canceled too
    }
}
```

### Fix

Add a `ctx.Err()` guard that returns early (without Ack or Nack) when the context
is done. The message stays unacknowledged and RabbitMQ redelivers it on connection
close — zero messages to DLQ during graceful shutdown.

### Relation to dapr/dapr#9619

The runtime fix in dapr/dapr#9619 changed the error from `"subscription is closed"`
to `"context canceled"`. This PR closes the remaining component-level gap.

### Reproduction

https://github.com/kayvonkhosrowpour/dapr-repro (branch `components-contrib-bug`) — updated for Dapr v1.18.1.

| Scenario | DLQ messages | daprd log |
|---|---|---|
| v1.18.1 without this fix | **1** | `context canceled` |
| v1.18.1 with this fix | **0** | (none) |

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests updated — `TestHandleMessageSkipsNACKOnContextCanceled` with 3 subtests
- [x] All existing unit tests pass