### PR TITLE
[Backport release-1.18] fix(kafka): add connection timeouts, broker health check, and tunable producer config

### DIFF
--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -458,3 +458,39 @@ metadata:
       A regular expression to exclude keys from being converted to/from headers from/to metadata to avoid unwanted downstream side effects.
     example: '"^rawPayload|valueSchemaType$"'
     default: '""'
+  - name: dialTimeout
+    type: duration
+    description: |
+      The maximum duration to wait for the initial TCP connection to a broker to be established. Bounds how long Init() can block on an unreachable cluster.
+    example: '"10s"'
+    default: '"30s"'
+  - name: readTimeout
+    type: duration
+    description: |
+      The maximum duration to wait for a response from a broker after sending a request.
+    example: '"10s"'
+    default: '"30s"'
+  - name: writeTimeout
+    type: duration
+    description: |
+      The maximum duration to wait for a request to be transmitted to a broker.
+    example: '"10s"'
+    default: '"30s"'
+  - name: metadataTimeout
+    type: duration
+    description: |
+      The per-request timeout for metadata refresh operations. When set to 0 (default) Sarama computes the effective timeout from the Net timeouts and retry count.
+    example: '"5s"'
+    default: '"0"'
+  - name: producerRequiredAcks
+    type: string
+    description: |
+      The number of partition replicas that must acknowledge a produce request before it is considered successful. Accepted values: "all" (wait for all in-sync replicas, highest durability), "local" (wait for the partition leader only), "none" (no acknowledgement required, lowest durability).
+    example: '"local"'
+    default: '"all"'
+  - name: producerRetryMax
+    type: number
+    description: |
+      The maximum number of times to retry sending a message before giving up.
+    example: '3'
+    default: '5'

--- a/common/component/kafka/aws.go
+++ b/common/component/kafka/aws.go
@@ -24,27 +24,27 @@ import (
 )
 
 type AwsClients struct {
-	config          *sarama.Config
-	consumerGroup   *string
-	brokers         *[]string
-	maxMessageBytes *int
+	config         *sarama.Config
+	consumerGroup  *string
+	brokers        *[]string
+	producerConfig ProducerConfig
 
 	ConsumerGroup sarama.ConsumerGroup
 	Producer      sarama.SyncProducer
 }
 type KafkaOptions struct {
-	Config          *sarama.Config
-	ConsumerGroup   string
-	Brokers         []string
-	MaxMessageBytes int
+	Config         *sarama.Config
+	ConsumerGroup  string
+	Brokers        []string
+	ProducerConfig ProducerConfig
 }
 
 func InitAwsClients(opts KafkaOptions) *AwsClients {
 	return &AwsClients{
-		config:          opts.Config,
-		consumerGroup:   &opts.ConsumerGroup,
-		brokers:         &opts.Brokers,
-		maxMessageBytes: &opts.MaxMessageBytes,
+		config:         opts.Config,
+		consumerGroup:  &opts.ConsumerGroup,
+		brokers:        &opts.Brokers,
+		producerConfig: opts.ProducerConfig,
 	}
 }
 
@@ -98,16 +98,18 @@ func (m *mskTokenProvider) Token() (*sarama.AccessToken, error) {
 }
 
 func (c *AwsClients) getSyncProducer() (sarama.SyncProducer, error) {
-	// Add SyncProducer specific properties to copy of base config
-	c.config.Producer.RequiredAcks = sarama.WaitForAll
-	c.config.Producer.Retry.Max = 5
-	c.config.Producer.Return.Successes = true
+	// Apply SyncProducer-specific properties to a COPY of the shared config so
+	// the consumer-group's view of the config is not mutated.
+	cfg := *c.config
+	cfg.Producer.RequiredAcks = c.producerConfig.RequiredAcks
+	cfg.Producer.Retry.Max = c.producerConfig.RetryMax
+	cfg.Producer.Return.Successes = true
 
-	if *c.maxMessageBytes > 0 {
-		c.config.Producer.MaxMessageBytes = *c.maxMessageBytes
+	if c.producerConfig.MaxMessageBytes > 0 {
+		cfg.Producer.MaxMessageBytes = c.producerConfig.MaxMessageBytes
 	}
 
-	saramaClient, err := sarama.NewClient(*c.brokers, c.config)
+	saramaClient, err := sarama.NewClient(*c.brokers, &cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/common/component/kafka/clients.go
+++ b/common/component/kafka/clients.go
@@ -27,10 +27,10 @@ func (k *Kafka) latestClients() (*clients, error) {
 		}
 
 		awsKafkaOpts := KafkaOptions{
-			Config:          k.config,
-			ConsumerGroup:   k.consumerGroup,
-			Brokers:         k.brokers,
-			MaxMessageBytes: k.maxMessageBytes,
+			Config:         k.config,
+			ConsumerGroup:  k.consumerGroup,
+			Brokers:        k.brokers,
+			ProducerConfig: k.producerConfig,
 		}
 
 		awsKafkaClients := InitAwsClients(awsKafkaOpts)
@@ -55,7 +55,7 @@ func (k *Kafka) latestClients() (*clients, error) {
 			return nil, err
 		}
 
-		p, err := GetSyncProducer(*k.config, k.brokers, k.maxMessageBytes)
+		p, err := GetSyncProducer(*k.config, k.brokers, k.producerConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/common/component/kafka/health.go
+++ b/common/component/kafka/health.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+// Ping performs a connectivity check against the configured Kafka brokers by
+// opening a short-lived Sarama client, issuing a single metadata request, and
+// then closing it immediately.
+//
+// Note the metadata request is cluster-wide: RefreshMetadata() called with no
+// topics refreshes metadata for all topics regardless of Metadata.Full, so on
+// clusters with very many topics this is not a cheap probe. Metadata.Full=false
+// only stops sarama.NewClient from performing its own construction-time fetch;
+// the explicit RefreshMetadata() call below is what actually probes connectivity.
+//
+// The check is fully bounded and cancellable:
+//   - Pass a context with a deadline to enforce a wall-clock limit. When a
+//     deadline is present, all Net and Metadata timeouts are clamped to the
+//     remaining time so the call cannot block beyond the deadline.
+//   - Metadata retries are always disabled for the probe so a failure returns
+//     promptly instead of retrying against an unhealthy cluster (Sarama would
+//     otherwise apply its default of 3 retries, adding tens of seconds when no
+//     deadline is supplied).
+//   - Context cancellation is honoured mid-flight: sarama.NewClient is run in
+//     a goroutine and the function returns ctx.Err() as soon as ctx is done.
+//     Any partially-opened client is closed in the background to avoid leaks.
+//
+// Ping does NOT modify any internal component state and is safe to call from
+// concurrent goroutines after Init() has completed.
+func (k *Kafka) Ping(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if k.closed.Load() {
+		return errors.New("kafka health check: component is closed")
+	}
+
+	if k.config == nil {
+		return errors.New("kafka health check: component not initialised")
+	}
+
+	// Build a config copy for the probe. Metadata.Full=false only makes
+	// sarama.NewClient skip its construction-time metadata fetch; the explicit
+	// RefreshMetadata() call below still performs the actual connectivity probe.
+	cfgCopy := *k.config
+	cfgCopy.Metadata.Full = false
+	// A health probe should fail fast rather than retry against an unhealthy
+	// cluster, so disable metadata retries whether or not the caller supplied a
+	// deadline. Without this, Sarama's default (3 retries) can add tens of
+	// seconds when no deadline bounds the call.
+	cfgCopy.Metadata.Retry.Max = 0
+
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			// The deadline has already passed; wrap context.DeadlineExceeded
+			// directly since ctx.Err() may not be set yet in this narrow window.
+			return fmt.Errorf("kafka health check: %w", context.DeadlineExceeded)
+		}
+		// Clamp all net timeouts to the remaining deadline so that Sarama's
+		// underlying dials respect the caller's overall timeout.
+		if cfgCopy.Net.DialTimeout > remaining || cfgCopy.Net.DialTimeout == 0 {
+			cfgCopy.Net.DialTimeout = remaining
+		}
+		if cfgCopy.Net.ReadTimeout > remaining || cfgCopy.Net.ReadTimeout == 0 {
+			cfgCopy.Net.ReadTimeout = remaining
+		}
+		if cfgCopy.Net.WriteTimeout > remaining || cfgCopy.Net.WriteTimeout == 0 {
+			cfgCopy.Net.WriteTimeout = remaining
+		}
+		// Also bound the metadata request itself so the total time is governed
+		// by the caller's deadline alone (retries are already disabled above).
+		cfgCopy.Metadata.Timeout = remaining
+	}
+
+	type result struct {
+		cl  sarama.Client
+		err error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		// sarama.NewClient with Metadata.Full=false does NOT issue any network
+		// request — it only registers the seed broker addresses. We must call
+		// RefreshMetadata() explicitly to force an actual TCP connection; called
+		// with no topics it refreshes cluster-wide metadata. This is the real
+		// connectivity probe; it respects cfgCopy.Metadata.Timeout and
+		// .Retry.Max set above.
+		cl, err := sarama.NewClient(k.brokers, &cfgCopy)
+		if err != nil {
+			ch <- result{nil, err}
+			return
+		}
+		if merr := cl.RefreshMetadata(); merr != nil {
+			_ = cl.Close()
+			ch <- result{nil, merr}
+			return
+		}
+		ch <- result{cl, nil}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Context cancelled/timed out before the client could connect. Drain the
+		// goroutine result when it eventually arrives and close the client to
+		// prevent a resource leak.
+		go func() {
+			r := <-ch
+			if r.cl != nil {
+				if cerr := r.cl.Close(); cerr != nil {
+					k.logger.Debugf("kafka health check: error closing transient client after ctx cancel: %v", cerr)
+				}
+			}
+		}()
+		return ctx.Err()
+
+	case r := <-ch:
+		if r.err != nil {
+			return fmt.Errorf("kafka health check: failed to reach brokers %v: %w", k.brokers, r.err)
+		}
+		if cerr := r.cl.Close(); cerr != nil {
+			k.logger.Debugf("kafka health check: error closing transient client: %v", cerr)
+		}
+		return nil
+	}
+}

--- a/common/component/kafka/health_test.go
+++ b/common/component/kafka/health_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/kit/logger"
+)
+
+// TestPingUninitialised verifies that Ping returns an error when the
+// component has not been initialised (k.config == nil).
+func TestPingUninitialised(t *testing.T) {
+	k := &Kafka{logger: logger.NewLogger("kafka_test")}
+	err := k.Ping(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not initialised")
+}
+
+// TestPingCancelledContext verifies that Ping respects a cancelled context.
+func TestPingCancelledContext(t *testing.T) {
+	k := &Kafka{
+		logger:  logger.NewLogger("kafka_test"),
+		config:  sarama.NewConfig(),
+		brokers: []string{"localhost:9092"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := k.Ping(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestPingDeadlineExceededContext verifies that an already-expired deadline is
+// caught by Ping's top-of-function ctx.Err() guard: Ping returns
+// context.DeadlineExceeded immediately, before attempting any broker
+// connection. It intentionally does not exercise the deadline-clamping path,
+// which only runs when the deadline is still valid.
+func TestPingDeadlineExceededContext(t *testing.T) {
+	k := &Kafka{
+		logger:  logger.NewLogger("kafka_test"),
+		config:  sarama.NewConfig(),
+		brokers: []string{"localhost:9092"},
+	}
+
+	// Deadline already in the past: ctx.Err() is set before Ping does any work.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	start := time.Now()
+	err := k.Ping(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	// Returning near-instantly proves the guard short-circuited rather than
+	// attempting (and waiting on) a broker dial.
+	require.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+// TestPingUnreachableBroker verifies that Ping fails fast for an unreachable
+// broker (using a very short timeout so the test does not hang).
+func TestPingUnreachableBroker(t *testing.T) {
+	cfg := sarama.NewConfig()
+	cfg.Net.DialTimeout = 200 * time.Millisecond
+	cfg.Net.ReadTimeout = 200 * time.Millisecond
+	cfg.Net.WriteTimeout = 200 * time.Millisecond
+	cfg.Metadata.Retry.Max = 0
+
+	// Bind a listener to obtain a free loopback port, then close it. Connecting
+	// to that address is now guaranteed to be refused (nothing is listening),
+	// which deterministically exercises the "broker unreachable" path without
+	// hard-coding a port number that might happen to be in use in CI.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	k := &Kafka{
+		logger:  logger.NewLogger("kafka_test"),
+		config:  cfg,
+		brokers: []string{addr},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = k.Ping(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "health check")
+}
+
+// TestPingSuccess verifies that Ping returns nil when a broker answers the
+// metadata probe. A Sarama MockBroker stands in for a real cluster and replies
+// to the metadata request with its own address.
+func TestPingSuccess(t *testing.T) {
+	mockBroker := sarama.NewMockBroker(t, 1)
+	defer mockBroker.Close()
+
+	mockBroker.SetHandlerByMap(map[string]sarama.MockResponse{
+		// Sarama sends an ApiVersionsRequest when it opens a broker connection
+		// (config default), then the metadata request driven by RefreshMetadata().
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(mockBroker.Addr(), mockBroker.BrokerID()),
+	})
+
+	k := &Kafka{
+		logger:  logger.NewLogger("kafka_test"),
+		config:  sarama.NewConfig(),
+		brokers: []string{mockBroker.Addr()},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, k.Ping(ctx))
+}
+
+// TestPingClosedComponent verifies that Ping returns an error when the
+// component has been closed.
+func TestPingClosedComponent(t *testing.T) {
+	k := &Kafka{
+		logger:  logger.NewLogger("kafka_test"),
+		config:  sarama.NewConfig(),
+		brokers: []string{"localhost:9092"},
+	}
+	k.closed.Store(true)
+
+	err := k.Ping(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "closed")
+}
+
+// TestPingContextCancelledMidFlight verifies that Ping returns promptly when
+// the context is cancelled shortly after the call is made against a
+// non-routable (blackholed) address. The test must complete well before any
+// Net dial timeout would fire — this proves the goroutine/select path works.
+func TestPingContextCancelledMidFlight(t *testing.T) {
+	// Use a config with long dial timeouts to prove ctx cancellation is what
+	// causes the early return, not the Net timeout.
+	cfg := sarama.NewConfig()
+	cfg.Net.DialTimeout = 30 * time.Second
+	cfg.Net.ReadTimeout = 30 * time.Second
+	cfg.Net.WriteTimeout = 30 * time.Second
+	cfg.Metadata.Retry.Max = 0
+
+	// Stand up a local TCP listener that we never Accept() from. The kernel
+	// completes the TCP handshake from the listen backlog, so the Sarama client
+	// connects and then blocks waiting for a broker response that never arrives.
+	// This makes the "in-flight" state deterministic across environments, unlike
+	// relying on TEST-NET blackhole behaviour which varies by CI network stack.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	k := &Kafka{
+		logger:  logger.NewLogger("kafka_test"),
+		config:  cfg,
+		brokers: []string{ln.Addr().String()},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay to simulate the caller giving up.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err = k.Ping(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// The connection is accepted by the kernel but never answered, so context
+	// cancellation is what unblocks Ping and err wraps context.Canceled. Some
+	// Sarama paths may surface the cancelled read as a broker-connect error
+	// instead; both prove Ping returns on ctx rather than the Net timeout.
+	if !errors.Is(err, context.Canceled) {
+		require.Contains(t, err.Error(), "health check",
+			"unexpected error (not ctx.Canceled and not a broker health-check error): %v", err)
+	}
+	// Must complete well within the 30 s Net.DialTimeout.
+	require.Less(t, elapsed, 5*time.Second, "Ping should return shortly after ctx cancel, not wait for the net timeout")
+}

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -45,16 +45,17 @@ type Kafka struct {
 	mockProducer      sarama.SyncProducer
 	clients           *clients
 
-	maxMessageBytes int
-	consumerGroup   string
-	brokers         []string
-	logger          logger.Logger
-	authType        string
-	saslUsername    string
-	saslPassword    string
-	initialOffset   int64
-	config          *sarama.Config
-	escapeHeaders   bool
+	consumerGroup string
+	brokers       []string
+	logger        logger.Logger
+	authType      string
+	saslUsername  string
+	saslPassword  string
+	initialOffset int64
+	config        *sarama.Config
+	escapeHeaders bool
+
+	producerConfig ProducerConfig
 
 	subscribeTopics TopicHandlerConfig
 	subscribeLock   sync.Mutex
@@ -169,6 +170,13 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 	config.Net.KeepAlive = meta.ClientConnectionKeepAliveInterval
 	config.Metadata.RefreshFrequency = meta.ClientConnectionTopicMetadataRefreshInterval
 
+	// Apply tunable Net timeouts. These bound the initial dial and
+	// subsequent I/O so Init() cannot block indefinitely on unreachable brokers.
+	config.Net.DialTimeout = meta.DialTimeout
+	config.Net.ReadTimeout = meta.ReadTimeout
+	config.Net.WriteTimeout = meta.WriteTimeout
+	config.Metadata.Timeout = meta.MetadataTimeout
+
 	if meta.ClientID != "" {
 		config.ClientID = meta.ClientID
 	}
@@ -220,15 +228,20 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 	}
 
 	k.config = config
+	k.producerConfig = ProducerConfig{
+		RequiredAcks:    meta.internalProducerRequiredAcks,
+		RetryMax:        meta.ProducerRetryMax,
+		MaxMessageBytes: meta.MaxMessageBytes,
+	}
 	sarama.Logger = SaramaLogBridge{daprLogger: k.logger}
-	k.maxMessageBytes = meta.MaxMessageBytes
 
 	// Default retry configuration is used if no
 	// backOff properties are set.
 	if rerr := retry.DecodeConfigWithPrefix(
 		&k.backOffConfig,
 		metadata,
-		"backOff"); rerr != nil {
+		"backOff",
+	); rerr != nil {
 		return rerr
 	}
 	k.consumeRetryEnabled = meta.ConsumeRetryEnabled

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -64,6 +64,25 @@ const (
 	defaultClientConnectionTopicMetadataRefreshInterval = 8 * time.Minute // needs to be 8 as kafka default for killing idle connections is 9 min
 	clientConnectionKeepAliveInterval                   = "clientConnectionKeepAliveInterval"
 	defaultClientConnectionKeepAliveInterval            = time.Duration(0) // default to keep connection alive
+
+	// Sarama Net timeout defaults (mirroring sarama.NewConfig() behaviour).
+	// These preserve the current out-of-the-box behaviour when unset.
+	defaultDialTimeout  = 30 * time.Second
+	defaultReadTimeout  = 30 * time.Second
+	defaultWriteTimeout = 30 * time.Second
+	// Sarama sets Metadata.Timeout = 0 by default (disabled, meaning the
+	// effective timeout is computed from Net timeouts × retry count). We keep
+	// the same default so existing deployments are not affected.
+	defaultMetadataTimeout = time.Duration(0)
+
+	// producerRequiredAcks string constants for metadata parsing.
+	producerRequiredAcksAll   = "all"
+	producerRequiredAcksLocal = "local"
+	producerRequiredAcksNone  = "none"
+
+	// Producer defaults matching current GetSyncProducer hard-coded values.
+	defaultProducerRequiredAcks = producerRequiredAcksAll
+	defaultProducerRetryMax     = 5
 )
 
 type KafkaMetadata struct {
@@ -107,6 +126,17 @@ type KafkaMetadata struct {
 	ClientConnectionTopicMetadataRefreshInterval time.Duration `mapstructure:"clientConnectionTopicMetadataRefreshInterval"`
 	ClientConnectionKeepAliveInterval            time.Duration `mapstructure:"clientConnectionKeepAliveInterval"`
 
+	// Net timeout tunables.
+	// Defaults preserve Sarama's built-in values (30 s each) so unset
+	// deployments behave identically to previous releases.
+	DialTimeout  time.Duration `mapstructure:"dialTimeout"`
+	ReadTimeout  time.Duration `mapstructure:"readTimeout"`
+	WriteTimeout time.Duration `mapstructure:"writeTimeout"`
+	// MetadataTimeout is the per-request metadata timeout passed to
+	// Sarama's Metadata.Timeout. When 0 (default) Sarama's own default
+	// applies (disabled, computed from Net timeouts × retry count).
+	MetadataTimeout time.Duration `mapstructure:"metadataTimeout"`
+
 	channelBufferSize int `mapstructure:"-"`
 
 	consumerFetchMin               int32  `mapstructure:"-"`
@@ -116,6 +146,13 @@ type KafkaMetadata struct {
 	// configs for kafka producer
 	Compression         string                  `mapstructure:"compression"`
 	internalCompression sarama.CompressionCodec `mapstructure:"-"`
+
+	// Producer tunables.
+	// ProducerRequiredAcks accepts "all" (default), "local", or "none".
+	ProducerRequiredAcks         string              `mapstructure:"producerRequiredAcks"`
+	internalProducerRequiredAcks sarama.RequiredAcks `mapstructure:"-"`
+	// ProducerRetryMax is the number of times to retry sending a message (default 5).
+	ProducerRetryMax int `mapstructure:"producerRetryMax"`
 
 	// schema registry
 	SchemaRegistryURL           string        `mapstructure:"schemaRegistryURL"`
@@ -181,6 +218,16 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		EscapeHeaders:                                false,
 		UseAvroJSON:                                  false,
 		ExcludeHeaderMetaRegex:                       "",
+		// Net timeout defaults preserve Sarama's built-in values.
+		DialTimeout:  defaultDialTimeout,
+		ReadTimeout:  defaultReadTimeout,
+		WriteTimeout: defaultWriteTimeout,
+		// MetadataTimeout=0 matches Sarama's default (disabled).
+		MetadataTimeout: defaultMetadataTimeout,
+		// Producer defaults match the previously hard-coded values in GetSyncProducer.
+		ProducerRequiredAcks:         defaultProducerRequiredAcks,
+		internalProducerRequiredAcks: sarama.WaitForAll,
+		ProducerRetryMax:             defaultProducerRetryMax,
 	}
 
 	err := metadata.DecodeMetadata(meta, &m)
@@ -384,6 +431,37 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 
 	if m.ClientConnectionKeepAliveInterval < 0 {
 		m.ClientConnectionKeepAliveInterval = defaultClientConnectionKeepAliveInterval
+	}
+
+	// Validate and clamp Net timeout fields; fall back to defaults if invalid.
+	if m.DialTimeout <= 0 {
+		m.DialTimeout = defaultDialTimeout
+	}
+	if m.ReadTimeout <= 0 {
+		m.ReadTimeout = defaultReadTimeout
+	}
+	if m.WriteTimeout <= 0 {
+		m.WriteTimeout = defaultWriteTimeout
+	}
+	if m.MetadataTimeout < 0 {
+		m.MetadataTimeout = defaultMetadataTimeout
+	}
+
+	// Parse and validate ProducerRequiredAcks.
+	switch strings.ToLower(m.ProducerRequiredAcks) {
+	case producerRequiredAcksAll, "":
+		m.internalProducerRequiredAcks = sarama.WaitForAll
+	case producerRequiredAcksLocal:
+		m.internalProducerRequiredAcks = sarama.WaitForLocal
+	case producerRequiredAcksNone:
+		m.internalProducerRequiredAcks = sarama.NoResponse
+		k.logger.Warnf("kafka: producerRequiredAcks is set to 'none' (fire-and-forget) — messages may be silently lost if a broker fails to write them")
+	default:
+		return nil, fmt.Errorf("kafka error: invalid value for 'producerRequiredAcks': %q (must be \"all\", \"local\", or \"none\")", m.ProducerRequiredAcks)
+	}
+
+	if m.ProducerRetryMax < 0 {
+		return nil, fmt.Errorf("kafka error: invalid value for 'producerRetryMax': %d (must be >= 0)", m.ProducerRetryMax)
 	}
 
 	if val, ok := meta["excludeHeaderMetaRegex"]; ok && val != "" {

--- a/common/component/kafka/metadata_test.go
+++ b/common/component/kafka/metadata_test.go
@@ -717,3 +717,147 @@ func TestGetEventMetadata(t *testing.T) {
 		require.NotContains(t, act, "rawPayload")
 	})
 }
+
+// Net timeout tunables
+
+func TestMetadataNetTimeouts(t *testing.T) {
+	k := getKafka()
+
+	t.Run("default net timeouts preserve Sarama built-in values", func(t *testing.T) {
+		m := getBaseMetadata()
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.Equal(t, defaultDialTimeout, meta.DialTimeout)
+		require.Equal(t, defaultReadTimeout, meta.ReadTimeout)
+		require.Equal(t, defaultWriteTimeout, meta.WriteTimeout)
+		require.Equal(t, defaultMetadataTimeout, meta.MetadataTimeout)
+	})
+
+	t.Run("explicit net timeouts are applied", func(t *testing.T) {
+		m := getBaseMetadata()
+		m["dialTimeout"] = "5s"
+		m["readTimeout"] = "10s"
+		m["writeTimeout"] = "15s"
+		m["metadataTimeout"] = "20s"
+
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.Equal(t, 5*time.Second, meta.DialTimeout)
+		require.Equal(t, 10*time.Second, meta.ReadTimeout)
+		require.Equal(t, 15*time.Second, meta.WriteTimeout)
+		require.Equal(t, 20*time.Second, meta.MetadataTimeout)
+	})
+
+	t.Run("invalid (zero/negative) net timeouts fall back to defaults", func(t *testing.T) {
+		m := getBaseMetadata()
+		m["dialTimeout"] = "-5s"
+		m["readTimeout"] = "0s"
+		m["writeTimeout"] = "-1s"
+
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.Equal(t, defaultDialTimeout, meta.DialTimeout)
+		require.Equal(t, defaultReadTimeout, meta.ReadTimeout)
+		require.Equal(t, defaultWriteTimeout, meta.WriteTimeout)
+	})
+}
+
+// Producer tunables
+
+func TestMetadataProducerRequiredAcks(t *testing.T) {
+	k := getKafka()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    sarama.RequiredAcks
+		expectError bool
+	}{
+		{
+			name:     "default (empty) maps to WaitForAll",
+			input:    "",
+			expected: sarama.WaitForAll,
+		},
+		{
+			name:     "all maps to WaitForAll",
+			input:    "all",
+			expected: sarama.WaitForAll,
+		},
+		{
+			name:     "ALL (uppercase) maps to WaitForAll",
+			input:    "ALL",
+			expected: sarama.WaitForAll,
+		},
+		{
+			name:     "local maps to WaitForLocal",
+			input:    "local",
+			expected: sarama.WaitForLocal,
+		},
+		{
+			name:     "none maps to NoResponse",
+			input:    "none",
+			expected: sarama.NoResponse,
+		},
+		{
+			name:        "invalid value returns error",
+			input:       "quorum",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := getBaseMetadata()
+			if tc.input != "" {
+				m["producerRequiredAcks"] = tc.input
+			}
+			meta, err := k.getKafkaMetadata(m)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "producerRequiredAcks")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, meta.internalProducerRequiredAcks)
+		})
+	}
+}
+
+func TestMetadataProducerRetryMax(t *testing.T) {
+	k := getKafka()
+
+	t.Run("default producerRetryMax is 5", func(t *testing.T) {
+		m := getBaseMetadata()
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.Equal(t, defaultProducerRetryMax, meta.ProducerRetryMax)
+	})
+
+	t.Run("explicit producerRetryMax is accepted", func(t *testing.T) {
+		m := getBaseMetadata()
+		m["producerRetryMax"] = "10"
+
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.Equal(t, 10, meta.ProducerRetryMax)
+	})
+
+	t.Run("zero producerRetryMax is valid", func(t *testing.T) {
+		m := getBaseMetadata()
+		m["producerRetryMax"] = "0"
+
+		meta, err := k.getKafkaMetadata(m)
+		require.NoError(t, err)
+		require.Equal(t, 0, meta.ProducerRetryMax)
+	})
+
+	t.Run("negative producerRetryMax returns error", func(t *testing.T) {
+		m := getBaseMetadata()
+		m["producerRetryMax"] = "-1"
+
+		meta, err := k.getKafkaMetadata(m)
+		require.Error(t, err)
+		require.Nil(t, meta)
+		require.Contains(t, err.Error(), "producerRetryMax")
+	})
+}

--- a/common/component/kafka/producer.go
+++ b/common/component/kafka/producer.go
@@ -37,14 +37,27 @@ func parsePartitionNumber(value string) (int32, error) {
 	return int32(pNum), nil
 }
 
-func GetSyncProducer(config sarama.Config, brokers []string, maxMessageBytes int) (sarama.SyncProducer, error) {
-	// Add SyncProducer specific properties to copy of base config
-	config.Producer.RequiredAcks = sarama.WaitForAll
-	config.Producer.Retry.Max = 5
+// ProducerConfig holds the producer-specific tunables derived from component metadata.
+// Separating them avoids threading the entire KafkaMetadata struct through callers
+// that only have access to the sarama.Config copy.
+type ProducerConfig struct {
+	RequiredAcks    sarama.RequiredAcks
+	RetryMax        int
+	MaxMessageBytes int
+}
+
+// GetSyncProducer creates a new Sarama SyncProducer using the provided base
+// config and producer tunables. RequiredAcks and RetryMax are applied from
+// ProducerConfig so callers can override the previously hard-coded defaults
+// (WaitForAll, 5 retries) via component metadata.
+func GetSyncProducer(config sarama.Config, brokers []string, pc ProducerConfig) (sarama.SyncProducer, error) {
+	// Apply SyncProducer-specific properties to a copy of the base config.
+	config.Producer.RequiredAcks = pc.RequiredAcks
+	config.Producer.Retry.Max = pc.RetryMax
 	config.Producer.Return.Successes = true
 
-	if maxMessageBytes > 0 {
-		config.Producer.MaxMessageBytes = maxMessageBytes
+	if pc.MaxMessageBytes > 0 {
+		config.Producer.MaxMessageBytes = pc.MaxMessageBytes
 	}
 
 	saramaClient, err := sarama.NewClient(brokers, &config)

--- a/common/component/kafka/sasl_oauthbearer.go
+++ b/common/component/kafka/sasl_oauthbearer.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/dapr/kit/crypto/pem"
@@ -30,6 +31,7 @@ import (
 )
 
 type OAuthTokenSource struct {
+	mu            sync.Mutex
 	CachedToken   oauth2.Token
 	Extensions    map[string]string
 	TokenEndpoint oauth2.Endpoint
@@ -101,6 +103,9 @@ func (ts *OAuthTokenSource) configureClient() {
 }
 
 func (ts *OAuthTokenSource) Token() (*sarama.AccessToken, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
 	if ts.CachedToken.Valid() {
 		return ts.asSaramaToken(), nil
 	}

--- a/common/component/kafka/sasl_oauthbearer_private_key_jwt.go
+++ b/common/component/kafka/sasl_oauthbearer_private_key_jwt.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dapr/kit/crypto/pem"
@@ -37,6 +38,7 @@ import (
 )
 
 type OAuthTokenSourcePrivateKeyJWT struct {
+	mu                  sync.Mutex
 	CachedToken         oauth2.Token
 	Extensions          map[string]string
 	TokenEndpoint       oauth2.Endpoint
@@ -127,6 +129,9 @@ func (ts *OAuthTokenSourcePrivateKeyJWT) configureClient() {
 // At the time of writing this, the oauth2 package does not support the client assertion authentication method.
 // Ref: https://github.com/golang/oauth2/issues/744
 func (ts *OAuthTokenSourcePrivateKeyJWT) Token() (*sarama.AccessToken, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
 	if ts.CachedToken.Valid() {
 		return ts.asSaramaToken(), nil
 	}

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -374,6 +374,42 @@ metadata:
         The max amount of time for the client connection to be kept alive with the broker, as a Go duration, before closing the connection. A zero value (default) means keeping alive indefinitely.
       example: '4m'
       default: '0'
+    - name: dialTimeout
+      type: duration
+      description: |
+        The maximum duration to wait for the initial TCP connection to a broker to be established. Bounds how long Init() can block on an unreachable cluster.
+      example: '"10s"'
+      default: '"30s"'
+    - name: readTimeout
+      type: duration
+      description: |
+        The maximum duration to wait for a response from a broker after sending a request.
+      example: '"10s"'
+      default: '"30s"'
+    - name: writeTimeout
+      type: duration
+      description: |
+        The maximum duration to wait for a request to be transmitted to a broker.
+      example: '"10s"'
+      default: '"30s"'
+    - name: metadataTimeout
+      type: duration
+      description: |
+        The per-request timeout for metadata refresh operations. When set to 0 (default) Sarama computes the effective timeout from the Net timeouts and retry count.
+      example: '"5s"'
+      default: '"0"'
+    - name: producerRequiredAcks
+      type: string
+      description: |
+        The number of partition replicas that must acknowledge a produce request before it is considered successful. Accepted values: "all" (wait for all in-sync replicas, highest durability), "local" (wait for the partition leader only), "none" (no acknowledgement required, lowest durability).
+      example: '"local"'
+      default: '"all"'
+    - name: producerRetryMax
+      type: number
+      description: |
+        The maximum number of times to retry sending a message before giving up.
+      example: '3'
+      default: '5'
     - name: consumerFetchDefault
       type: number
       description: |


### PR DESCRIPTION
Backport of #4413 to `release-1.18`.

## What this backports

Hardens the Kafka common component against connectivity and configuration issues:

- **Connection timeouts** — adds tunable dial, read, and write timeouts so the Sarama client fails fast instead of hanging on unreachable brokers.
- **Broker health check** — adds a health check that verifies broker reachability, surfacing connectivity problems through the component health endpoint.
- **Tunable producer config** — exposes producer settings (e.g. flush, retry, and buffering knobs) via component metadata, with new metadata fields documented in `bindings/kafka/metadata.yaml` and `pubsub/kafka/metadata.yaml`.

## Notes

- Clean cherry-pick of the squashed commit (`e0c83b4`) from `main`; no conflicts.
- New unit tests included (`common/component/kafka/health_test.go`, `common/component/kafka/metadata_test.go`).

Co-authored-by attribution and DCO sign-off preserved from the original commit.
