### PR TITLE
feat(bindings/localstorage): add fromTemp metadata for cross-platform temp dir

### DIFF
--- a/bindings/localstorage/localstorage.go
+++ b/bindings/localstorage/localstorage.go
@@ -57,6 +57,7 @@ type LocalStorage struct {
 // Metadata defines the metadata.
 type Metadata struct {
 	RootPath string `json:"rootPath"`
+	FromTemp bool   `json:"fromTemp"`
 }
 
 type createResponse struct {
@@ -89,6 +90,10 @@ func (ls *LocalStorage) parseMetadata(meta bindings.Metadata) (*Metadata, error)
 	err := kitmd.DecodeMetadata(meta.Properties, &m)
 	if err != nil {
 		return nil, err
+	}
+
+	if m.FromTemp {
+		m.RootPath = filepath.Join(os.TempDir(), m.RootPath)
 	}
 
 	m.RootPath, err = validateRootPath(m.RootPath)

--- a/bindings/localstorage/localstorage_test.go
+++ b/bindings/localstorage/localstorage_test.go
@@ -39,6 +39,16 @@ func TestParseMetadata(t *testing.T) {
 	assert.Equal(t, path, meta.RootPath)
 }
 
+func TestParseMetadataFromTemp(t *testing.T) {
+	m := bindings.Metadata{}
+	m.Properties = map[string]string{"rootPath": "myapp_data", "fromTemp": "true"}
+	localStorage := NewLocalStorage(logger.NewLogger("test")).(*LocalStorage)
+	meta, err := localStorage.parseMetadata(m)
+	require.NoError(t, err)
+	assert.True(t, meta.FromTemp)
+	assert.Equal(t, filepath.Join(joinWithMustEvalSymlinks(os.TempDir()), "myapp_data"), meta.RootPath)
+}
+
 func TestValidateRootPath(t *testing.T) {
 	// Get the current working directory
 	cwd, err := os.Getwd()

--- a/bindings/localstorage/metadata.yaml
+++ b/bindings/localstorage/metadata.yaml
@@ -23,3 +23,9 @@ metadata:
     required: true
     description: "The file name to write"
     example: "data.txt"
+  - name: fromTemp
+    required: false
+    description: "If true, resolves rootPath relative to the system-wide temporary directory, for cross-platform compatibility"
+    type: bool
+    default: "false"
+    example: "true"


### PR DESCRIPTION
Motivation:
The localstorage output binding requires rootPath to be set explicitly,
and there is no cross-platform way to point it at the OS temp directory.
Users have to hardcode OS-specific paths (e.g. "/tmp" on Unix,
"C:\Windows\Temp" or "%LocalAppData%\Temp" on Windows), which breaks when
a component definition is shared across development environments running
different operating systems.

Approach:
Add an optional `fromTemp` boolean metadata field. When true, rootPath is
resolved relative to os.TempDir() before the existing path validation
(disallowed-location checks, symlink resolution, etc.) runs unchanged.
When fromTemp is unset (the default, false), behavior is identical to
before this change. This is the same approach the issue author proposed
and that a maintainer previously reacted to positively on a stale, closed
PR for this issue (#4280); this change reimplements it from scratch since
that PR was auto-closed for inactivity with no code merged.

Validation:
go build ./bindings/localstorage/...
go test ./bindings/localstorage/... -v
All tests pass, including the new TestParseMetadataFromTemp case.

Fixes #3158

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>