### PR TITLE
fix(ci): dapr-bot runs

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -38,7 +38,8 @@ module.exports = async ({ github, context }) => {
     ) {
         await handleIssueCommentCreate({ github, context })
     } else if (
-        context.eventName == 'issues' &&
+        (context.eventName == 'issues' ||
+            context.eventName == 'pull_request_target') &&
         context.payload.action == 'labeled'
     ) {
         await handleIssueOrPrLabeled({ github, context })
@@ -101,7 +102,7 @@ async function handleIssueCommentCreate({ github, context }) {
 async function handleIssueOrPrLabeled({ github, context }) {
     const payload = context.payload
     const label = payload.label.name
-    const issueNumber = payload.issue.number
+    const issueNumber = context.issue.number
 
     // This should not run in forks.
     if (context.repo.owner !== 'dapr') {
@@ -111,8 +112,7 @@ async function handleIssueOrPrLabeled({ github, context }) {
         return
     }
 
-    // Authorization is not required here because it's triggered by an issue label event.
-    // Only authorized users can add labels to issues.
+    // Authorization is not required here because only authorized users can add labels.
     if (label == 'documentation required') {
         // Open a new docs issue
         await github.rest.issues.create({

--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -14,16 +14,17 @@
 name: dapr-bot
 
 on:
-  issue_comment: 
+  issue_comment:
     types: [created]
   issues:
     types: [labeled]
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:
   daprbot:
     name: bot-processor
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
uses the normalised context rather than raw payload which is not supported by pull_request_target also omits events triggered by dependabot which have do not have secrets populated

# Description

fixes dapr-bot noise which has been failing after a recent upstream change that has allowed runs on pull_event triggers rather than previously silently failing.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
