### PR TITLE
fix(ci): adds a global concurrency lock for workflow runs

### DIFF
--- a/.github/scripts/test-info.mjs
+++ b/.github/scripts/test-info.mjs
@@ -936,6 +936,7 @@ const components = {
  * Test matrix object
  * @typedef {Object} TestMatrixElement
  * @property {string} component Component name
+ * @property {boolean} authenticated Whether the test requires credentials
  * @property {string?} required-secrets Required secrets
  * @property {string?} required-certs Required certs
  * @property {boolean?} require-aws-credentials Requires AWS credentials
@@ -967,22 +968,22 @@ function GenerateMatrix(testKind, enableCloudTests) {
             continue
         }
 
-        // Skip cloud-only tests if enableCloudTests is false
-        if (!enableCloudTests) {
-            if (
-                comp.requiredSecrets?.length ||
+        const authenticated = Boolean(
+            comp.requiredSecrets?.length ||
                 comp.requiredCerts?.length ||
                 comp.requireAWSCredentials ||
                 comp.requireGCPCredentials ||
-                comp.requireCloudflareCredentials
-            ) {
-                continue
-            }
-        } else {
-            // For conformance tests, avoid running Docker and Cloud Tests together.
-            if (comp.conformance && comp.requireDocker) {
-                continue
-            }
+                comp.requireCloudflareCredentials,
+        )
+
+        // Skip cloud-only tests if enableCloudTests is false
+        if (!enableCloudTests && authenticated) {
+            continue
+        }
+
+        // For conformance tests, avoid running Docker and Cloud Tests together.
+        if (enableCloudTests && comp.conformance && comp.requireDocker) {
+            continue
         }
 
         if (comp.sourcePkg) {
@@ -998,6 +999,7 @@ function GenerateMatrix(testKind, enableCloudTests) {
         // Add the component to the array
         res.push({
             component: name,
+            authenticated,
             'required-secrets': comp.requiredSecrets?.length
                 ? comp.requiredSecrets.join(',')
                 : undefined,

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -86,6 +86,12 @@ jobs:
   certification:
     name: ${{ matrix.component }} certification
 
+    # Only authenticated tests share a concurrency group across workflow runs.
+    concurrency:
+      group: component-test-${{ matrix.authenticated && matrix.component || format('{0}-{1}-{2}', github.run_id, github.run_attempt, strategy.job-index) }}
+      cancel-in-progress: false
+      queue: max
+
     # Add "id-token" with the intended permissions.
     # Needed by the 'Authenticate to Google Cloud' step.
     permissions:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -88,6 +88,12 @@ jobs:
   conformance:
     name: ${{ matrix.component }} conformance
 
+    # Only authenticated tests share a concurrency group across workflow runs.
+    concurrency:
+      group: component-test-${{ matrix.authenticated && matrix.component || format('{0}-{1}-{2}', github.run_id, github.run_attempt, strategy.job-index) }}
+      cancel-in-progress: false
+      queue: max
+
     # Add "id-token" with the intended permissions.
     # Needed by the 'Authenticate to Google Cloud' step.
     permissions:


### PR DESCRIPTION
# Description

adds a global concurrency lock for workflow runs- preventing clashes during cert and conf test runs for authenticated components such as azure etc where some components will fail due to collisions. Other jobs will continue to run in advance and thus the effects minimised e.g. postgresql runs take a long time but are not delayed.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
