### PR TITLE
fix(common/redis): Pipeliner.Do queues every command twice when writeTimeout is set

### DIFF
--- a/common/component/redis/pipeliner_timeout_test.go
+++ b/common/component/redis/pipeliner_timeout_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPipelinerDoQueuesOnceWithWriteTimeout is the regression test for the
+// double-queue bug: Pipeliner.Do used to queue the command TWICE when
+// writeTimeout was set (the writeTimeout branch was missing a return, so the
+// unbounded call below it also ran). Every pipelined command — including the
+// state store's transactional CAS EVALs — then executed twice per Exec,
+// inflating versions and breaking ETag/first-write semantics for any
+// component configured with writeTimeout (Dapr Workflow actor state being the
+// visible casualty: "ERR user_script:14: failed to set key").
+func TestPipelinerDoQueuesOnceWithWriteTimeout(t *testing.T) {
+	ctx := context.Background()
+
+	run := func(t *testing.T, s *Settings) {
+		t.Helper()
+		mr := miniredis.RunT(t)
+		s.Host = mr.Addr()
+		s.RedisType = NodeType
+
+		clients := map[string]func(*Settings) (RedisClient, error){
+			"v8": newV8Client,
+			"v9": newV9Client,
+		}
+		for name, newClient := range clients {
+			t.Run(name, func(t *testing.T) {
+				c, err := newClient(s)
+				require.NoError(t, err)
+				defer c.Close()
+
+				mr.FlushAll()
+				pipe := c.TxPipeline()
+				pipe.Do(ctx, "INCR", "counter")
+				require.NoError(t, pipe.Exec(ctx))
+
+				got, err := c.Get(ctx, "counter")
+				require.NoError(t, err)
+				require.Equal(t, "1", got,
+					"a single pipelined INCR must execute exactly once (twice means Do double-queued)")
+			})
+		}
+	}
+
+	t.Run("writeTimeout set (the arming condition)", func(t *testing.T) {
+		run(t, &Settings{WriteTimeout: Duration(3 * time.Second)})
+	})
+	t.Run("writeTimeout unset", func(t *testing.T) {
+		run(t, &Settings{})
+	})
+}

--- a/common/component/redis/v8client.go
+++ b/common/component/redis/v8client.go
@@ -38,6 +38,7 @@ func (p v8Pipeliner) Do(ctx context.Context, args ...interface{}) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(p.writeTimeout))
 		defer cancel()
 		p.pipeliner.Do(timeoutCtx, args...)
+		return
 	}
 	p.pipeliner.Do(ctx, args...)
 }

--- a/common/component/redis/v9client.go
+++ b/common/component/redis/v9client.go
@@ -38,6 +38,7 @@ func (p v9Pipeliner) Do(ctx context.Context, args ...interface{}) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(p.writeTimeout))
 		defer cancel()
 		p.pipeliner.Do(timeoutCtx, args...)
+		return
 	}
 	p.pipeliner.Do(ctx, args...)
 }


### PR DESCRIPTION
## Description

Fixes #4464.

`Pipeliner.Do` (both `v8client.go` and `v9client.go`) is missing a `return` in its `writeTimeout > 0` branch: after queueing the command with a timeout context, execution falls through and queues the same command **again** with the unbounded context. Every command sent through a `TxPipeline` then executes **twice per `Exec`** whenever the component sets `writeTimeout` metadata.

## Impact

- **State transactions execute every operation twice.** `StateStore.Multi` pipelines the CAS `EVAL` per operation, so a single transactional write runs the script twice — the `version` hash field increments by 2 per write, breaking ETag/`first-write` semantics.
- **Dapr Workflow / actor state stores fail hard on daprd ≥ 1.17.9** (whose workflow engine plants the Lua `first-write` flag): every second workflow write fails with `ERR user_script:14: failed to set key …||workflow||…||metadata`. On earlier daprd the duplication is silent — versions inflate and transactional Redis CPU is ~doubled.
- Encountered in production against Azure Managed Redis: all Dapr Workflow submissions failed once daprd moved to 1.17.9; Redis CPU dropped materially once the duplication was removed. Reproduces identically through built-in `state.redis` and pluggable components (shared client).

Minimal repro and full analysis in #4464 (e.g. one transactional upsert on a fresh key → `GET` returns ETag `2`).

## Fix

Add the missing `return` (mirrors the existing pattern in `DoWrite`/`DoRead` on the same clients).

## Testing

New regression test `TestPipelinerDoQueuesOnceWithWriteTimeout` drives a pipelined `INCR` through both v8 and v9 clients against miniredis and asserts single execution, with and without `writeTimeout` (fails on the previous code with counter=2).

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Extended the documentation — n/a (no user-facing behavior beyond the bug fix)