### PR TITLE
fix(pubsub/redis): bound XREADGROUP BLOCK duration to release canceled subscriptions

### DIFF
--- a/pubsub/redis/redis.go
+++ b/pubsub/redis/redis.go
@@ -39,6 +39,14 @@ const (
 	concurrency       = "concurrency"
 	maxLenApprox      = "maxLenApprox"
 	streamTTL         = "streamTTL"
+
+	// defaultBlockDuration bounds how long a single XREADGROUP call blocks
+	// when readTimeout is left unset. Without this, BLOCK 0 tells Redis to
+	// block the connection indefinitely; if the subscription's context is
+	// canceled while that read is in flight, go-redis has no deadline to
+	// interrupt it, so the connection leaks until a new message happens to
+	// arrive on the stream.
+	defaultBlockDuration = 3 * time.Second
 )
 
 // redisStreams handles consuming from a Redis stream using
@@ -280,9 +288,15 @@ func (r *redisStreams) pollNewMessagesLoop(ctx context.Context, stream string, h
 			return
 		}
 
-		// Read messages
+		// Read messages. Block for at most defaultBlockDuration when
+		// readTimeout is unset so a canceled subscription context is
+		// noticed promptly instead of blocking the connection forever.
+		block := time.Duration(r.clientSettings.ReadTimeout)
+		if block == 0 {
+			block = defaultBlockDuration
+		}
 		//nolint:gosec
-		streams, err := r.client.XReadGroupResult(ctx, r.clientSettings.ConsumerID, r.clientSettings.ConsumerID, []string{stream, ">"}, int64(r.clientSettings.QueueDepth), time.Duration(r.clientSettings.ReadTimeout))
+		streams, err := r.client.XReadGroupResult(ctx, r.clientSettings.ConsumerID, r.clientSettings.ConsumerID, []string{stream, ">"}, int64(r.clientSettings.QueueDepth), block)
 		if err != nil {
 			if !r.client.IsNilValueError(err) && err != context.Canceled {
 				if strings.Contains(err.Error(), "NOGROUP") {

--- a/pubsub/redis/redis_test.go
+++ b/pubsub/redis/redis_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	miniredis "github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -314,6 +315,70 @@ func TestPollNewMessagesLoopWhenXReadGroupResultReturnsRedisNil(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("pollNewMessagesLoop did not exit after context cancel")
+	}
+}
+
+// TestSubscribeReleasesConnectionWhenSubscriptionCtxCanceled uses a real
+// miniredis server and a real go-redis client (no stubs) to verify that when
+// an individual subscription's context is canceled (e.g. the calling app
+// unsubscribes while the pubsub component and its shared client stay alive
+// for other subscriptions), the goroutines backing that subscription still
+// exit and release the underlying XREADGROUP connection.
+//
+// With readTimeout left unset, the BLOCK argument sent to XREADGROUP
+// defaults to 0 (block forever). go-redis then sets no socket read deadline
+// at all for that command, so canceling the subscription context cannot
+// interrupt the in-flight blocking read: the goroutine leaks and the
+// connection is never returned to the pool until a new message happens to
+// arrive on the stream.
+func TestSubscribeReleasesConnectionWhenSubscriptionCtxCanceled(t *testing.T) {
+	s, err := miniredis.Run()
+	require.NoError(t, err)
+	defer s.Close()
+
+	testLogger := logger.NewLogger("test")
+	client, settings, err := commonredis.ParseClientFromProperties(map[string]string{
+		"redisHost":  s.Addr(),
+		"consumerID": "fakeConsumer",
+	}, mdata.PubSubType, t.Context(), &testLogger)
+	require.NoError(t, err)
+	defer client.Close()
+	t.Logf("settings: ReadTimeout=%s", time.Duration(settings.ReadTimeout))
+
+	rs := &redisStreams{
+		logger:         testLogger,
+		client:         client,
+		clientSettings: settings,
+		closeCh:        make(chan struct{}),
+	}
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	err = rs.Subscribe(subCtx, pubsub.SubscribeRequest{Topic: "test-topic"}, func(context.Context, *pubsub.NewMessage) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Give pollNewMessagesLoop time to enter its blocking XREADGROUP call.
+	time.Sleep(2 * time.Second)
+
+	// Simulate the app unsubscribing: cancel only this subscription's
+	// context. The component and its shared client stay up for other
+	// subscriptions, so Close() (which force-closes the shared client and
+	// would mask this bug) is deliberately not called here.
+	start := time.Now()
+	subCancel()
+
+	done := make(chan struct{})
+	go func() {
+		rs.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Logf("subscription goroutines exited after %s", time.Since(start))
+	case <-time.After(6 * time.Second):
+		t.Fatal("subscription goroutines did not exit after the subscription context was canceled: the blocked XREADGROUP connection was never released")
 	}
 }
 


### PR DESCRIPTION
# Description

Redis Streams pubsub subscriptions call `XREADGROUP` with `BLOCK` set to the `readTimeout` setting, which defaults to the Go zero value (`0`) when left unconfigured. `BLOCK 0` tells Redis to hold the connection open indefinitely, and go-redis sets no socket read deadline for it either. When an individual subscription's context is canceled (e.g. the calling app unsubscribes) while a read is in flight, there is nothing available to interrupt the blocked call. The connection is only released when the whole pubsub component is closed or a new message happens to arrive on the stream, so repeated subscribe/unsubscribe cycles without new messages leak one blocked connection each, matching the growing `blockedClients` behavior described in the report.

This PR bounds the `BLOCK` duration passed to `XREADGROUP` in `pollNewMessagesLoop` to a new `defaultBlockDuration` (3s) whenever `readTimeout` is left unset, instead of passing the raw zero value straight through. Explicit user-configured values (positive durations, or `-1` for "no timeout") are unaffected. Bounding the default keeps the socket read deadline finite, so the loop's existing `ctx.Err()` cancellation check runs periodically, and a canceled subscription context is now noticed within a few seconds instead of never.

An earlier version of this fix applied the same default at the shared client-settings level (`common/component/redis`) instead, but that field also feeds a separate `context.WithTimeout` wrapper used by every Redis command on the connection, which raced against the `BLOCK` timeout and produced spurious "error reading from stream" log lines on every idle poll cycle. This version is scoped to the local block variable inside `pollNewMessagesLoop` only, which avoids that regression.

Added `TestSubscribeReleasesConnectionWhenSubscriptionCtxCanceled`, which uses a real miniredis server and a real go-redis client (no stubs) to subscribe, let the poll loop enter its blocking `XREADGROUP` call, cancel only that subscription's context (not the whole component), and assert its goroutines exit and release the connection. Confirmed the test hangs past its timeout against the pre-fix code and passes (exiting in ~1s) with the fix applied. Ran `go test ./pubsub/redis/... ./common/component/redis/... -race -v`, `go build ./pubsub/redis/... ./common/component/redis/...`, `go vet`, and `gofmt -l` on the changed files; all pass with no findings. Also confirmed with a throwaway test (not included) that idle polling with no messages and no cancellation produces no error log lines across multiple `BLOCK` cycles.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #4497

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.

---
AI assistance: this change was drafted with Claude Code.

Fixes #4497