### PR TITLE
adopt structured logging from dapr/kit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,14 @@ linters:
     paths:
       - ^vendor$
     rules:
+      # Temporary, for the structured-logging migration (dapr/kit#165). The
+      # printf-style methods on kit's logger.Logger are deprecated in favour of
+      # structured attributes on *logger.Log, but the existing call sites are
+      # being converted incrementally. Delete this rule once the migration
+      # completes and the deprecated methods are removed from kit.
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*is deprecated: use \[Log\.'
       # G101 in test files: test fixtures use fake credentials by design
       - path: _test\.go$
         text: "G101"
@@ -64,6 +72,27 @@ linters:
         linters:
           - gosec
   settings:
+    sloglint:
+      # Structured-logging conventions, mirroring dapr/kit. Fields are only
+      # machine-filterable if the same concept is always logged under the same
+      # key in the same shape.
+      no-mixed-args: true
+      # Package-level loggers named for their scope are the established Dapr
+      # pattern, and component constructors receive loggers; both are fine.
+      no-global: ""
+      # Context-aware logging is deliberately out of scope for now.
+      context: ""
+      key-naming-case: snake
+      forbidden-keys:
+        # Reserved by the Dapr log schema; a per-call attribute with one of
+        # these names would collide with the schema field and be dropped.
+        - time
+        - level
+        - msg
+        - scope
+        - type
+        - instance
+        - ver
     gosec:
       excludes:
         # G117 (Audit: Exported struct field matches secret pattern) is noisy

--- a/bindings/dubbo/dubbo_output.go
+++ b/bindings/dubbo/dubbo_output.go
@@ -38,6 +38,12 @@ type DubboOutputBinding struct {
 
 var dubboBinding *DubboOutputBinding
 
+// dubbo-go accepts the Dapr logger structurally through its own Logger
+// interface, which requires the printf-style methods. This assertion makes a
+// change to either interface fail here, in this repo, rather than surfacing as
+// a confusing downstream build break.
+var _ dubboLogger.Logger = (logger.Logger)(nil)
+
 func NewDubboOutput(logger logger.Logger) bindings.OutputBinding {
 	if dubboBinding == nil {
 		dubboBinding = &DubboOutputBinding{

--- a/common/component/cloudflare/workers/workers.go
+++ b/common/component/cloudflare/workers/workers.go
@@ -51,7 +51,7 @@ type Base struct {
 	infoResponseValidate func(*InfoEndpointResponse) error
 	componentDocsURL     string
 	client               *http.Client
-	logger               logger.Logger
+	logger               *logger.Log
 	ctx                  context.Context
 	cancel               context.CancelFunc
 }
@@ -70,14 +70,14 @@ func (w *Base) Init(workerBindings []CFBinding, componentDocsURL string, infoRes
 		w.logger.Info("Using externally-managed worker: " + w.metadata.WorkerURL)
 		err = w.checkWorker(w.metadata.WorkerURL)
 		if err != nil {
-			w.logger.Errorf("The component could not be initialized because the externally-managed worker cannot be used: %v", err)
+			w.logger.Error("The component could not be initialized because the externally-managed worker cannot be used", logger.Err(err))
 			return err
 		}
 	} else {
 		// We are using a Dapr-managed worker, so let's check if it exists or needs to be created or updated
 		err = w.setupWorker(workerBindings)
 		if err != nil {
-			w.logger.Errorf("The component could not be initialized because the worker cannot be created or updated: %v", err)
+			w.logger.Error("The component could not be initialized because the worker cannot be created or updated", logger.Err(err))
 			return err
 		}
 	}
@@ -86,8 +86,8 @@ func (w *Base) Init(workerBindings []CFBinding, componentDocsURL string, infoRes
 }
 
 // SetLogger sets the logger object.
-func (w *Base) SetLogger(logger logger.Logger) {
-	w.logger = logger
+func (w *Base) SetLogger(l logger.Logger) {
+	w.logger = logger.FromLogger(l)
 }
 
 // SetMetadata sets the metadata for the base object.
@@ -114,7 +114,7 @@ func (w *Base) setupWorker(workerBindings []CFBinding) error {
 	workerURL := fmt.Sprintf("https://%s.%s.workers.dev/", w.metadata.WorkerName, subdomain)
 	err = w.checkWorker(workerURL)
 	if err != nil {
-		w.logger.Infof("Deploying updated worker at URL '%s'", workerURL)
+		w.logger.Info("Deploying updated worker", "url", workerURL)
 		err = w.deployWorker(workerBindings)
 		if err != nil {
 			return fmt.Errorf("error deploying or updating the worker with the Cloudflare APIs: %w", err)
@@ -127,7 +127,7 @@ func (w *Base) setupWorker(workerBindings []CFBinding) error {
 		}
 
 		// Wait for the worker to be deplopyed, which can take up to 30 seconds (but let's give it 1 minute)
-		w.logger.Debugf("Deployed a new version of the worker at '%s' - waiting for propagation", workerURL)
+		w.logger.Debug("Deployed a new version of the worker - waiting for propagation", "url", workerURL)
 		start := time.Now()
 		for time.Since(start) < time.Minute {
 			err = w.checkWorker(workerURL)
@@ -142,7 +142,7 @@ func (w *Base) setupWorker(workerBindings []CFBinding) error {
 		}
 		w.logger.Debug("Worker is ready")
 	} else {
-		w.logger.Infof("Using worker at URL '%s'", workerURL)
+		w.logger.Info("Using worker", "url", workerURL)
 	}
 
 	// Update the URL of the worker

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -233,7 +233,7 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 		RetryMax:        meta.ProducerRetryMax,
 		MaxMessageBytes: meta.MaxMessageBytes,
 	}
-	sarama.Logger = SaramaLogBridge{daprLogger: k.logger}
+	sarama.Logger = newSaramaLogBridge(k.logger)
 
 	// Default retry configuration is used if no
 	// backOff properties are set.

--- a/common/component/kafka/sarama_log_bridge.go
+++ b/common/component/kafka/sarama_log_bridge.go
@@ -14,21 +14,32 @@ limitations under the License.
 package kafka
 
 import (
+	"fmt"
+
 	"github.com/dapr/kit/logger"
 )
 
+// SaramaLogBridge implements sarama.StdLogger over the Dapr logger. Sarama
+// hands over pre-rendered strings, so records carry no structured attributes;
+// everything is emitted at debug level as before.
 type SaramaLogBridge struct {
-	daprLogger logger.Logger
+	log *logger.Log
+}
+
+func newSaramaLogBridge(l logger.Logger) SaramaLogBridge {
+	return SaramaLogBridge{log: logger.FromLogger(l)}
 }
 
 func (b SaramaLogBridge) Print(v ...interface{}) {
-	b.daprLogger.Debug(v...)
+	b.log.Debug(fmt.Sprint(v...))
 }
 
 func (b SaramaLogBridge) Printf(format string, v ...interface{}) {
-	b.daprLogger.Debugf(format, v...)
+	b.log.Debug(fmt.Sprintf(format, v...))
 }
 
 func (b SaramaLogBridge) Println(v ...interface{}) {
-	b.daprLogger.Debug(v...)
+	// The previous bridge rendered Println identically to Print, and output
+	// compatibility wins over stdlib Println semantics here.
+	b.log.Debug(fmt.Sprint(v...))
 }

--- a/go.mod
+++ b/go.mod
@@ -506,4 +506,4 @@ replace github.com/apache/thrift => github.com/apache/thrift v0.13.0
 // Uncomment for local development for testing with changes in the components-contrib && kit repositories.
 // Don't commit with this uncommented!
 //
-// replace github.com/dapr/kit => ../kit
+replace github.com/dapr/kit => github.com/joshvanl/kit v0.0.0-20260813182616-fd5d465c8baa

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,6 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/kit v0.18.2 h1:nOhtpNz5U171Pl8R1hf+KKDNmkNkMUVYcb1x1mWIL1Q=
-github.com/dapr/kit v0.18.2/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1037,6 +1035,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/kit v0.0.0-20260813182616-fd5d465c8baa h1:LfQX/YxwtbPGQ9SRCS6sUCVy+AQZKtgrFA6dqO71zBk=
+github.com/joshvanl/kit v0.0.0-20260813182616-fd5d465c8baa/go.mod h1:sPky/01yDLTfQpE8wsUPvouAE/m1LgM1xf8TLs3xaTc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/middleware/http/sentinel/logger.go
+++ b/middleware/http/sentinel/logger.go
@@ -14,18 +14,26 @@ limitations under the License.
 package sentinel
 
 import (
-	"github.com/alibaba/sentinel-golang/logging"
-
 	"github.com/dapr/kit/logger"
 )
 
+// loggerAdaptor implements sentinel's logging.Logger over the Dapr logger.
+//
+// Sentinel already logs with a message plus alternating keys and values, which
+// maps directly onto the structured logger. The previous adaptor flattened
+// everything into one string via logging.AssembleMsg, burying sentinel's own
+// timestamp and caller inside the message, and logged warnings and errors at
+// info level; both are corrected here.
 type loggerAdaptor struct {
-	logger logger.Logger
+	log *logger.Log
+}
+
+func newLoggerAdaptor(l logger.Logger) *loggerAdaptor {
+	return &loggerAdaptor{log: logger.FromLogger(l)}
 }
 
 func (l *loggerAdaptor) Debug(msg string, keysAndValues ...interface{}) {
-	s := logging.AssembleMsg(logging.GlobalCallerDepth, "DEBUG", msg, nil, keysAndValues...)
-	l.logger.Debug(s)
+	l.log.Debug(msg, keysAndValues...)
 }
 
 func (l *loggerAdaptor) DebugEnabled() bool {
@@ -33,8 +41,7 @@ func (l *loggerAdaptor) DebugEnabled() bool {
 }
 
 func (l *loggerAdaptor) Info(msg string, keysAndValues ...interface{}) {
-	s := logging.AssembleMsg(logging.GlobalCallerDepth, "INFO", msg, nil, keysAndValues...)
-	l.logger.Info(s)
+	l.log.Info(msg, keysAndValues...)
 }
 
 func (l *loggerAdaptor) InfoEnabled() bool {
@@ -42,8 +49,7 @@ func (l *loggerAdaptor) InfoEnabled() bool {
 }
 
 func (l *loggerAdaptor) Warn(msg string, keysAndValues ...interface{}) {
-	s := logging.AssembleMsg(logging.GlobalCallerDepth, "WARNING", msg, nil, keysAndValues...)
-	l.logger.Info(s)
+	l.log.Warn(msg, keysAndValues...)
 }
 
 func (l *loggerAdaptor) WarnEnabled() bool {
@@ -51,8 +57,14 @@ func (l *loggerAdaptor) WarnEnabled() bool {
 }
 
 func (l *loggerAdaptor) Error(err error, msg string, keysAndValues ...interface{}) {
-	s := logging.AssembleMsg(logging.GlobalCallerDepth, "ERROR", msg, nil, keysAndValues...)
-	l.logger.Info(s)
+	args := make([]any, 0, len(keysAndValues)+1)
+	args = append(args, keysAndValues...)
+
+	if err != nil {
+		args = append(args, logger.Err(err))
+	}
+
+	l.log.Error(msg, args...)
 }
 
 func (l *loggerAdaptor) ErrorEnabled() bool {

--- a/middleware/http/sentinel/middleware.go
+++ b/middleware/http/sentinel/middleware.go
@@ -144,7 +144,7 @@ func (m *Middleware) newSentinelConfig(metadata *middlewareMetadata) *config.Ent
 		conf.Sentinel.Log.Dir = metadata.LogDir
 	}
 
-	conf.Sentinel.Log.Logger = &loggerAdaptor{m.logger}
+	conf.Sentinel.Log.Logger = newLoggerAdaptor(m.logger)
 
 	return conf
 }

--- a/middleware/http/wasm/httpwasm.go
+++ b/middleware/http/wasm/httpwasm.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"time"
@@ -33,7 +34,7 @@ import (
 )
 
 type middleware struct {
-	logger logger.Logger
+	log *logger.Log
 }
 
 type Metadata struct {
@@ -42,8 +43,8 @@ type Metadata struct {
 	GuestConfig string `mapstructure:"guestConfig"`
 }
 
-func NewMiddleware(logger logger.Logger) dapr.Middleware {
-	return &middleware{logger: logger}
+func NewMiddleware(l logger.Logger) dapr.Middleware {
+	return &middleware{log: logger.FromLogger(l)}
 }
 
 func (m *middleware) GetHandler(ctx context.Context, metadata dapr.Metadata) (func(next http.Handler) http.Handler, error) {
@@ -81,38 +82,38 @@ func (m *middleware) getHandler(ctx context.Context, metadata dapr.Metadata) (*r
 		return nil, err
 	}
 
-	return &requestHandler{mw: mw, logger: m.logger, stdout: &stdout, stderr: &stderr}, nil
+	return &requestHandler{mw: mw, log: m.log, stdout: &stdout, stderr: &stderr}, nil
 }
 
 // IsEnabled implements the same method as documented on api.Logger.
 func (m *middleware) IsEnabled(level api.LogLevel) bool {
-	var l logger.LogLevel
+	var l slog.Level
 	switch level {
 	case api.LogLevelError:
-		l = logger.ErrorLevel
+		l = logger.LevelError
 	case api.LogLevelWarn:
-		l = logger.WarnLevel
+		l = logger.LevelWarn
 	case api.LogLevelInfo:
-		l = logger.InfoLevel
+		l = logger.LevelInfo
 	case api.LogLevelDebug:
-		l = logger.DebugLevel
+		l = logger.LevelDebug
 	default: // same as api.LogLevelNone
 		return false
 	}
-	return m.logger.IsOutputLevelEnabled(l)
+	return m.log.Enabled(context.Background(), l)
 }
 
 // Log implements the same method as documented on api.Logger.
 func (m *middleware) Log(_ context.Context, level api.LogLevel, message string) {
 	switch level {
 	case api.LogLevelError:
-		m.logger.Error(message)
+		m.log.Error(message)
 	case api.LogLevelWarn:
-		m.logger.Warn(message)
+		m.log.Warn(message)
 	case api.LogLevelInfo:
-		m.logger.Info(message)
+		m.log.Info(message)
 	case api.LogLevelDebug:
-		m.logger.Debug(message)
+		m.log.Debug(message)
 	default: // same as api.LogLevelNone
 		return
 	}
@@ -120,7 +121,7 @@ func (m *middleware) Log(_ context.Context, level api.LogLevel, message string) 
 
 type requestHandler struct {
 	mw             wasmnethttp.Middleware
-	logger         logger.Logger
+	log            *logger.Log
 	stdout, stderr *bytes.Buffer
 }
 
@@ -135,10 +136,10 @@ func (rh *requestHandler) requestHandler(next http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 
 		if stdout := rh.stdout.String(); len(stdout) > 0 {
-			rh.logger.Debugf("wasm stdout: %s", stdout)
+			rh.log.Debug("wasm stdout: " + stdout)
 		}
 		if stderr := rh.stderr.String(); len(stderr) > 0 {
-			rh.logger.Debugf("wasm stderr: %s", stderr)
+			rh.log.Debug("wasm stderr: " + stderr)
 		}
 	})
 }

--- a/middleware/http/wasm/httpwasm_test.go
+++ b/middleware/http/wasm/httpwasm_test.go
@@ -35,7 +35,7 @@ var exampleWasmBin []byte
 
 func Test_NewMiddleWare(t *testing.T) {
 	l := logger.NewLogger(t.Name())
-	require.Equal(t, &middleware{logger: l}, NewMiddleware(l))
+	require.Equal(t, &middleware{log: logger.FromLogger(l)}, NewMiddleware(l))
 }
 
 func Test_middleware_log(t *testing.T) {
@@ -43,7 +43,7 @@ func Test_middleware_log(t *testing.T) {
 	var buf bytes.Buffer
 	l.SetOutput(&buf)
 
-	m := &middleware{logger: l}
+	m := &middleware{log: logger.FromLogger(l)}
 	message := "alert"
 	m.Log(t.Context(), api.LogLevelInfo, message)
 
@@ -51,7 +51,7 @@ func Test_middleware_log(t *testing.T) {
 }
 
 func Test_middleware_getHandler(t *testing.T) {
-	m := &middleware{logger: logger.NewLogger(t.Name())}
+	m := &middleware{log: logger.FromLogger(logger.NewLogger(t.Name()))}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/example.wasm" {
 			_, _ = w.Write(exampleWasmBin)


### PR DESCRIPTION
dapr/kit's logger is now backed by log/slog (dapr/kit#165) and exposes a structured API, *logger.Log, alongside the existing printf-style Logger interface. Log output is byte-identical to the previous logrus backend, so nothing here changes what components emit; the tests that capture and assert on log text pass unchanged.

Component constructors keep their func NewX(logger.Logger) signature, which is public API for out-of-tree component authors. A component reaches the structured API without changing that signature by wrapping the logger it receives:

```go
    func NewRedis(l logger.Logger) state.Store {
        return &redis{log: logger.FromLogger(l)}
    }
```

This change converts the shared third-party log adapters, which duplicated what slog now provides:

* common/component/kafka: SaramaLogBridge renders sarama's pre-formatted strings through the structured logger, output unchanged.
* middleware/http/sentinel: sentinel already passes a message plus alternating keys and values, which previously got flattened into one string via logging.AssembleMsg; the pairs now pass straight through as attributes. This also fixes the adaptor logging sentinel warnings and errors at info level.
* middleware/http/wasm: level checks go through the structured logger; guest messages and the "wasm stdout:"/"wasm stderr:" pipe lines keep their exact wording, which the e2e tests assert on.
* common/component/cloudflare/workers: worker deploy logging carries the URL as an attribute and errors via logger.Err.

bindings/dubbo gains a compile-time assertion that logger.Logger still satisfies dubbo-go's Logger interface: dubbo consumes the printf methods structurally, so a change to either interface now fails in this repo rather than surfacing as a confusing downstream break.

Lint configuration:

* staticcheck SA1019 findings for the deprecated printf logging methods are excluded while the ~877 existing call sites are converted incrementally; the rule is scoped to exactly those deprecation messages and is deleted when the migration completes.
* sloglint enforces the shared conventions from kit: snake_case keys, no mixed key-value pairs and attributes, and the reserved log schema field names (time, level, msg, scope, type, instance, ver) are forbidden as per-call attr