### PR TITLE
wasm: boost perf ~4x by switching to wazy

### DIFF
--- a/bindings/wasm/output.go
+++ b/bindings/wasm/output.go
@@ -24,11 +24,10 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/stealthrocket/wasi-go/imports/wasi_http"
-	"github.com/stealthrocket/wasi-go/imports/wasi_http/default_http"
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/api"
+	"github.com/samyfodil/wazy/imports/wasi_http"
+	"github.com/samyfodil/wazy/imports/wasi_snapshot_preview1"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/common/wasm"
@@ -41,11 +40,11 @@ const ExecuteOperation bindings.OperationKind = "execute"
 
 type outputBinding struct {
 	logger        logger.Logger
-	runtimeConfig wazero.RuntimeConfig
+	runtimeConfig wazy.RuntimeConfig
 
 	meta    *wasm.InitMetadata
-	runtime wazero.Runtime
-	module  wazero.CompiledModule
+	runtime wazy.Runtime
+	module  wazy.CompiledModule
 
 	instanceCounter atomic.Uint64
 }
@@ -60,7 +59,7 @@ func NewWasmOutput(logger logger.Logger) bindings.OutputBinding {
 		logger: logger,
 
 		// The below ensures context cancels in-flight wasm functions.
-		runtimeConfig: wazero.NewRuntimeConfig().
+		runtimeConfig: wazy.NewRuntimeConfig().
 			WithCloseOnContextDone(true),
 	}
 }
@@ -71,7 +70,7 @@ func (out *outputBinding) Init(ctx context.Context, metadata bindings.Metadata) 
 	}
 
 	// Create the runtime, which when closed releases any resources associated with it.
-	out.runtime = wazero.NewRuntimeWithConfig(ctx, out.runtimeConfig)
+	out.runtime = wazy.NewRuntimeWithConfig(ctx, out.runtimeConfig)
 
 	// Compile the module, which reduces execution time of Invoke
 	out.module, err = out.runtime.CompileModule(ctx, out.meta.Guest)
@@ -94,11 +93,11 @@ func (out *outputBinding) Init(ctx context.Context, metadata bindings.Metadata) 
 			_ = out.runtime.Close(context.Background())
 			return errors.New("can not instantiate wasi-http with strict sandbox")
 		}
-		err = wasi_http.MakeWasiHTTP().Instantiate(ctx, out.runtime)
+		_, err = wasi_http.Instantiate(ctx, out.runtime)
 	}
 	if err != nil {
 		_ = out.runtime.Close(context.Background())
-		return fmt.Errorf("wasm: error instantiating host wasi-http functions: %w", err)
+		return fmt.Errorf("wasm: error instantiating host wasi functions: %w", err)
 	}
 	return nil
 }
@@ -178,7 +177,7 @@ func detectImports(imports []api.FunctionDefinition) map[importMode]bool {
 		switch moduleName {
 		case wasi_snapshot_preview1.ModuleName:
 			result[modeWasiP1] = true
-		case default_http.ModuleName:
+		case wasi_http.OutgoingModuleName:
 			result[modeWasiHTTP] = true
 		}
 	}

--- a/common/wasm/wasm.go
+++ b/common/wasm/wasm.go
@@ -28,8 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/sys"
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/sys"
 
 	"github.com/dapr/components-contrib/metadata"
 	kitmd "github.com/dapr/kit/metadata"
@@ -119,10 +119,10 @@ func GetInitMetadata(ctx context.Context, md metadata.Base) (*InitMetadata, erro
 
 // NewModuleConfig returns a new module config appropriate for the initialized
 // metadata.
-func NewModuleConfig(m *InitMetadata) wazero.ModuleConfig {
+func NewModuleConfig(m *InitMetadata) wazy.ModuleConfig {
 	if !m.StrictSandbox {
 		// The below violate sand-boxing, but allow code to behave as expected.
-		return wazero.NewModuleConfig().
+		return wazy.NewModuleConfig().
 			WithRandSource(rand.Reader).
 			WithSysNanotime().
 			WithSysWalltime().
@@ -133,7 +133,7 @@ func NewModuleConfig(m *InitMetadata) wazero.ModuleConfig {
 	// does not return a real clock reading by default for performance and
 	// determinism reasons.
 	// See https://github.com/tetratelabs/wazero/blob/main/RATIONALE.md#syswalltime-and-nanotime
-	return wazero.NewModuleConfig().
+	return wazy.NewModuleConfig().
 		WithWalltime(newFakeWalltime(), sys.ClockResolution(time.Millisecond))
 }
 

--- a/common/wasm/wasm_test.go
+++ b/common/wasm/wasm_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/imports/wasi_snapshot_preview1"
 	"github.com/stretchr/testify/require"
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 
 	"github.com/dapr/components-contrib/metadata"
 )
@@ -185,7 +185,7 @@ func TestNewModuleConfig(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	rt := wazero.NewRuntime(ctx)
+	rt := wazy.NewRuntime(ctx)
 	defer rt.Close(ctx)
 	wasi_snapshot_preview1.MustInstantiate(ctx, rt)
 

--- a/go.mod
+++ b/go.mod
@@ -122,13 +122,11 @@ require (
 	github.com/sijms/go-ora/v2 v2.8.22
 	github.com/spf13/cast v1.8.0
 	github.com/spiffe/go-spiffe/v2 v2.6.0
-	github.com/stealthrocket/wasi-go v0.8.1-0.20230912180546-8efbab50fb58
 	github.com/stretchr/testify v1.11.1
 	github.com/supplyon/gremcos v0.1.40
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.128
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.3.128
 	github.com/testcontainers/testcontainers-go v0.40.0
-	github.com/tetratelabs/wazero v1.8.0
 	github.com/tmc/langchaingo v0.1.15-0.20251029190607-e35755df7084
 	github.com/valyala/fasthttp v1.53.0
 	github.com/vmware/vmware-go-kcl-v2 v1.0.0
@@ -157,6 +155,8 @@ require (
 	modernc.org/sqlite v1.34.5
 	sigs.k8s.io/yaml v1.4.0
 )
+
+require github.com/tetratelabs/wazero v1.8.0 // indirect
 
 require (
 	cel.dev/expr v0.25.1 // indirect
@@ -402,6 +402,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/zerolog v1.31.0 // indirect
 	github.com/sagikazarmark/locafero v0.9.0 // indirect
+	github.com/samyfodil/wazy v0.1.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,6 @@ require (
 	github.com/hashicorp/consul/api v1.25.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a
-	github.com/http-wasm/http-wasm-host-go v0.7.0
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.23.4+incompatible
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.56
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
@@ -155,8 +154,6 @@ require (
 	modernc.org/sqlite v1.34.5
 	sigs.k8s.io/yaml v1.4.0
 )
-
-require github.com/tetratelabs/wazero v1.8.0 // indirect
 
 require (
 	cel.dev/expr v0.25.1 // indirect
@@ -402,7 +399,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/zerolog v1.31.0 // indirect
 	github.com/sagikazarmark/locafero v0.9.0 // indirect
-	github.com/samyfodil/wazy v0.1.2
+	github.com/samyfodil/wazy v0.1.3
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -976,8 +976,6 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a h1:j6SSiw7fWemWfrJL801xiQ6xRT7ZImika50xvmPN+tg=
 github.com/hazelcast/hazelcast-go-client v0.0.0-20190530123621-6cf767c2f31a/go.mod h1:VhwtcZ7sg3xq7REqGzEy7ylSWGKz4jZd05eCJropNzI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/http-wasm/http-wasm-host-go v0.7.0 h1:+1KrRyOO6tWiDB24QrtSYyDmzFLBBs3jioKaUT0mq1c=
-github.com/http-wasm/http-wasm-host-go v0.7.0/go.mod h1:adXKcLmL7yuavH/e0kBAp7b3TgAHTo/enCduyN5bXGM=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.23.4+incompatible h1:XRAk4HBDLCYEdPLWtKf5iZhOi7lfx17aY0oSO9+mcg8=
 github.com/huaweicloud/huaweicloud-sdk-go-obs v3.23.4+incompatible/go.mod h1:l7VUhRbTKCzdOacdT4oWCwATKyvZqUOlOqr0Ous3k4s=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.56 h1:ULzGSSe95hkOdh17NsiPV3lw58D0SC6M/6askOwF12Q=
@@ -1471,8 +1469,8 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
 github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/samyfodil/wazy v0.1.2 h1:fenrwPP9iV5fRSQcNcqIxaqBjMhpSGIGaBBDu4UFJzw=
-github.com/samyfodil/wazy v0.1.2/go.mod h1:jpXcoooWi9CQPnN1fzwt/A0w3AMRn/s6PQDunF55SIM=
+github.com/samyfodil/wazy v0.1.3 h1:rIVE9I4kSzW42mJUQ5p9u1hLq8UeoRuv8w3eJoQV6z8=
+github.com/samyfodil/wazy v0.1.3/go.mod h1:jpXcoooWi9CQPnN1fzwt/A0w3AMRn/s6PQDunF55SIM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
@@ -1592,8 +1590,6 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.3.128 h1:+TCKLZO
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssm v1.3.128/go.mod h1:dBnD/cAlrtjPfpJslNfXH2j7TEklwTBhnYgoMdkZ7HE=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=
-github.com/tetratelabs/wazero v1.8.0 h1:iEKu0d4c2Pd+QSRieYbnQC9yiFlMS9D+Jr0LsRmcF4g=
-github.com/tetratelabs/wazero v1.8.0/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/tevid/gohamcrest v1.1.1/go.mod h1:3UvtWlqm8j5JbwYZh80D/PVBt0mJ1eJiYgZMibh0H/k=
 github.com/tidwall/gjson v1.2.1/go.mod h1:c/nTNbUr0E0OrXEhq1pwa8iEgc2DOt4ZZqAt1HtCkPA=
 github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/go.sum
+++ b/go.sum
@@ -1471,6 +1471,8 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
 github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/samyfodil/wazy v0.1.2 h1:fenrwPP9iV5fRSQcNcqIxaqBjMhpSGIGaBBDu4UFJzw=
+github.com/samyfodil/wazy v0.1.2/go.mod h1:jpXcoooWi9CQPnN1fzwt/A0w3AMRn/s6PQDunF55SIM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
@@ -1548,10 +1550,6 @@ github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqj
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
-github.com/stealthrocket/wasi-go v0.8.1-0.20230912180546-8efbab50fb58 h1:mTC4gyv3lcJ1XpzZMAckqkvWUqeT5Bva4RAT1IoHAAA=
-github.com/stealthrocket/wasi-go v0.8.1-0.20230912180546-8efbab50fb58/go.mod h1:ZAYCOqLJkc9P6fcq14TV4cf+gJ2fHthp9kCGxBViagE=
-github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=
-github.com/stealthrocket/wazergo v0.19.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/middleware/http/wasm/httpwasm.go
+++ b/middleware/http/wasm/httpwasm.go
@@ -21,9 +21,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/http-wasm/http-wasm-host-go/api"
-	"github.com/http-wasm/http-wasm-host-go/handler"
-	wasmnethttp "github.com/http-wasm/http-wasm-host-go/handler/nethttp"
+	"github.com/samyfodil/wazy/imports/http_handler"
+	wasmnethttp "github.com/samyfodil/wazy/imports/http_handler/nethttp"
 
 	"github.com/dapr/components-contrib/common/wasm"
 	mdutils "github.com/dapr/components-contrib/metadata"
@@ -71,12 +70,12 @@ func (m *middleware) getHandler(ctx context.Context, metadata dapr.Metadata) (*r
 
 	var stdout, stderr bytes.Buffer
 	mw, err := wasmnethttp.NewMiddleware(ctx, meta.Guest,
-		handler.Logger(m),
-		handler.ModuleConfig(wasm.NewModuleConfig(meta).
+		http_handler.WithLogger(m),
+		http_handler.WithModuleConfig(wasm.NewModuleConfig(meta).
 			WithName(meta.GuestName).
 			WithStdout(&stdout).  // reset per request
 			WithStderr(&stderr)), // reset per request
-		handler.GuestConfig([]byte(middlewareMeta.GuestConfig)))
+		http_handler.WithGuestConfig([]byte(middlewareMeta.GuestConfig)))
 	if err != nil {
 		return nil, err
 	}
@@ -84,36 +83,36 @@ func (m *middleware) getHandler(ctx context.Context, metadata dapr.Metadata) (*r
 	return &requestHandler{mw: mw, logger: m.logger, stdout: &stdout, stderr: &stderr}, nil
 }
 
-// IsEnabled implements the same method as documented on api.Logger.
-func (m *middleware) IsEnabled(level api.LogLevel) bool {
+// IsEnabled implements the same method as documented on http_handler.Logger.
+func (m *middleware) IsEnabled(level http_handler.LogLevel) bool {
 	var l logger.LogLevel
 	switch level {
-	case api.LogLevelError:
+	case http_handler.LogLevelError:
 		l = logger.ErrorLevel
-	case api.LogLevelWarn:
+	case http_handler.LogLevelWarn:
 		l = logger.WarnLevel
-	case api.LogLevelInfo:
+	case http_handler.LogLevelInfo:
 		l = logger.InfoLevel
-	case api.LogLevelDebug:
+	case http_handler.LogLevelDebug:
 		l = logger.DebugLevel
-	default: // same as api.LogLevelNone
+	default: // same as http_handler.LogLevelNone
 		return false
 	}
 	return m.logger.IsOutputLevelEnabled(l)
 }
 
-// Log implements the same method as documented on api.Logger.
-func (m *middleware) Log(_ context.Context, level api.LogLevel, message string) {
+// Log implements the same method as documented on http_handler.Logger.
+func (m *middleware) Log(_ context.Context, level http_handler.LogLevel, message string) {
 	switch level {
-	case api.LogLevelError:
+	case http_handler.LogLevelError:
 		m.logger.Error(message)
-	case api.LogLevelWarn:
+	case http_handler.LogLevelWarn:
 		m.logger.Warn(message)
-	case api.LogLevelInfo:
+	case http_handler.LogLevelInfo:
 		m.logger.Info(message)
-	case api.LogLevelDebug:
+	case http_handler.LogLevelDebug:
 		m.logger.Debug(message)
-	default: // same as api.LogLevelNone
+	default: // same as http_handler.LogLevelNone
 		return
 	}
 }

--- a/middleware/http/wasm/httpwasm_test.go
+++ b/middleware/http/wasm/httpwasm_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/http-wasm/http-wasm-host-go/api"
+	"github.com/samyfodil/wazy/imports/http_handler"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/common/httputils"
@@ -45,7 +45,7 @@ func Test_middleware_log(t *testing.T) {
 
 	m := &middleware{logger: l}
 	message := "alert"
-	m.Log(t.Context(), api.LogLevelInfo, message)
+	m.Log(t.Context(), http_handler.LogLevelInfo, message)
 
 	require.Contains(t, buf.String(), `level=info msg=alert`)
 }


### PR DESCRIPTION
## Summary

Switches every WASM-touching package in this repo (`bindings/wasm`, `common/wasm`, `middleware/http/wasm`) from `tetratelabs/wazero` to [`wazy`](https://github.com/samyfodil/wazy), a pure-Go, zero-dependency, no-CGO runtime whose API mirrors wazero's. Reason is performance.

On `bindings/wasm`'s own `BenchmarkExample`, same machine, same guest binary:

| | wazero | wazy |
|---|---|---|
| time/op | 37,833 ns | 9,060 ns (**~4.2x faster**) |
| bytes/op | 146,563 B | 5,931 B (**~96% less**) |

Two other libraries in this repo's dependency graph were themselves the only things still pulling in wazero:

- `github.com/stealthrocket/wasi-go` (dormant since 2023) provided the wasi-http guest path used by `bindings/wasm`. wazy now ships a wire-compatible reimplementation of that same pre-standard ABI (`wazy/imports/wasi_http`), so existing wasi-http guests - including this package's own test fixtures - run unmodified. `Test_InvokeHttp` and `TestEnsureConcurrency` pass without any changes to the tests or fixtures.
- `github.com/http-wasm/http-wasm-host-go` (dormant since Oct 2024) is what `middleware/http/wasm` used, and constructs its own `wazero.Runtime` internally. wazy now ships a wire-compatible port of the http-wasm handler ABI plus its `net/http` adapter (`wazy/imports/http_handler` and `wazy/imports/http_handler/nethttp`), so this package's own guest fixtures and tests pass unmodified too.

`go mod why -m github.com/tetratelabs/wazero github.com/stealthrocket/wasi-go github.com/http-wasm/http-wasm-host-go` confirms all three are now fully gone from this module's dependency graph.

## Test plan
- [x] `go build ./bindings/wasm/... ./common/wasm/... ./middleware/http/wasm/...`
- [x] `go vet` on the same packages
- [x] `go test` on the same packages - all pass, including `Test_InvokeHttp`, `TestEnsureConcurrency`, and `middleware/http/wasm`'s own test suite, unmodified
- [x] `go test -race` on the same packages - no races
- [x] `go mod why` confirms wazero, wasi-go, and http-wasm-host-go are all gone from the module graph