### PR TITLE
test(wasm): isolate e2e logger buffer per subtest

### DIFF
--- a/middleware/http/wasm/internal/e2e_test.go
+++ b/middleware/http/wasm/internal/e2e_test.go
@@ -55,11 +55,6 @@ func TestMain(m *testing.M) {
 }
 
 func Test_EndToEnd(t *testing.T) {
-	l := logger.NewLogger(t.Name())
-	var buf bytes.Buffer
-	l.SetOutputLevel(logger.DebugLevel)
-	l.SetOutput(&buf)
-
 	type testCase struct {
 		name     string
 		guest    []byte
@@ -169,7 +164,10 @@ func Test_EndToEnd(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			t.Run(tc.name, func(t *testing.T) {
-				defer buf.Reset()
+				var buf bytes.Buffer
+				l := logger.NewLogger(t.Name())
+				l.SetOutputLevel(logger.DebugLevel)
+				l.SetOutput(&buf)
 
 				wasmPath := path.Join(t.TempDir(), "guest.wasm")
 				require.NoError(t, os.WriteFile(wasmPath, tc.guest, 0o600))
@@ -218,7 +216,11 @@ func Test_EndToEnd(t *testing.T) {
 			for _, tt := range tests {
 				tc := tt
 				t.Run(tc.name, func(t *testing.T) {
-					defer buf.Reset()
+					var buf bytes.Buffer
+					l := logger.NewLogger(t.Name())
+					l.SetOutputLevel(logger.DebugLevel)
+					l.SetOutput(&buf)
+
 					ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						ht.handler(w, r, tc.guest)
 					}))


### PR DESCRIPTION
## Summary
- Moves the shared logger/`bytes.Buffer` into each `t.Run` so delayed WASM stdout/stderr from earlier cases cannot leak into later assertions.
- Addresses flaky `consoleLog_stdout_and_stderr` / related e2e failures.

Fixes #4186

## Test plan
- [ ] `go test ./middleware/http/wasm/internal/ -count=20`