### PR TITLE
conversation/anthropic: use anthropic-sdk-go directly instead of langchaingo

### DIFF
--- a/conversation/anthropic/anthropic.go
+++ b/conversation/anthropic/anthropic.go
@@ -16,55 +16,70 @@ package anthropic
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
+	"sync"
+	"time"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 
 	"github.com/dapr/components-contrib/conversation"
-	"github.com/dapr/components-contrib/conversation/langchaingokit"
 	"github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/kit/logger"
 	kmeta "github.com/dapr/kit/metadata"
 
-	"github.com/tmc/langchaingo/llms/anthropic"
+	"github.com/tmc/langchaingo/llms"
 )
 
-const apiTypeFoundry = "foundry"
+const (
+	apiTypeFoundry = "foundry"
+
+	// defaultMaxTokens matches the fallback the pinned langchaingo client used
+	// when no max_tokens was provided, keeping behavior identical for callers
+	// that never set one.
+	defaultMaxTokens = 2048
+)
 
 type Anthropic struct {
-	langchaingokit.LLM
+	client    anthropicsdk.Client
+	model     string
+	maxTokens int64
+
+	cache *responseCache
 
 	logger logger.Logger
 }
 
 func NewAnthropic(logger logger.Logger) conversation.Conversation {
-	a := &Anthropic{
+	return &Anthropic{
 		logger: logger,
-		LLM:    langchaingokit.New(logger),
 	}
-
-	return a
 }
 
-func (a *Anthropic) buildClientOptions(md AnthropicLangchainMetadata) (string, []anthropic.Option, error) {
+func (a *Anthropic) buildClientOptions(md AnthropicLangchainMetadata) (string, []option.RequestOption, error) {
 	model := conversation.GetAnthropicModel(md.Model)
 
-	options := []anthropic.Option{
-		anthropic.WithModel(model),
-		anthropic.WithToken(md.Key),
+	options := []option.RequestOption{
+		option.WithAPIKey(md.Key),
 	}
 
 	if strings.EqualFold(md.APIType, apiTypeFoundry) {
 		if md.Endpoint == "" {
 			return "", nil, errors.New("endpoint must be provided when apiType is set to 'foundry'")
 		}
-		options = append(options, anthropic.WithBaseURL(strings.TrimSuffix(md.Endpoint, "/")))
+		options = append(options, option.WithBaseURL(strings.TrimSuffix(md.Endpoint, "/")))
 	} else if md.Endpoint != "" {
-		options = append(options, anthropic.WithBaseURL(strings.TrimSuffix(md.Endpoint, "/")))
+		options = append(options, option.WithBaseURL(strings.TrimSuffix(md.Endpoint, "/")))
 	}
 
 	if httpClient := conversation.BuildHTTPClient(); httpClient != nil {
-		options = append(options, anthropic.WithHTTPClient(httpClient))
+		options = append(options, option.WithHTTPClient(httpClient))
 	}
 
 	return model, options, nil
@@ -82,24 +97,116 @@ func (a *Anthropic) Init(ctx context.Context, meta conversation.Metadata) error 
 		return err
 	}
 
-	llm, err := anthropic.New(options...)
-	if err != nil {
-		return err
+	a.client = anthropicsdk.NewClient(options...)
+	a.model = model
+
+	a.maxTokens = defaultMaxTokens
+	if md.MaxTokens > 0 {
+		a.maxTokens = md.MaxTokens
 	}
 
-	a.Model = llm
-	a.SetModel(model)
-
 	if md.ResponseCacheTTL != nil {
-		cachedModel, cacheErr := conversation.CacheResponses(ctx, md.ResponseCacheTTL, a.Model)
-		if cacheErr != nil {
-			return cacheErr
-		}
-
-		a.Model = cachedModel
+		a.cache = newResponseCache(*md.ResponseCacheTTL)
 	}
 
 	return nil
+}
+
+func (a *Anthropic) Converse(ctx context.Context, r *conversation.Request) (*conversation.Response, error) {
+	var messages []llms.MessageContent
+	if r.Message != nil {
+		messages = *r.Message
+	}
+
+	var tools []llms.Tool
+	if r.Tools != nil {
+		tools = *r.Tools
+	}
+
+	params, err := a.buildParams(messages, tools, r)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.cache != nil {
+		if cached, ok := a.cache.get(params); ok {
+			return cached, nil
+		}
+	}
+
+	msg, err := a.client.Messages.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: failed to create message: %w", err)
+	}
+
+	resp := buildResponse(a.model, msg)
+
+	// If tool_choice was "required" but the model returned neither content nor a
+	// tool call, surface it as a retriable error rather than a silent success.
+	// This mirrors the shared langchaingokit behavior.
+	if r.ToolChoice != nil && strings.EqualFold(*r.ToolChoice, "required") && len(tools) > 0 {
+		if !hasUsefulResponse(resp) {
+			return nil, fmt.Errorf("LLM returned empty response with no tool calls despite %d tools being available", len(tools))
+		}
+	}
+
+	if a.cache != nil {
+		a.cache.set(params, resp)
+	}
+
+	return resp, nil
+}
+
+func (a *Anthropic) buildParams(messages []llms.MessageContent, tools []llms.Tool, r *conversation.Request) (anthropicsdk.MessageNewParams, error) {
+	msgs, system, err := buildMessages(messages)
+	if err != nil {
+		return anthropicsdk.MessageNewParams{}, fmt.Errorf("anthropic: failed to process messages: %w", err)
+	}
+
+	params := anthropicsdk.MessageNewParams{
+		Model:     a.model,
+		MaxTokens: a.maxTokens,
+		Messages:  msgs,
+	}
+
+	if system != "" {
+		params.System = []anthropicsdk.TextBlockParam{{Text: system}}
+	}
+
+	// The pinned langchaingo serialized temperature unconditionally, which breaks
+	// newer Claude generations that reject the parameter. Set it only when the
+	// caller actually provided one (dapr uses 0 to mean unset).
+	if r.Temperature > 0 {
+		params.Temperature = anthropicsdk.Float(r.Temperature)
+	}
+
+	toolParams, err := buildTools(tools)
+	if err != nil {
+		return anthropicsdk.MessageNewParams{}, err
+	}
+	if len(toolParams) > 0 {
+		params.Tools = toolParams
+		params.ToolChoice = buildToolChoice(r.ToolChoice)
+	}
+
+	return params, nil
+}
+
+func hasUsefulResponse(resp *conversation.Response) bool {
+	for _, output := range resp.Outputs {
+		for _, choice := range output.Choices {
+			if choice.Message.Content != "" ||
+				(choice.Message.ToolCallRequest != nil && len(*choice.Message.ToolCallRequest) > 0) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// GetModel returns the resolved model name used for this component.
+func (a *Anthropic) GetModel() string {
+	return a.model
 }
 
 func (a *Anthropic) GetComponentMetadata() (metadataInfo metadata.MetadataMap) {
@@ -110,4 +217,69 @@ func (a *Anthropic) GetComponentMetadata() (metadataInfo metadata.MetadataMap) {
 
 func (a *Anthropic) Close() error {
 	return nil
+}
+
+// responseCache is a small TTL cache over Converse responses, keyed by the
+// request parameters. It preserves the responseCacheTTL/cacheTTL behavior the
+// langchaingo-backed component provided.
+type responseCache struct {
+	ttl     time.Duration
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	response *conversation.Response
+	expiry   time.Time
+}
+
+func newResponseCache(ttl time.Duration) *responseCache {
+	return &responseCache{
+		ttl:     ttl,
+		entries: make(map[string]cacheEntry),
+	}
+}
+
+func cacheKey(params anthropicsdk.MessageNewParams) string {
+	b, err := json.Marshal(params)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func (c *responseCache) get(params anthropicsdk.MessageNewParams) (*conversation.Response, bool) {
+	key := cacheKey(params)
+	if key == "" {
+		return nil, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiry) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return entry.response, true
+}
+
+func (c *responseCache) set(params anthropicsdk.MessageNewParams, resp *conversation.Response) {
+	key := cacheKey(params)
+	if key == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[key] = cacheEntry{
+		response: resp,
+		expiry:   time.Now().Add(c.ttl),
+	}
 }

--- a/conversation/anthropic/anthropic_test.go
+++ b/conversation/anthropic/anthropic_test.go
@@ -40,7 +40,7 @@ func TestInit(t *testing.T) {
 			expectedModel: conversation.DefaultAnthropicModel,
 			testFn: func(t *testing.T, a *Anthropic, err error) {
 				require.NoError(t, err)
-				assert.NotNil(t, a.LLM)
+				assert.NotEmpty(t, a.GetModel())
 			},
 		},
 		{
@@ -52,7 +52,7 @@ func TestInit(t *testing.T) {
 			expectedModel: "claude-opus-4-7",
 			testFn: func(t *testing.T, a *Anthropic, err error) {
 				require.NoError(t, err)
-				assert.NotNil(t, a.LLM)
+				assert.NotEmpty(t, a.GetModel())
 			},
 		},
 		{
@@ -65,7 +65,7 @@ func TestInit(t *testing.T) {
 			expectedModel: conversation.DefaultAnthropicModel,
 			testFn: func(t *testing.T, a *Anthropic, err error) {
 				require.NoError(t, err)
-				assert.NotNil(t, a.LLM)
+				assert.NotEmpty(t, a.GetModel())
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func TestInit(t *testing.T) {
 			expectedModel: "claude-opus-4-7",
 			testFn: func(t *testing.T, a *Anthropic, err error) {
 				require.NoError(t, err)
-				assert.NotNil(t, a.LLM)
+				assert.NotEmpty(t, a.GetModel())
 			},
 		},
 		{
@@ -104,7 +104,7 @@ func TestInit(t *testing.T) {
 			expectedModel: conversation.DefaultAnthropicModel,
 			testFn: func(t *testing.T, a *Anthropic, err error) {
 				require.NoError(t, err)
-				assert.NotNil(t, a.LLM)
+				assert.NotEmpty(t, a.GetModel())
 			},
 		},
 	}

--- a/conversation/anthropic/converse_test.go
+++ b/conversation/anthropic/converse_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package anthropic
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/dapr/components-contrib/conversation"
+	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
+)
+
+// newTestComponent spins up a component pointed at a test server that records
+// the outgoing request body and replies with the supplied message JSON.
+func newTestComponent(t *testing.T, response string, captured *map[string]any) *Anthropic {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if captured != nil {
+			require.NoError(t, json.Unmarshal(body, captured))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, response)
+	}))
+	t.Cleanup(srv.Close)
+
+	a := NewAnthropic(logger.NewLogger("anthropic test")).(*Anthropic)
+	err := a.Init(t.Context(), conversation.Metadata{
+		Base: metadata.Base{
+			Properties: map[string]string{
+				"key":      "test-key",
+				"model":    "claude-sonnet-5",
+				"endpoint": srv.URL,
+			},
+		},
+	})
+	require.NoError(t, err)
+	return a
+}
+
+const textResponse = `{
+  "id": "msg_1",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-5",
+  "content": [{"type": "text", "text": "hello there"}],
+  "stop_reason": "end_turn",
+  "usage": {"input_tokens": 10, "output_tokens": 5, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+}`
+
+func userMessage(text string) *[]llms.MessageContent {
+	return &[]llms.MessageContent{
+		{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextContent{Text: text}},
+		},
+	}
+}
+
+// TestTemperatureOmittedWhenUnset is the core regression: the pinned langchaingo
+// always serialized temperature, which 400s on newer Claude generations. When
+// the caller does not set one, no temperature key should reach the wire.
+func TestTemperatureOmittedWhenUnset(t *testing.T) {
+	var body map[string]any
+	a := newTestComponent(t, textResponse, &body)
+
+	_, err := a.Converse(t.Context(), &conversation.Request{Message: userMessage("hi")})
+	require.NoError(t, err)
+
+	_, ok := body["temperature"]
+	assert.False(t, ok, "temperature must not be sent when the caller did not set one")
+}
+
+func TestTemperatureSentWhenProvided(t *testing.T) {
+	var body map[string]any
+	a := newTestComponent(t, textResponse, &body)
+
+	_, err := a.Converse(t.Context(), &conversation.Request{
+		Message:     userMessage("hi"),
+		Temperature: 0.5,
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, body, "temperature")
+	assert.InEpsilon(t, 0.5, body["temperature"], 1e-9)
+}
+
+// TestToolChoicePassthrough verifies tools and tool_choice actually reach the
+// request; the pinned langchaingo dropped tool_choice for Anthropic.
+func TestToolChoicePassthrough(t *testing.T) {
+	var body map[string]any
+	a := newTestComponent(t, textResponse, &body)
+
+	toolChoice := "required"
+	tools := []llms.Tool{
+		{
+			Type: "function",
+			Function: &llms.FunctionDefinition{
+				Name:        "get_weather",
+				Description: "Get the weather",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city": map[string]any{"type": "string"},
+					},
+					"required": []string{"city"},
+				},
+			},
+		},
+	}
+
+	_, err := a.Converse(t.Context(), &conversation.Request{
+		Message:    userMessage("weather?"),
+		Tools:      &tools,
+		ToolChoice: &toolChoice,
+	})
+	require.NoError(t, err)
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	require.True(t, ok, "tool_choice must be present")
+	assert.Equal(t, "any", tc["type"], "required maps to the Anthropic 'any' choice")
+
+	sentTools, ok := body["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, sentTools, 1)
+	tool := sentTools[0].(map[string]any)
+	assert.Equal(t, "get_weather", tool["name"])
+	assert.Equal(t, "Get the weather", tool["description"])
+	assert.Contains(t, tool, "input_schema")
+}
+
+func TestResponseMapping(t *testing.T) {
+	const toolResponse = `{
+  "id": "msg_2",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-5",
+  "content": [
+    {"type": "text", "text": "let me check"},
+    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Paris"}}
+  ],
+  "stop_reason": "tool_use",
+  "usage": {"input_tokens": 12, "output_tokens": 7, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 3}
+}`
+
+	a := newTestComponent(t, toolResponse, nil)
+
+	resp, err := a.Converse(t.Context(), &conversation.Request{Message: userMessage("weather?")})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Outputs, 1)
+	out := resp.Outputs[0]
+	assert.Equal(t, "tool_use", out.StopReason)
+	require.Len(t, out.Choices, 1)
+
+	choice := out.Choices[0]
+	assert.Equal(t, "let me check", choice.Message.Content)
+	require.NotNil(t, choice.Message.ToolCallRequest)
+	require.Len(t, *choice.Message.ToolCallRequest, 1)
+
+	call := (*choice.Message.ToolCallRequest)[0]
+	assert.Equal(t, "toolu_1", call.ID)
+	require.NotNil(t, call.FunctionCall)
+	assert.Equal(t, "get_weather", call.FunctionCall.Name)
+	assert.JSONEq(t, `{"city":"Paris"}`, call.FunctionCall.Arguments)
+
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, uint64(12), resp.Usage.PromptTokens)
+	assert.Equal(t, uint64(7), resp.Usage.CompletionTokens)
+	assert.Equal(t, uint64(19), resp.Usage.TotalTokens)
+	require.NotNil(t, resp.Usage.PromptTokensDetails)
+	assert.Equal(t, uint64(3), resp.Usage.PromptTokensDetails.CachedTokens)
+}
+
+// TestRequiredToolChoiceEmptyResponseErrors mirrors the shared langchaingokit
+// contract: tool_choice=required with tools but an empty model reply is an error.
+func TestRequiredToolChoiceEmptyResponseErrors(t *testing.T) {
+	const emptyResponse = `{
+  "id": "msg_3",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-5",
+  "content": [],
+  "stop_reason": "end_turn",
+  "usage": {"input_tokens": 4, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+}`
+
+	a := newTestComponent(t, emptyResponse, nil)
+
+	toolChoice := "required"
+	tools := []llms.Tool{
+		{Type: "function", Function: &llms.FunctionDefinition{Name: "noop"}},
+	}
+
+	_, err := a.Converse(t.Context(), &conversation.Request{
+		Message:    userMessage("do it"),
+		Tools:      &tools,
+		ToolChoice: &toolChoice,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response with no tool calls")
+}
+
+func TestFoundryRequiresEndpoint(t *testing.T) {
+	a := NewAnthropic(logger.NewLogger("anthropic test")).(*Anthropic)
+	err := a.Init(t.Context(), conversation.Metadata{
+		Base: metadata.Base{
+			Properties: map[string]string{
+				"key":     "test-key",
+				"apiType": "foundry",
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.EqualError(t, err, "endpoint must be provided when apiType is set to 'foundry'")
+}

--- a/conversation/anthropic/convert.go
+++ b/conversation/anthropic/convert.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package anthropic
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/dapr/components-contrib/conversation"
+)
+
+// The dapr conversation surface (Request/Response) is built on langchaingo llms
+// types, so these adapters convert between those and the anthropic-sdk-go types
+// at the component boundary. That keeps the public contract identical while the
+// component talks to the Messages API directly.
+
+var errUnsupportedMessageType = errors.New("unsupported message type")
+
+// buildMessages splits the dapr request messages into a system prompt and the
+// anthropic message list. System messages collapse into the top-level system
+// string; everything else becomes a MessageParam.
+func buildMessages(messages []llms.MessageContent) ([]anthropicsdk.MessageParam, string, error) {
+	out := make([]anthropicsdk.MessageParam, 0, len(messages))
+	var system strings.Builder
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case llms.ChatMessageTypeSystem:
+			for _, part := range msg.Parts {
+				if text, ok := part.(llms.TextContent); ok {
+					system.WriteString(text.Text)
+				} else {
+					return nil, "", fmt.Errorf("anthropic: %w: system message part %T", errUnsupportedMessageType, part)
+				}
+			}
+		case llms.ChatMessageTypeHuman:
+			blocks, err := userBlocks(msg.Parts)
+			if err != nil {
+				return nil, "", err
+			}
+			out = append(out, anthropicsdk.NewUserMessage(blocks...))
+		case llms.ChatMessageTypeAI:
+			blocks, err := assistantBlocks(msg.Parts)
+			if err != nil {
+				return nil, "", err
+			}
+			out = append(out, anthropicsdk.NewAssistantMessage(blocks...))
+		case llms.ChatMessageTypeTool:
+			blocks, err := toolResultBlocks(msg.Parts)
+			if err != nil {
+				return nil, "", err
+			}
+			// Tool results are sent back to Anthropic on a user-role turn.
+			out = append(out, anthropicsdk.NewUserMessage(blocks...))
+		default:
+			return nil, "", fmt.Errorf("anthropic: %w: %v", errUnsupportedMessageType, msg.Role)
+		}
+	}
+
+	return out, system.String(), nil
+}
+
+func userBlocks(parts []llms.ContentPart) ([]anthropicsdk.ContentBlockParamUnion, error) {
+	blocks := make([]anthropicsdk.ContentBlockParamUnion, 0, len(parts))
+	for _, part := range parts {
+		switch p := part.(type) {
+		case llms.TextContent:
+			blocks = append(blocks, anthropicsdk.NewTextBlock(p.Text))
+		case llms.BinaryContent:
+			blocks = append(blocks, anthropicsdk.NewImageBlockBase64(p.MIMEType, base64.StdEncoding.EncodeToString(p.Data)))
+		case llms.ToolCallResponse:
+			blocks = append(blocks, anthropicsdk.NewToolResultBlock(p.ToolCallID, p.Content, false))
+		default:
+			return nil, fmt.Errorf("anthropic: %w: human message part %T", errUnsupportedMessageType, part)
+		}
+	}
+	if len(blocks) == 0 {
+		return nil, errors.New("anthropic: no valid content in human message")
+	}
+	return blocks, nil
+}
+
+func assistantBlocks(parts []llms.ContentPart) ([]anthropicsdk.ContentBlockParamUnion, error) {
+	blocks := make([]anthropicsdk.ContentBlockParamUnion, 0, len(parts))
+	for _, part := range parts {
+		switch p := part.(type) {
+		case llms.TextContent:
+			blocks = append(blocks, anthropicsdk.NewTextBlock(p.Text))
+		case llms.ToolCall:
+			if p.FunctionCall == nil {
+				return nil, errors.New("anthropic: assistant tool call is missing a function call")
+			}
+			var input any
+			if args := strings.TrimSpace(p.FunctionCall.Arguments); args != "" {
+				if err := json.Unmarshal([]byte(args), &input); err != nil {
+					return nil, fmt.Errorf("anthropic: failed to unmarshal tool call arguments: %w", err)
+				}
+			} else {
+				input = map[string]any{}
+			}
+			blocks = append(blocks, anthropicsdk.NewToolUseBlock(p.ID, input, p.FunctionCall.Name))
+		default:
+			return nil, fmt.Errorf("anthropic: %w: AI message part %T", errUnsupportedMessageType, part)
+		}
+	}
+	if len(blocks) == 0 {
+		return nil, errors.New("anthropic: no valid content in AI message")
+	}
+	return blocks, nil
+}
+
+func toolResultBlocks(parts []llms.ContentPart) ([]anthropicsdk.ContentBlockParamUnion, error) {
+	blocks := make([]anthropicsdk.ContentBlockParamUnion, 0, len(parts))
+	for _, part := range parts {
+		if resp, ok := part.(llms.ToolCallResponse); ok {
+			blocks = append(blocks, anthropicsdk.NewToolResultBlock(resp.ToolCallID, resp.Content, false))
+			continue
+		}
+		return nil, fmt.Errorf("anthropic: %w: tool message part %T", errUnsupportedMessageType, part)
+	}
+	if len(blocks) == 0 {
+		return nil, errors.New("anthropic: no valid content in tool message")
+	}
+	return blocks, nil
+}
+
+func buildTools(tools []llms.Tool) ([]anthropicsdk.ToolUnionParam, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	out := make([]anthropicsdk.ToolUnionParam, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Function == nil {
+			return nil, errors.New("anthropic: tool is missing a function definition")
+		}
+		param := anthropicsdk.ToolParam{
+			Name:        tool.Function.Name,
+			InputSchema: toolInputSchema(tool.Function.Parameters),
+		}
+		if tool.Function.Description != "" {
+			param.Description = anthropicsdk.String(tool.Function.Description)
+		}
+		out = append(out, anthropicsdk.ToolUnionParam{OfTool: &param})
+	}
+	return out, nil
+}
+
+// toolInputSchema maps a langchaingo JSON-schema parameters blob onto the SDK's
+// ToolInputSchemaParam. Any keys beyond properties/required are preserved via
+// ExtraFields so custom schema attributes survive the round trip.
+func toolInputSchema(parameters any) anthropicsdk.ToolInputSchemaParam {
+	schema := anthropicsdk.ToolInputSchemaParam{}
+	params, ok := parameters.(map[string]any)
+	if !ok {
+		return schema
+	}
+
+	if props, ok := params["properties"]; ok {
+		schema.Properties = props
+	}
+	if required, ok := params["required"]; ok {
+		schema.Required = toStringSlice(required)
+	}
+
+	var extra map[string]any
+	for k, v := range params {
+		switch k {
+		case "type", "properties", "required":
+			continue
+		default:
+			if extra == nil {
+				extra = map[string]any{}
+			}
+			extra[k] = v
+		}
+	}
+	schema.ExtraFields = extra
+
+	return schema
+}
+
+func toStringSlice(v any) []string {
+	switch vals := v.(type) {
+	case []string:
+		return vals
+	case []any:
+		out := make([]string, 0, len(vals))
+		for _, item := range vals {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// buildToolChoice maps the dapr tool_choice string onto the SDK union. The value
+// follows the same conventions the other conversation components accept: auto,
+// none, required/any, or a specific tool name. Anthropic never received the
+// value through the pinned langchaingo, so this passthrough is the point.
+func buildToolChoice(toolChoice *string) anthropicsdk.ToolChoiceUnionParam {
+	if toolChoice == nil {
+		return anthropicsdk.ToolChoiceUnionParam{}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(*toolChoice)) {
+	case "", "auto":
+		return anthropicsdk.ToolChoiceUnionParam{OfAuto: &anthropicsdk.ToolChoiceAutoParam{}}
+	case "none":
+		return anthropicsdk.ToolChoiceUnionParam{OfNone: &anthropicsdk.ToolChoiceNoneParam{}}
+	case "required", "any":
+		return anthropicsdk.ToolChoiceUnionParam{OfAny: &anthropicsdk.ToolChoiceAnyParam{}}
+	default:
+		return anthropicsdk.ToolChoiceUnionParam{OfTool: &anthropicsdk.ToolChoiceToolParam{Name: *toolChoice}}
+	}
+}
+
+// buildResponse maps an Anthropic Message back onto the dapr conversation
+// response, collecting text and tool calls into a single choice.
+func buildResponse(model string, msg *anthropicsdk.Message) *conversation.Response {
+	var text strings.Builder
+	var toolCalls []llms.ToolCall
+
+	for i := range msg.Content {
+		block := msg.Content[i]
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				if text.Len() > 0 {
+					text.WriteString("\n")
+				}
+				text.WriteString(block.Text)
+			}
+		case "tool_use":
+			toolCalls = append(toolCalls, llms.ToolCall{
+				ID:   block.ID,
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      block.Name,
+					Arguments: string(block.Input),
+				},
+			})
+		}
+	}
+
+	finishReason := normalizeFinishReason(string(msg.StopReason))
+
+	choice := conversation.Choice{
+		FinishReason: finishReason,
+		Index:        0,
+		Message: conversation.Message{
+			Content: text.String(),
+		},
+	}
+	if len(toolCalls) > 0 {
+		choice.Message.ToolCallRequest = &toolCalls
+	}
+
+	return &conversation.Response{
+		Model: model,
+		Outputs: []conversation.Result{
+			{
+				StopReason: finishReason,
+				Choices:    []conversation.Choice{choice},
+			},
+		},
+		Usage: buildUsage(msg.Usage),
+	}
+}
+
+func buildUsage(usage anthropicsdk.Usage) *conversation.Usage {
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 &&
+		usage.CacheReadInputTokens == 0 && usage.CacheCreationInputTokens == 0 {
+		return nil
+	}
+
+	out := &conversation.Usage{
+		PromptTokens:     safeUint64(usage.InputTokens),
+		CompletionTokens: safeUint64(usage.OutputTokens),
+		TotalTokens:      safeUint64(usage.InputTokens + usage.OutputTokens),
+	}
+
+	if usage.CacheReadInputTokens > 0 {
+		out.PromptTokensDetails = &conversation.PromptTokensDetails{
+			CachedTokens: safeUint64(usage.CacheReadInputTokens),
+		}
+	}
+
+	return out
+}
+
+// safeUint64 converts a token count to uint64, clamping negatives to 0. Token
+// counts are never negative, but this keeps the conversion overflow-safe.
+func safeUint64(v int64) uint64 {
+	if v < 0 {
+		return 0
+	}
+	return uint64(v)
+}
+
+// normalizeFinishReason mirrors the langchaingokit behavior: an empty stop
+// reason is reported as "unknown" rather than an empty string.
+func normalizeFinishReason(stopReason string) string {
+	if stopReason == "" {
+		return "unknown"
+	}
+	return stopReason
+}

--- a/conversation/anthropic/metadata.go
+++ b/conversation/anthropic/metadata.go
@@ -21,4 +21,6 @@ import (
 type AnthropicLangchainMetadata struct {
 	conversation.LangchainMetadata `json:",inline" mapstructure:",squash"`
 	APIType                        string `json:"apiType" mapstructure:"apiType"`
+	// MaxTokens is the maximum number of tokens to generate. Defaults to 2048 when unset.
+	MaxTokens int64 `json:"maxTokens" mapstructure:"maxTokens"`
 }

--- a/conversation/anthropic/metadata.yaml
+++ b/conversation/anthropic/metadata.yaml
@@ -55,3 +55,9 @@ metadata:
       A time-to-live value for a prompt cache to expire. Uses Golang durations
     type: string
     example: '10m'
+  - name: maxTokens
+    required: false
+    description: |
+      The maximum number of tokens to generate before stopping. Defaults to 2048 when unset.
+    type: number
+    example: '2048'

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.54
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible
 	github.com/aliyun/aliyun-tablestore-go-sdk v1.7.10
+	github.com/anthropics/anthropic-sdk-go v1.63.1
 	github.com/apache/dubbo-go-hessian2 v1.11.5
 	github.com/apache/pulsar-client-go v0.18.0
 	github.com/apache/rocketmq-client-go/v2 v2.1.2-0.20230412142645-25003f6f083d
@@ -217,10 +218,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20211222152315-953b66f67407 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.12.0 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
@@ -323,6 +326,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // indirect
+	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -383,6 +387,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
@@ -413,11 +418,13 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tjfoc/gmsm v1.3.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
@@ -450,6 +457,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.14.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/aliyunmq/mq-http-go-sdk v1.0.3/go.mod h1:JYfRMQoPexERvnNNBcal0ZQ2TVQ5
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/anthropics/anthropic-sdk-go v1.63.1 h1:M9dIoZzUWB453ulVpBkQp3FX0769udzrTscDrsJk1w4=
+github.com/anthropics/anthropic-sdk-go v1.63.1/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/dubbo-getty v1.4.9-0.20220610060150-8af010f3f3dc h1:NZRon3MDqT4vddR3UIRBnwbbhEerghAimCSBsiESs3g=
 github.com/apache/dubbo-getty v1.4.9-0.20220610060150-8af010f3f3dc/go.mod h1:cPJlbcHUTNTpiboMQjMHhE9XBni11LiBiG8FdrDuVzk=
@@ -345,6 +347,8 @@ github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20211222152315-953b66f67407 
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20211222152315-953b66f67407/go.mod h1:0Qr1uMHFmHsIYMcG4T7BJ9yrJtWadhOmpABCX69dwuc=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -372,6 +376,8 @@ github.com/bufbuild/protocompile v0.6.0 h1:Uu7WiSQ6Yj9DbkdnOe7U4mNKp58y9WDMKDn28
 github.com/bufbuild/protocompile v0.6.0/go.mod h1:YNP35qEYoYGme7QMtz5SBCoN4kL4g12jTtjuzRNdjpE=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2/go.mod h1:RnUjnIXxEJcL6BgCvNyzCCRzZcxCgsZCi+RNlvYor5Q=
 github.com/bytedance/gopkg v0.1.1/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
@@ -489,8 +495,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/creasty/defaults v1.5.2 h1:/VfB6uxpyp6h0fr7SPp7n8WJBoV8jfxQXPCnkVSjyls=
 github.com/creasty/defaults v1.5.2/go.mod h1:FPZ+Y0WNrbqOVw+c6av63eyHUAl6pMHZwqLPvXUZGfY=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
@@ -526,6 +532,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -998,6 +1006,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3If
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -1340,6 +1350,8 @@ github.com/pashagolub/pgxmock/v2 v2.12.0 h1:IVRmQtVFNCoq7NOZ+PdfvB6fwnLJmEuWDhnc
 github.com/pashagolub/pgxmock/v2 v2.12.0/go.mod h1:D3YslkN/nJ4+umVqWmbwfSXugJIjPMChkGBG47OJpNw=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
@@ -1548,6 +1560,8 @@ github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqj
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 h1:uOfcYT+3QungH6tIGSVCR/Y3KJmgJiHcojJbMTPDZAI=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stealthrocket/wasi-go v0.8.1-0.20230912180546-8efbab50fb58 h1:mTC4gyv3lcJ1XpzZMAckqkvWUqeT5Bva4RAT1IoHAAA=
 github.com/stealthrocket/wasi-go v0.8.1-0.20230912180546-8efbab50fb58/go.mod h1:ZAYCOqLJkc9P6fcq14TV4cf+gJ2fHthp9kCGxBViagE=
 github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=
@@ -1599,6 +1613,7 @@ github.com/tetratelabs/wazero v1.8.0/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P
 github.com/tevid/gohamcrest v1.1.1/go.mod h1:3UvtWlqm8j5JbwYZh80D/PVBt0mJ1eJiYgZMibh0H/k=
 github.com/tidwall/gjson v1.2.1/go.mod h1:c/nTNbUr0E0OrXEhq1pwa8iEgc2DOt4ZZqAt1HtCkPA=
 github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
@@ -1608,6 +1623,8 @@ github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65/go.mod h1:XNkn88O1C
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/tjfoc/gmsm v1.3.2 h1:7JVkAn5bvUJ7HtU08iW6UiD+UTmJTIToHCfeFzkcCxM=
 github.com/tjfoc/gmsm v1.3.2/go.mod h1:HaUcFuY0auTiaHB9MHFGCPx5IaLhTUd2atbCFBQXn9w=
@@ -1788,6 +1805,8 @@ go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 goji.io v2.0.2+incompatible h1:uIssv/elbKRLznFUy3Xj4+2Mz/qKhek/9aZQDUMae7c=
 goji.io v2.0.2+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMIk=
 golang.org/x/arch v0.14.0 h1:z9JUEZWr8x4rR0OU6c4/4t6E6jOZ8/QBS2bBYBm4tx4=


### PR DESCRIPTION
The pinned langchaingo serializes `temperature` unconditionally and no longer passes `tool_choice` through for Anthropic, which caps the `conversation/anthropic` component at the 4.6-generation Claude models; this switches the component to call `anthropic-sdk-go` directly (option C from the issue).

`conversation.Request`/`Response` are still built on langchaingo `llms` types, so the public surface stays the same and an adapter (`convert.go`) translates messages, tools, `tool_choice`, and the response back at the component boundary. The two concrete fixes fall out of that:

- Temperature is set only when the caller actually provides one. dapr treats `Temperature == 0` as unset, and the SDK's `param.Opt[float64]` is `omitzero`, so nothing goes on the wire when it's unset — which is the langchaingo bug that was 400ing newer models.
- `tool_choice` and `tools` now reach the request. `required`/`any` map to Anthropic's `any`, `none` to `none`, `auto` to `auto`, and any other value to a specific tool by name.

Config stays compatible: same metadata keys plus an optional `maxTokens` (defaults to 2048, the old langchaingo fallback). `cacheTTL`/`responseCacheTTL` still works, backed by a small in-component response cache since the langchaingo cache wrapper is gone. The `required`-tool-choice-returned-nothing retriable error from `langchaingokit` is preserved.

## Testing

`go build`, `go test`, `go vet`, `gofmt`, and `golangci-lint run` (v2.10.1) all clean on `conversation/anthropic/...`. New tests drive an `httptest` server and assert on the actual request body: temperature absent when unset and present (0.5) when set, `tool_choice=required` serialized as `{"type":"any"}` with tools forwarded, and the response (text + tool_use + usage) mapped back into `conversation.Response`. Existing `Init` tests are updated for the new struct.

The Anthropic conformance suite (`tests/conformance -run TestConversationConformance/anthropic`) needs a live `ANTHROPIC_API_KEY` so I couldn't run it here, but it's the reproduction from the issue and should now pass on `claude-sonnet-5` etc.

Docs PR to follow in dapr/docs for the new `maxTokens` field.

Fixes #4533