### PR TITLE
Add Cloudflare Queues input binding

### DIFF
--- a/bindings/cloudflare/queues/cfqueues.go
+++ b/bindings/cloudflare/queues/cfqueues.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/common/component/cloudflare/workers"
@@ -33,16 +35,23 @@ import (
 // Link to the documentation for the component
 const componentDocsURL = "https://docs.dapr.io/reference/components-reference/supported-bindings/cloudflare-queues/"
 
-// CFQueues is a binding for publishing messages on Cloudflare Queues
+// CFQueues is a binding for publishing messages on Cloudflare Queues, and for receiving them
+// through an HTTP pull consumer.
 type CFQueues struct {
 	*workers.Base
 	metadata componentMetadata
+	logger   logger.Logger
+	closed   atomic.Bool
+	closeCh  chan struct{}
+	wg       sync.WaitGroup
 }
 
 // NewCFQueues returns a new CFQueues.
-func NewCFQueues(logger logger.Logger) bindings.OutputBinding {
+func NewCFQueues(logger logger.Logger) bindings.InputOutputBinding {
 	q := &CFQueues{
-		Base: &workers.Base{},
+		Base:    &workers.Base{},
+		logger:  logger,
+		closeCh: make(chan struct{}),
 	}
 	q.SetLogger(logger)
 	return q
@@ -128,11 +137,11 @@ func (q *CFQueues) invokePublish(parentCtx context.Context, ir *bindings.InvokeR
 
 // Close the component
 func (q *CFQueues) Close() error {
-	err := q.Base.Close()
-	if err != nil {
-		return err
+	if q.closed.CompareAndSwap(false, true) {
+		close(q.closeCh)
 	}
-	return nil
+	q.wg.Wait()
+	return q.Base.Close()
 }
 
 // GetComponentMetadata returns the metadata of the component.

--- a/bindings/cloudflare/queues/input.go
+++ b/bindings/cloudflare/queues/input.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cfqueues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/dapr/components-contrib/bindings"
+)
+
+// Base URL of the Cloudflare API. It's a variable so tests can point it to a local server.
+var cfAPIBaseURL = "https://api.cloudflare.com/client/v4"
+
+// Message as returned by the messages/pull endpoint.
+type pullMessage struct {
+	Body        json.RawMessage `json:"body"`
+	ID          string          `json:"id"`
+	TimestampMs int64           `json:"timestamp_ms"`
+	Attempts    int             `json:"attempts"`
+	LeaseID     string          `json:"lease_id"`
+}
+
+// Data returns the message body as it was published.
+// Messages published as strings (including those sent by the output binding) are unwrapped,
+// while structured bodies are passed through as JSON.
+func (m pullMessage) Data() []byte {
+	var str string
+	if json.Unmarshal(m.Body, &str) == nil {
+		return []byte(str)
+	}
+	return m.Body
+}
+
+type leaseRef struct {
+	LeaseID string `json:"lease_id"`
+}
+
+type ackRequest struct {
+	Acks    []leaseRef `json:"acks,omitempty"`
+	Retries []leaseRef `json:"retries,omitempty"`
+}
+
+// Read messages from the queue with an HTTP pull consumer, invoking handler for each one.
+func (q *CFQueues) Read(ctx context.Context, handler bindings.Handler) error {
+	if q.closed.Load() {
+		return errors.New("binding is closed")
+	}
+
+	// Pull consumers are served by the Cloudflare API rather than by the worker, so the
+	// worker-only ("workerUrl") authentication profile cannot be used for the input binding.
+	if q.metadata.CfAPIToken == "" || q.metadata.CfAccountID == "" {
+		return fmt.Errorf("the input binding requires the metadata properties 'cfAPIToken' (with the 'queues#read' and 'queues#write' permissions) and 'cfAccountID'; see the documentation at %s", componentDocsURL)
+	}
+
+	queueID, err := q.resolveQueueID(ctx)
+	if err != nil {
+		return err
+	}
+
+	q.wg.Add(1)
+	go func() {
+		defer q.wg.Done()
+		for {
+			if ctx.Err() != nil || q.closed.Load() {
+				return
+			}
+
+			count, err := q.pollOnce(ctx, queueID, handler)
+			if err != nil && ctx.Err() == nil {
+				q.logger.Errorf("Failed to receive messages from queue '%s': %v", q.metadata.QueueName, err)
+			}
+
+			// A full batch means there is likely more in the queue, so drain it before pausing.
+			if err == nil && count >= q.metadata.BatchSize {
+				continue
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-q.closeCh:
+				return
+			case <-time.After(q.metadata.PollingInterval):
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Pulls one batch of messages, invokes the handler for each, then acknowledges the batch.
+// Returns the number of messages that were pulled.
+func (q *CFQueues) pollOnce(ctx context.Context, queueID string, handler bindings.Handler) (int, error) {
+	pullBody := map[string]any{
+		"batch_size":            q.metadata.BatchSize,
+		"visibility_timeout_ms": q.metadata.VisibilityTimeout.Milliseconds(),
+	}
+	var pulled struct {
+		Result struct {
+			Messages []pullMessage `json:"messages"`
+		} `json:"result"`
+	}
+	err := q.apiRequest(ctx, http.MethodPost, "/accounts/"+q.metadata.CfAccountID+"/queues/"+queueID+"/messages/pull", pullBody, &pulled)
+	if err != nil {
+		return 0, err
+	}
+	if len(pulled.Result.Messages) == 0 {
+		return 0, nil
+	}
+
+	// Messages whose lease is neither acknowledged nor retried become visible again when their
+	// visibility timeout expires, so delivery is at-least-once.
+	ack := ackRequest{}
+	for _, msg := range pulled.Result.Messages {
+		if ctx.Err() != nil {
+			break
+		}
+		_, hErr := handler(ctx, &bindings.ReadResponse{
+			Data: msg.Data(),
+			Metadata: map[string]string{
+				"id":        msg.ID,
+				"attempts":  strconv.Itoa(msg.Attempts),
+				"timestamp": strconv.FormatInt(msg.TimestampMs, 10),
+			},
+		})
+		if hErr != nil {
+			q.logger.Errorf("Error processing message '%s' from queue '%s': %v", msg.ID, q.metadata.QueueName, hErr)
+			ack.Retries = append(ack.Retries, leaseRef{LeaseID: msg.LeaseID})
+			continue
+		}
+		ack.Acks = append(ack.Acks, leaseRef{LeaseID: msg.LeaseID})
+	}
+
+	if len(ack.Acks) == 0 && len(ack.Retries) == 0 {
+		return len(pulled.Result.Messages), nil
+	}
+	err = q.apiRequest(ctx, http.MethodPost, "/accounts/"+q.metadata.CfAccountID+"/queues/"+queueID+"/messages/ack", ack, nil)
+	return len(pulled.Result.Messages), err
+}
+
+// Returns the ID of the queue, looking it up by name unless it's set in the metadata.
+func (q *CFQueues) resolveQueueID(ctx context.Context) (string, error) {
+	if q.metadata.QueueID != "" {
+		return q.metadata.QueueID, nil
+	}
+
+	for page := 1; ; page++ {
+		var list struct {
+			Result []struct {
+				QueueID   string `json:"queue_id"`
+				QueueName string `json:"queue_name"`
+			} `json:"result"`
+			ResultInfo struct {
+				TotalPages int `json:"total_pages"`
+			} `json:"result_info"`
+		}
+		err := q.apiRequest(ctx, http.MethodGet, fmt.Sprintf("/accounts/%s/queues?page=%d&per_page=100", q.metadata.CfAccountID, page), nil, &list)
+		if err != nil {
+			return "", fmt.Errorf("failed to list the queues in the account: %w", err)
+		}
+		for _, queue := range list.Result {
+			if queue.QueueName == q.metadata.QueueName {
+				return queue.QueueID, nil
+			}
+		}
+		if len(list.Result) == 0 || page >= list.ResultInfo.TotalPages {
+			return "", fmt.Errorf("queue '%s' was not found in account '%s'", q.metadata.QueueName, q.metadata.CfAccountID)
+		}
+	}
+}
+
+// Performs a request against the Cloudflare API, decoding the response into dest when it's not nil.
+func (q *CFQueues) apiRequest(parentCtx context.Context, method string, path string, body any, dest any) error {
+	var reqBody io.Reader
+	if body != nil {
+		enc, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to encode the request body: %w", err)
+		}
+		reqBody = bytes.NewReader(enc)
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, q.metadata.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, cfAPIBaseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("error creating network request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+q.metadata.CfAPIToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := q.Client().Do(req)
+	if err != nil {
+		return fmt.Errorf("error invoking the Cloudflare API: %w", err)
+	}
+	defer func() {
+		// Drain the body before closing it
+		_, _ = io.ReadAll(res.Body)
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("invalid response status code: %d", res.StatusCode)
+	}
+
+	if dest == nil {
+		return nil
+	}
+	err = json.NewDecoder(res.Body).Decode(dest)
+	if err != nil {
+		return fmt.Errorf("invalid response format: %w", err)
+	}
+	return nil
+}

--- a/bindings/cloudflare/queues/input_test.go
+++ b/bindings/cloudflare/queues/input_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cfqueues
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/bindings"
+	contribMetadata "github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	testAccountID = "testaccount"
+	testQueueName = "testqueue"
+	testQueueID   = "8ceb4b1b5b6f4f8fa54b8b0dd7c4a6d9"
+)
+
+// Fake Cloudflare worker and API, serving the endpoints the component uses.
+type testServer struct {
+	*httptest.Server
+	queues   []map[string]string
+	messages []pullMessage
+	acks     []ackRequest
+}
+
+func newTestServer(t *testing.T) *testServer {
+	t.Helper()
+	ts := &testServer{
+		queues: []map[string]string{{"queue_id": testQueueID, "queue_name": testQueueName}},
+	}
+
+	mux := http.NewServeMux()
+	// Worker info endpoint, used while initializing the component
+	mux.HandleFunc("/.well-known/dapr/info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"version": "20221219",
+			"queues":  []string{testQueueName},
+		})
+	})
+	mux.HandleFunc("/client/v4/accounts/"+testAccountID+"/queues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result":      ts.queues,
+			"result_info": map[string]int{"total_pages": 1},
+		})
+	})
+	mux.HandleFunc("/client/v4/accounts/"+testAccountID+"/queues/"+testQueueID+"/messages/pull", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"messages": ts.messages},
+		})
+	})
+	mux.HandleFunc("/client/v4/accounts/"+testAccountID+"/queues/"+testQueueID+"/messages/ack", func(w http.ResponseWriter, r *http.Request) {
+		ack := ackRequest{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&ack))
+		ts.acks = append(ts.acks, ack)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	})
+
+	ts.Server = httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	origBaseURL := cfAPIBaseURL
+	cfAPIBaseURL = ts.URL + "/client/v4"
+	t.Cleanup(func() { cfAPIBaseURL = origBaseURL })
+
+	return ts
+}
+
+func testKey(t *testing.T) string {
+	t.Helper()
+	_, pk, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(pk)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+func initComponent(t *testing.T, ts *testServer, extraProps map[string]string) *CFQueues {
+	t.Helper()
+	props := map[string]string{
+		"workerUrl":   ts.URL,
+		"workerName":  "testworker",
+		"queueName":   testQueueName,
+		"cfAccountID": testAccountID,
+		"cfAPIToken":  "testtoken",
+		"key":         testKey(t),
+	}
+	for k, v := range extraProps {
+		props[k] = v
+	}
+
+	q := NewCFQueues(logger.NewLogger("test")).(*CFQueues)
+	require.NoError(t, q.Init(t.Context(), bindings.Metadata{Base: contribMetadata.Base{Properties: props}}))
+	t.Cleanup(func() { require.NoError(t, q.Close()) })
+	return q
+}
+
+func TestPollOnceAcknowledgesAndRetries(t *testing.T) {
+	ts := newTestServer(t)
+	ts.messages = []pullMessage{
+		{Body: json.RawMessage(`"hello"`), ID: "msg1", LeaseID: "lease1", Attempts: 1, TimestampMs: 1689615013586},
+		{Body: json.RawMessage(`{"key":"value"}`), ID: "msg2", LeaseID: "lease2", Attempts: 2},
+		{Body: json.RawMessage(`"fails"`), ID: "msg3", LeaseID: "lease3", Attempts: 1},
+	}
+	q := initComponent(t, ts, nil)
+
+	received := []*bindings.ReadResponse{}
+	handler := func(_ context.Context, res *bindings.ReadResponse) ([]byte, error) {
+		received = append(received, res)
+		if string(res.Data) == "fails" {
+			return nil, errors.New("simulated failure")
+		}
+		return nil, nil
+	}
+
+	count, err := q.pollOnce(t.Context(), testQueueID, handler)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	require.Len(t, received, 3)
+	// Bodies published as strings are unwrapped, structured bodies are passed through as JSON
+	assert.Equal(t, "hello", string(received[0].Data))
+	assert.JSONEq(t, `{"key":"value"}`, string(received[1].Data))
+	assert.Equal(t, "msg1", received[0].Metadata["id"])
+	assert.Equal(t, "1", received[0].Metadata["attempts"])
+	assert.Equal(t, "1689615013586", received[0].Metadata["timestamp"])
+
+	// Only the messages the app processed are acknowledged; the failed one is retried
+	require.Len(t, ts.acks, 1)
+	assert.Equal(t, []leaseRef{{LeaseID: "lease1"}, {LeaseID: "lease2"}}, ts.acks[0].Acks)
+	assert.Equal(t, []leaseRef{{LeaseID: "lease3"}}, ts.acks[0].Retries)
+}
+
+func TestPollOnceWithEmptyQueue(t *testing.T) {
+	ts := newTestServer(t)
+	q := initComponent(t, ts, nil)
+
+	count, err := q.pollOnce(t.Context(), testQueueID, func(context.Context, *bindings.ReadResponse) ([]byte, error) {
+		t.Error("handler must not be invoked when the queue is empty")
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Empty(t, ts.acks)
+}
+
+func TestResolveQueueID(t *testing.T) {
+	t.Run("looked up by name", func(t *testing.T) {
+		ts := newTestServer(t)
+		ts.queues = append([]map[string]string{{"queue_id": "otherid", "queue_name": "otherqueue"}}, ts.queues...)
+		q := initComponent(t, ts, nil)
+
+		queueID, err := q.resolveQueueID(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, testQueueID, queueID)
+	})
+
+	t.Run("from metadata without a lookup", func(t *testing.T) {
+		ts := newTestServer(t)
+		ts.queues = nil
+		q := initComponent(t, ts, map[string]string{"queueID": testQueueID})
+
+		queueID, err := q.resolveQueueID(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, testQueueID, queueID)
+	})
+
+	t.Run("queue not in the account", func(t *testing.T) {
+		ts := newTestServer(t)
+		ts.queues = []map[string]string{{"queue_id": "otherid", "queue_name": "otherqueue"}}
+		q := initComponent(t, ts, nil)
+
+		_, err := q.resolveQueueID(t.Context())
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "was not found")
+	})
+}
+
+func TestReadDeliversMessages(t *testing.T) {
+	ts := newTestServer(t)
+	ts.messages = []pullMessage{{Body: json.RawMessage(`"hello"`), ID: "msg1", LeaseID: "lease1"}}
+	q := initComponent(t, ts, map[string]string{"pollingInterval": "1s"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	delivered := make(chan []byte, 1)
+	require.NoError(t, q.Read(ctx, func(_ context.Context, res *bindings.ReadResponse) ([]byte, error) {
+		select {
+		case delivered <- res.Data:
+		default:
+		}
+		return nil, nil
+	}))
+
+	select {
+	case data := <-delivered:
+		assert.Equal(t, "hello", string(data))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}
+
+func TestReadRequiresAPIToken(t *testing.T) {
+	ts := newTestServer(t)
+	q := NewCFQueues(logger.NewLogger("test")).(*CFQueues)
+	props := map[string]string{
+		"workerUrl":  ts.URL,
+		"workerName": "testworker",
+		"queueName":  testQueueName,
+		"key":        testKey(t),
+	}
+	require.NoError(t, q.Init(t.Context(), bindings.Metadata{Base: contribMetadata.Base{Properties: props}}))
+	t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+	err := q.Read(t.Context(), func(context.Context, *bindings.ReadResponse) ([]byte, error) { return nil, nil })
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cfAPIToken")
+}

--- a/bindings/cloudflare/queues/metadata.go
+++ b/bindings/cloudflare/queues/metadata.go
@@ -16,17 +16,34 @@ package cfqueues
 import (
 	"errors"
 	"regexp"
+	"time"
 
 	"github.com/dapr/components-contrib/common/component/cloudflare/workers"
+)
+
+// Defaults and limits for the input binding, matching the Cloudflare Queues pull consumer API.
+const (
+	defaultBatchSize         = 5
+	maxBatchSize             = 100
+	defaultVisibilityTimeout = 30 * time.Second
+	maxVisibilityTimeout     = 12 * time.Hour
+	defaultPollingInterval   = 10 * time.Second
 )
 
 // Component metadata struct.
 type componentMetadata struct {
 	workers.BaseMetadata `mapstructure:",squash"`
-	QueueName            string `mapstructure:"queueName"`
+	QueueName            string        `mapstructure:"queueName"`
+	QueueID              string        `mapstructure:"queueID"`
+	BatchSize            int           `mapstructure:"batchSize"`
+	VisibilityTimeout    time.Duration `mapstructure:"visibilityTimeout"`
+	PollingInterval      time.Duration `mapstructure:"pollingInterval"`
 }
 
-var queueNameValidation = regexp.MustCompile(`^([a-zA-Z0-9_\-\.]+)$`)
+var (
+	queueNameValidation = regexp.MustCompile(`^([a-zA-Z0-9_\-\.]+)$`)
+	queueIDValidation   = regexp.MustCompile(`^([a-zA-Z0-9]+)$`)
+)
 
 // Validate the metadata object.
 func (m *componentMetadata) Validate() error {
@@ -42,6 +59,31 @@ func (m *componentMetadata) Validate() error {
 	}
 	if !queueNameValidation.MatchString(m.QueueName) {
 		return errors.New("metadata property 'queueName' is invalid")
+	}
+
+	// QueueID is optional: when empty, the input binding looks the queue up by name
+	if m.QueueID != "" && !queueIDValidation.MatchString(m.QueueID) {
+		return errors.New("metadata property 'queueID' is invalid")
+	}
+
+	// Input binding options
+	if m.BatchSize == 0 {
+		m.BatchSize = defaultBatchSize
+	}
+	if m.BatchSize < 1 || m.BatchSize > maxBatchSize {
+		return errors.New("metadata property 'batchSize' must be between 1 and 100")
+	}
+	if m.VisibilityTimeout == 0 {
+		m.VisibilityTimeout = defaultVisibilityTimeout
+	}
+	if m.VisibilityTimeout < time.Second || m.VisibilityTimeout > maxVisibilityTimeout {
+		return errors.New("metadata property 'visibilityTimeout' must be between 1s and 12h")
+	}
+	if m.PollingInterval == 0 {
+		m.PollingInterval = defaultPollingInterval
+	}
+	if m.PollingInterval < time.Second {
+		return errors.New("metadata property 'pollingInterval' must be at least 1s")
 	}
 
 	return nil

--- a/bindings/cloudflare/queues/metadata.yaml
+++ b/bindings/cloudflare/queues/metadata.yaml
@@ -10,12 +10,12 @@ urls:
     url: https://docs.dapr.io/reference/components-reference/supported-bindings/cloudflare-queues/
 binding:
   output: true
-  input: false
+  input: true
   operations:
     - name: create
       description: "Send message to Cloudflare Queue"
-    - name: read
-      description: "Receive messages from Cloudflare Queue"
+    - name: publish
+      description: "Send message to Cloudflare Queue"
 authenticationProfiles:
   - title: "API Token Authentication"
     description: |
@@ -66,3 +66,39 @@ metadata:
     description: "Timeout for network requests in seconds"
     example: '20'
     default: '20'
+  - name: queueID
+    required: false
+    binding:
+      input: true
+    description: |
+      The ID of the Cloudflare queue to receive messages from.
+      When empty, the ID is looked up by name in the account, which requires the API token to have the "queues#read" permission.
+    example: '"8ceb4b1b5b6f4f8fa54b8b0dd7c4a6d9"'
+  - name: batchSize
+    required: false
+    type: number
+    binding:
+      input: true
+    description: |
+      Maximum number of messages to receive with each pull, between 1 and 100.
+    example: '10'
+    default: '5'
+  - name: visibilityTimeout
+    required: false
+    type: duration
+    binding:
+      input: true
+    description: |
+      How long the pulled messages stay invisible to other consumers, between 1s and 12h.
+      It must be longer than the time the application needs to process a full batch, otherwise the messages are delivered again.
+    example: '"1m"'
+    default: '"30s"'
+  - name: pollingInterval
+    required: false
+    type: duration
+    binding:
+      input: true
+    description: |
+      How long to wait before pulling again after the queue came back empty.
+    example: '"5s"'
+    default: '"10s"'


### PR DESCRIPTION
# Description

Makes the Cloudflare Queues binding bi-directional by implementing the input binding with a Cloudflare [HTTP pull consumer](https://developers.cloudflare.com/queues/configuration/pull-consumers/) — approach 1 of the two suggested in the issue.

**Why a pull consumer and not the Worker.** Worker queue bindings only expose `send()`, and a push consumer would have to reach the application from Cloudflare's edge, which Dapr cannot assume is routable. Pull consumers are served by the Cloudflare API (`/accounts/{account_id}/queues/{queue_id}/messages/pull` and `/messages/ack`), so the input binding talks to the API directly and the deployed Worker keeps serving the output binding unchanged. The Worker script is untouched by this PR.

**Behavior.** `Read` resolves the queue ID (by name, unless `queueID` is set), then polls in a background goroutine: each pull requests up to `batchSize` messages with a `visibilityTimeout` lease, the handler is invoked once per message, and the leases are then acknowledged in one `messages/ack` call — successes in `acks`, handler failures in `retries` so they are redelivered immediately. When a full batch comes back the queue is drained without pausing; when it comes back empty the loop waits `pollingInterval`. Messages that are neither acknowledged nor retried (for example when Dapr shuts down mid-batch) become visible again when their lease expires, so delivery is at-least-once.

Message bodies published as strings — including everything sent by this component's output binding — are unwrapped, while structured bodies are passed through as JSON. Each message carries `id`, `attempts`, and `timestamp` metadata.

**Authentication.** Because the pull endpoints live on the Cloudflare API, the input binding requires `cfAPIToken` (with `queues#read` and `queues#write`) and `cfAccountID`. A component configured with only `workerUrl` returns a descriptive error pointing at the documentation instead of failing at the first request.

**New metadata properties** (input binding only, all optional): `queueID`, `batchSize` (1–100, default 5), `visibilityTimeout` (1s–12h, default 30s), `pollingInterval` (default 10s). `metadata.yaml` is updated accordingly, and the stale `read` entry under `operations` is replaced with the `publish` alias that the output binding actually implements.

**Follow-up needed in dapr/dapr.** `NewCFQueues` now returns `bindings.InputOutputBinding`, so `cmd/daprd/components/bindings_cloudflare_queues.go` needs the two-closure registration used by other bi-directional bindings such as `aws.sqs`:

```go
bindingsLoader.DefaultRegistry.RegisterInputBinding(func(l logger.Logger) bindings.InputBinding {
	return cfqueues.NewCFQueues(l)
}, "cloudflare.queues")
bindingsLoader.DefaultRegistry.RegisterOutputBinding(func(l logger.Logger) bindings.OutputBinding {
	return cfqueues.NewCFQueues(l)
}, "cloudflare.queues")
```

I will open that PR as soon as this one is merged and the dependency is bumped — happy to do it earlier if maintainers prefer.

## Issue reference

Please reference the issue this PR will close: #4151

## Testing

`bindings/cloudflare/queues/input_test.go` runs the component against a local server that stands in for both the Worker info endpoint and the Cloudflare API, covering the pull/ack cycle (acknowledged versus retried leases, body decoding, per-message metadata), an empty queue, queue-ID resolution by name / from metadata / not found, end-to-end delivery through `Read`, and the missing-API-token error. `go test -race ./bindings/cloudflare/queues/` passes.

Conformance and certification tests are not included because they would need a live Cloudflare account with a Queue and a deployed Worker; the component has no existing conformance suite for the same reason.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5293
