### PR TITLE
Add GCP Cloud KMS cryptography component

### DIFF
--- a/crypto/gcp/kms/kms.go
+++ b/crypto/gcp/kms/kms.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"google.golang.org/api/option"
+
+	contribCrypto "github.com/dapr/components-contrib/crypto"
+	contribMetadata "github.com/dapr/components-contrib/metadata"
+	internals "github.com/dapr/kit/crypto"
+	"github.com/dapr/kit/logger"
+)
+
+// AlgorithmSymmetric is the identifier for Google's symmetric encryption keys. Those keys have no
+// JWA equivalent because Cloud KMS manages the nonce and the authentication tag internally.
+const AlgorithmSymmetric = "GOOGLE_SYMMETRIC_ENCRYPTION"
+
+var (
+	encryptionAlgorithms = []string{
+		AlgorithmSymmetric,
+		internals.Algorithm_RSA_OAEP,     // RSA_DECRYPT_OAEP_*_SHA1
+		internals.Algorithm_RSA_OAEP_256, // RSA_DECRYPT_OAEP_*_SHA256
+		internals.Algorithm_RSA_OAEP_512, // RSA_DECRYPT_OAEP_4096_SHA512
+	}
+	signatureAlgorithms = []string{
+		internals.Algorithm_RS256, // RSA_SIGN_PKCS1_*_SHA256
+		internals.Algorithm_RS512, // RSA_SIGN_PKCS1_4096_SHA512
+		internals.Algorithm_PS256, // RSA_SIGN_PSS_*_SHA256
+		internals.Algorithm_PS512, // RSA_SIGN_PSS_4096_SHA512
+		internals.Algorithm_ES256, // EC_SIGN_P256_SHA256
+		internals.Algorithm_ES384, // EC_SIGN_P384_SHA384
+		internals.Algorithm_EdDSA, // EC_SIGN_ED25519
+	}
+)
+
+// Subset of the Cloud KMS client used by this component, so tests can replace it.
+type kmsClient interface {
+	GetPublicKey(ctx context.Context, req *kmspb.GetPublicKeyRequest, opts ...gax.CallOption) (*kmspb.PublicKey, error)
+	Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error)
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
+	AsymmetricDecrypt(ctx context.Context, req *kmspb.AsymmetricDecryptRequest, opts ...gax.CallOption) (*kmspb.AsymmetricDecryptResponse, error)
+	AsymmetricSign(ctx context.Context, req *kmspb.AsymmetricSignRequest, opts ...gax.CallOption) (*kmspb.AsymmetricSignResponse, error)
+	Close() error
+}
+
+type kmsCrypto struct {
+	client   kmsClient
+	md       kmsMetadata
+	keyCache *contribCrypto.PubKeyCache
+	logger   logger.Logger
+}
+
+// NewGCPKMSCrypto returns a new GCP Cloud KMS crypto provider.
+func NewGCPKMSCrypto(logger logger.Logger) contribCrypto.SubtleCrypto {
+	return &kmsCrypto{
+		logger: logger,
+	}
+}
+
+// Init creates a Cloud KMS client.
+func (k *kmsCrypto) Init(ctx context.Context, metadata contribCrypto.Metadata) error {
+	err := k.md.InitWithMetadata(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to load metadata: %w", err)
+	}
+
+	k.keyCache = contribCrypto.NewPubKeyCache(k.getKeyCacheFn)
+
+	var opts []option.ClientOption
+	if k.md.hasExplicitCredentials() {
+		// Explicit authentication, with the service account credentials in the component metadata
+		var creds []byte
+		creds, err = json.Marshal(k.md)
+		if err != nil {
+			return fmt.Errorf("failed to encode the credentials: %w", err)
+		}
+		opts = append(opts, option.WithCredentialsJSON(creds))
+	}
+	// Otherwise, implicit authentication with GCP Application Default Credentials (ADC):
+	// https://cloud.google.com/docs/authentication/application-default-credentials#order
+
+	k.client, err = kms.NewKeyManagementClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create the Cloud KMS client: %w", err)
+	}
+
+	return nil
+}
+
+// Features returns the features available in this crypto provider.
+func (k *kmsCrypto) Features() []contribCrypto.Feature {
+	return []contribCrypto.Feature{} // No Feature supported.
+}
+
+// GetKey returns the public part of a key stored in Cloud KMS.
+// This method returns an error if the key is symmetric.
+// The key argument must be in the format "name/version".
+func (k *kmsCrypto) GetKey(parentCtx context.Context, key string) (pubKey jwk.Key, err error) {
+	kid := newKeyID(key)
+
+	if kid.Cacheable() {
+		return k.keyCache.GetKey(parentCtx, key)
+	}
+
+	return k.getPublicKey(parentCtx, kid)
+}
+
+func (k *kmsCrypto) getPublicKey(parentCtx context.Context, kid keyID) (jwk.Key, error) {
+	name, err := k.md.cryptoKeyVersionPath(kid)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
+	res, err := k.client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{Name: name})
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the public key from Cloud KMS: %w", err)
+	}
+	if res.GetPem() == "" {
+		return nil, errors.New("response from Cloud KMS does not contain a public key: the key may be symmetric")
+	}
+
+	pubKey, err := jwk.ParseKey([]byte(res.GetPem()), jwk.WithPEM(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the public key returned by Cloud KMS: %w", err)
+	}
+
+	return pubKey, nil
+}
+
+// Handler for the getKeyCacheFn method
+func (k *kmsCrypto) getKeyCacheFn(ctx context.Context, key string) func(resolve func(jwk.Key), reject func(error)) {
+	kid := newKeyID(key)
+	return func(resolve func(jwk.Key), reject func(error)) {
+		pk, err := k.getPublicKey(ctx, kid)
+		if err != nil {
+			reject(err)
+			return
+		}
+		resolve(pk)
+	}
+}
+
+// Encrypt a small message and returns the ciphertext.
+// Symmetric keys are used through Cloud KMS, while data encrypted with an asymmetric key is
+// encrypted locally with the public key, because Cloud KMS only offers asymmetric decryption.
+func (k *kmsCrypto) Encrypt(parentCtx context.Context, plaintext []byte, algorithm string, key string, nonce []byte, associatedData []byte) (ciphertext []byte, tag []byte, err error) {
+	switch algorithm {
+	case AlgorithmSymmetric:
+		if len(nonce) > 0 {
+			return nil, nil, errors.New("nonce is not supported with symmetric keys: Cloud KMS manages the nonce internally")
+		}
+
+		kid := newKeyID(key)
+		ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
+		res, rErr := k.client.Encrypt(ctx, &kmspb.EncryptRequest{
+			Name:                        k.md.cryptoKeyPath(kid),
+			Plaintext:                   plaintext,
+			AdditionalAuthenticatedData: associatedData,
+		})
+		cancel()
+		if rErr != nil {
+			return nil, nil, fmt.Errorf("error from Cloud KMS: %w", rErr)
+		}
+		// The authentication tag is included in the ciphertext returned by Cloud KMS
+		return res.GetCiphertext(), nil, nil
+
+	case internals.Algorithm_RSA_OAEP, internals.Algorithm_RSA_OAEP_256, internals.Algorithm_RSA_OAEP_512:
+		if len(associatedData) > 0 {
+			// Cloud KMS does not accept an OAEP label when decrypting, so data encrypted with one could never be decrypted
+			return nil, nil, errors.New("associated data is not supported with asymmetric keys")
+		}
+
+		pk, pkErr := k.GetKey(parentCtx, key)
+		if pkErr != nil {
+			return nil, nil, fmt.Errorf("failed to retrieve public key: %w", pkErr)
+		}
+
+		ciphertext, err = internals.EncryptPublicKey(plaintext, algorithm, pk, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to encrypt data: %w", err)
+		}
+		return ciphertext, nil, nil
+
+	default:
+		return nil, nil, fmt.Errorf("invalid algorithm: %s", algorithm)
+	}
+}
+
+// Decrypt a small message and returns the plaintext.
+func (k *kmsCrypto) Decrypt(parentCtx context.Context, ciphertext []byte, algorithm string, key string, nonce []byte, tag []byte, associatedData []byte) (plaintext []byte, err error) {
+	kid := newKeyID(key)
+
+	switch algorithm {
+	case AlgorithmSymmetric:
+		// Cloud KMS selects the key version from the ciphertext, so decryption always uses the crypto key
+		ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
+		res, rErr := k.client.Decrypt(ctx, &kmspb.DecryptRequest{
+			Name:                        k.md.cryptoKeyPath(kid),
+			Ciphertext:                  ciphertext,
+			AdditionalAuthenticatedData: associatedData,
+		})
+		cancel()
+		if rErr != nil {
+			return nil, fmt.Errorf("error from Cloud KMS: %w", rErr)
+		}
+		return res.GetPlaintext(), nil
+
+	case internals.Algorithm_RSA_OAEP, internals.Algorithm_RSA_OAEP_256, internals.Algorithm_RSA_OAEP_512:
+		if len(associatedData) > 0 {
+			return nil, errors.New("associated data is not supported with asymmetric keys")
+		}
+
+		name, nErr := k.md.cryptoKeyVersionPath(kid)
+		if nErr != nil {
+			return nil, nErr
+		}
+
+		ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
+		res, rErr := k.client.AsymmetricDecrypt(ctx, &kmspb.AsymmetricDecryptRequest{
+			Name:       name,
+			Ciphertext: ciphertext,
+		})
+		cancel()
+		if rErr != nil {
+			return nil, fmt.Errorf("error from Cloud KMS: %w", rErr)
+		}
+		return res.GetPlaintext(), nil
+
+	default:
+		return nil, fmt.Errorf("invalid algorithm: %s", algorithm)
+	}
+}
+
+// WrapKey wraps a symmetric key.
+func (k *kmsCrypto) WrapKey(ctx context.Context, plaintextKey jwk.Key, algorithm string, key string, nonce []byte, associatedData []byte) (wrappedKey []byte, tag []byte, err error) {
+	// Like the other vault-backed components, only symmetric keys can be wrapped, so the unwrapped
+	// key can be reconstructed without guessing how it was serialized
+	if plaintextKey.KeyType() != jwa.OctetSeq {
+		return nil, nil, errors.New("cannot wrap asymmetric keys")
+	}
+	plaintext, err := internals.SerializeKey(plaintextKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot serialize key: %w", err)
+	}
+
+	return k.Encrypt(ctx, plaintext, algorithm, key, nonce, associatedData)
+}
+
+// UnwrapKey unwraps a key.
+func (k *kmsCrypto) UnwrapKey(ctx context.Context, wrappedKey []byte, algorithm string, key string, nonce []byte, tag []byte, associatedData []byte) (plaintextKey jwk.Key, err error) {
+	plaintext, err := k.Decrypt(ctx, wrappedKey, algorithm, key, nonce, tag, associatedData)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintextKey, err = jwk.FromRaw(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWK from raw key: %w", err)
+	}
+
+	return plaintextKey, nil
+}
+
+// Sign a digest.
+// The key argument must be in the format "name/version".
+func (k *kmsCrypto) Sign(parentCtx context.Context, digest []byte, algorithm string, key string) (signature []byte, err error) {
+	req, err := signRequestDigest(digest, algorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Name, err = k.md.cryptoKeyVersionPath(newKeyID(key))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
+	res, err := k.client.AsymmetricSign(ctx, req)
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("error from Cloud KMS: %w", err)
+	}
+	if len(res.GetSignature()) == 0 {
+		return nil, errors.New("response from Cloud KMS does not contain a signature")
+	}
+
+	return res.GetSignature(), nil
+}
+
+// Builds the signing request for the given algorithm, validating the length of the digest.
+// Cloud KMS signs Ed25519 messages directly, which matches how the rest of Dapr treats EdDSA.
+func signRequestDigest(digest []byte, algorithm string) (*kmspb.AsymmetricSignRequest, error) {
+	switch algorithm {
+	case internals.Algorithm_EdDSA:
+		if len(digest) == 0 {
+			return nil, errors.New("message to sign is empty")
+		}
+		return &kmspb.AsymmetricSignRequest{Data: digest}, nil
+
+	case internals.Algorithm_ES256, internals.Algorithm_RS256, internals.Algorithm_PS256:
+		if len(digest) != 32 {
+			return nil, fmt.Errorf("digest for algorithm %s must be 32 bytes long, but it's %d", algorithm, len(digest))
+		}
+		return &kmspb.AsymmetricSignRequest{
+			Digest: &kmspb.Digest{Digest: &kmspb.Digest_Sha256{Sha256: digest}},
+		}, nil
+
+	case internals.Algorithm_ES384:
+		if len(digest) != 48 {
+			return nil, fmt.Errorf("digest for algorithm %s must be 48 bytes long, but it's %d", algorithm, len(digest))
+		}
+		return &kmspb.AsymmetricSignRequest{
+			Digest: &kmspb.Digest{Digest: &kmspb.Digest_Sha384{Sha384: digest}},
+		}, nil
+
+	case internals.Algorithm_RS512, internals.Algorithm_PS512:
+		if len(digest) != 64 {
+			return nil, fmt.Errorf("digest for algorithm %s must be 64 bytes long, but it's %d", algorithm, len(digest))
+		}
+		return &kmspb.AsymmetricSignRequest{
+			Digest: &kmspb.Digest{Digest: &kmspb.Digest_Sha512{Sha512: digest}},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("invalid algorithm: %s", algorithm)
+	}
+}
+
+// Verify a signature.
+// Cloud KMS has no verification API for asymmetric keys, so the signature is verified locally
+// with the public key.
+// The key argument must be in the format "name/version".
+func (k *kmsCrypto) Verify(parentCtx context.Context, digest []byte, signature []byte, algorithm string, key string) (valid bool, err error) {
+	pk, err := k.GetKey(parentCtx, key)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve public key: %w", err)
+	}
+
+	valid, err = internals.VerifyPublicKey(digest, signature, algorithm, pk)
+	if err != nil {
+		return false, fmt.Errorf("failed to verify signature: %w", err)
+	}
+
+	return valid, nil
+}
+
+func (k *kmsCrypto) Close() error {
+	if k.client == nil {
+		return nil
+	}
+	return k.client.Close()
+}
+
+func (*kmsCrypto) SupportedEncryptionAlgorithms() []string {
+	return encryptionAlgorithms
+}
+
+func (*kmsCrypto) SupportedSignatureAlgorithms() []string {
+	return signatureAlgorithms
+}
+
+func (*kmsCrypto) GetComponentMetadata() (metadataInfo contribMetadata.MetadataMap) {
+	metadataStruct := kmsMetadata{}
+	_ = contribMetadata.GetMetadataInfoFromStructType(reflect.TypeOf(metadataStruct), &metadataInfo, contribMetadata.CryptoType)
+	return
+}

--- a/crypto/gcp/kms/kms.go
+++ b/crypto/gcp/kms/kms.go
@@ -119,6 +119,9 @@ func (k *kmsCrypto) Features() []contribCrypto.Feature {
 // The key argument must be in the format "name/version".
 func (k *kmsCrypto) GetKey(parentCtx context.Context, key string) (pubKey jwk.Key, err error) {
 	kid := newKeyID(key)
+	if err = kid.validate(true); err != nil {
+		return nil, err
+	}
 
 	if kid.Cacheable() {
 		return k.keyCache.GetKey(parentCtx, key)
@@ -175,6 +178,9 @@ func (k *kmsCrypto) Encrypt(parentCtx context.Context, plaintext []byte, algorit
 		}
 
 		kid := newKeyID(key)
+		if err = kid.validate(false); err != nil {
+			return nil, nil, err
+		}
 		ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
 		res, rErr := k.client.Encrypt(ctx, &kmspb.EncryptRequest{
 			Name:                        k.md.cryptoKeyPath(kid),
@@ -216,6 +222,9 @@ func (k *kmsCrypto) Decrypt(parentCtx context.Context, ciphertext []byte, algori
 
 	switch algorithm {
 	case AlgorithmSymmetric:
+		if err = kid.validate(false); err != nil {
+			return nil, err
+		}
 		// Cloud KMS selects the key version from the ciphertext, so decryption always uses the crypto key
 		ctx, cancel := context.WithTimeout(parentCtx, k.md.RequestTimeout)
 		res, rErr := k.client.Decrypt(ctx, &kmspb.DecryptRequest{

--- a/crypto/gcp/kms/kms_test.go
+++ b/crypto/gcp/kms/kms_test.go
@@ -1,0 +1,388 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kms
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contribCrypto "github.com/dapr/components-contrib/crypto"
+	contribMetadata "github.com/dapr/components-contrib/metadata"
+	internals "github.com/dapr/kit/crypto"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	testKeyPath        = "projects/myproject/locations/global/keyRings/myring/cryptoKeys/mykey"
+	testKeyVersionPath = testKeyPath + "/cryptoKeyVersions/1"
+)
+
+// Cloud KMS client double, recording the last request of each kind.
+type fakeClient struct {
+	publicKeyPEM      string
+	publicKeyCalls    int
+	encryptRequest    *kmspb.EncryptRequest
+	decryptRequest    *kmspb.DecryptRequest
+	asymDecryptReq    *kmspb.AsymmetricDecryptRequest
+	asymSignRequest   *kmspb.AsymmetricSignRequest
+	returnedSignature []byte
+	err               error
+}
+
+func (f *fakeClient) GetPublicKey(_ context.Context, req *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+	f.publicKeyCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &kmspb.PublicKey{Name: req.GetName(), Pem: f.publicKeyPEM}, nil
+}
+
+func (f *fakeClient) Encrypt(_ context.Context, req *kmspb.EncryptRequest, _ ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	f.encryptRequest = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &kmspb.EncryptResponse{Ciphertext: append([]byte("enc:"), req.GetPlaintext()...)}, nil
+}
+
+func (f *fakeClient) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	f.decryptRequest = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &kmspb.DecryptResponse{Plaintext: req.GetCiphertext()[len("enc:"):]}, nil
+}
+
+func (f *fakeClient) AsymmetricDecrypt(_ context.Context, req *kmspb.AsymmetricDecryptRequest, _ ...gax.CallOption) (*kmspb.AsymmetricDecryptResponse, error) {
+	f.asymDecryptReq = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &kmspb.AsymmetricDecryptResponse{Plaintext: []byte("decrypted")}, nil
+}
+
+func (f *fakeClient) AsymmetricSign(_ context.Context, req *kmspb.AsymmetricSignRequest, _ ...gax.CallOption) (*kmspb.AsymmetricSignResponse, error) {
+	f.asymSignRequest = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &kmspb.AsymmetricSignResponse{Signature: f.returnedSignature}, nil
+}
+
+func (f *fakeClient) Close() error { return nil }
+
+func newTestComponent(client kmsClient) *kmsCrypto {
+	k := &kmsCrypto{
+		logger: logger.NewLogger("test"),
+		client: client,
+		md: kmsMetadata{
+			ProjectID:      "myproject",
+			Location:       "global",
+			KeyRing:        "myring",
+			RequestTimeout: 10 * time.Second,
+		},
+	}
+	k.keyCache = contribCrypto.NewPubKeyCache(k.getKeyCacheFn)
+	return k
+}
+
+func publicKeyPEM(t *testing.T, pub any) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func TestMetadata(t *testing.T) {
+	newMetadata := func(props map[string]string) contribCrypto.Metadata {
+		return contribCrypto.Metadata{Base: contribMetadata.Base{Properties: props}}
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		md := &kmsMetadata{}
+		require.NoError(t, md.InitWithMetadata(newMetadata(map[string]string{
+			"projectID": "myproject",
+			"location":  "us-east1",
+			"keyRing":   "myring",
+		})))
+		assert.Equal(t, "myproject", md.ProjectID)
+		assert.Equal(t, defaultRequestTimeout, md.RequestTimeout)
+	})
+
+	t.Run("project ID from the service account alias", func(t *testing.T) {
+		md := &kmsMetadata{}
+		require.NoError(t, md.InitWithMetadata(newMetadata(map[string]string{
+			"project_id":     "myproject",
+			"location":       "global",
+			"keyRing":        "myring",
+			"requestTimeout": "5s",
+		})))
+		assert.Equal(t, "myproject", md.ProjectID)
+		assert.Equal(t, 5*time.Second, md.RequestTimeout)
+	})
+
+	t.Run("missing required properties", func(t *testing.T) {
+		for _, missing := range []string{"projectID", "location", "keyRing"} {
+			props := map[string]string{"projectID": "myproject", "location": "global", "keyRing": "myring"}
+			delete(props, missing)
+
+			md := &kmsMetadata{}
+			err := md.InitWithMetadata(newMetadata(props))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, missing)
+		}
+	})
+}
+
+func TestKeyID(t *testing.T) {
+	md := kmsMetadata{ProjectID: "myproject", Location: "global", KeyRing: "myring"}
+
+	assert.Equal(t, testKeyPath, md.cryptoKeyPath(newKeyID("mykey")))
+	assert.False(t, newKeyID("mykey").Cacheable())
+
+	versionPath, err := md.cryptoKeyVersionPath(newKeyID("mykey/1"))
+	require.NoError(t, err)
+	assert.Equal(t, testKeyVersionPath, versionPath)
+	assert.True(t, newKeyID("mykey/1").Cacheable())
+
+	_, err = md.cryptoKeyVersionPath(newKeyID("mykey"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does not include a version")
+}
+
+func TestGetKey(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	client := &fakeClient{publicKeyPEM: publicKeyPEM(t, privKey.Public())}
+	k := newTestComponent(client)
+
+	pubKey, err := k.GetKey(t.Context(), "mykey/1")
+	require.NoError(t, err)
+	assert.Equal(t, jwa.EC, pubKey.KeyType())
+
+	// Keys pinned to a version are immutable, so they are only fetched once
+	_, err = k.GetKey(t.Context(), "mykey/1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.publicKeyCalls)
+
+	// Asymmetric operations need a key version
+	_, err = k.GetKey(t.Context(), "mykey")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does not include a version")
+}
+
+func TestSymmetricEncryptDecrypt(t *testing.T) {
+	client := &fakeClient{}
+	k := newTestComponent(client)
+
+	ciphertext, tag, err := k.Encrypt(t.Context(), []byte("hello"), AlgorithmSymmetric, "mykey", nil, []byte("aad"))
+	require.NoError(t, err)
+	assert.Nil(t, tag, "Cloud KMS includes the authentication tag in the ciphertext")
+	// Symmetric operations address the crypto key, not one of its versions
+	assert.Equal(t, testKeyPath, client.encryptRequest.GetName())
+	assert.Equal(t, []byte("aad"), client.encryptRequest.GetAdditionalAuthenticatedData())
+
+	plaintext, err := k.Decrypt(t.Context(), ciphertext, AlgorithmSymmetric, "mykey", nil, nil, []byte("aad"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), plaintext)
+	assert.Equal(t, testKeyPath, client.decryptRequest.GetName())
+
+	// The key version is embedded in the ciphertext, so a version in the key name is not used
+	_, err = k.Decrypt(t.Context(), ciphertext, AlgorithmSymmetric, "mykey/1", nil, nil, []byte("aad"))
+	require.NoError(t, err)
+	assert.Equal(t, testKeyPath, client.decryptRequest.GetName())
+
+	// Cloud KMS generates the nonce itself, so accepting one would be misleading
+	_, _, err = k.Encrypt(t.Context(), []byte("hello"), AlgorithmSymmetric, "mykey", []byte("nonce"), nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "nonce is not supported")
+}
+
+func TestAsymmetricEncryptDecrypt(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	client := &fakeClient{publicKeyPEM: publicKeyPEM(t, privKey.Public())}
+	k := newTestComponent(client)
+
+	// Encryption happens locally, with the public key retrieved from Cloud KMS
+	ciphertext, tag, err := k.Encrypt(t.Context(), []byte("hello"), internals.Algorithm_RSA_OAEP_256, "mykey/1", nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, tag)
+	assert.Nil(t, client.encryptRequest, "asymmetric encryption must not call the Cloud KMS encrypt API")
+
+	decrypted, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, privKey, ciphertext, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), decrypted)
+
+	// Decryption happens in Cloud KMS, addressing a specific key version
+	plaintext, err := k.Decrypt(t.Context(), ciphertext, internals.Algorithm_RSA_OAEP_256, "mykey/1", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("decrypted"), plaintext)
+	assert.Equal(t, testKeyVersionPath, client.asymDecryptReq.GetName())
+
+	// Cloud KMS does not accept an OAEP label, so data encrypted with one could never be decrypted
+	_, _, err = k.Encrypt(t.Context(), []byte("hello"), internals.Algorithm_RSA_OAEP_256, "mykey/1", nil, []byte("aad"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "associated data is not supported")
+
+	_, err = k.Decrypt(t.Context(), ciphertext, internals.Algorithm_RSA_OAEP_256, "mykey", nil, nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does not include a version")
+}
+
+func TestUnsupportedAlgorithm(t *testing.T) {
+	k := newTestComponent(&fakeClient{})
+
+	_, _, err := k.Encrypt(t.Context(), []byte("hello"), "A256GCM", "mykey", nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid algorithm")
+
+	_, err = k.Decrypt(t.Context(), []byte("hello"), "A256GCM", "mykey", nil, nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid algorithm")
+
+	_, err = k.Sign(t.Context(), make([]byte, 32), "HS256", "mykey/1")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid algorithm")
+}
+
+func TestWrapUnwrapKey(t *testing.T) {
+	client := &fakeClient{}
+	k := newTestComponent(client)
+
+	rawKey := []byte("0123456789abcdef0123456789abcdef")
+	symmetricKey, err := jwk.FromRaw(rawKey)
+	require.NoError(t, err)
+
+	wrapped, tag, err := k.WrapKey(t.Context(), symmetricKey, AlgorithmSymmetric, "mykey", nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, tag)
+	assert.Equal(t, rawKey, client.encryptRequest.GetPlaintext())
+
+	unwrapped, err := k.UnwrapKey(t.Context(), wrapped, AlgorithmSymmetric, "mykey", nil, nil, nil)
+	require.NoError(t, err)
+	unwrappedRaw := []byte{}
+	require.NoError(t, unwrapped.Raw(&unwrappedRaw))
+	assert.Equal(t, rawKey, unwrappedRaw)
+
+	// Asymmetric keys cannot be reconstructed unambiguously after unwrapping
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	asymmetricKey, err := jwk.FromRaw(privKey)
+	require.NoError(t, err)
+	_, _, err = k.WrapKey(t.Context(), asymmetricKey, AlgorithmSymmetric, "mykey", nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot wrap asymmetric keys")
+}
+
+func TestSign(t *testing.T) {
+	client := &fakeClient{returnedSignature: []byte("signature")}
+	k := newTestComponent(client)
+
+	t.Run("digest is sent in the field matching the algorithm", func(t *testing.T) {
+		digest := make([]byte, 32)
+		signature, err := k.Sign(t.Context(), digest, internals.Algorithm_ES256, "mykey/1")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("signature"), signature)
+		assert.Equal(t, testKeyVersionPath, client.asymSignRequest.GetName())
+		assert.Equal(t, digest, client.asymSignRequest.GetDigest().GetSha256())
+
+		_, err = k.Sign(t.Context(), make([]byte, 48), internals.Algorithm_ES384, "mykey/1")
+		require.NoError(t, err)
+		assert.Equal(t, 48, len(client.asymSignRequest.GetDigest().GetSha384()))
+
+		_, err = k.Sign(t.Context(), make([]byte, 64), internals.Algorithm_PS512, "mykey/1")
+		require.NoError(t, err)
+		assert.Equal(t, 64, len(client.asymSignRequest.GetDigest().GetSha512()))
+	})
+
+	t.Run("Ed25519 signs the message rather than a digest", func(t *testing.T) {
+		_, err := k.Sign(t.Context(), []byte("a message of any length"), internals.Algorithm_EdDSA, "mykey/1")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("a message of any length"), client.asymSignRequest.GetData())
+		assert.Nil(t, client.asymSignRequest.GetDigest())
+	})
+
+	t.Run("digest length is validated", func(t *testing.T) {
+		_, err := k.Sign(t.Context(), make([]byte, 20), internals.Algorithm_ES256, "mykey/1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "must be 32 bytes long")
+	})
+
+	t.Run("key version is required", func(t *testing.T) {
+		_, err := k.Sign(t.Context(), make([]byte, 32), internals.Algorithm_ES256, "mykey")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "does not include a version")
+	})
+
+	t.Run("errors from Cloud KMS are returned", func(t *testing.T) {
+		failing := newTestComponent(&fakeClient{err: errors.New("permission denied")})
+		_, err := failing.Sign(t.Context(), make([]byte, 32), internals.Algorithm_ES256, "mykey/1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+}
+
+func TestVerify(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	k := newTestComponent(&fakeClient{publicKeyPEM: publicKeyPEM(t, privKey.Public())})
+
+	digest := sha256.Sum256([]byte("hello"))
+	signature, err := ecdsa.SignASN1(rand.Reader, privKey, digest[:])
+	require.NoError(t, err)
+
+	valid, err := k.Verify(t.Context(), digest[:], signature, internals.Algorithm_ES256, "mykey/1")
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	otherDigest := sha256.Sum256([]byte("tampered"))
+	valid, err = k.Verify(t.Context(), otherDigest[:], signature, internals.Algorithm_ES256, "mykey/1")
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestSupportedAlgorithms(t *testing.T) {
+	k := newTestComponent(&fakeClient{})
+	assert.Contains(t, k.SupportedEncryptionAlgorithms(), AlgorithmSymmetric)
+	assert.Contains(t, k.SupportedSignatureAlgorithms(), internals.Algorithm_ES256)
+
+	// Every advertised signature algorithm must produce a valid request
+	for _, algorithm := range k.SupportedSignatureAlgorithms() {
+		digest := make([]byte, 64)
+		if algorithm == internals.Algorithm_ES384 {
+			digest = make([]byte, 48)
+		} else if algorithm == internals.Algorithm_ES256 || algorithm == internals.Algorithm_RS256 || algorithm == internals.Algorithm_PS256 {
+			digest = make([]byte, 32)
+		}
+		_, err := signRequestDigest(digest, algorithm)
+		require.NoErrorf(t, err, "algorithm %s", algorithm)
+	}
+}

--- a/crypto/gcp/kms/kms_test.go
+++ b/crypto/gcp/kms/kms_test.go
@@ -164,6 +164,12 @@ func TestMetadata(t *testing.T) {
 func TestKeyID(t *testing.T) {
 	md := kmsMetadata{ProjectID: "myproject", Location: "global", KeyRing: "myring"}
 
+	require.NoError(t, newKeyID("mykey").validate(false))
+	require.NoError(t, newKeyID("mykey/1").validate(true))
+	for _, invalid := range []string{"", "/1", "mykey/", "mykey/1/extra"} {
+		require.Error(t, newKeyID(invalid).validate(false), invalid)
+	}
+
 	assert.Equal(t, testKeyPath, md.cryptoKeyPath(newKeyID("mykey")))
 	assert.False(t, newKeyID("mykey").Cacheable())
 
@@ -196,6 +202,31 @@ func TestGetKey(t *testing.T) {
 	_, err = k.GetKey(t.Context(), "mykey")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "does not include a version")
+
+	_, err = k.GetKey(t.Context(), "mykey/1/extra")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "expected 'name' or 'name/version'")
+
+	t.Run("errors from Cloud KMS are returned", func(t *testing.T) {
+		failing := newTestComponent(&fakeClient{err: errors.New("permission denied")})
+		_, err := failing.GetKey(t.Context(), "mykey/1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("empty public keys are rejected", func(t *testing.T) {
+		empty := newTestComponent(&fakeClient{})
+		_, err := empty.GetKey(t.Context(), "mykey/1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "does not contain a public key")
+	})
+
+	t.Run("malformed public keys are rejected", func(t *testing.T) {
+		malformed := newTestComponent(&fakeClient{publicKeyPEM: "not a PEM key"})
+		_, err := malformed.GetKey(t.Context(), "mykey/1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse")
+	})
 }
 
 func TestSymmetricEncryptDecrypt(t *testing.T) {
@@ -223,6 +254,18 @@ func TestSymmetricEncryptDecrypt(t *testing.T) {
 	_, _, err = k.Encrypt(t.Context(), []byte("hello"), AlgorithmSymmetric, "mykey", []byte("nonce"), nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "nonce is not supported")
+
+	_, _, err = k.Encrypt(t.Context(), []byte("hello"), AlgorithmSymmetric, "mykey/", nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "expected 'name' or 'name/version'")
+
+	failing := newTestComponent(&fakeClient{err: errors.New("invalid ciphertext")})
+	_, _, err = failing.Encrypt(t.Context(), []byte("hello"), AlgorithmSymmetric, "mykey", nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid ciphertext")
+	_, err = failing.Decrypt(t.Context(), []byte("ciphertext"), AlgorithmSymmetric, "mykey", nil, nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid ciphertext")
 }
 
 func TestAsymmetricEncryptDecrypt(t *testing.T) {
@@ -255,6 +298,11 @@ func TestAsymmetricEncryptDecrypt(t *testing.T) {
 	_, err = k.Decrypt(t.Context(), ciphertext, internals.Algorithm_RSA_OAEP_256, "mykey", nil, nil, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "does not include a version")
+
+	failing := newTestComponent(&fakeClient{err: errors.New("permission denied")})
+	_, err = failing.Decrypt(t.Context(), ciphertext, internals.Algorithm_RSA_OAEP_256, "mykey/1", nil, nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "permission denied")
 }
 
 func TestUnsupportedAlgorithm(t *testing.T) {
@@ -340,6 +388,10 @@ func TestSign(t *testing.T) {
 		_, err := k.Sign(t.Context(), make([]byte, 32), internals.Algorithm_ES256, "mykey")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "does not include a version")
+
+		_, err = k.Sign(t.Context(), make([]byte, 32), internals.Algorithm_ES256, "mykey/1/extra")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "expected 'name' or 'name/version'")
 	})
 
 	t.Run("errors from Cloud KMS are returned", func(t *testing.T) {
@@ -347,6 +399,13 @@ func TestSign(t *testing.T) {
 		_, err := failing.Sign(t.Context(), make([]byte, 32), internals.Algorithm_ES256, "mykey/1")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("empty signatures are rejected", func(t *testing.T) {
+		empty := newTestComponent(&fakeClient{})
+		_, err := empty.Sign(t.Context(), make([]byte, 32), internals.Algorithm_ES256, "mykey/1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "does not contain a signature")
 	})
 }
 
@@ -367,6 +426,15 @@ func TestVerify(t *testing.T) {
 	valid, err = k.Verify(t.Context(), otherDigest[:], signature, internals.Algorithm_ES256, "mykey/1")
 	require.NoError(t, err)
 	assert.False(t, valid)
+
+	_, err = k.Verify(t.Context(), digest[:], signature, "HS256", "mykey/1")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to verify signature")
+
+	failing := newTestComponent(&fakeClient{err: errors.New("permission denied")})
+	_, err = failing.Verify(t.Context(), digest[:], signature, internals.Algorithm_ES256, "mykey/1")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to retrieve public key")
 }
 
 func TestSupportedAlgorithms(t *testing.T) {

--- a/crypto/gcp/kms/metadata.go
+++ b/crypto/gcp/kms/metadata.go
@@ -80,13 +80,30 @@ func (m kmsMetadata) hasExplicitCredentials() bool {
 
 // keyID identifies a key in the key ring, optionally including its version.
 type keyID struct {
-	Name    string
-	Version string
+	Name      string
+	Version   string
+	raw       string
+	malformed bool
 }
 
 func newKeyID(val string) keyID {
-	name, version, _ := strings.Cut(val, "/")
-	return keyID{Name: name, Version: version}
+	name, version, found := strings.Cut(val, "/")
+	return keyID{
+		Name:      name,
+		Version:   version,
+		raw:       val,
+		malformed: name == "" || (found && version == "") || strings.Contains(version, "/"),
+	}
+}
+
+func (id keyID) validate(requireVersion bool) error {
+	if id.malformed {
+		return fmt.Errorf("key %q is invalid: expected 'name' or 'name/version'", id.raw)
+	}
+	if requireVersion && id.Version == "" {
+		return fmt.Errorf("key '%s' does not include a version: operations with asymmetric keys require a key in the format 'name/version'", id.Name)
+	}
+	return nil
 }
 
 // Cacheable returns true if the public key can be cached locally, which is the case for
@@ -102,8 +119,8 @@ func (m kmsMetadata) cryptoKeyPath(id keyID) string {
 
 // Returns the full resource name of a crypto key version, which asymmetric operations require.
 func (m kmsMetadata) cryptoKeyVersionPath(id keyID) (string, error) {
-	if id.Version == "" {
-		return "", fmt.Errorf("key '%s' does not include a version: operations with asymmetric keys require a key in the format 'name/version'", id.Name)
+	if err := id.validate(true); err != nil {
+		return "", err
 	}
 	return m.cryptoKeyPath(id) + "/cryptoKeyVersions/" + id.Version, nil
 }

--- a/crypto/gcp/kms/metadata.go
+++ b/crypto/gcp/kms/metadata.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kms
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	contribCrypto "github.com/dapr/components-contrib/crypto"
+	kitmd "github.com/dapr/kit/metadata"
+)
+
+const defaultRequestTimeout = 30 * time.Second
+
+type kmsMetadata struct {
+	// Ignored by the metadata parser because they are included in the built-in "gcp" authentication profile
+	Type                string `json:"type" mapstructure:"type" mdignore:"true"`
+	ProjectID           string `json:"project_id" mapstructure:"projectID" mdignore:"true" mapstructurealiases:"project_id"`
+	PrivateKeyID        string `json:"private_key_id" mapstructure:"privateKeyID" mdignore:"true" mapstructurealiases:"private_key_id"`
+	PrivateKey          string `json:"private_key" mapstructure:"privateKey" mdignore:"true" mapstructurealiases:"private_key"`
+	ClientEmail         string `json:"client_email" mapstructure:"clientEmail" mdignore:"true" mapstructurealiases:"client_email"`
+	ClientID            string `json:"client_id" mapstructure:"clientID" mdignore:"true" mapstructurealiases:"client_id"`
+	AuthURI             string `json:"auth_uri" mapstructure:"authURI" mdignore:"true" mapstructurealiases:"auth_uri"`
+	TokenURI            string `json:"token_uri" mapstructure:"tokenURI" mdignore:"true" mapstructurealiases:"token_uri"`
+	AuthProviderCertURL string `json:"auth_provider_x509_cert_url" mapstructure:"authProviderX509CertURL" mdignore:"true" mapstructurealiases:"auth_provider_x509_cert_url"`
+	ClientCertURL       string `json:"client_x509_cert_url" mapstructure:"clientX509CertURL" mdignore:"true" mapstructurealiases:"client_x509_cert_url"`
+
+	// Location of the key ring, for example "global" or "us-east1".
+	Location string `json:"-" mapstructure:"location"`
+	// Name of the key ring that contains the keys used by this component.
+	KeyRing string `json:"-" mapstructure:"keyRing"`
+	// Timeout for network requests.
+	RequestTimeout time.Duration `json:"-" mapstructure:"requestTimeout"`
+}
+
+func (m *kmsMetadata) InitWithMetadata(meta contribCrypto.Metadata) error {
+	*m = kmsMetadata{
+		RequestTimeout: defaultRequestTimeout,
+	}
+
+	err := kitmd.DecodeMetadata(meta.Properties, m)
+	if err != nil {
+		return err
+	}
+
+	if m.ProjectID == "" {
+		return errors.New("property 'projectID' is required")
+	}
+	if m.Location == "" {
+		return errors.New("property 'location' is required")
+	}
+	if m.KeyRing == "" {
+		return errors.New("property 'keyRing' is required")
+	}
+	if m.RequestTimeout < time.Second {
+		return errors.New("property 'requestTimeout' must be at least 1s")
+	}
+
+	return nil
+}
+
+// Returns true when the component is configured with explicit service account credentials,
+// rather than relying on Application Default Credentials.
+func (m kmsMetadata) hasExplicitCredentials() bool {
+	return m.PrivateKeyID != ""
+}
+
+// keyID identifies a key in the key ring, optionally including its version.
+type keyID struct {
+	Name    string
+	Version string
+}
+
+func newKeyID(val string) keyID {
+	name, version, _ := strings.Cut(val, "/")
+	return keyID{Name: name, Version: version}
+}
+
+// Cacheable returns true if the public key can be cached locally, which is the case for
+// keys pinned to a specific (and therefore immutable) version.
+func (id keyID) Cacheable() bool {
+	return id.Version != ""
+}
+
+// Returns the full resource name of the crypto key.
+func (m kmsMetadata) cryptoKeyPath(id keyID) string {
+	return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", m.ProjectID, m.Location, m.KeyRing, id.Name)
+}
+
+// Returns the full resource name of a crypto key version, which asymmetric operations require.
+func (m kmsMetadata) cryptoKeyVersionPath(id keyID) (string, error) {
+	if id.Version == "" {
+		return "", fmt.Errorf("key '%s' does not include a version: operations with asymmetric keys require a key in the format 'name/version'", id.Name)
+	}
+	return m.cryptoKeyPath(id) + "/cryptoKeyVersions/" + id.Version, nil
+}

--- a/crypto/gcp/kms/metadata.yaml
+++ b/crypto/gcp/kms/metadata.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../../component-metadata-schema.json
+schemaVersion: v1
+type: crypto
+name: gcp.kms
+version: v1
+status: alpha
+title: "GCP Cloud KMS"
+urls:
+  - title: Reference
+    url: https://docs.dapr.io/reference/components-reference/supported-cryptography/gcp-kms/
+builtinAuthenticationProfiles:
+  - name: "gcp"
+metadata:
+  - name: location
+    required: true
+    description: |
+      Location of the key ring, as configured in Cloud KMS.
+    example: '"global"'
+  - name: keyRing
+    required: true
+    description: |
+      Name of the Cloud KMS key ring that contains the keys used by this component.
+      Keys are then referenced by their name, or by "name/version" for operations with asymmetric keys.
+    example: '"my-key-ring"'
+  - name: requestTimeout
+    required: false
+    type: duration
+    description: |
+      Timeout for network requests to Cloud KMS.
+    example: '"10s"'
+    default: '"30s"'

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	cloud.google.com/go/datastore v1.20.0
+	cloud.google.com/go/kms v1.21.2
 	cloud.google.com/go/pubsub v1.49.0
 	cloud.google.com/go/secretmanager v1.14.7
 	cloud.google.com/go/storage v1.50.0
@@ -165,6 +166,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
+	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	dario.cat/mergo v1.0.2 // indirect


### PR DESCRIPTION
# Description

Adds `crypto.gcp.kms`, a cryptography component backed by [Google Cloud KMS](https://cloud.google.com/kms/docs), so the cryptography building block is no longer Azure-only.

**How the operations map onto Cloud KMS.** The Cloud KMS API surface is narrower than Azure Key Vault's, so each `SubtleCrypto` method lands where the platform actually supports it:

| Dapr operation | Where it runs |
|---|---|
| `GetKey` | `GetPublicKey` (asymmetric keys only) |
| `Encrypt` / `Decrypt` with a symmetric key | `Encrypt` / `Decrypt` in Cloud KMS |
| `Encrypt` with an asymmetric key | locally, with the public key from Cloud KMS — Cloud KMS has no asymmetric encrypt API |
| `Decrypt` with an asymmetric key | `AsymmetricDecrypt` |
| `WrapKey` / `UnwrapKey` | serialized, then the encrypt/decrypt paths above |
| `Sign` | `AsymmetricSign` |
| `Verify` | locally, with the public key — Cloud KMS has no verify API |

Consequences worth calling out, all covered by tests:

- Symmetric keys are exposed under Cloud KMS' own `GOOGLE_SYMMETRIC_ENCRYPTION` identifier, because they have no JOSE equivalent: Cloud KMS generates the nonce itself and returns the authentication tag inside the ciphertext. Passing a nonce is rejected rather than silently ignored, and decryption addresses the `CryptoKey` since the version is resolved from the ciphertext.
- Cloud KMS does not accept an OAEP label, so associated data is rejected for asymmetric algorithms instead of producing ciphertext that could never be decrypted.
- Asymmetric operations require a key version (`name/version`), matching `CryptoKeyVersion` semantics; the error says so explicitly. Public keys of pinned versions are cached through the existing `PubKeyCache`, since key versions are immutable.
- Only symmetric keys can be wrapped, as in the Azure Key Vault component, so the unwrapped key can be reconstructed unambiguously.
- `Sign` validates the digest length against the algorithm before the request, and Ed25519 is sent through `Data` because Cloud KMS signs the message rather than a digest — which is also how the rest of Dapr treats EdDSA. ECDSA signatures need no conversion: Cloud KMS returns ASN.1 DER, which is what `dapr/kit` produces and verifies.

**Supported algorithms.** Encryption: `GOOGLE_SYMMETRIC_ENCRYPTION`, `RSA-OAEP`, `RSA-OAEP-256`, `RSA-OAEP-512`. Signature: `RS256`, `RS512`, `PS256`, `PS512`, `ES256`, `ES384`, `EdDSA`. Each one corresponds to a Cloud KMS key algorithm; `RSA-OAEP-384` and `ES512` are deliberately absent because Cloud KMS has no matching key algorithm.

**Authentication** follows the other GCP components: the built-in `gcp` authentication profile, using Application Default Credentials unless explicit service account fields are supplied.

**Dependencies:** adds `cloud.google.com/go/kms` (and `cloud.google.com/go/longrunning`, which it pulls in). No other module in `go.mod` changes.

**Follow-up needed in dapr/dapr:** registering the component, in the same shape as the existing crypto components:

```go
cryptoLoader.DefaultRegistry.RegisterComponent(gcpkms.NewGCPKMSCrypto, "gcp.kms")
```

I will open that PR once this one is merged and the dependency is bumped.

## Issue reference

Please reference the issue this PR will close: #3087

## Testing

`crypto/gcp/kms/kms_test.go` runs the component against a Cloud KMS client double, covering metadata validation and key-name parsing, public key retrieval and caching, symmetric encrypt/decrypt (including the resource names used and the rejected nonce), asymmetric encryption verified by decrypting with the real private key, the rejected OAEP label, wrap/unwrap round-trips and the asymmetric-key rejection, per-algorithm digest fields and length validation, the Ed25519 message path, and local signature verification of a genuine ECDSA signature. `go test -race ./crypto/gcp/kms/` passes.

Conformance tests are not included because they would need a live Cloud KMS key ring; the Azure Key Vault crypto component has none for the same reason. Happy to add CRC32C integrity verification on Cloud KMS requests and responses if maintainers want it — I left it out since gRPC already runs over TLS, and it would add a checksum to every call.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5294
