### PR TITLE
feat(pubsub/solace-amqp): make the topic and queue address prefixes configurable

### DIFF
--- a/pubsub/solace/amqp/amqp.go
+++ b/pubsub/solace/amqp/amqp.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	time "time"
@@ -78,21 +77,6 @@ func (a *amqpPubSub) Init(ctx context.Context, metadata pubsub.Metadata) error {
 	return err
 }
 
-func AddPrefixToAddress(t string) string {
-	dest := t
-
-	// Unless the request comes in to publish on a queue, publish directly on a topic
-	if !strings.HasPrefix(dest, "queue:") && !strings.HasPrefix(dest, "topic:") {
-		dest = "topic://" + dest
-	} else if strings.HasPrefix(dest, "queue:") {
-		dest = strings.Replace(dest, "queue:", "queue://", 1)
-	} else if strings.HasPrefix(dest, "topic:") {
-		dest = strings.Replace(dest, "topic:", "topic://", 1)
-	}
-
-	return dest
-}
-
 // Publish the topic to amqp pubsub
 func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
 	a.publishLock.Lock()
@@ -106,6 +90,11 @@ func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) er
 
 	if req.Topic == "" {
 		return pubsub.NewTerminalError(errors.New("topic name is empty"))
+	}
+
+	address := a.metadata.addressFor(req.Topic)
+	if address == "" {
+		return pubsub.NewTerminalError(fmt.Errorf("topic %q maps to an empty AMQP address", req.Topic))
 	}
 
 	m := amqp.NewMessage(req.Data)
@@ -122,7 +111,7 @@ func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) er
 	}
 
 	sender, err := a.session.NewSender(ctx,
-		AddPrefixToAddress(req.Topic),
+		address,
 		nil,
 	)
 
@@ -159,15 +148,18 @@ func (a *amqpPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 		return errors.New("component is closed")
 	}
 
-	prefixedTopic := AddPrefixToAddress(req.Topic)
+	address := a.metadata.addressFor(req.Topic)
+	if address == "" {
+		return fmt.Errorf("topic %q maps to an empty AMQP address", req.Topic)
+	}
 
 	receiver, err := a.session.NewReceiver(ctx,
-		prefixedTopic,
+		address,
 		nil,
 	)
 
 	if err == nil {
-		a.logger.Infof("Attempting to subscribe to %s", prefixedTopic)
+		a.logger.Infof("Attempting to subscribe to %s", address)
 		a.wg.Add(2)
 		subCtx, cancel := context.WithCancel(ctx)
 		go func() {
@@ -180,7 +172,7 @@ func (a *amqpPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 		}()
 		go func() {
 			defer a.wg.Done()
-			a.subscribeForever(subCtx, receiver, handler, prefixedTopic)
+			a.subscribeForever(subCtx, receiver, handler, req.Topic, address)
 		}()
 	} else {
 		a.logger.Error("Unable to create a receiver:", err)
@@ -189,25 +181,17 @@ func (a *amqpPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 	return err
 }
 
-// function that subscribes to a queue in a tight loop
-func (a *amqpPubSub) subscribeForever(ctx context.Context, receiver *amqp.Receiver, handler pubsub.Handler, t string) {
-	defer a.logger.Infof("closing receiver for %s", t)
+// function that subscribes to a queue in a tight loop.
+// topic is the Dapr topic name the messages are delivered under, address is the
+// AMQP address the receiver link is attached to.
+func (a *amqpPubSub) subscribeForever(ctx context.Context, receiver *amqp.Receiver, handler pubsub.Handler, topic string, address string) {
+	defer a.logger.Infof("closing receiver for %s", address)
 	for ctx.Err() == nil {
 		// Receive next message
 		msg, err := receiver.Receive(ctx, nil)
 
 		if msg != nil {
-			data := msg.GetData()
-
-			// if data is empty, then check the value field for data
-			if len(data) == 0 {
-				data = []byte(fmt.Sprint(msg.Value))
-			}
-
-			pubsubMsg := &pubsub.NewMessage{
-				Data:  data,
-				Topic: receiver.LinkName(),
-			}
+			pubsubMsg := newPubsubMessage(topic, msg)
 
 			if err != nil {
 				a.logger.Errorf("failed to establish receiver")
@@ -222,7 +206,7 @@ func (a *amqpPubSub) subscribeForever(ctx context.Context, receiver *amqp.Receiv
 					a.logger.Errorf("failed to acknowledge a message")
 				}
 			} else {
-				a.logger.Errorf("Error processing message from %s", receiver.LinkName())
+				a.logger.Errorf("Error processing message from %s", address)
 				a.logger.Debugf("NAKd a message")
 				err := receiver.RejectMessage(ctx, msg, nil)
 				if err != nil {
@@ -230,6 +214,22 @@ func (a *amqpPubSub) subscribeForever(ctx context.Context, receiver *amqp.Receiv
 				}
 			}
 		}
+	}
+}
+
+// newPubsubMessage converts a message received from the broker into a Dapr
+// pub/sub message delivered under the topic the subscription was created for.
+func newPubsubMessage(topic string, msg *amqp.Message) *pubsub.NewMessage {
+	data := msg.GetData()
+
+	// if data is empty, then check the value field for data
+	if len(data) == 0 {
+		data = []byte(fmt.Sprint(msg.Value))
+	}
+
+	return &pubsub.NewMessage{
+		Data:  data,
+		Topic: topic,
 	}
 }
 

--- a/pubsub/solace/amqp/amqp_test.go
+++ b/pubsub/solace/amqp/amqp_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	amqp "github.com/Azure/go-amqp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -40,6 +41,152 @@ func getFakeProperties() map[string]string {
 		username:     "default",
 		password:     "default",
 	}
+}
+
+// TestAddressFor verifies how a Dapr topic name is translated into the AMQP
+// address used for the sender/receiver link, for each prefix configuration.
+func TestAddressFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		topicPrefix string
+		queuePrefix string
+		topic       string
+		want        string
+	}{
+		// Solace defaults.
+		{
+			name:        "bare topic uses the topic prefix",
+			topicPrefix: defaultTopicAddressPrefix,
+			queuePrefix: defaultQueueAddressPrefix,
+			topic:       "orders",
+			want:        "topic://orders",
+		},
+		{
+			name:        "topic scheme uses the topic prefix",
+			topicPrefix: defaultTopicAddressPrefix,
+			queuePrefix: defaultQueueAddressPrefix,
+			topic:       "topic:orders",
+			want:        "topic://orders",
+		},
+		{
+			name:        "queue scheme uses the queue prefix",
+			topicPrefix: defaultTopicAddressPrefix,
+			queuePrefix: defaultQueueAddressPrefix,
+			topic:       "queue:orders",
+			want:        "queue://orders",
+		},
+		{
+			name:        "an already prefixed topic address is left untouched",
+			topicPrefix: defaultTopicAddressPrefix,
+			queuePrefix: defaultQueueAddressPrefix,
+			topic:       "topic://orders",
+			want:        "topic://orders",
+		},
+		{
+			name:        "an already prefixed queue address is left untouched",
+			topicPrefix: defaultTopicAddressPrefix,
+			queuePrefix: defaultQueueAddressPrefix,
+			topic:       "queue://orders",
+			want:        "queue://orders",
+		},
+		// Brokers that address topics and queues by name, such as ActiveMQ Artemis.
+		{
+			name:        "empty prefixes pass a bare topic through",
+			topicPrefix: "",
+			queuePrefix: "",
+			topic:       "orders",
+			want:        "orders",
+		},
+		{
+			name:        "empty prefixes strip the topic scheme",
+			topicPrefix: "",
+			queuePrefix: "",
+			topic:       "topic:orders",
+			want:        "orders",
+		},
+		{
+			name:        "empty prefixes strip the queue scheme",
+			topicPrefix: "",
+			queuePrefix: "",
+			topic:       "queue:orders",
+			want:        "orders",
+		},
+		{
+			name:        "empty prefixes strip a fully qualified topic address",
+			topicPrefix: "",
+			queuePrefix: "",
+			topic:       "topic://orders",
+			want:        "orders",
+		},
+		{
+			name:        "empty prefixes strip a fully qualified queue address",
+			topicPrefix: "",
+			queuePrefix: "",
+			topic:       "queue://orders",
+			want:        "orders",
+		},
+		{
+			name:        "one empty prefix strips only its own fully qualified address",
+			topicPrefix: defaultTopicAddressPrefix,
+			queuePrefix: "",
+			topic:       "queue://orders",
+			want:        "orders",
+		},
+		// Brokers configured with their own routing prefixes.
+		{
+			name:        "custom topic prefix is applied",
+			topicPrefix: "multicast::",
+			queuePrefix: "anycast::",
+			topic:       "orders",
+			want:        "multicast::orders",
+		},
+		{
+			name:        "custom queue prefix is applied",
+			topicPrefix: "multicast::",
+			queuePrefix: "anycast::",
+			topic:       "queue:orders",
+			want:        "anycast::orders",
+		},
+		{
+			name:        "custom prefixes replace a fully qualified topic address",
+			topicPrefix: "multicast::",
+			queuePrefix: "anycast::",
+			topic:       "topic://orders",
+			want:        "multicast::orders",
+		},
+		{
+			name:        "custom prefixes replace a fully qualified queue address",
+			topicPrefix: "multicast::",
+			queuePrefix: "anycast::",
+			topic:       "queue://orders",
+			want:        "anycast::orders",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &metadata{TopicAddressPrefix: tt.topicPrefix, QueueAddressPrefix: tt.queuePrefix}
+			assert.Equal(t, tt.want, m.addressFor(tt.topic))
+		})
+	}
+}
+
+// TestNewPubsubMessage verifies the topic and the payload a received AMQP
+// message is delivered with.
+func TestNewPubsubMessage(t *testing.T) {
+	t.Run("message is delivered under the subscribed topic", func(t *testing.T) {
+		msg := newPubsubMessage("orders", amqp.NewMessage([]byte("hello")))
+
+		assert.Equal(t, "orders", msg.Topic)
+		assert.Equal(t, []byte("hello"), msg.Data)
+	})
+
+	t.Run("the value field is used when the message carries no data", func(t *testing.T) {
+		msg := newPubsubMessage("orders", &amqp.Message{Value: "hello"})
+
+		assert.Equal(t, "orders", msg.Topic)
+		assert.Equal(t, []byte("hello"), msg.Data)
+	})
 }
 
 // TestPublishErrorClassification verifies that terminal Publish error paths
@@ -67,6 +214,33 @@ func TestPublishErrorClassification(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, codes.FailedPrecondition, st.Code())
 	})
+
+	t.Run("a topic that maps to an empty address is terminal", func(t *testing.T) {
+		a := NewAMQPPubsub(logger.NewLogger("test")).(*amqpPubSub)
+		// Both prefixes empty, so the scheme alone maps to an empty address.
+		a.metadata = &metadata{}
+
+		err := a.Publish(context.Background(), &pubsub.PublishRequest{Topic: topicScheme})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty AMQP address")
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+}
+
+// TestSubscribeEmptyAddress verifies that a subscription whose topic maps to an
+// empty AMQP address is rejected instead of attaching a link to the anonymous
+// relay.
+func TestSubscribeEmptyAddress(t *testing.T) {
+	a := NewAMQPPubsub(logger.NewLogger("test")).(*amqpPubSub)
+	// Both prefixes empty, so the scheme alone maps to an empty address.
+	a.metadata = &metadata{}
+
+	err := a.Subscribe(context.Background(), pubsub.SubscribeRequest{Topic: queueScheme}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty AMQP address")
 }
 
 func TestParseMetadata(t *testing.T) {
@@ -81,6 +255,47 @@ func TestParseMetadata(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		assert.Equal(t, fakeProperties[amqpURL], m.URL)
+	})
+
+	t.Run("address prefixes default to the Solace convention", func(t *testing.T) {
+		fakeMetaData := pubsub.Metadata{Base: mdata.Base{Properties: getFakeProperties()}}
+
+		m, err := parseAMQPMetaData(fakeMetaData, log)
+
+		// assert
+		require.NoError(t, err)
+		assert.Equal(t, defaultTopicAddressPrefix, m.TopicAddressPrefix)
+		assert.Equal(t, defaultQueueAddressPrefix, m.QueueAddressPrefix)
+		assert.Equal(t, "topic://orders", m.addressFor("orders"))
+	})
+
+	t.Run("address prefixes are overridden", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeProperties["topicAddressPrefix"] = "multicast::"
+		fakeProperties["queueAddressPrefix"] = "anycast::"
+		fakeMetaData := pubsub.Metadata{Base: mdata.Base{Properties: fakeProperties}}
+
+		m, err := parseAMQPMetaData(fakeMetaData, log)
+
+		// assert
+		require.NoError(t, err)
+		assert.Equal(t, "multicast::", m.TopicAddressPrefix)
+		assert.Equal(t, "anycast::", m.QueueAddressPrefix)
+	})
+
+	t.Run("address prefixes are disabled when set to an empty value", func(t *testing.T) {
+		fakeProperties := getFakeProperties()
+		fakeProperties["topicAddressPrefix"] = ""
+		fakeProperties["queueAddressPrefix"] = ""
+		fakeMetaData := pubsub.Metadata{Base: mdata.Base{Properties: fakeProperties}}
+
+		m, err := parseAMQPMetaData(fakeMetaData, log)
+
+		// assert
+		require.NoError(t, err)
+		assert.Empty(t, m.TopicAddressPrefix)
+		assert.Empty(t, m.QueueAddressPrefix)
+		assert.Equal(t, "orders", m.addressFor("orders"))
 	})
 
 	t.Run("url is not given", func(t *testing.T) {

--- a/pubsub/solace/amqp/metadata.go
+++ b/pubsub/solace/amqp/metadata.go
@@ -16,6 +16,7 @@ package amqp
 import (
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dapr/components-contrib/pubsub"
@@ -34,6 +35,14 @@ type metadata struct {
 	Username  string
 	Password  string
 	Anonymous bool
+
+	// TopicAddressPrefix and QueueAddressPrefix are prepended to the AMQP
+	// address of every link opened by this component, for topics and queues
+	// respectively. They default to the Solace addressing convention and can be
+	// set to an empty value for brokers that address topics and queues by name,
+	// or to the prefixes the broker is configured with.
+	TopicAddressPrefix string
+	QueueAddressPrefix string
 }
 
 type tlsCfg struct {
@@ -52,7 +61,49 @@ const (
 	amqpClientCert = "clientCert"
 	amqpClientKey  = "clientKey"
 	defaultWait    = 30 * time.Second
+
+	// Address prefixes of the Solace addressing convention, kept as the
+	// defaults so that existing Solace configurations are unaffected.
+	defaultTopicAddressPrefix = "topic://"
+	defaultQueueAddressPrefix = "queue://"
+
+	// Optional scheme of a topic name, selecting which prefix is applied.
+	topicScheme = "topic:"
+	queueScheme = "queue:"
 )
+
+// addressFor returns the AMQP address a link is opened on for the given Dapr
+// topic name.
+//
+// A topic name may carry an optional "topic:" or "queue:" scheme, selecting
+// which of the two configured prefixes is applied; a bare topic name is
+// addressed as a topic. A topic name that already carries one of the configured
+// prefixes is used as the address as-is.
+func (m *metadata) addressFor(topic string) string {
+	if hasPrefix(topic, m.TopicAddressPrefix) || hasPrefix(topic, m.QueueAddressPrefix) {
+		return topic
+	}
+
+	switch {
+	case strings.HasPrefix(topic, queueScheme):
+		return m.QueueAddressPrefix + trimScheme(topic, queueScheme)
+	case strings.HasPrefix(topic, topicScheme):
+		return m.TopicAddressPrefix + trimScheme(topic, topicScheme)
+	default:
+		return m.TopicAddressPrefix + topic
+	}
+}
+
+// trimScheme removes a scheme, and the "//" that follows it in a fully
+// qualified address, from the front of a topic name.
+func trimScheme(topic string, scheme string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(topic, scheme), "//")
+}
+
+// hasPrefix reports whether s begins with a non-empty prefix.
+func hasPrefix(s, prefix string) bool {
+	return prefix != "" && strings.HasPrefix(s, prefix)
+}
 
 // isValidPEM validates the provided input has PEM formatted block.
 func isValidPEM(val string) bool {
@@ -62,7 +113,11 @@ func isValidPEM(val string) bool {
 }
 
 func parseAMQPMetaData(md pubsub.Metadata, log logger.Logger) (*metadata, error) {
-	m := metadata{Anonymous: false}
+	m := metadata{
+		Anonymous:          false,
+		TopicAddressPrefix: defaultTopicAddressPrefix,
+		QueueAddressPrefix: defaultQueueAddressPrefix,
+	}
 
 	err := kitmd.DecodeMetadata(md.Properties, &m)
 	if err != nil {

--- a/pubsub/solace/amqp/metadata.yaml
+++ b/pubsub/solace/amqp/metadata.yaml
@@ -62,4 +62,26 @@ metadata:
     description: |
       TLS client key in PEM format, for using TLS.
     example: '"-----BEGIN PRIVATE KEY-----\n<base64-encoded PKCS8>\n-----END RSA PRIVATE KEY-----"'
-    type: string    
+    type: string
+  - name: topicAddressPrefix
+    required: false
+    description: |
+      Prefix prepended to the AMQP address of a topic, which is used for a bare topic name and for
+      topics named `topic:<name>`.
+      Defaults to the Solace addressing convention. Set it to the multicast prefix the broker is
+      configured with, or to an empty value for brokers that address topics by name, such as
+      Apache ActiveMQ Artemis.
+    default: '"topic://"'
+    example: '"topic://"'
+    type: string
+  - name: queueAddressPrefix
+    required: false
+    description: |
+      Prefix prepended to the AMQP address of a queue, which is used for topics named `queue:<name>`.
+      Defaults to the Solace addressing convention. Set it to the anycast prefix the broker is
+      configured with, or to an empty value for brokers that address queues by name, such as
+      Apache ActiveMQ Artemis. Note that when both prefixes are set to an empty value,
+      `queue:<name>` addresses the same destination as `<name>`.
+    default: '"queue://"'
+    example: '"queue://"'
+    type: string


### PR DESCRIPTION
# Description

`pubsub.solace.amqp` hardcoded the Solace addressing convention: every AMQP address it opened a link on was prefixed with `topic://` or `queue://`.

On a broker that addresses destinations by name, that prefix becomes part of the address name — a Dapr topic `orders` is published on an address literally called `topic://orders`. I checked what that means in practice against Apache ActiveMQ Artemis 2.42 (`apache/activemq-artemis:latest-alpine`, default AMQP acceptor, one Dapr component per side):

| publisher | subscriber | result |
|---|---|---|
| default prefixes | default prefixes | delivered, on an address named `topic://<topic>` |
| default prefixes | addresses by name | **not delivered** |
| addresses by name | default prefixes | **not delivered** |
| addresses by name | addresses by name | delivered |

Two Dapr applications sharing the component do reach each other, because Artemis auto-creates the prefixed address. What does not work is anything that addresses the destination by its name — another application on the broker, or an address or queue provisioned in advance — and the queue/topic distinction the prefix is meant to express is lost, since Artemis resolves the routing type from its own configuration rather than from the address name.

This PR moves the two prefixes into component metadata:

| field | default |
|---|---|
| `topicAddressPrefix` | `topic://` |
| `queueAddressPrefix` | `queue://` |

The defaults are the Solace values, so existing components are unaffected. Setting both to an empty value addresses destinations by name, which is what a broker like Artemis needs; setting them to the prefixes the broker is configured with — Artemis' `anycastPrefix` and `multicastPrefix` acceptor parameters, for instance — works too and keeps the routing-type distinction.

Two smaller changes in the same code path:

- An address that already begins with one of the configured prefixes is used as-is rather than prefixed a second time, and a topic name that maps to an empty address is rejected instead of opening a link to the anonymous relay.
- Received messages carried `receiver.LinkName()` as their topic. The component creates receivers without a link name, so go-amqp generates a random one, and that random string surfaced as the topic of every delivered message: the CloudEvent `topic` of raw payloads, and the topic label on the runtime's pub/sub ingress metrics and log lines. Messages are now delivered under the topic their subscription was created for. Wildcard subscriptions report the subscribed pattern rather than the concrete destination of each message.

Notes for reviewers:

- The exported `AddPrefixToAddress` helper is gone; the prefixing it did is now driven by the component's configured prefixes. There are no callers left in components-contrib, dapr/dapr, cli or go-sdk.
- The Artemis results above come from running the component against a broker by hand. There is no conformance profile for Artemis in this PR — the existing `pubsub.solace` conformance job still covers the default addressing against a real Solace broker.

## Issue reference

Please reference the issue this PR will close: dapr/dapr#10363

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
    * [x] Created the dapr/docs PR: https://github.com/dapr/docs/pull/5295