### PR TITLE
fix: declare FeatureMultipleKeyValuesPerSecret in Kubernetes secret store

### DIFF
--- a/secretstores/kubernetes/kubernetes.go
+++ b/secretstores/kubernetes/kubernetes.go
@@ -127,7 +127,9 @@ func (k *kubernetesSecretStore) getNamespaceFromMetadata(metadata map[string]str
 
 // Features returns the features available in this secret store.
 func (k *kubernetesSecretStore) Features() []secretstores.Feature {
-	return []secretstores.Feature{}
+	// A Kubernetes Secret's Data field is a map[string][]byte: multiple keys per secret is
+	// the normal case, not an edge case, as GetSecret/BulkGetSecret above already reflect.
+	return []secretstores.Feature{secretstores.FeatureMultipleKeyValuesPerSecret}
 }
 
 func (k *kubernetesSecretStore) GetComponentMetadata() (metadataInfo metadata.MetadataMap) {

--- a/secretstores/kubernetes/kubernetes_test.go
+++ b/secretstores/kubernetes/kubernetes_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/kit/logger"
 )
 
@@ -67,8 +68,10 @@ func TestGetNamespace(t *testing.T) {
 func TestGetFeatures(t *testing.T) {
 	s := kubernetesSecretStore{logger: logger.NewLogger("test")}
 	// Yes, we are skipping initialization as feature retrieval doesn't depend on it.
-	t.Run("no features are advertised", func(t *testing.T) {
+	t.Run("declares multiple key-values per secret", func(t *testing.T) {
+		// A Kubernetes Secret's Data field is a map[string][]byte, so GetSecret/BulkGetSecret
+		// already return multiple keys per secret; the declared feature must match that.
 		f := s.Features()
-		assert.Empty(t, f)
+		assert.Contains(t, f, secretstores.FeatureMultipleKeyValuesPerSecret)
 	})
 }


### PR DESCRIPTION
## Description

Fixes #4544.

The Kubernetes secret store's `Features()` returned an empty list, but its own `GetSecret()`/`BulkGetSecret()` already correctly return multiple key-value pairs per secret - a Kubernetes `Secret`'s `Data` field is a `map[string][]byte`, so this is the normal case, not an edge case:

```go
func (k *kubernetesSecretStore) GetSecret(ctx context.Context, req secretstores.GetSecretRequest) (secretstores.GetSecretResponse, error) {
	resp := secretstores.GetSecretResponse{Data: map[string]string{}}
	...
	for k, v := range secret.Data {
		resp.Data[k] = string(v)
	}
	return resp, nil
}
```

## Comparison across all secret store providers

Checked `Features()` across every provider under `secretstores/`:

- **Correctly declare `FeatureMultipleKeyValuesPerSecret`** (multi-key-value backend): `local/file`, `hashicorp/vault` (conditionally, based on `vaultValueType`), `aws/secretmanager`
- **Correctly declare no features** (genuinely single-value-per-secret backend): `azure/keyvault`, `gcp/secretmanager`, `huaweicloud/csms`, `tencentcloud/ssm` - each has an explicit `// No Feature supported.` comment
- **`kubernetes`**: the one outlier - same multi-key-value shape as the first group, but declared no features

## Testing

Updates the existing `TestGetFeatures` test in `kubernetes_test.go`, which previously asserted the empty feature list as expected behavior (`assert.Empty(t, f)`), to assert the correct feature is now declared (`assert.Contains(t, f, secretstores.FeatureMultipleKeyValuesPerSecret)`).

I don't have a Go toolchain available in my environment to run `go test`/`go vet` locally - I've manually reviewed the diff for syntax and import-grouping correctness against the surrounding file conventions, but would appreciate a CI run / maintainer review to confirm.

## Note on scope

I didn't find `FeatureMultipleKeyValuesPerSecret` wired into any runtime control-flow decision in `dapr/dapr` today (only referenced in test mocks), so this is a metadata/capability-advertisement correctness fix rather than a change in request-handling behavior.