### PR TITLE
fix(pubsub/solace-amqp): stop killing the sidecar and leaking links on failure

### DIFF
--- a/pubsub/solace/amqp/amqp.go
+++ b/pubsub/solace/amqp/amqp.go
@@ -36,18 +36,20 @@ import (
 const (
 	publishRetryWaitSeconds = 2
 	publishMaxRetries       = 3
+
+	// defaultCloseTimeout bounds how long closing a link or session may block.
+	defaultCloseTimeout = 5 * time.Second
 )
 
 // amqpPubSub type allows sending and receiving data to/from an AMQP 1.0 broker
 type amqpPubSub struct {
-	session           *amqp.Session
-	metadata          *metadata
-	logger            logger.Logger
-	publishLock       sync.RWMutex
-	publishRetryCount int
-	wg                sync.WaitGroup
-	closed            atomic.Bool
-	closeCh           chan struct{}
+	session     *amqp.Session
+	metadata    *metadata
+	logger      logger.Logger
+	publishLock sync.RWMutex
+	wg          sync.WaitGroup
+	closed      atomic.Bool
+	closeCh     chan struct{}
 }
 
 // NewAMQPPubsub returns a new AMQPPubSub instance
@@ -86,8 +88,6 @@ func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) er
 		return pubsub.NewTerminalError(errors.New("component is closed"))
 	}
 
-	a.publishRetryCount = 0
-
 	if req.Topic == "" {
 		return pubsub.NewTerminalError(errors.New("topic name is empty"))
 	}
@@ -114,29 +114,38 @@ func (a *amqpPubSub) Publish(ctx context.Context, req *pubsub.PublishRequest) er
 		address,
 		nil,
 	)
-
 	if err != nil {
-		a.logger.Errorf("Unable to create link to %s: %v", req.Topic, err)
-	} else {
+		a.logger.Errorf("Unable to create link to %s: %v", address, err)
+		return pubsub.NewRetriableError(err)
+	}
+
+	// The link is opened per publish, so it has to be closed again here;
+	// otherwise every published message leaks a link on the broker.
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), defaultCloseTimeout)
+		defer cancel()
+		if cerr := sender.Close(closeCtx); cerr != nil {
+			a.logger.Warnf("failed to close the sender link for %s: %v", address, cerr)
+		}
+	}()
+
+	// Publish the message, retrying a bounded number of times before giving up.
+	for attempt := 0; ; attempt++ {
 		err = sender.Send(ctx, m, nil)
-		// If the publish operation has failed, attempt to republish a maximum number of times
-		// before giving up
-		if err != nil {
-			for a.publishRetryCount <= publishMaxRetries {
-				a.publishRetryCount++
+		if err == nil {
+			return nil
+		}
 
-				// Send message
-				err = sender.Send(ctx, m, nil)
-				if err != nil {
-					a.logger.Warnf("Failed to publish a message to the broker: %v", err)
-				}
+		if attempt >= publishMaxRetries {
+			break
+		}
 
-				select {
-				case <-time.After(publishRetryWaitSeconds * time.Second):
-				case <-ctx.Done():
-					break //nolint:staticcheck // SA4011: preserved for backwards compat
-				}
-			}
+		a.logger.Warnf("Failed to publish a message to %s, retrying: %v", address, err)
+
+		select {
+		case <-time.After(publishRetryWaitSeconds * time.Second):
+		case <-ctx.Done():
+			return pubsub.NewRetriableError(ctx.Err())
 		}
 	}
 
@@ -157,62 +166,79 @@ func (a *amqpPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 		address,
 		nil,
 	)
-
-	if err == nil {
-		a.logger.Infof("Attempting to subscribe to %s", address)
-		a.wg.Add(2)
-		subCtx, cancel := context.WithCancel(ctx)
-		go func() {
-			defer a.wg.Done()
-			defer cancel()
-			select {
-			case <-a.closeCh:
-			case <-subCtx.Done():
-			}
-		}()
-		go func() {
-			defer a.wg.Done()
-			a.subscribeForever(subCtx, receiver, handler, req.Topic, address)
-		}()
-	} else {
-		a.logger.Error("Unable to create a receiver:", err)
+	if err != nil {
+		a.logger.Errorf("Unable to create a receiver for %s: %v", address, err)
+		return err
 	}
 
-	return err
+	a.logger.Infof("Attempting to subscribe to %s", address)
+	a.wg.Add(2)
+	subCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer a.wg.Done()
+		defer cancel()
+		select {
+		case <-a.closeCh:
+		case <-subCtx.Done():
+		}
+	}()
+	go func() {
+		defer a.wg.Done()
+		a.subscribeForever(subCtx, receiver, handler, req.Topic, address)
+	}()
+
+	return nil
 }
 
-// function that subscribes to a queue in a tight loop.
+// subscribeForever delivers messages from the receiver link until the context
+// is cancelled or the link fails.
 // topic is the Dapr topic name the messages are delivered under, address is the
 // AMQP address the receiver link is attached to.
 func (a *amqpPubSub) subscribeForever(ctx context.Context, receiver *amqp.Receiver, handler pubsub.Handler, topic string, address string) {
-	defer a.logger.Infof("closing receiver for %s", address)
-	for ctx.Err() == nil {
+	defer func() {
+		a.logger.Infof("closing receiver for %s", address)
+		closeCtx, cancel := context.WithTimeout(context.Background(), defaultCloseTimeout)
+		defer cancel()
+		if err := receiver.Close(closeCtx); err != nil {
+			a.logger.Warnf("failed to close the receiver link for %s: %v", address, err)
+		}
+	}()
+
+	for {
 		// Receive next message
 		msg, err := receiver.Receive(ctx, nil)
-
-		if msg != nil {
-			pubsubMsg := newPubsubMessage(topic, msg)
-
-			if err != nil {
-				a.logger.Errorf("failed to establish receiver")
+		if err != nil {
+			if ctx.Err() != nil {
+				// The subscription is being torn down.
+				return
 			}
+			// Receive only fails on a cancelled context or on a link that is
+			// done for good, in which case it returns the same error
+			// immediately every time. Returning here rather than continuing
+			// avoids spinning on it.
+			a.logger.Errorf("Ending the subscription to %s, the receiver link failed: %v", address, err)
+			return
+		}
 
-			err = handler(ctx, pubsubMsg)
+		if msg == nil {
+			continue
+		}
 
-			if err == nil {
-				err := receiver.AcceptMessage(ctx, msg)
-				a.logger.Debugf("ACKed a message")
-				if err != nil {
-					a.logger.Errorf("failed to acknowledge a message")
-				}
+		if err = handler(ctx, newPubsubMessage(topic, msg)); err != nil {
+			a.logger.Errorf("Error processing message from %s: %v", address, err)
+			if err = receiver.RejectMessage(ctx, msg, nil); err != nil {
+				a.logger.Errorf("failed to NAK a message from %s: %v", address, err)
 			} else {
-				a.logger.Errorf("Error processing message from %s", address)
 				a.logger.Debugf("NAKd a message")
-				err := receiver.RejectMessage(ctx, msg, nil)
-				if err != nil {
-					a.logger.Errorf("failed to NAK a message")
-				}
 			}
+
+			continue
+		}
+
+		if err = receiver.AcceptMessage(ctx, msg); err != nil {
+			a.logger.Errorf("failed to acknowledge a message from %s: %v", address, err)
+		} else {
+			a.logger.Debugf("ACKed a message")
 		}
 	}
 }
@@ -245,13 +271,16 @@ func (a *amqpPubSub) connect(ctx context.Context) (*amqp.Session, error) {
 	a.logger.Infof("Attempting to connect to %s", a.metadata.URL)
 	client, err := amqp.Dial(ctx, a.metadata.URL, &clientOpts)
 	if err != nil {
-		a.logger.Fatal("Dialing AMQP server:", err)
+		return nil, fmt.Errorf("%s dialing AMQP server: %w", errorMsgPrefix, err)
 	}
 
 	// Open a session
 	session, err := client.NewSession(ctx, nil)
 	if err != nil {
-		a.logger.Fatal("Creating AMQP session:", err)
+		if cerr := client.Close(); cerr != nil {
+			a.logger.Warnf("failed to close the connection after a failed session: %v", cerr)
+		}
+		return nil, fmt.Errorf("%s creating AMQP session: %w", errorMsgPrefix, err)
 	}
 
 	return session, nil
@@ -310,7 +339,12 @@ func (a *amqpPubSub) Close() error {
 		close(a.closeCh)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Init may have failed before a session was established.
+	if a.session == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCloseTimeout)
 	defer cancel()
 	err := a.session.Close(ctx)
 	if err != nil {

--- a/pubsub/solace/amqp/amqp_test.go
+++ b/pubsub/solace/amqp/amqp_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"testing"
+	"time"
 
 	amqp "github.com/Azure/go-amqp"
 	"google.golang.org/grpc/codes"
@@ -241,6 +242,34 @@ func TestSubscribeEmptyAddress(t *testing.T) {
 	err := a.Subscribe(context.Background(), pubsub.SubscribeRequest{Topic: queueScheme}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty AMQP address")
+}
+
+// TestInitUnreachableBroker verifies that a broker which cannot be reached is
+// reported as an error from Init. A failed dial used to be passed to
+// logger.Fatal, which terminated the process, so this case could not be
+// exercised at all before.
+func TestInitUnreachableBroker(t *testing.T) {
+	a := NewAMQPPubsub(logger.NewLogger("test"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := a.Init(ctx, pubsub.Metadata{Base: mdata.Base{Properties: map[string]string{
+		// Port 1 is reserved, so nothing is listening on it.
+		amqpURL:   "amqp://127.0.0.1:1",
+		anonymous: "true",
+	}}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dialing AMQP server")
+}
+
+// TestCloseWithoutSession verifies that a component whose Init never
+// established a session can still be closed.
+func TestCloseWithoutSession(t *testing.T) {
+	a := NewAMQPPubsub(logger.NewLogger("test"))
+
+	require.NoError(t, a.Close())
 }
 
 func TestParseMetadata(t *testing.T) {


### PR DESCRIPTION
# Description

Draft, for discussion.

`pubsub.solace.amqp` mishandles every failure path it has. None of it is broker-specific — it all applies to Solace users today — and none of it came from #4539.

| Now | Before |
| --- | --- |
| `connect()` returns errors | `logger.Fatal` on a failed dial or session **killed the sidecar**, and since it never returns, `Init` could not report the failure |
| Receive loop exits on link failure | The error was dropped whenever `msg` was nil — which is what happens once a link is done — and a detach doesn't cancel the context, so it spun on the same error at **100% CPU, silently, forever** |
| Sender and receiver links are closed | A sender link was **leaked per published message** |
| Retry loop stops on success | Once the first send failed it ran every remaining attempt regardless of outcome, resending a delivered message **up to 3 more times**. Its `ctx.Done()` `break` only left the `select`, which is what the `SA4011` suppression was hiding |
| `Close()` guards a nil session | Unreachable only because the `Fatal` above exited first |

The added `TestInitUnreachableBroker` doesn't fail an assertion on `main` — it kills the test binary:

```
level=fatal msg="Dialing AMQP server:dial tcp 127.0.0.1:1: connect: connection refused"
FAIL	github.com/dapr/components-contrib/pubsub/solace/amqp	0.522s
```

Deliberately out of scope: reconnect on connection loss, the publish-wide write lock that serialises all publishing, and `Features()` claiming `SUBSCRIBE_WILDCARDS` (absent from `metadata.yaml`, and the syntax is broker-specific).

## Issue reference

None — found while reviewing this component for use with other AMQP 1.0 brokers. Happy to split it up if preferred.

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
