### PR TITLE
[1.19] feat(pubsub/rabbitmq): support externally managed and consistent hash exchanges

### DIFF
--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -48,6 +48,7 @@ type rabbitmqMetadata struct {
 	MaxLenBytes                        int64                  `mapstructure:"maxLenBytes"`
 	ExchangeKind                       string                 `mapstructure:"exchangeKind"`
 	ExchangeDeclareMode                string                 `mapstructure:"exchangeDeclareMode"`
+	QueueDeclareMode                   string                 `mapstructure:"queueDeclareMode"`
 	ClientName                         string                 `mapstructure:"clientName"`
 	HeartBeat                          time.Duration          `mapstructure:"heartBeat"`
 	PublisherConfirm                   bool                   `mapstructure:"publisherConfirm"`
@@ -80,6 +81,7 @@ const (
 	metadataMaxLenBytesKey                        = "maxLenBytes"
 	metadataExchangeKindKey                       = "exchangeKind"
 	metadataExchangeDeclareModeKey                = "exchangeDeclareMode"
+	metadataQueueDeclareModeKey                   = "queueDeclareMode"
 	metadataPublisherConfirmKey                   = "publisherConfirm"
 	metadataSaslExternal                          = "saslExternal"
 	metadataMaxPriority                           = "maxPriority"
@@ -93,15 +95,22 @@ const (
 	protocolAMQP  = "amqp"
 	protocolAMQPS = "amqps"
 
-	// exchangeDeclareModeDeclare makes the component declare the exchange itself
-	// (an active AMQP exchange.declare). This is the default and the historical
-	// behavior.
-	exchangeDeclareModeDeclare = "declare"
-	// exchangeDeclareModePassive makes the component verify that the exchange
-	// already exists (a passive AMQP exchange.declare) without creating or
-	// modifying it. Use this when the topology is owned by something else, such
-	// as the RabbitMQ Cluster Kubernetes Topology Operator or Terraform.
-	exchangeDeclareModePassive = "passive"
+	// declareModeDeclare makes the component declare the topology object itself
+	// (an active AMQP declare). This is the default and the historical behavior.
+	declareModeDeclare = "declare"
+	// declareModePassive makes the component verify that the topology object
+	// already exists (a passive AMQP declare) without creating or modifying it.
+	// Use this when the topology is owned by something else, such as the
+	// RabbitMQ Cluster Kubernetes Topology Operator or Terraform.
+	declareModePassive = "passive"
+
+	// Kept as distinct names because the two knobs are independent: an
+	// operator-owned exchange is commonly paired with queues that the component
+	// still creates, since consumer queue names are only known at runtime.
+	exchangeDeclareModeDeclare = declareModeDeclare
+	exchangeDeclareModePassive = declareModePassive
+	queueDeclareModeDeclare    = declareModeDeclare
+	queueDeclareModePassive    = declareModePassive
 
 	// exchangeKindConsistentHash is the exchange type provided by the
 	// rabbitmq_consistent_hash_exchange plugin. It is not a built-in AMQP
@@ -121,6 +130,7 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*rabbitm
 		ReconnectWait:                      time.Duration(defaultReconnectWaitSeconds) * time.Second,
 		ExchangeKind:                       fanoutExchangeKind,
 		ExchangeDeclareMode:                exchangeDeclareModeDeclare,
+		QueueDeclareMode:                   queueDeclareModeDeclare,
 		PublisherConfirm:                   false,
 		SaslExternal:                       false,
 		HeartBeat:                          defaultHeartbeat,
@@ -160,8 +170,13 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*rabbitm
 	}
 
 	result.ExchangeDeclareMode = strings.ToLower(result.ExchangeDeclareMode)
-	if !exchangeDeclareModeValid(result.ExchangeDeclareMode) {
-		return &result, fmt.Errorf("%s invalid RabbitMQ exchange declare mode %q, accepted values are %q and %q", errorMessagePrefix, result.ExchangeDeclareMode, exchangeDeclareModeDeclare, exchangeDeclareModePassive)
+	if !declareModeValid(result.ExchangeDeclareMode) {
+		return &result, fmt.Errorf("%s invalid RabbitMQ %s %q, accepted values are %q and %q", errorMessagePrefix, metadataExchangeDeclareModeKey, result.ExchangeDeclareMode, declareModeDeclare, declareModePassive)
+	}
+
+	result.QueueDeclareMode = strings.ToLower(result.QueueDeclareMode)
+	if !declareModeValid(result.QueueDeclareMode) {
+		return &result, fmt.Errorf("%s invalid RabbitMQ %s %q, accepted values are %q and %q", errorMessagePrefix, metadataQueueDeclareModeKey, result.QueueDeclareMode, declareModeDeclare, declareModePassive)
 	}
 
 	if err := validateExchangeKind(result.ExchangeKind, result.ExchangeDeclareMode); err != nil {
@@ -204,8 +219,8 @@ func (m *rabbitmqMetadata) formatQueueDeclareArgs(origin amqp.Table) amqp.Table 
 	return origin
 }
 
-func exchangeDeclareModeValid(mode string) bool {
-	return mode == exchangeDeclareModeDeclare || mode == exchangeDeclareModePassive
+func declareModeValid(mode string) bool {
+	return mode == declareModeDeclare || mode == declareModePassive
 }
 
 // exchangeKindValid reports whether the component is able to declare an
@@ -238,10 +253,17 @@ func validateExchangeKind(kind string, declareMode string) error {
 	return nil
 }
 
-// isPassiveExchangeDeclare reports whether the exchange topology is managed
-// outside of Dapr.
+// isPassiveExchangeDeclare reports whether exchanges are managed outside of
+// Dapr.
 func (m *rabbitmqMetadata) isPassiveExchangeDeclare() bool {
 	return m.ExchangeDeclareMode == exchangeDeclareModePassive
+}
+
+// isPassiveQueueDeclare reports whether queues and their bindings are managed
+// outside of Dapr. In that case the component neither declares the queue nor
+// binds it: the external owner is responsible for both.
+func (m *rabbitmqMetadata) isPassiveQueueDeclare() bool {
+	return m.QueueDeclareMode == queueDeclareModePassive
 }
 
 func (m *rabbitmqMetadata) connectionURI() string {

--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -16,6 +16,7 @@ package rabbitmq
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -46,6 +47,7 @@ type rabbitmqMetadata struct {
 	MaxLen                             int64                  `mapstructure:"maxLen"`
 	MaxLenBytes                        int64                  `mapstructure:"maxLenBytes"`
 	ExchangeKind                       string                 `mapstructure:"exchangeKind"`
+	ExchangeDeclareMode                string                 `mapstructure:"exchangeDeclareMode"`
 	ClientName                         string                 `mapstructure:"clientName"`
 	HeartBeat                          time.Duration          `mapstructure:"heartBeat"`
 	PublisherConfirm                   bool                   `mapstructure:"publisherConfirm"`
@@ -77,6 +79,7 @@ const (
 	metadataMaxLenKey                             = "maxLen"
 	metadataMaxLenBytesKey                        = "maxLenBytes"
 	metadataExchangeKindKey                       = "exchangeKind"
+	metadataExchangeDeclareModeKey                = "exchangeDeclareMode"
 	metadataPublisherConfirmKey                   = "publisherConfirm"
 	metadataSaslExternal                          = "saslExternal"
 	metadataMaxPriority                           = "maxPriority"
@@ -89,6 +92,22 @@ const (
 
 	protocolAMQP  = "amqp"
 	protocolAMQPS = "amqps"
+
+	// exchangeDeclareModeDeclare makes the component declare the exchange itself
+	// (an active AMQP exchange.declare). This is the default and the historical
+	// behavior.
+	exchangeDeclareModeDeclare = "declare"
+	// exchangeDeclareModePassive makes the component verify that the exchange
+	// already exists (a passive AMQP exchange.declare) without creating or
+	// modifying it. Use this when the topology is owned by something else, such
+	// as the RabbitMQ Cluster Kubernetes Topology Operator or Terraform.
+	exchangeDeclareModePassive = "passive"
+
+	// exchangeKindConsistentHash is the exchange type provided by the
+	// rabbitmq_consistent_hash_exchange plugin. It is not a built-in AMQP
+	// exchange type, so it is only usable against a broker with that plugin
+	// enabled.
+	exchangeKindConsistentHash = "x-consistent-hash"
 )
 
 // createMetadata creates a new instance from the pubsub metadata.
@@ -101,6 +120,7 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*rabbitm
 		AutoAck:                            false,
 		ReconnectWait:                      time.Duration(defaultReconnectWaitSeconds) * time.Second,
 		ExchangeKind:                       fanoutExchangeKind,
+		ExchangeDeclareMode:                exchangeDeclareModeDeclare,
 		PublisherConfirm:                   false,
 		SaslExternal:                       false,
 		HeartBeat:                          defaultHeartbeat,
@@ -139,8 +159,13 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*rabbitm
 		return &result, fmt.Errorf("%s invalid RabbitMQ delivery mode, accepted values are between 0 and 2", errorMessagePrefix)
 	}
 
-	if !exchangeKindValid(result.ExchangeKind) {
-		return &result, fmt.Errorf("%s invalid RabbitMQ exchange kind %s", errorMessagePrefix, result.ExchangeKind)
+	result.ExchangeDeclareMode = strings.ToLower(result.ExchangeDeclareMode)
+	if !exchangeDeclareModeValid(result.ExchangeDeclareMode) {
+		return &result, fmt.Errorf("%s invalid RabbitMQ exchange declare mode %q, accepted values are %q and %q", errorMessagePrefix, result.ExchangeDeclareMode, exchangeDeclareModeDeclare, exchangeDeclareModePassive)
+	}
+
+	if err := validateExchangeKind(result.ExchangeKind, result.ExchangeDeclareMode); err != nil {
+		return &result, err
 	}
 
 	ttl, ok, err := metadata.TryGetTTL(pubSubMetadata.Properties)
@@ -179,8 +204,44 @@ func (m *rabbitmqMetadata) formatQueueDeclareArgs(origin amqp.Table) amqp.Table 
 	return origin
 }
 
+func exchangeDeclareModeValid(mode string) bool {
+	return mode == exchangeDeclareModeDeclare || mode == exchangeDeclareModePassive
+}
+
+// exchangeKindValid reports whether the component is able to declare an
+// exchange of the given kind itself.
 func exchangeKindValid(kind string) bool {
-	return kind == amqp.ExchangeFanout || kind == amqp.ExchangeTopic || kind == amqp.ExchangeDirect || kind == amqp.ExchangeHeaders
+	switch kind {
+	case amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateExchangeKind checks exchangeKind against what the configured declare
+// mode allows. In passive mode the component never declares the exchange, so
+// any kind the broker supports (including plugin-provided kinds) is accepted.
+func validateExchangeKind(kind string, declareMode string) error {
+	if declareMode == exchangeDeclareModePassive {
+		if kind == "" {
+			return fmt.Errorf("%s %s cannot be empty", errorMessagePrefix, metadataExchangeKindKey)
+		}
+
+		return nil
+	}
+
+	if !exchangeKindValid(kind) {
+		return fmt.Errorf("%s invalid RabbitMQ exchange kind %q; the component can declare %s, %s, %s, %s and %s. To use an exchange of any other kind, create it out-of-band and set %s to %q", errorMessagePrefix, kind, amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash, metadataExchangeDeclareModeKey, exchangeDeclareModePassive)
+	}
+
+	return nil
+}
+
+// isPassiveExchangeDeclare reports whether the exchange topology is managed
+// outside of Dapr.
+func (m *rabbitmqMetadata) isPassiveExchangeDeclare() bool {
+	return m.ExchangeDeclareMode == exchangeDeclareModePassive
 }
 
 func (m *rabbitmqMetadata) connectionURI() string {

--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -179,7 +179,7 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*rabbitm
 		return &result, fmt.Errorf("%s invalid RabbitMQ %s %q, accepted values are %q and %q", errorMessagePrefix, metadataQueueDeclareModeKey, result.QueueDeclareMode, declareModeDeclare, declareModePassive)
 	}
 
-	if err := validateExchangeKind(result.ExchangeKind, result.ExchangeDeclareMode); err != nil {
+	if err := validateExchangeKind(result.ExchangeKind); err != nil {
 		return &result, err
 	}
 
@@ -223,8 +223,8 @@ func declareModeValid(mode string) bool {
 	return mode == declareModeDeclare || mode == declareModePassive
 }
 
-// exchangeKindValid reports whether the component is able to declare an
-// exchange of the given kind itself.
+// exchangeKindValid reports whether the component supports an exchange of the
+// given kind. Keep in sync with the exchangeKind allowedValues in metadata.yaml.
 func exchangeKindValid(kind string) bool {
 	switch kind {
 	case amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash:
@@ -234,20 +234,13 @@ func exchangeKindValid(kind string) bool {
 	}
 }
 
-// validateExchangeKind checks exchangeKind against what the configured declare
-// mode allows. In passive mode the component never declares the exchange, so
-// any kind the broker supports (including plugin-provided kinds) is accepted.
-func validateExchangeKind(kind string, declareMode string) error {
-	if declareMode == exchangeDeclareModePassive {
-		if kind == "" {
-			return fmt.Errorf("%s %s cannot be empty", errorMessagePrefix, metadataExchangeKindKey)
-		}
-
-		return nil
-	}
-
+// validateExchangeKind checks exchangeKind against the kinds this component
+// supports. The set is the same in both declare modes so that it matches the
+// allowedValues advertised in metadata.yaml, which the component metadata
+// schema treats as a hard allowlist.
+func validateExchangeKind(kind string) error {
 	if !exchangeKindValid(kind) {
-		return fmt.Errorf("%s invalid RabbitMQ exchange kind %q; the component can declare %s, %s, %s, %s and %s. To use an exchange of any other kind, create it out-of-band and set %s to %q", errorMessagePrefix, kind, amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash, metadataExchangeDeclareModeKey, exchangeDeclareModePassive)
+		return fmt.Errorf("%s invalid RabbitMQ exchange kind %q, accepted values are %s, %s, %s, %s and %s", errorMessagePrefix, kind, amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash)
 	}
 
 	return nil

--- a/pubsub/rabbitmq/metadata.go
+++ b/pubsub/rabbitmq/metadata.go
@@ -179,7 +179,7 @@ func createMetadata(pubSubMetadata pubsub.Metadata, log logger.Logger) (*rabbitm
 		return &result, fmt.Errorf("%s invalid RabbitMQ %s %q, accepted values are %q and %q", errorMessagePrefix, metadataQueueDeclareModeKey, result.QueueDeclareMode, declareModeDeclare, declareModePassive)
 	}
 
-	if err := validateExchangeKind(result.ExchangeKind); err != nil {
+	if err := validateExchangeKind(result.ExchangeKind, result.ExchangeDeclareMode); err != nil {
 		return &result, err
 	}
 
@@ -223,8 +223,8 @@ func declareModeValid(mode string) bool {
 	return mode == declareModeDeclare || mode == declareModePassive
 }
 
-// exchangeKindValid reports whether the component supports an exchange of the
-// given kind. Keep in sync with the exchangeKind allowedValues in metadata.yaml.
+// exchangeKindValid reports whether the component is able to declare an
+// exchange of the given kind itself.
 func exchangeKindValid(kind string) bool {
 	switch kind {
 	case amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash:
@@ -234,13 +234,23 @@ func exchangeKindValid(kind string) bool {
 	}
 }
 
-// validateExchangeKind checks exchangeKind against the kinds this component
-// supports. The set is the same in both declare modes so that it matches the
-// allowedValues advertised in metadata.yaml, which the component metadata
-// schema treats as a hard allowlist.
-func validateExchangeKind(kind string) error {
+// validateExchangeKind checks exchangeKind against what the configured declare
+// mode allows. In passive mode the component never declares the exchange and
+// RabbitMQ ignores the kind on a passive declare, so any kind the broker
+// supports - including plugin kinds this component cannot declare itself - is
+// accepted. The allowedValues in metadata.yaml therefore describe what can be
+// declared; they are not enforced at runtime.
+func validateExchangeKind(kind string, declareMode string) error {
+	if declareMode == exchangeDeclareModePassive {
+		if kind == "" {
+			return fmt.Errorf("%s %s cannot be empty", errorMessagePrefix, metadataExchangeKindKey)
+		}
+
+		return nil
+	}
+
 	if !exchangeKindValid(kind) {
-		return fmt.Errorf("%s invalid RabbitMQ exchange kind %q, accepted values are %s, %s, %s, %s and %s", errorMessagePrefix, kind, amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash)
+		return fmt.Errorf("%s invalid RabbitMQ exchange kind %q; the component can declare %s, %s, %s, %s and %s. To use an exchange of any other kind, create it out-of-band and set %s to %q", errorMessagePrefix, kind, amqp.ExchangeFanout, amqp.ExchangeTopic, amqp.ExchangeDirect, amqp.ExchangeHeaders, exchangeKindConsistentHash, metadataExchangeDeclareModeKey, exchangeDeclareModePassive)
 	}
 
 	return nil

--- a/pubsub/rabbitmq/metadata.yaml
+++ b/pubsub/rabbitmq/metadata.yaml
@@ -169,6 +169,22 @@ metadata:
       - "declare"
       - "passive"
     example: '"declare","passive"'
+  - name: queueDeclareMode
+    type: string
+    description: |
+      How the component obtains the queue for a subscription. "declare" creates
+      the queue and binds it to the exchange. "passive" only asserts that the
+      queue already exists, and leaves its bindings to the external owner; queue
+      arguments such as "maxLen", "maxPriority" and "queueType" are then the
+      owner's responsibility and are ignored by the component. Independent of
+      "exchangeDeclareMode": an operator-managed exchange is commonly paired with
+      queues the component still declares, because consumer queue names are only
+      known at runtime.
+    default: '"declare"'
+    allowedValues:
+      - "declare"
+      - "passive"
+    example: '"declare","passive"'
   - name: deliveryMode
     type: number
     description: |

--- a/pubsub/rabbitmq/metadata.yaml
+++ b/pubsub/rabbitmq/metadata.yaml
@@ -140,14 +140,35 @@ metadata:
   - name: exchangeKind
     type: string
     description: |
-      Exchange kind of the rabbitmq exchange.
+      Exchange kind of the rabbitmq exchange. "x-consistent-hash" requires the
+      rabbitmq_consistent_hash_exchange plugin to be enabled on the broker; with
+      it, the "routingKey" publish metadata is the partition key and the
+      "routingKey" subscription metadata is the queue's bucket weight.
+      When "exchangeDeclareMode" is "passive" any exchange kind supported by the
+      broker is accepted, because the component does not declare the exchange.
     default: '"fanout"'
     allowedValues:
       - "fanout"
       - "topic"
       - "direct"
       - "headers"
-    example: '"fanout","topic","direct","headers"'
+      - "x-consistent-hash"
+    example: '"fanout","topic","direct","headers","x-consistent-hash"'
+  - name: exchangeDeclareMode
+    type: string
+    description: |
+      How the component obtains the exchange for a topic. "declare" issues an
+      active AMQP exchange.declare, creating the exchange if it does not exist.
+      "passive" only asserts that the exchange already exists and never creates
+      or modifies it, which lets an external owner - such as the RabbitMQ Cluster
+      Kubernetes Topology Operator or Terraform - be the single source of truth
+      for the topology. In "passive" mode the dead-letter exchange must also
+      exist up front when "enableDeadLetter" is true.
+    default: '"declare"'
+    allowedValues:
+      - "declare"
+      - "passive"
+    example: '"declare","passive"'
   - name: deliveryMode
     type: number
     description: |

--- a/pubsub/rabbitmq/metadata.yaml
+++ b/pubsub/rabbitmq/metadata.yaml
@@ -144,8 +144,6 @@ metadata:
       rabbitmq_consistent_hash_exchange plugin to be enabled on the broker; with
       it, the "routingKey" publish metadata is the partition key and the
       "routingKey" subscription metadata is the queue's bucket weight.
-      When "exchangeDeclareMode" is "passive" any exchange kind supported by the
-      broker is accepted, because the component does not declare the exchange.
     default: '"fanout"'
     allowedValues:
       - "fanout"

--- a/pubsub/rabbitmq/metadata.yaml
+++ b/pubsub/rabbitmq/metadata.yaml
@@ -143,7 +143,10 @@ metadata:
       Exchange kind of the rabbitmq exchange. "x-consistent-hash" requires the
       rabbitmq_consistent_hash_exchange plugin to be enabled on the broker; with
       it, the "routingKey" publish metadata is the partition key and the
-      "routingKey" subscription metadata is the queue's bucket weight.
+      "routingKey" subscription metadata is the queue's single bucket weight.
+      When "exchangeDeclareMode" is "passive" any exchange kind the broker
+      supports is accepted, because the component does not declare the exchange
+      and RabbitMQ ignores the kind on a passive declare.
     default: '"fanout"'
     allowedValues:
       - "fanout"
@@ -160,8 +163,9 @@ metadata:
       "passive" only asserts that the exchange already exists and never creates
       or modifies it, which lets an external owner - such as the RabbitMQ Cluster
       Kubernetes Topology Operator or Terraform - be the single source of truth
-      for the topology. In "passive" mode the dead-letter exchange must also
-      exist up front when "enableDeadLetter" is true.
+      for the topology. This applies to the topic exchange only: the dead-letter
+      exchange is named after the consumer at runtime, so it follows
+      "queueDeclareMode" instead.
     default: '"declare"'
     allowedValues:
       - "declare"
@@ -171,10 +175,12 @@ metadata:
     type: string
     description: |
       How the component obtains the queue for a subscription. "declare" creates
-      the queue and binds it to the exchange. "passive" only asserts that the
-      queue already exists, and leaves its bindings to the external owner; queue
-      arguments such as "maxLen", "maxPriority" and "queueType" are then the
-      owner's responsibility and are ignored by the component. Independent of
+      the queue, its dead-letter objects when "enableDeadLetter" is true, and
+      binds them to their exchanges. "passive" only asserts that the queue
+      already exists, and leaves its bindings and its dead-lettering to the
+      external owner; queue arguments such as "maxLen", "maxPriority" and
+      "queueType", and "enableDeadLetter" itself, are then the owner's
+      responsibility and are ignored by the component. Independent of
       "exchangeDeclareMode": an operator-managed exchange is commonly paired with
       queues the component still declares, because consumer queue names are only
       known at runtime.

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -536,3 +536,90 @@ func TestConnectionURI(t *testing.T) {
 		assert.Equal(t, testCase.expectedOutput, m.connectionURI())
 	}
 }
+
+func TestCreateMetadataExchangeDeclareMode(t *testing.T) {
+	log := logger.NewLogger("test")
+
+	t.Run("defaults to declare", func(t *testing.T) {
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: getFakeProperties()}}, log)
+
+		require.NoError(t, err)
+		assert.Equal(t, exchangeDeclareModeDeclare, m.ExchangeDeclareMode)
+		assert.False(t, m.isPassiveExchangeDeclare())
+	})
+
+	validModes := map[string]string{
+		"declare": exchangeDeclareModeDeclare,
+		"passive": exchangeDeclareModePassive,
+		"Passive": exchangeDeclareModePassive,
+		"PASSIVE": exchangeDeclareModePassive,
+	}
+	for in, expected := range validModes {
+		t.Run("exchangeDeclareMode value="+in, func(t *testing.T) {
+			props := getFakeProperties()
+			props[metadataExchangeDeclareModeKey] = in
+
+			m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+			require.NoError(t, err)
+			assert.Equal(t, expected, m.ExchangeDeclareMode)
+			assert.Equal(t, expected == exchangeDeclareModePassive, m.isPassiveExchangeDeclare())
+		})
+	}
+
+	t.Run("exchangeDeclareMode is invalid", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeDeclareModeKey] = "use-existing"
+
+		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid RabbitMQ exchange declare mode")
+	})
+}
+
+func TestCreateMetadataExchangeKindWithDeclareMode(t *testing.T) {
+	log := logger.NewLogger("test")
+
+	t.Run("consistent hash is declarable", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = exchangeKindConsistentHash
+
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.NoError(t, err)
+		assert.Equal(t, exchangeKindConsistentHash, m.ExchangeKind)
+	})
+
+	t.Run("plugin exchange kind is rejected in declare mode", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = "x-delayed-message"
+
+		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
+	})
+
+	t.Run("plugin exchange kind is accepted in passive mode", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = "x-delayed-message"
+		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
+
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.NoError(t, err)
+		assert.Equal(t, "x-delayed-message", m.ExchangeKind)
+	})
+
+	t.Run("exchangeKind cannot be empty in passive mode", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = ""
+		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
+
+		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), metadataExchangeKindKey)
+	})
+}

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -574,7 +574,7 @@ func TestCreateMetadataExchangeDeclareMode(t *testing.T) {
 		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid RabbitMQ exchange declare mode")
+		assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
 	})
 }
 
@@ -621,5 +621,53 @@ func TestCreateMetadataExchangeKindWithDeclareMode(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), metadataExchangeKindKey)
+	})
+}
+
+func TestCreateMetadataQueueDeclareMode(t *testing.T) {
+	log := logger.NewLogger("test")
+
+	t.Run("defaults to declare", func(t *testing.T) {
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: getFakeProperties()}}, log)
+
+		require.NoError(t, err)
+		assert.Equal(t, queueDeclareModeDeclare, m.QueueDeclareMode)
+		assert.False(t, m.isPassiveQueueDeclare())
+	})
+
+	t.Run("passive is accepted", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataQueueDeclareModeKey] = "Passive"
+
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.NoError(t, err)
+		assert.Equal(t, queueDeclareModePassive, m.QueueDeclareMode)
+		assert.True(t, m.isPassiveQueueDeclare())
+	})
+
+	t.Run("queueDeclareMode is invalid", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataQueueDeclareModeKey] = "use-existing"
+
+		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), metadataQueueDeclareModeKey)
+	})
+
+	// The two knobs are independent: an operator-owned exchange paired with
+	// component-declared queues is the combination needed for per-pod consumer
+	// queues, whose names are only known at runtime.
+	t.Run("modes are independent", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
+		props[metadataExchangeKindKey] = exchangeKindConsistentHash
+
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.NoError(t, err)
+		assert.True(t, m.isPassiveExchangeDeclare())
+		assert.False(t, m.isPassiveQueueDeclare())
 	})
 }

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -591,37 +591,31 @@ func TestCreateMetadataExchangeKindWithDeclareMode(t *testing.T) {
 		assert.Equal(t, exchangeKindConsistentHash, m.ExchangeKind)
 	})
 
-	t.Run("plugin exchange kind is rejected in declare mode", func(t *testing.T) {
-		props := getFakeProperties()
-		props[metadataExchangeKindKey] = "x-delayed-message"
+	// The supported set is identical in both declare modes, so that it matches
+	// the allowedValues advertised in metadata.yaml.
+	for _, mode := range []string{exchangeDeclareModeDeclare, exchangeDeclareModePassive} {
+		t.Run("unsupported exchange kind is rejected in "+mode+" mode", func(t *testing.T) {
+			props := getFakeProperties()
+			props[metadataExchangeKindKey] = "x-delayed-message"
+			props[metadataExchangeDeclareModeKey] = mode
 
-		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+			_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
-	})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid RabbitMQ exchange kind")
+		})
 
-	t.Run("plugin exchange kind is accepted in passive mode", func(t *testing.T) {
-		props := getFakeProperties()
-		props[metadataExchangeKindKey] = "x-delayed-message"
-		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
+		t.Run("exchangeKind cannot be empty in "+mode+" mode", func(t *testing.T) {
+			props := getFakeProperties()
+			props[metadataExchangeKindKey] = ""
+			props[metadataExchangeDeclareModeKey] = mode
 
-		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+			_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
 
-		require.NoError(t, err)
-		assert.Equal(t, "x-delayed-message", m.ExchangeKind)
-	})
-
-	t.Run("exchangeKind cannot be empty in passive mode", func(t *testing.T) {
-		props := getFakeProperties()
-		props[metadataExchangeKindKey] = ""
-		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
-
-		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), metadataExchangeKindKey)
-	})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid RabbitMQ exchange kind")
+		})
+	}
 }
 
 func TestCreateMetadataQueueDeclareMode(t *testing.T) {

--- a/pubsub/rabbitmq/metadata_test.go
+++ b/pubsub/rabbitmq/metadata_test.go
@@ -591,31 +591,40 @@ func TestCreateMetadataExchangeKindWithDeclareMode(t *testing.T) {
 		assert.Equal(t, exchangeKindConsistentHash, m.ExchangeKind)
 	})
 
-	// The supported set is identical in both declare modes, so that it matches
-	// the allowedValues advertised in metadata.yaml.
-	for _, mode := range []string{exchangeDeclareModeDeclare, exchangeDeclareModePassive} {
-		t.Run("unsupported exchange kind is rejected in "+mode+" mode", func(t *testing.T) {
-			props := getFakeProperties()
-			props[metadataExchangeKindKey] = "x-delayed-message"
-			props[metadataExchangeDeclareModeKey] = mode
+	t.Run("kind the component cannot declare is rejected in declare mode", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = "x-delayed-message"
 
-			_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
 
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid RabbitMQ exchange kind")
-		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
+	})
 
-		t.Run("exchangeKind cannot be empty in "+mode+" mode", func(t *testing.T) {
-			props := getFakeProperties()
-			props[metadataExchangeKindKey] = ""
-			props[metadataExchangeDeclareModeKey] = mode
+	// RabbitMQ ignores the kind on a passive declare, so any kind the broker
+	// supports is usable that way. allowedValues in metadata.yaml documents
+	// what can be declared; it is not enforced at runtime.
+	t.Run("plugin exchange kind is accepted in passive mode", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = "x-delayed-message"
+		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
 
-			_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+		m, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
 
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid RabbitMQ exchange kind")
-		})
-	}
+		require.NoError(t, err)
+		assert.Equal(t, "x-delayed-message", m.ExchangeKind)
+	})
+
+	t.Run("exchangeKind cannot be empty in passive mode", func(t *testing.T) {
+		props := getFakeProperties()
+		props[metadataExchangeKindKey] = ""
+		props[metadataExchangeDeclareModeKey] = exchangeDeclareModePassive
+
+		_, err := createMetadata(pubsub.Metadata{Base: mdata.Base{Properties: props}}, log)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), metadataExchangeKindKey)
+	})
 }
 
 func TestCreateMetadataQueueDeclareMode(t *testing.T) {

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -67,6 +67,11 @@ const (
 	reqMetadataMaxLenBytesKey          = "maxLenBytes"
 )
 
+// errTerminalSubscription marks a subscription failure that retrying cannot
+// fix, because it is caused by the component or subscription configuration
+// rather than by the state of the broker.
+var errTerminalSubscription = errors.New("subscription configuration is not valid")
+
 // RabbitMQ allows sending/receiving messages in pub/sub format.
 type rabbitMQ struct {
 	connection        rabbitMQConnectionBroker
@@ -97,6 +102,7 @@ type rabbitMQChannelBroker interface {
 	Nack(tag uint64, multiple bool, requeue bool) error
 	Ack(tag uint64, multiple bool) error
 	ExchangeDeclare(name string, kind string, durable bool, autoDelete bool, internal bool, noWait bool, args amqp.Table) error
+	ExchangeDeclarePassive(name string, kind string, durable bool, autoDelete bool, internal bool, noWait bool, args amqp.Table) error
 	Qos(prefetchCount, prefetchSize int, global bool) error
 	Confirm(noWait bool) error
 	Close() error
@@ -159,6 +165,10 @@ func (r *rabbitMQ) Init(_ context.Context, metadata pubsub.Metadata) error {
 	}
 
 	r.metadata = meta
+
+	if meta.ExchangeKind == exchangeKindConsistentHash {
+		r.logger.Infof("%s exchange kind is %s: publishers must set the '%s' publish metadata to the partition key, and subscribers must set it to the queue's bucket weight", logMessagePrefix, exchangeKindConsistentHash, reqMetadataRoutingKey)
+	}
 
 	if err := r.reconnect(0); err != nil {
 		return err
@@ -372,6 +382,13 @@ func (r *rabbitMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, h
 
 // this function call should be wrapped by channelMutex.
 func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub.SubscribeRequest, queueName string) (*amqp.Queue, error) {
+	routingKeys := strings.Split(req.Metadata[reqMetadataRoutingKey], ",")
+	// Validated before anything is declared on the broker, so an unusable
+	// subscription never leaves a queue behind.
+	if err := r.validateBindingRoutingKeys(req.Topic, queueName, routingKeys); err != nil {
+		return nil, err
+	}
+
 	err := r.ensureExchangeDeclared(channel, req.Topic, r.metadata.ExchangeKind, r.metadata.Durable, r.metadata.DeleteWhenUnused)
 	if err != nil {
 		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in ensureExchangeDeclared: %v", logMessagePrefix, req.Topic, queueName, err)
@@ -484,11 +501,6 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		}
 	}
 
-	metadataRoutingKey := ""
-	if val, ok := req.Metadata[reqMetadataRoutingKey]; ok && val != "" {
-		metadataRoutingKey = val
-	}
-	routingKeys := strings.Split(metadataRoutingKey, ",")
 	for i := range routingKeys {
 		routingKey := routingKeys[i]
 		r.logger.Debugf("%s binding queue '%s' to exchange '%s' with routing key '%s'", logMessagePrefix, q.Name, req.Topic, routingKey)
@@ -501,6 +513,28 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 	}
 
 	return &q, nil
+}
+
+// validateBindingRoutingKeys rejects binding keys that the configured exchange
+// kind cannot accept, so that the failure is reported against the component
+// configuration rather than as an opaque channel error from the broker.
+func (r *rabbitMQ) validateBindingRoutingKeys(topic, queueName string, routingKeys []string) error {
+	if r.metadata.ExchangeKind != exchangeKindConsistentHash {
+		return nil
+	}
+
+	// For a consistent hash exchange the binding key is the weight of the bound
+	// queue, which must be a positive integer.
+	for _, routingKey := range routingKeys {
+		weight, err := strconv.ParseUint(strings.TrimSpace(routingKey), 10, 32)
+		if err != nil || weight == 0 {
+			return fmt.Errorf(
+				"%s prepareSubscription for topic/queue '%s/%s': exchange kind %s requires the '%s' subscription metadata to be a positive integer bucket weight, got %q: %w",
+				errorMessagePrefix, topic, queueName, exchangeKindConsistentHash, reqMetadataRoutingKey, routingKey, errTerminalSubscription)
+		}
+	}
+
+	return nil
 }
 
 func (r *rabbitMQ) ensureSubscription(req pubsub.SubscribeRequest, queueName string) (rabbitMQChannelBroker, int, *amqp.Queue, error) {
@@ -578,7 +612,7 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 			}
 		}
 
-		if err != nil && strings.Contains(err.Error(), errorInvalidQueueType) {
+		if err != nil && (errors.Is(err, errTerminalSubscription) || strings.Contains(err.Error(), errorInvalidQueueType)) {
 			if ackCh != nil {
 				ackCh <- true
 			}
@@ -689,19 +723,61 @@ func (r *rabbitMQ) handleMessage(ctx context.Context, d amqp.Delivery, topic str
 
 // this function call should be wrapped by channelMutex.
 func (r *rabbitMQ) ensureExchangeDeclared(channel rabbitMQChannelBroker, exchange, exchangeKind string, durable bool, autoDelete bool) error {
-	if !r.containsExchange(exchange) {
-		r.logger.Debugf("%s declaring exchange '%s' of kind '%s'", logMessagePrefix, exchange, exchangeKind)
-		err := channel.ExchangeDeclare(exchange, exchangeKind, durable, autoDelete, false, false, nil)
-		if err != nil {
-			r.logger.Errorf("%s ensureExchangeDeclared: channel.ExchangeDeclare failed: %v", logMessagePrefix, err)
-
-			return err
-		}
-
-		r.putExchange(exchange)
+	if r.containsExchange(exchange) {
+		return nil
 	}
 
+	var err error
+	if r.metadata.isPassiveExchangeDeclare() {
+		// The exchange is managed outside of Dapr: only assert that it exists.
+		// RabbitMQ ignores every argument but the name on a passive declare, so
+		// an externally created exchange of any kind - including plugin kinds
+		// such as x-consistent-hash - is accepted as-is.
+		r.logger.Debugf("%s passively declaring exchange '%s'", logMessagePrefix, exchange)
+		err = channel.ExchangeDeclarePassive(exchange, exchangeKind, durable, autoDelete, false, false, nil)
+	} else {
+		r.logger.Debugf("%s declaring exchange '%s' of kind '%s'", logMessagePrefix, exchange, exchangeKind)
+		err = channel.ExchangeDeclare(exchange, exchangeKind, durable, autoDelete, false, false, nil)
+	}
+	if err != nil {
+		err = r.decorateExchangeDeclareError(exchange, exchangeKind, durable, autoDelete, err)
+		r.logger.Errorf("%s ensureExchangeDeclared: %v", logMessagePrefix, err)
+
+		return err
+	}
+
+	r.putExchange(exchange)
+
 	return nil
+}
+
+// decorateExchangeDeclareError turns the two AMQP failures that are specific to
+// externally managed topologies into actionable messages. Any other error is
+// returned untouched.
+func (r *rabbitMQ) decorateExchangeDeclareError(exchange, exchangeKind string, durable, autoDelete bool, err error) error {
+	var amqpErr *amqp.Error
+	if !errors.As(err, &amqpErr) {
+		return err
+	}
+
+	switch amqpErr.Code {
+	case amqp.PreconditionFailed:
+		// The exchange already exists with different properties. Dapr's declare
+		// is idempotent only when every property matches.
+		return fmt.Errorf(
+			"%w: exchange '%s' already exists with properties that differ from the ones this component declares (kind=%s, durable=%t, autoDelete=%t). "+
+				"Either align the existing exchange with those properties, or set %s to %q so that this component uses the existing exchange instead of declaring its own",
+			err, exchange, exchangeKind, durable, autoDelete, metadataExchangeDeclareModeKey, exchangeDeclareModePassive)
+	case amqp.NotFound:
+		if r.metadata.isPassiveExchangeDeclare() {
+			return fmt.Errorf(
+				"%w: exchange '%s' does not exist and %s is %q, so this component will not create it. "+
+					"Create the exchange out-of-band (for example with the RabbitMQ Cluster Kubernetes Topology Operator), or remove %s to let this component declare it",
+				err, exchange, metadataExchangeDeclareModeKey, exchangeDeclareModePassive, metadataExchangeDeclareModeKey)
+		}
+	}
+
+	return err
 }
 
 // this function call should be wrapped by channelMutex.

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -96,6 +96,7 @@ type rabbitMQChannelBroker interface {
 	PublishWithContext(ctx context.Context, exchange string, key string, mandatory bool, immediate bool, msg amqp.Publishing) error
 	PublishWithDeferredConfirmWithContext(ctx context.Context, exchange string, key string, mandatory bool, immediate bool, msg amqp.Publishing) (*amqp.DeferredConfirmation, error)
 	QueueDeclare(name string, durable bool, autoDelete bool, exclusive bool, noWait bool, args amqp.Table) (amqp.Queue, error)
+	QueueDeclarePassive(name string, durable bool, autoDelete bool, exclusive bool, noWait bool, args amqp.Table) (amqp.Queue, error)
 	QueueBind(name string, key string, exchange string, noWait bool, args amqp.Table) error
 	Consume(queue string, consumer string, autoAck bool, exclusive bool, noLocal bool, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
 	Cancel(consumer string, noWait bool) error
@@ -396,7 +397,6 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		return nil, err
 	}
 
-	r.logger.Infof("%s declaring queue '%s'", logMessagePrefix, queueName)
 	var args amqp.Table
 	if r.metadata.EnableDeadLetter {
 		// declare dead letter exchange
@@ -413,19 +413,21 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		dlqArgs := r.metadata.formatQueueDeclareArgs(nil)
 		// dead letter queue use lazy mode, keeping as many messages as possible on disk to reduce RAM usage
 		dlqArgs[argQueueMode] = queueModeLazy
-		q, err = channel.QueueDeclare(dlqName, true, r.metadata.DeleteWhenUnused, false, false, dlqArgs)
+		q, err = r.declareQueue(channel, dlqName, true, r.metadata.DeleteWhenUnused, dlqArgs)
 		if err != nil {
-			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueDeclare: %v", logMessagePrefix, req.Topic, dlqName, err)
+			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in queue declare: %v", logMessagePrefix, req.Topic, dlqName, err)
 
 			return nil, err
 		}
-		err = channel.QueueBind(q.Name, "", dlxName, false, nil)
-		if err != nil {
-			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, dlqName, err)
+		if !r.metadata.isPassiveQueueDeclare() {
+			err = channel.QueueBind(q.Name, "", dlxName, false, nil)
+			if err != nil {
+				r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, dlqName, err)
 
-			return nil, err
+				return nil, err
+			}
+			r.logger.Infof("%s declared dead letter exchange for queue '%s' bind dead letter queue '%s' to dead letter exchange '%s'", logMessagePrefix, queueName, dlqName, dlxName)
 		}
-		r.logger.Infof("%s declared dead letter exchange for queue '%s' bind dead letter queue '%s' to dead letter exchange '%s'", logMessagePrefix, queueName, dlqName, dlxName)
 		args = amqp.Table{argDeadLetterExchange: dlxName}
 	}
 	args = r.metadata.formatQueueDeclareArgs(args)
@@ -484,9 +486,9 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		args[argMaxLength] = parsedVal
 	}
 
-	q, err := channel.QueueDeclare(queueName, r.metadata.Durable, r.metadata.DeleteWhenUnused, false, false, args)
+	q, err := r.declareQueue(channel, queueName, r.metadata.Durable, r.metadata.DeleteWhenUnused, args)
 	if err != nil {
-		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueDeclare: %v", logMessagePrefix, req.Topic, queueName, err)
+		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in queue declare: %v", logMessagePrefix, req.Topic, queueName, err)
 
 		return nil, err
 	}
@@ -501,24 +503,60 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		}
 	}
 
-	for i := range routingKeys {
-		routingKey := routingKeys[i]
-		r.logger.Debugf("%s binding queue '%s' to exchange '%s' with routing key '%s'", logMessagePrefix, q.Name, req.Topic, routingKey)
-		err = channel.QueueBind(q.Name, routingKey, req.Topic, false, nil)
-		if err != nil {
-			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, queueName, err)
+	if r.metadata.isPassiveQueueDeclare() {
+		// Bindings belong to whoever owns the queue.
+		r.logger.Debugf("%s %s is '%s': leaving the bindings of queue '%s' to their external owner", logMessagePrefix, metadataQueueDeclareModeKey, queueDeclareModePassive, q.Name)
+	} else {
+		for i := range routingKeys {
+			routingKey := routingKeys[i]
+			r.logger.Debugf("%s binding queue '%s' to exchange '%s' with routing key '%s'", logMessagePrefix, q.Name, req.Topic, routingKey)
+			err = channel.QueueBind(q.Name, routingKey, req.Topic, false, nil)
+			if err != nil {
+				r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, queueName, err)
 
-			return nil, err
+				return nil, err
+			}
 		}
 	}
 
 	return &q, nil
 }
 
+// declareQueue creates the queue, or asserts that an externally managed one
+// exists when queueDeclareMode is passive. RabbitMQ ignores every argument but
+// the name on a passive declare, so queue arguments are the external owner's
+// responsibility in that mode.
+func (r *rabbitMQ) declareQueue(channel rabbitMQChannelBroker, queueName string, durable, autoDelete bool, args amqp.Table) (amqp.Queue, error) {
+	if !r.metadata.isPassiveQueueDeclare() {
+		r.logger.Infof("%s declaring queue '%s'", logMessagePrefix, queueName)
+
+		return channel.QueueDeclare(queueName, durable, autoDelete, false, false, args)
+	}
+
+	r.logger.Debugf("%s passively declaring queue '%s'", logMessagePrefix, queueName)
+	q, err := channel.QueueDeclarePassive(queueName, durable, autoDelete, false, false, nil)
+	if err != nil {
+		var amqpErr *amqp.Error
+		if errors.As(err, &amqpErr) && amqpErr.Code == amqp.NotFound {
+			return q, fmt.Errorf(
+				"%w: queue '%s' does not exist and %s is %q, so this component will not create it. "+
+					"Create the queue and its bindings out-of-band (for example with the RabbitMQ Cluster Kubernetes Topology Operator), or remove %s to let this component declare them",
+				err, queueName, metadataQueueDeclareModeKey, queueDeclareModePassive, metadataQueueDeclareModeKey)
+		}
+	}
+
+	return q, err
+}
+
 // validateBindingRoutingKeys rejects binding keys that the configured exchange
 // kind cannot accept, so that the failure is reported against the component
 // configuration rather than as an opaque channel error from the broker.
 func (r *rabbitMQ) validateBindingRoutingKeys(topic, queueName string, routingKeys []string) error {
+	// Not our binding to make.
+	if r.metadata.isPassiveQueueDeclare() {
+		return nil
+	}
+
 	if r.metadata.ExchangeKind != exchangeKindConsistentHash {
 		return nil
 	}

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -350,7 +350,7 @@ func (r *rabbitMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, h
 	r.logger.Infof("%s subscribe to topic/queue '%s/%s'", logMessagePrefix, req.Topic, queueName)
 
 	// Do not set a timeout on the context, as we're just waiting for the first ack; we're using a semaphore instead
-	ackCh := make(chan bool, 1)
+	ackCh := make(chan error, 1)
 	defer close(ackCh)
 
 	subctx, cancel := context.WithCancel(ctx)
@@ -372,12 +372,12 @@ func (r *rabbitMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, h
 	select {
 	case <-time.After(time.Minute):
 		return fmt.Errorf("failed to subscribe to %s", queueName)
-	case failed := <-ackCh:
-		if failed {
-			return fmt.Errorf("error not retriable for %s", queueName)
-		} else {
-			return nil
+	case err := <-ackCh:
+		if err != nil {
+			return fmt.Errorf("error not retriable for %s: %w", queueName, err)
 		}
+
+		return nil
 	}
 }
 
@@ -395,6 +395,14 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in ensureExchangeDeclared: %v", logMessagePrefix, req.Topic, queueName, err)
 
 		return nil, err
+	}
+
+	// In passive mode the queue and its arguments belong to the external owner
+	// and RabbitMQ ignores every argument but the name, so none of the argument
+	// handling below applies - including its validation, which would otherwise
+	// reject queue types this component cannot declare but can consume from.
+	if r.metadata.isPassiveQueueDeclare() {
+		return r.preparePassiveSubscription(channel, req, queueName)
 	}
 
 	var args amqp.Table
@@ -419,15 +427,13 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 
 			return nil, err
 		}
-		if !r.metadata.isPassiveQueueDeclare() {
-			err = channel.QueueBind(q.Name, "", dlxName, false, nil)
-			if err != nil {
-				r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, dlqName, err)
+		err = channel.QueueBind(q.Name, "", dlxName, false, nil)
+		if err != nil {
+			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, dlqName, err)
 
-				return nil, err
-			}
-			r.logger.Infof("%s declared dead letter exchange for queue '%s' bind dead letter queue '%s' to dead letter exchange '%s'", logMessagePrefix, queueName, dlqName, dlxName)
+			return nil, err
 		}
+		r.logger.Infof("%s declared dead letter exchange for queue '%s' bind dead letter queue '%s' to dead letter exchange '%s'", logMessagePrefix, queueName, dlqName, dlxName)
 		args = amqp.Table{argDeadLetterExchange: dlxName}
 	}
 	args = r.metadata.formatQueueDeclareArgs(args)
@@ -503,21 +509,51 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		}
 	}
 
-	if r.metadata.isPassiveQueueDeclare() {
-		// Bindings belong to whoever owns the queue.
-		r.logger.Debugf("%s %s is '%s': leaving the bindings of queue '%s' to their external owner", logMessagePrefix, metadataQueueDeclareModeKey, queueDeclareModePassive, q.Name)
-	} else {
-		for i := range routingKeys {
-			routingKey := routingKeys[i]
-			r.logger.Debugf("%s binding queue '%s' to exchange '%s' with routing key '%s'", logMessagePrefix, q.Name, req.Topic, routingKey)
-			err = channel.QueueBind(q.Name, routingKey, req.Topic, false, nil)
-			if err != nil {
-				r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, queueName, err)
+	for i := range routingKeys {
+		routingKey := routingKeys[i]
+		r.logger.Debugf("%s binding queue '%s' to exchange '%s' with routing key '%s'", logMessagePrefix, q.Name, req.Topic, routingKey)
+		err = channel.QueueBind(q.Name, routingKey, req.Topic, false, nil)
+		if err != nil {
+			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.QueueBind: %v", logMessagePrefix, req.Topic, queueName, err)
 
-				return nil, err
-			}
+			return nil, err
 		}
 	}
+
+	return &q, nil
+}
+
+// preparePassiveSubscription binds to a queue that is managed outside of Dapr:
+// it asserts the queue (and, when dead lettering is enabled, the dead letter
+// queue) exists and applies QoS, leaving every declaration and binding to the
+// external owner.
+func (r *rabbitMQ) preparePassiveSubscription(channel rabbitMQChannelBroker, req pubsub.SubscribeRequest, queueName string) (*amqp.Queue, error) {
+	if r.metadata.EnableDeadLetter {
+		dlqName := fmt.Sprintf(defaultDeadLetterQueueFormat, queueName)
+		if _, err := r.declareQueue(channel, dlqName, true, r.metadata.DeleteWhenUnused, nil); err != nil {
+			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in queue declare: %v", logMessagePrefix, req.Topic, dlqName, err)
+
+			return nil, err
+		}
+	}
+
+	q, err := r.declareQueue(channel, queueName, r.metadata.Durable, r.metadata.DeleteWhenUnused, nil)
+	if err != nil {
+		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in queue declare: %v", logMessagePrefix, req.Topic, queueName, err)
+
+		return nil, err
+	}
+
+	if r.metadata.PrefetchCount > 0 {
+		r.logger.Infof("%s setting prefetch count to %s", logMessagePrefix, strconv.Itoa(int(r.metadata.PrefetchCount)))
+		if err = channel.Qos(int(r.metadata.PrefetchCount), 0, false); err != nil {
+			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in channel.Qos: %v", logMessagePrefix, req.Topic, queueName, err)
+
+			return nil, err
+		}
+	}
+
+	r.logger.Debugf("%s %s is '%s': leaving the bindings of queue '%s' to their external owner", logMessagePrefix, metadataQueueDeclareModeKey, queueDeclareModePassive, q.Name)
 
 	return &q, nil
 }
@@ -529,8 +565,18 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 func (r *rabbitMQ) declareQueue(channel rabbitMQChannelBroker, queueName string, durable, autoDelete bool, args amqp.Table) (amqp.Queue, error) {
 	if !r.metadata.isPassiveQueueDeclare() {
 		r.logger.Infof("%s declaring queue '%s'", logMessagePrefix, queueName)
+		q, err := channel.QueueDeclare(queueName, durable, autoDelete, false, false, args)
+		if err != nil {
+			var amqpErr *amqp.Error
+			if errors.As(err, &amqpErr) && amqpErr.Code == amqp.PreconditionFailed {
+				return q, fmt.Errorf(
+					"%w: queue '%s' already exists with properties that differ from the ones this component declares (durable=%t, autoDelete=%t, arguments=%v). "+
+						"Either align the existing queue with those properties, or set %s to %q so that this component uses the existing queue instead of declaring its own",
+					err, queueName, durable, autoDelete, args, metadataQueueDeclareModeKey, queueDeclareModePassive)
+			}
+		}
 
-		return channel.QueueDeclare(queueName, durable, autoDelete, false, false, args)
+		return q, err
 	}
 
 	r.logger.Debugf("%s passively declaring queue '%s'", logMessagePrefix, queueName)
@@ -563,8 +609,11 @@ func (r *rabbitMQ) validateBindingRoutingKeys(topic, queueName string, routingKe
 
 	// For a consistent hash exchange the binding key is the weight of the bound
 	// queue, which must be a positive integer.
+	// Validate the exact values that will be bound: trimming here but binding
+	// the original would let " 10 " pass and still reach the broker as a
+	// non-integer binding key.
 	for _, routingKey := range routingKeys {
-		weight, err := strconv.ParseUint(strings.TrimSpace(routingKey), 10, 32)
+		weight, err := strconv.ParseUint(routingKey, 10, 32)
 		if err != nil || weight == 0 {
 			return fmt.Errorf(
 				"%s prepareSubscription for topic/queue '%s/%s': exchange kind %s requires the '%s' subscription metadata to be a positive integer bucket weight, got %q: %w",
@@ -588,7 +637,7 @@ func (r *rabbitMQ) ensureSubscription(req pubsub.SubscribeRequest, queueName str
 	return r.channel, r.connectionCount, q, err
 }
 
-func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeRequest, queueName string, handler pubsub.Handler, ackCh chan bool) {
+func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeRequest, queueName string, handler pubsub.Handler, ackCh chan error) {
 	for {
 		var (
 			err             error
@@ -633,7 +682,7 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 
 			// one-time notification on successful subscribe
 			if ackCh != nil {
-				ackCh <- false
+				ackCh <- nil
 				ackCh = nil
 			}
 
@@ -651,8 +700,9 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 		}
 
 		if err != nil && (errors.Is(err, errTerminalSubscription) || strings.Contains(err.Error(), errorInvalidQueueType)) {
+			r.logger.Errorf("%s error in subscription for %s in %s, giving up: %v", logMessagePrefix, queueName, errFuncName, err)
 			if ackCh != nil {
-				ackCh <- true
+				ackCh <- err
 			}
 			return
 		}

--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -67,9 +67,12 @@ const (
 	reqMetadataMaxLenBytesKey          = "maxLenBytes"
 )
 
-// errTerminalSubscription marks a subscription failure that retrying cannot
-// fix, because it is caused by the component or subscription configuration
-// rather than by the state of the broker.
+// errTerminalSubscription marks a failure that retrying cannot fix, because it
+// is caused by the component or subscription configuration rather than by the
+// state of the broker. Retrying these is actively harmful on the subscribe
+// path: a failed declare is a channel exception, so the retry redials and
+// reset() drops the connection shared by every other subscription and
+// publisher on this component.
 var errTerminalSubscription = errors.New("subscription configuration is not valid")
 
 // RabbitMQ allows sending/receiving messages in pub/sub format.
@@ -236,7 +239,7 @@ func (r *rabbitMQ) publishSync(ctx context.Context, req *pubsub.PublishRequest) 
 		return r.channel, r.connectionCount, errors.New(errorChannelNotInitialized)
 	}
 
-	if err := r.ensureExchangeDeclared(r.channel, req.Topic, r.metadata.ExchangeKind, r.metadata.Durable, r.metadata.DeleteWhenUnused); err != nil {
+	if err := r.ensureExchangeDeclared(r.channel, req.Topic, r.metadata.ExchangeKind, r.metadata.Durable, r.metadata.DeleteWhenUnused, r.metadata.isPassiveExchangeDeclare()); err != nil {
 		r.logger.Errorf("%s publishing to %s failed in ensureExchangeDeclared: %v", logMessagePrefix, req.Topic, err)
 
 		return r.channel, r.connectionCount, err
@@ -350,8 +353,10 @@ func (r *rabbitMQ) Subscribe(ctx context.Context, req pubsub.SubscribeRequest, h
 	r.logger.Infof("%s subscribe to topic/queue '%s/%s'", logMessagePrefix, req.Topic, queueName)
 
 	// Do not set a timeout on the context, as we're just waiting for the first ack; we're using a semaphore instead
+	// Buffered and never closed: subscribeForever sends at most once, and
+	// closing here would race that send once the timeout below fires, which
+	// panics the sidecar.
 	ackCh := make(chan error, 1)
-	defer close(ackCh)
 
 	subctx, cancel := context.WithCancel(ctx)
 	r.wg.Add(2)
@@ -390,7 +395,7 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		return nil, err
 	}
 
-	err := r.ensureExchangeDeclared(channel, req.Topic, r.metadata.ExchangeKind, r.metadata.Durable, r.metadata.DeleteWhenUnused)
+	err := r.ensureExchangeDeclared(channel, req.Topic, r.metadata.ExchangeKind, r.metadata.Durable, r.metadata.DeleteWhenUnused, r.metadata.isPassiveExchangeDeclare())
 	if err != nil {
 		r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in ensureExchangeDeclared: %v", logMessagePrefix, req.Topic, queueName, err)
 
@@ -411,7 +416,10 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 		dlxName := fmt.Sprintf(defaultDeadLetterExchangeFormat, queueName)
 		dlqName := fmt.Sprintf(defaultDeadLetterQueueFormat, queueName)
 		// dead letter exchange is always durable
-		err = r.ensureExchangeDeclared(channel, dlxName, fanoutExchangeKind, true, r.metadata.DeleteWhenUnused)
+		// The dead letter exchange is named from consumerID and topic at
+		// runtime, so it is this component's object regardless of who owns the
+		// topic exchange: always declare it actively.
+		err = r.ensureExchangeDeclared(channel, dlxName, fanoutExchangeKind, true, r.metadata.DeleteWhenUnused, false)
 		if err != nil {
 			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in ensureExchangeDeclared: %v", logMessagePrefix, req.Topic, dlqName, err)
 
@@ -528,13 +536,12 @@ func (r *rabbitMQ) prepareSubscription(channel rabbitMQChannelBroker, req pubsub
 // queue) exists and applies QoS, leaving every declaration and binding to the
 // external owner.
 func (r *rabbitMQ) preparePassiveSubscription(channel rabbitMQChannelBroker, req pubsub.SubscribeRequest, queueName string) (*amqp.Queue, error) {
+	// Dead lettering is part of the queue's definition, so under a passive
+	// queue it belongs entirely to the external owner: the component neither
+	// declares nor asserts the dead letter objects, and does not require them
+	// to follow its own naming convention.
 	if r.metadata.EnableDeadLetter {
-		dlqName := fmt.Sprintf(defaultDeadLetterQueueFormat, queueName)
-		if _, err := r.declareQueue(channel, dlqName, true, r.metadata.DeleteWhenUnused, nil); err != nil {
-			r.logger.Errorf("%s prepareSubscription for topic/queue '%s/%s' failed in queue declare: %v", logMessagePrefix, req.Topic, dlqName, err)
-
-			return nil, err
-		}
+		r.logger.Warnf("%s %s is '%s': %s is ignored, dead lettering is part of the externally managed definition of queue '%s'", logMessagePrefix, metadataQueueDeclareModeKey, queueDeclareModePassive, metadataEnableDeadLetterKey, queueName)
 	}
 
 	q, err := r.declareQueue(channel, queueName, r.metadata.Durable, r.metadata.DeleteWhenUnused, nil)
@@ -571,8 +578,8 @@ func (r *rabbitMQ) declareQueue(channel rabbitMQChannelBroker, queueName string,
 			if errors.As(err, &amqpErr) && amqpErr.Code == amqp.PreconditionFailed {
 				return q, fmt.Errorf(
 					"%w: queue '%s' already exists with properties that differ from the ones this component declares (durable=%t, autoDelete=%t, arguments=%v). "+
-						"Either align the existing queue with those properties, or set %s to %q so that this component uses the existing queue instead of declaring its own",
-					err, queueName, durable, autoDelete, args, metadataQueueDeclareModeKey, queueDeclareModePassive)
+						"Either align the existing queue with those properties, or set %s to %q so that this component uses the existing queue instead of declaring its own: %w",
+					err, queueName, durable, autoDelete, args, metadataQueueDeclareModeKey, queueDeclareModePassive, errTerminalSubscription)
 			}
 		}
 
@@ -586,8 +593,8 @@ func (r *rabbitMQ) declareQueue(channel rabbitMQChannelBroker, queueName string,
 		if errors.As(err, &amqpErr) && amqpErr.Code == amqp.NotFound {
 			return q, fmt.Errorf(
 				"%w: queue '%s' does not exist and %s is %q, so this component will not create it. "+
-					"Create the queue and its bindings out-of-band (for example with the RabbitMQ Cluster Kubernetes Topology Operator), or remove %s to let this component declare them",
-				err, queueName, metadataQueueDeclareModeKey, queueDeclareModePassive, metadataQueueDeclareModeKey)
+					"Create the queue and its bindings out-of-band (for example with the RabbitMQ Cluster Kubernetes Topology Operator), or remove %s to let this component declare them: %w",
+				err, queueName, metadataQueueDeclareModeKey, queueDeclareModePassive, metadataQueueDeclareModeKey, errTerminalSubscription)
 		}
 	}
 
@@ -605,6 +612,15 @@ func (r *rabbitMQ) validateBindingRoutingKeys(topic, queueName string, routingKe
 
 	if r.metadata.ExchangeKind != exchangeKindConsistentHash {
 		return nil
+	}
+
+	// A consistent hash exchange has one effective ring binding per
+	// destination, so a list of weights would silently leave only one of them
+	// in force.
+	if len(routingKeys) != 1 {
+		return fmt.Errorf(
+			"%s prepareSubscription for topic/queue '%s/%s': exchange kind %s takes exactly one '%s' value, the bucket weight of this queue, got %d: %w",
+			errorMessagePrefix, topic, queueName, exchangeKindConsistentHash, reqMetadataRoutingKey, len(routingKeys), errTerminalSubscription)
 	}
 
 	// For a consistent hash exchange the binding key is the weight of the bound
@@ -810,13 +826,13 @@ func (r *rabbitMQ) handleMessage(ctx context.Context, d amqp.Delivery, topic str
 }
 
 // this function call should be wrapped by channelMutex.
-func (r *rabbitMQ) ensureExchangeDeclared(channel rabbitMQChannelBroker, exchange, exchangeKind string, durable bool, autoDelete bool) error {
+func (r *rabbitMQ) ensureExchangeDeclared(channel rabbitMQChannelBroker, exchange, exchangeKind string, durable bool, autoDelete bool, passive bool) error {
 	if r.containsExchange(exchange) {
 		return nil
 	}
 
 	var err error
-	if r.metadata.isPassiveExchangeDeclare() {
+	if passive {
 		// The exchange is managed outside of Dapr: only assert that it exists.
 		// RabbitMQ ignores every argument but the name on a passive declare, so
 		// an externally created exchange of any kind - including plugin kinds
@@ -828,7 +844,7 @@ func (r *rabbitMQ) ensureExchangeDeclared(channel rabbitMQChannelBroker, exchang
 		err = channel.ExchangeDeclare(exchange, exchangeKind, durable, autoDelete, false, false, nil)
 	}
 	if err != nil {
-		err = r.decorateExchangeDeclareError(exchange, exchangeKind, durable, autoDelete, err)
+		err = r.decorateExchangeDeclareError(exchange, exchangeKind, durable, autoDelete, passive, err)
 		r.logger.Errorf("%s ensureExchangeDeclared: %v", logMessagePrefix, err)
 
 		return err
@@ -842,7 +858,7 @@ func (r *rabbitMQ) ensureExchangeDeclared(channel rabbitMQChannelBroker, exchang
 // decorateExchangeDeclareError turns the two AMQP failures that are specific to
 // externally managed topologies into actionable messages. Any other error is
 // returned untouched.
-func (r *rabbitMQ) decorateExchangeDeclareError(exchange, exchangeKind string, durable, autoDelete bool, err error) error {
+func (r *rabbitMQ) decorateExchangeDeclareError(exchange, exchangeKind string, durable, autoDelete, passive bool, err error) error {
 	var amqpErr *amqp.Error
 	if !errors.As(err, &amqpErr) {
 		return err
@@ -854,14 +870,14 @@ func (r *rabbitMQ) decorateExchangeDeclareError(exchange, exchangeKind string, d
 		// is idempotent only when every property matches.
 		return fmt.Errorf(
 			"%w: exchange '%s' already exists with properties that differ from the ones this component declares (kind=%s, durable=%t, autoDelete=%t). "+
-				"Either align the existing exchange with those properties, or set %s to %q so that this component uses the existing exchange instead of declaring its own",
-			err, exchange, exchangeKind, durable, autoDelete, metadataExchangeDeclareModeKey, exchangeDeclareModePassive)
+				"Either align the existing exchange with those properties, or set %s to %q so that this component uses the existing exchange instead of declaring its own: %w",
+			err, exchange, exchangeKind, durable, autoDelete, metadataExchangeDeclareModeKey, exchangeDeclareModePassive, errTerminalSubscription)
 	case amqp.NotFound:
-		if r.metadata.isPassiveExchangeDeclare() {
+		if passive {
 			return fmt.Errorf(
 				"%w: exchange '%s' does not exist and %s is %q, so this component will not create it. "+
-					"Create the exchange out-of-band (for example with the RabbitMQ Cluster Kubernetes Topology Operator), or remove %s to let this component declare it",
-				err, exchange, metadataExchangeDeclareModeKey, exchangeDeclareModePassive, metadataExchangeDeclareModeKey)
+					"Create the exchange out-of-band (for example with the RabbitMQ Cluster Kubernetes Topology Operator), or remove %s to let this component declare it: %w",
+				err, exchange, metadataExchangeDeclareModeKey, exchangeDeclareModePassive, metadataExchangeDeclareModeKey, errTerminalSubscription)
 		}
 	}
 
@@ -935,6 +951,13 @@ func mustReconnect(channel rabbitMQChannelBroker, err error) bool {
 
 	if err == nil {
 		return false
+	}
+
+	// Any AMQP error is a channel exception, so the broker has already closed
+	// the channel even when the message does not say so.
+	var amqpErr *amqp.Error
+	if errors.As(err, &amqpErr) {
+		return true
 	}
 
 	return strings.Contains(err.Error(), errorChannelConnection)

--- a/pubsub/rabbitmq/rabbitmq_integration_test.go
+++ b/pubsub/rabbitmq/rabbitmq_integration_test.go
@@ -19,6 +19,7 @@ package rabbitmq
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -209,4 +210,252 @@ func publishN(t *testing.T, r pubsub.PubSub, topic string, n int) {
 		})
 		require.NoError(t, err)
 	}
+}
+
+// declareExchangeOutOfBand creates an exchange the way an external owner (the
+// RabbitMQ Cluster Kubernetes Topology Operator, Terraform, rabbitmqadmin)
+// would, i.e. without any involvement from the component.
+func declareExchangeOutOfBand(t *testing.T, name, kind string, args amqp.Table) {
+	t.Helper()
+
+	conn, err := amqp.Dial(testRabbitMQURL)
+	require.NoError(t, err, "RabbitMQ must be running at %s", testRabbitMQURL)
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	require.NoError(t, err)
+	defer ch.Close()
+
+	// durable, not auto-deleted: the properties an operator-managed exchange
+	// normally has, and deliberately different from what the component would
+	// declare by default (fanout, autoDelete=true).
+	err = ch.ExchangeDeclare(name, kind, true, false, false, false, args)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		conn, err := amqp.Dial(testRabbitMQURL)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		ch, err := conn.Channel()
+		if err != nil {
+			return
+		}
+		defer ch.Close()
+		_ = ch.ExchangeDelete(name, false, false)
+	})
+}
+
+// TestPassiveExchangeDeclareUsesExistingExchange verifies that a component
+// configured with exchangeDeclareMode=passive binds to an exchange it did not
+// create, instead of trying to declare its own.
+func TestPassiveExchangeDeclareUsesExistingExchange(t *testing.T) {
+	const topic = "passive-topic"
+	declareExchangeOutOfBand(t, topic, amqp.ExchangeTopic, nil)
+
+	log := logger.NewLogger("test")
+	r := NewRabbitMQ(log).(*rabbitMQ)
+	err := r.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataConnectionStringKey:    testRabbitMQURL,
+			metadataConsumerIDKey:          "passive-test",
+			metadataExchangeDeclareModeKey: exchangeDeclareModePassive,
+			metadataExchangeKindKey:        amqp.ExchangeTopic,
+			metadataDurableKey:             "true",
+			metadataDeleteWhenUnusedKey:    "false",
+		},
+	}})
+	require.NoError(t, err)
+	defer r.Close()
+
+	var received atomic.Int32
+	err = r.Subscribe(t.Context(), pubsub.SubscribeRequest{
+		Topic:    topic,
+		Metadata: map[string]string{reqMetadataRoutingKey: "orders.#"},
+	}, func(_ context.Context, msg *pubsub.NewMessage) error {
+		received.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	for i := range 5 {
+		err = r.Publish(t.Context(), &pubsub.PublishRequest{
+			Topic:    topic,
+			Data:     []byte(fmt.Sprintf("msg-%d", i)),
+			Metadata: map[string]string{reqMetadataRoutingKey: "orders.created"},
+		})
+		require.NoError(t, err)
+	}
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 5
+	}, 10*time.Second, 100*time.Millisecond, "messages published through an externally managed exchange should be delivered")
+}
+
+// TestActiveExchangeDeclareCollidesWithExistingExchange documents the failure
+// that exchangeDeclareMode=passive exists to avoid: an exchange created by an
+// external owner with different properties makes the component's own
+// exchange.declare fail with PRECONDITION_FAILED.
+func TestActiveExchangeDeclareCollidesWithExistingExchange(t *testing.T) {
+	const topic = "collision-topic"
+	declareExchangeOutOfBand(t, topic, amqp.ExchangeTopic, nil)
+
+	log := logger.NewLogger("test")
+	r := NewRabbitMQ(log).(*rabbitMQ)
+	err := r.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataConnectionStringKey: testRabbitMQURL,
+			metadataConsumerIDKey:       "collision-test",
+			// Defaults: fanout, autoDelete=true. Every property differs from
+			// the exchange declared above.
+		},
+	}})
+	require.NoError(t, err)
+	defer r.Close()
+
+	err = r.Publish(t.Context(), &pubsub.PublishRequest{Topic: topic, Data: []byte("msg")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists with properties that differ")
+	assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
+}
+
+// TestPassiveExchangeDeclareMissingExchange verifies that a passive component
+// reports a clear error rather than silently creating the exchange.
+func TestPassiveExchangeDeclareMissingExchange(t *testing.T) {
+	log := logger.NewLogger("test")
+	r := NewRabbitMQ(log).(*rabbitMQ)
+	err := r.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataConnectionStringKey:    testRabbitMQURL,
+			metadataConsumerIDKey:          "passive-missing-test",
+			metadataExchangeDeclareModeKey: exchangeDeclareModePassive,
+			metadataExchangeKindKey:        amqp.ExchangeTopic,
+		},
+	}})
+	require.NoError(t, err)
+	defer r.Close()
+
+	err = r.Publish(t.Context(), &pubsub.PublishRequest{Topic: "no-such-exchange", Data: []byte("msg")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+// consistentHashPluginEnabled reports whether the broker has the
+// rabbitmq_consistent_hash_exchange plugin enabled.
+func consistentHashPluginEnabled(t *testing.T) bool {
+	t.Helper()
+
+	conn, err := amqp.Dial(testRabbitMQURL)
+	require.NoError(t, err, "RabbitMQ must be running at %s", testRabbitMQURL)
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	require.NoError(t, err)
+
+	const probe = "consistent-hash-probe"
+	if err = ch.ExchangeDeclare(probe, exchangeKindConsistentHash, false, true, false, false, nil); err != nil {
+		return false
+	}
+
+	_ = ch.ExchangeDelete(probe, false, false)
+	_ = ch.Close()
+
+	return true
+}
+
+// TestConsistentHashExchangePartitionsByRoutingKey verifies partitioned
+// ordering: messages sharing a routing key always land on the same queue, while
+// the key space as a whole is spread across the bound queues.
+func TestConsistentHashExchangePartitionsByRoutingKey(t *testing.T) {
+	if !consistentHashPluginEnabled(t) {
+		t.Skip("rabbitmq_consistent_hash_exchange plugin is not enabled on the broker")
+	}
+
+	const topic = "consistent-hash-topic"
+	declareExchangeOutOfBand(t, topic, exchangeKindConsistentHash, nil)
+
+	log := logger.NewLogger("test")
+	r := NewRabbitMQ(log).(*rabbitMQ)
+	err := r.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataConnectionStringKey:    testRabbitMQURL,
+			metadataConsumerIDKey:          "consistent-hash-test",
+			metadataExchangeDeclareModeKey: exchangeDeclareModePassive,
+			metadataExchangeKindKey:        exchangeKindConsistentHash,
+			metadataDurableKey:             "true",
+			metadataDeleteWhenUnusedKey:    "false",
+			// Strict in-order processing within each partition.
+			pubsub.ConcurrencyKey: string(pubsub.Single),
+		},
+	}})
+	require.NoError(t, err)
+	defer r.Close()
+
+	const numPartitions = 2
+	var (
+		mu       sync.Mutex
+		received = make(map[string][]string, numPartitions) // partition queue -> keys seen
+		total    atomic.Int32
+	)
+
+	for i := range numPartitions {
+		queueName := fmt.Sprintf("consistent-hash-partition-%d", i)
+		err = r.Subscribe(t.Context(), pubsub.SubscribeRequest{
+			Topic: topic,
+			Metadata: map[string]string{
+				metadataQueueNameKey: queueName,
+				// For a consistent hash exchange the binding key is the
+				// bucket weight of the bound queue.
+				reqMetadataRoutingKey: "1",
+			},
+		}, func(_ context.Context, msg *pubsub.NewMessage) error {
+			mu.Lock()
+			received[queueName] = append(received[queueName], string(msg.Data))
+			mu.Unlock()
+			total.Add(1)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	const numKeys = 20
+	const msgsPerKey = 5
+	for k := range numKeys {
+		key := fmt.Sprintf("key-%d", k)
+		for i := range msgsPerKey {
+			err = r.Publish(t.Context(), &pubsub.PublishRequest{
+				Topic:    topic,
+				Data:     []byte(fmt.Sprintf("%s/%d", key, i)),
+				Metadata: map[string]string{reqMetadataRoutingKey: key},
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		return total.Load() >= numKeys*msgsPerKey
+	}, 30*time.Second, 100*time.Millisecond, "every published message should be delivered exactly once")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Each key must be handled by exactly one partition, otherwise per-key
+	// ordering is not preserved.
+	keyToQueue := make(map[string]string, numKeys)
+	for queueName, msgs := range received {
+		for _, msg := range msgs {
+			key := strings.Split(msg, "/")[0]
+			if prev, ok := keyToQueue[key]; ok {
+				assert.Equalf(t, prev, queueName, "key %s was delivered to more than one partition", key)
+				continue
+			}
+			keyToQueue[key] = queueName
+		}
+	}
+	assert.Len(t, keyToQueue, numKeys)
+
+	// And the key space must actually be spread, otherwise the exchange is not
+	// hashing on the routing key at all.
+	assert.Len(t, received, numPartitions, "keys should be spread across every bound partition")
 }

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -979,6 +979,7 @@ func TestConsistentHashBindingRoutingKey(t *testing.T) {
 		{name: "zero weight", routingKey: "0", wantErr: true},
 		{name: "valid weight", routingKey: "10", wantErr: false},
 		{name: "multiple valid weights", routingKey: "10,20", wantErr: false},
+		{name: "padded weight", routingKey: " 10 ", wantErr: true},
 		{name: "one invalid weight", routingKey: "10,orders", wantErr: true},
 	}
 
@@ -1135,4 +1136,87 @@ func TestDecorateExchangeDeclareErrorPassesThroughUnrelatedErrors(t *testing.T) 
 			assert.Equal(t, tt.err, got)
 		})
 	}
+}
+
+// TestSubscribeSurfacesTerminalError verifies that a subscription rejected for
+// a configuration reason reports why, instead of a bare "not retriable".
+func TestSubscribeSurfacesTerminalError(t *testing.T) {
+	broker := newBroker()
+	pubsubRabbitMQ := newRabbitMQTest(broker)
+	metadata := pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataHostnameKey:     "anyhost",
+			metadataConsumerIDKey:   "consumer",
+			metadataExchangeKindKey: exchangeKindConsistentHash,
+		},
+	}}
+	require.NoError(t, pubsubRabbitMQ.Init(t.Context(), metadata))
+
+	// No routingKey, so no bucket weight for the consistent hash binding.
+	err := pubsubRabbitMQ.Subscribe(t.Context(), pubsub.SubscribeRequest{Topic: "mytopic"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not retriable")
+	assert.Contains(t, err.Error(), reqMetadataRoutingKey, "the reason must reach the caller, not just the retry loop")
+	assert.Contains(t, err.Error(), exchangeKindConsistentHash)
+}
+
+// TestActiveQueueDeclarePreconditionFailed verifies that a queue property
+// mismatch points at the mode that resolves it, as exchange declares do.
+func TestActiveQueueDeclarePreconditionFailed(t *testing.T) {
+	broker := newBroker()
+	broker.queueDeclareErr = &amqp.Error{Code: amqp.PreconditionFailed, Reason: "PRECONDITION_FAILED - inequivalent arg 'durable'"}
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        amqp.ExchangeTopic,
+		ExchangeDeclareMode: exchangeDeclareModeDeclare,
+		QueueDeclareMode:    queueDeclareModeDeclare,
+	})
+
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "consumer-mytopic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists with properties that differ")
+	assert.Contains(t, err.Error(), metadataQueueDeclareModeKey)
+}
+
+// TestPassiveQueueDeclareIgnoresQueueArguments verifies that queue arguments
+// are neither validated nor sent when the queue belongs to someone else. A
+// queue type this component cannot declare must still be consumable.
+func TestPassiveQueueDeclareIgnoresQueueArguments(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        amqp.ExchangeTopic,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+		QueueDeclareMode:    queueDeclareModePassive,
+	})
+
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{
+		Topic: "mytopic",
+		Metadata: map[string]string{
+			reqMetadataQueueTypeKey: "stream", // neither classic nor quorum
+			metadataMaxPriority:     "5",
+			reqMetadataMaxLenKey:    "100",
+		},
+	}, "operator-owned-queue")
+
+	require.NoError(t, err, "queue arguments belong to the external owner and must not be validated")
+	assert.Equal(t, []string{"operator-owned-queue"}, broker.passiveQueueDeclares)
+	assert.Empty(t, broker.boundRoutingKeys)
+}
+
+// TestActiveQueueDeclareStillValidatesQueueType guards the counterpart: when
+// this component declares the queue, an unsupported type is still rejected.
+func TestActiveQueueDeclareStillValidatesQueueType(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        amqp.ExchangeTopic,
+		ExchangeDeclareMode: exchangeDeclareModeDeclare,
+		QueueDeclareMode:    queueDeclareModeDeclare,
+	})
+
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{
+		Topic:    "mytopic",
+		Metadata: map[string]string{reqMetadataQueueTypeKey: "stream"},
+	}, "consumer-mytopic")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errorInvalidQueueType)
 }

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -559,12 +560,23 @@ func createAMQPMessage(body []byte) amqp.Delivery {
 	return amqp.Delivery{Body: body}
 }
 
+type declaredExchange struct {
+	name       string
+	kind       string
+	durable    bool
+	autoDelete bool
+	passive    bool
+}
+
 type rabbitMQInMemoryBroker struct {
-	buffer          chan amqp.Delivery
-	declaredQueues  []string
-	connectCount    atomic.Int32
-	closeCount      atomic.Int32
-	lastMsgMetadata *amqp.Publishing // Add this field to capture the last message metadata
+	buffer             chan amqp.Delivery
+	declaredQueues     []string
+	declaredExchanges  []declaredExchange
+	boundRoutingKeys   []string
+	connectCount       atomic.Int32
+	closeCount         atomic.Int32
+	lastMsgMetadata    *amqp.Publishing // Add this field to capture the last message metadata
+	exchangeDeclareErr error
 }
 
 func (r *rabbitMQInMemoryBroker) Qos(prefetchCount, prefetchSize int, global bool) error {
@@ -603,6 +615,7 @@ func (r *rabbitMQInMemoryBroker) QueueDeclare(name string, durable bool, autoDel
 }
 
 func (r *rabbitMQInMemoryBroker) QueueBind(name string, key string, exchange string, noWait bool, args amqp.Table) error {
+	r.boundRoutingKeys = append(r.boundRoutingKeys, key)
 	return nil
 }
 
@@ -623,7 +636,13 @@ func (r *rabbitMQInMemoryBroker) Ack(tag uint64, multiple bool) error {
 }
 
 func (r *rabbitMQInMemoryBroker) ExchangeDeclare(name string, kind string, durable bool, autoDelete bool, internal bool, noWait bool, args amqp.Table) error {
-	return nil
+	r.declaredExchanges = append(r.declaredExchanges, declaredExchange{name: name, kind: kind, durable: durable, autoDelete: autoDelete})
+	return r.exchangeDeclareErr
+}
+
+func (r *rabbitMQInMemoryBroker) ExchangeDeclarePassive(name string, kind string, durable bool, autoDelete bool, internal bool, noWait bool, args amqp.Table) error {
+	r.declaredExchanges = append(r.declaredExchanges, declaredExchange{name: name, kind: kind, durable: durable, autoDelete: autoDelete, passive: true})
+	return r.exchangeDeclareErr
 }
 
 func (r *rabbitMQInMemoryBroker) Confirm(noWait bool) error {
@@ -835,4 +854,167 @@ func TestPublishMessagePropertiesToMetadataFlag(t *testing.T) {
 		assert.Equal(t, topicName, receivedMsg.Topic)
 		assert.Empty(t, receivedMsg.Metadata, "Metadata should be empty when flag is not set (defaults to false)")
 	})
+}
+
+func newRabbitMQForExchangeTest(broker *rabbitMQInMemoryBroker, meta *rabbitmqMetadata) *rabbitMQ {
+	return &rabbitMQ{
+		declaredExchanges: make(map[string]bool),
+		logger:            logger.NewLogger("test"),
+		metadata:          meta,
+		channel:           broker,
+		closeCh:           make(chan struct{}),
+	}
+}
+
+// TestEnsureExchangeDeclaredActive verifies that the default declare mode still
+// issues an active exchange.declare.
+func TestEnsureExchangeDeclaredActive(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        fanoutExchangeKind,
+		ExchangeDeclareMode: exchangeDeclareModeDeclare,
+	})
+
+	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true))
+	require.Len(t, broker.declaredExchanges, 1)
+	assert.Equal(t, "mytopic", broker.declaredExchanges[0].name)
+	assert.False(t, broker.declaredExchanges[0].passive)
+
+	// The exchange is cached, so a second call is a no-op.
+	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true))
+	assert.Len(t, broker.declaredExchanges, 1)
+}
+
+// TestEnsureExchangeDeclaredPassive verifies that passive mode only asserts that
+// the externally managed exchange exists.
+func TestEnsureExchangeDeclaredPassive(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        exchangeKindConsistentHash,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+	})
+
+	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", exchangeKindConsistentHash, true, true))
+	require.Len(t, broker.declaredExchanges, 1)
+	assert.Equal(t, "mytopic", broker.declaredExchanges[0].name)
+	assert.True(t, broker.declaredExchanges[0].passive)
+}
+
+// TestEnsureExchangeDeclaredPassiveMissingExchange verifies the error raised
+// when the externally managed exchange has not been created.
+func TestEnsureExchangeDeclaredPassiveMissingExchange(t *testing.T) {
+	broker := newBroker()
+	broker.exchangeDeclareErr = &amqp.Error{Code: amqp.NotFound, Reason: "NOT_FOUND - no exchange 'mytopic' in vhost '/'"}
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        exchangeKindConsistentHash,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+	})
+
+	err := r.ensureExchangeDeclared(broker, "mytopic", exchangeKindConsistentHash, true, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
+	assert.False(t, r.containsExchange("mytopic"))
+}
+
+// TestEnsureExchangeDeclaredPreconditionFailed verifies that a mismatch against
+// an exchange declared elsewhere points at the passive declare mode.
+func TestEnsureExchangeDeclaredPreconditionFailed(t *testing.T) {
+	broker := newBroker()
+	broker.exchangeDeclareErr = &amqp.Error{Code: amqp.PreconditionFailed, Reason: "PRECONDITION_FAILED - inequivalent arg 'type'"}
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        fanoutExchangeKind,
+		ExchangeDeclareMode: exchangeDeclareModeDeclare,
+	})
+
+	err := r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists with properties that differ")
+	assert.Contains(t, err.Error(), exchangeDeclareModePassive)
+}
+
+// TestSubscribeUsesPassiveExchangeDeclare covers the end-to-end path: with an
+// externally managed topology neither the topic exchange nor the dead letter
+// exchange may be created by the component.
+func TestSubscribeUsesPassiveExchangeDeclare(t *testing.T) {
+	broker := newBroker()
+	pubsubRabbitMQ := newRabbitMQTest(broker)
+	metadata := pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataHostnameKey:            "anyhost",
+			metadataConsumerIDKey:          "consumer",
+			metadataExchangeDeclareModeKey: exchangeDeclareModePassive,
+			metadataEnableDeadLetterKey:    "true",
+		},
+	}}
+	require.NoError(t, pubsubRabbitMQ.Init(t.Context(), metadata))
+
+	handler := func(ctx context.Context, msg *pubsub.NewMessage) error { return nil }
+	require.NoError(t, pubsubRabbitMQ.Subscribe(t.Context(), pubsub.SubscribeRequest{Topic: "mytopic"}, handler))
+
+	require.NotEmpty(t, broker.declaredExchanges)
+	for _, e := range broker.declaredExchanges {
+		assert.Truef(t, e.passive, "exchange %q was declared actively", e.name)
+	}
+}
+
+// TestConsistentHashBindingRoutingKey verifies the bucket weight validation
+// applied to subscriptions bound to a consistent hash exchange.
+func TestConsistentHashBindingRoutingKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		routingKey string
+		wantErr    bool
+	}{
+		{name: "missing weight", routingKey: "", wantErr: true},
+		{name: "non numeric weight", routingKey: "orders", wantErr: true},
+		{name: "zero weight", routingKey: "0", wantErr: true},
+		{name: "valid weight", routingKey: "10", wantErr: false},
+		{name: "multiple valid weights", routingKey: "10,20", wantErr: false},
+		{name: "one invalid weight", routingKey: "10,orders", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			broker := newBroker()
+			r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+				ExchangeKind:        exchangeKindConsistentHash,
+				ExchangeDeclareMode: exchangeDeclareModePassive,
+			})
+
+			req := pubsub.SubscribeRequest{Topic: "mytopic"}
+			if tt.routingKey != "" {
+				req.Metadata = map[string]string{reqMetadataRoutingKey: tt.routingKey}
+			}
+
+			_, err := r.prepareSubscription(broker, req, "consumer-mytopic")
+			if !tt.wantErr {
+				require.NoError(t, err)
+				assert.Equal(t, strings.Split(tt.routingKey, ","), broker.boundRoutingKeys)
+				return
+			}
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, errTerminalSubscription)
+			assert.Contains(t, err.Error(), exchangeKindConsistentHash)
+			assert.Empty(t, broker.boundRoutingKeys)
+		})
+	}
+}
+
+// TestBindingRoutingKeyNotValidatedForOtherKinds makes sure the bucket weight
+// rule is scoped to consistent hash exchanges only.
+func TestBindingRoutingKeyNotValidatedForOtherKinds(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        amqp.ExchangeTopic,
+		ExchangeDeclareMode: exchangeDeclareModeDeclare,
+	})
+
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{
+		Topic:    "mytopic",
+		Metadata: map[string]string{reqMetadataRoutingKey: "orders.created"},
+	}, "consumer-mytopic")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"orders.created"}, broker.boundRoutingKeys)
 }

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -1093,3 +1093,46 @@ func TestPassiveQueueDeclareSkipsBucketWeightValidation(t *testing.T) {
 	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
 	require.NoError(t, err)
 }
+
+// TestDecorateExchangeDeclareErrorPassesThroughUnrelatedErrors verifies that
+// only the two failures specific to externally managed topologies are
+// rewritten, and every other error reaches the caller untouched.
+func TestDecorateExchangeDeclareErrorPassesThroughUnrelatedErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		declareMode string
+		err         error
+	}{
+		{
+			name:        "not an AMQP error",
+			declareMode: exchangeDeclareModeDeclare,
+			err:         errors.New("channel/connection is not open"),
+		},
+		{
+			name:        "AMQP error of another code",
+			declareMode: exchangeDeclareModeDeclare,
+			err:         &amqp.Error{Code: amqp.AccessRefused, Reason: "ACCESS_REFUSED - access to exchange 'mytopic' refused"},
+		},
+		{
+			// Only meaningful when the component was not going to create the
+			// exchange anyway; in declare mode a 404 is not a topology
+			// ownership problem.
+			name:        "not found while declaring",
+			declareMode: exchangeDeclareModeDeclare,
+			err:         &amqp.Error{Code: amqp.NotFound, Reason: "NOT_FOUND - no exchange 'mytopic' in vhost '/'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRabbitMQForExchangeTest(newBroker(), &rabbitmqMetadata{
+				ExchangeKind:        fanoutExchangeKind,
+				ExchangeDeclareMode: tt.declareMode,
+			})
+
+			got := r.decorateExchangeDeclareError("mytopic", fanoutExchangeKind, true, true, tt.err)
+
+			assert.Equal(t, tt.err, got)
+		})
+	}
+}

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -569,14 +569,16 @@ type declaredExchange struct {
 }
 
 type rabbitMQInMemoryBroker struct {
-	buffer             chan amqp.Delivery
-	declaredQueues     []string
-	declaredExchanges  []declaredExchange
-	boundRoutingKeys   []string
-	connectCount       atomic.Int32
-	closeCount         atomic.Int32
-	lastMsgMetadata    *amqp.Publishing // Add this field to capture the last message metadata
-	exchangeDeclareErr error
+	buffer               chan amqp.Delivery
+	declaredQueues       []string
+	declaredExchanges    []declaredExchange
+	boundRoutingKeys     []string
+	connectCount         atomic.Int32
+	closeCount           atomic.Int32
+	lastMsgMetadata      *amqp.Publishing // Add this field to capture the last message metadata
+	exchangeDeclareErr   error
+	queueDeclareErr      error
+	passiveQueueDeclares []string
 }
 
 func (r *rabbitMQInMemoryBroker) Qos(prefetchCount, prefetchSize int, global bool) error {
@@ -611,7 +613,13 @@ func (r *rabbitMQInMemoryBroker) PublishWithDeferredConfirmWithContext(ctx conte
 
 func (r *rabbitMQInMemoryBroker) QueueDeclare(name string, durable bool, autoDelete bool, exclusive bool, noWait bool, args amqp.Table) (amqp.Queue, error) {
 	r.declaredQueues = append(r.declaredQueues, name)
-	return amqp.Queue{Name: name}, nil
+	return amqp.Queue{Name: name}, r.queueDeclareErr
+}
+
+func (r *rabbitMQInMemoryBroker) QueueDeclarePassive(name string, durable bool, autoDelete bool, exclusive bool, noWait bool, args amqp.Table) (amqp.Queue, error) {
+	r.declaredQueues = append(r.declaredQueues, name)
+	r.passiveQueueDeclares = append(r.passiveQueueDeclares, name)
+	return amqp.Queue{Name: name}, r.queueDeclareErr
 }
 
 func (r *rabbitMQInMemoryBroker) QueueBind(name string, key string, exchange string, noWait bool, args amqp.Table) error {
@@ -1017,4 +1025,71 @@ func TestBindingRoutingKeyNotValidatedForOtherKinds(t *testing.T) {
 	}, "consumer-mytopic")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"orders.created"}, broker.boundRoutingKeys)
+}
+
+// TestPassiveQueueDeclareSkipsDeclareAndBind verifies that with an externally
+// owned queue the component neither creates the queue nor binds it.
+func TestPassiveQueueDeclareSkipsDeclareAndBind(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        exchangeKindConsistentHash,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+		QueueDeclareMode:    queueDeclareModePassive,
+	})
+
+	q, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
+	require.NoError(t, err)
+	assert.Equal(t, "operator-owned-queue", q.Name)
+	assert.Equal(t, []string{"operator-owned-queue"}, broker.passiveQueueDeclares)
+	assert.Empty(t, broker.boundRoutingKeys, "bindings belong to the external owner")
+}
+
+// TestPassiveQueueDeclareCoversDeadLetterQueue verifies that the dead letter
+// queue is treated the same way as the consumer queue.
+func TestPassiveQueueDeclareCoversDeadLetterQueue(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        amqp.ExchangeTopic,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+		QueueDeclareMode:    queueDeclareModePassive,
+		EnableDeadLetter:    true,
+	})
+
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dlq-operator-owned-queue", "operator-owned-queue"}, broker.passiveQueueDeclares)
+	assert.Empty(t, broker.boundRoutingKeys)
+}
+
+// TestPassiveQueueDeclareMissingQueue verifies the error raised when the
+// externally managed queue has not been created.
+func TestPassiveQueueDeclareMissingQueue(t *testing.T) {
+	broker := newBroker()
+	broker.queueDeclareErr = &amqp.Error{Code: amqp.NotFound, Reason: "NOT_FOUND - no queue 'operator-owned-queue' in vhost '/'"}
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        amqp.ExchangeTopic,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+		QueueDeclareMode:    queueDeclareModePassive,
+	})
+
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Contains(t, err.Error(), metadataQueueDeclareModeKey)
+}
+
+// TestPassiveQueueDeclareSkipsBucketWeightValidation verifies that the
+// consistent hash bucket weight rule does not apply when the component is not
+// the one creating the binding.
+func TestPassiveQueueDeclareSkipsBucketWeightValidation(t *testing.T) {
+	broker := newBroker()
+	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+		ExchangeKind:        exchangeKindConsistentHash,
+		ExchangeDeclareMode: exchangeDeclareModePassive,
+		QueueDeclareMode:    queueDeclareModePassive,
+	})
+
+	// No routingKey at all, which would be rejected in declare mode.
+	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
+	require.NoError(t, err)
 }

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -883,13 +883,13 @@ func TestEnsureExchangeDeclaredActive(t *testing.T) {
 		ExchangeDeclareMode: exchangeDeclareModeDeclare,
 	})
 
-	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true))
+	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true, false))
 	require.Len(t, broker.declaredExchanges, 1)
 	assert.Equal(t, "mytopic", broker.declaredExchanges[0].name)
 	assert.False(t, broker.declaredExchanges[0].passive)
 
 	// The exchange is cached, so a second call is a no-op.
-	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true))
+	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true, false))
 	assert.Len(t, broker.declaredExchanges, 1)
 }
 
@@ -902,7 +902,7 @@ func TestEnsureExchangeDeclaredPassive(t *testing.T) {
 		ExchangeDeclareMode: exchangeDeclareModePassive,
 	})
 
-	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", exchangeKindConsistentHash, true, true))
+	require.NoError(t, r.ensureExchangeDeclared(broker, "mytopic", exchangeKindConsistentHash, true, true, true))
 	require.Len(t, broker.declaredExchanges, 1)
 	assert.Equal(t, "mytopic", broker.declaredExchanges[0].name)
 	assert.True(t, broker.declaredExchanges[0].passive)
@@ -918,11 +918,13 @@ func TestEnsureExchangeDeclaredPassiveMissingExchange(t *testing.T) {
 		ExchangeDeclareMode: exchangeDeclareModePassive,
 	})
 
-	err := r.ensureExchangeDeclared(broker, "mytopic", exchangeKindConsistentHash, true, true)
+	err := r.ensureExchangeDeclared(broker, "mytopic", exchangeKindConsistentHash, true, true, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not exist")
 	assert.Contains(t, err.Error(), metadataExchangeDeclareModeKey)
 	assert.False(t, r.containsExchange("mytopic"))
+	// Retrying cannot create it, and retrying drops the shared connection.
+	require.ErrorIs(t, err, errTerminalSubscription)
 }
 
 // TestEnsureExchangeDeclaredPreconditionFailed verifies that a mismatch against
@@ -935,15 +937,17 @@ func TestEnsureExchangeDeclaredPreconditionFailed(t *testing.T) {
 		ExchangeDeclareMode: exchangeDeclareModeDeclare,
 	})
 
-	err := r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true)
+	err := r.ensureExchangeDeclared(broker, "mytopic", fanoutExchangeKind, true, true, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists with properties that differ")
 	assert.Contains(t, err.Error(), exchangeDeclareModePassive)
+	require.ErrorIs(t, err, errTerminalSubscription)
 }
 
-// TestSubscribeUsesPassiveExchangeDeclare covers the end-to-end path: with an
-// externally managed topology neither the topic exchange nor the dead letter
-// exchange may be created by the component.
+// TestSubscribeUsesPassiveExchangeDeclare covers the end-to-end path: the topic
+// exchange is only asserted, while the dead letter exchange - whose name is
+// derived from consumerID and topic at runtime, so no external owner could have
+// pre-created it - is still declared by the component.
 func TestSubscribeUsesPassiveExchangeDeclare(t *testing.T) {
 	broker := newBroker()
 	pubsubRabbitMQ := newRabbitMQTest(broker)
@@ -960,10 +964,18 @@ func TestSubscribeUsesPassiveExchangeDeclare(t *testing.T) {
 	handler := func(ctx context.Context, msg *pubsub.NewMessage) error { return nil }
 	require.NoError(t, pubsubRabbitMQ.Subscribe(t.Context(), pubsub.SubscribeRequest{Topic: "mytopic"}, handler))
 
-	require.NotEmpty(t, broker.declaredExchanges)
+	byName := map[string]declaredExchange{}
 	for _, e := range broker.declaredExchanges {
-		assert.Truef(t, e.passive, "exchange %q was declared actively", e.name)
+		byName[e.name] = e
 	}
+
+	topic, ok := byName["mytopic"]
+	require.True(t, ok, "the topic exchange should have been declared")
+	assert.True(t, topic.passive, "the topic exchange is externally managed")
+
+	dlx, ok := byName["dlx-consumer-mytopic"]
+	require.True(t, ok, "the dead letter exchange should have been declared")
+	assert.False(t, dlx.passive, "the dead letter exchange is this component's own object")
 }
 
 // TestConsistentHashBindingRoutingKey verifies the bucket weight validation
@@ -978,7 +990,7 @@ func TestConsistentHashBindingRoutingKey(t *testing.T) {
 		{name: "non numeric weight", routingKey: "orders", wantErr: true},
 		{name: "zero weight", routingKey: "0", wantErr: true},
 		{name: "valid weight", routingKey: "10", wantErr: false},
-		{name: "multiple valid weights", routingKey: "10,20", wantErr: false},
+		{name: "multiple weights", routingKey: "10,20", wantErr: true},
 		{name: "padded weight", routingKey: " 10 ", wantErr: true},
 		{name: "one invalid weight", routingKey: "10,orders", wantErr: true},
 	}
@@ -1045,9 +1057,10 @@ func TestPassiveQueueDeclareSkipsDeclareAndBind(t *testing.T) {
 	assert.Empty(t, broker.boundRoutingKeys, "bindings belong to the external owner")
 }
 
-// TestPassiveQueueDeclareCoversDeadLetterQueue verifies that the dead letter
-// queue is treated the same way as the consumer queue.
-func TestPassiveQueueDeclareCoversDeadLetterQueue(t *testing.T) {
+// TestPassiveQueueDeclareIgnoresDeadLetter verifies that dead lettering is left
+// entirely to the external owner: the component must not require a dead letter
+// queue following its own naming convention to exist.
+func TestPassiveQueueDeclareIgnoresDeadLetter(t *testing.T) {
 	broker := newBroker()
 	r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
 		ExchangeKind:        amqp.ExchangeTopic,
@@ -1058,7 +1071,8 @@ func TestPassiveQueueDeclareCoversDeadLetterQueue(t *testing.T) {
 
 	_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"dlq-operator-owned-queue", "operator-owned-queue"}, broker.passiveQueueDeclares)
+	assert.Equal(t, []string{"operator-owned-queue"}, broker.passiveQueueDeclares,
+		"the dead letter queue belongs to the external owner and must not be asserted")
 	assert.Empty(t, broker.boundRoutingKeys)
 }
 
@@ -1131,7 +1145,7 @@ func TestDecorateExchangeDeclareErrorPassesThroughUnrelatedErrors(t *testing.T) 
 				ExchangeDeclareMode: tt.declareMode,
 			})
 
-			got := r.decorateExchangeDeclareError("mytopic", fanoutExchangeKind, true, true, tt.err)
+			got := r.decorateExchangeDeclareError("mytopic", fanoutExchangeKind, true, true, false, tt.err)
 
 			assert.Equal(t, tt.err, got)
 		})
@@ -1219,4 +1233,116 @@ func TestActiveQueueDeclareStillValidatesQueueType(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), errorInvalidQueueType)
+}
+
+// TestMustReconnectOnAMQPError verifies that any AMQP error is treated as a
+// dead channel. A failed declare is a channel exception, so without this the
+// loop spends an attempt on a channel the broker has already closed.
+func TestMustReconnectOnAMQPError(t *testing.T) {
+	broker := newBroker()
+
+	assert.True(t, mustReconnect(broker, &amqp.Error{Code: amqp.NotFound, Reason: "NOT_FOUND - no exchange 'mytopic' in vhost '/'"}))
+	assert.True(t, mustReconnect(broker, &amqp.Error{Code: amqp.PreconditionFailed, Reason: "PRECONDITION_FAILED - inequivalent arg 'type'"}))
+	assert.True(t, mustReconnect(broker, errors.New(errorChannelConnection)))
+	assert.True(t, mustReconnect(nil, nil))
+	assert.False(t, mustReconnect(broker, nil))
+	assert.False(t, mustReconnect(broker, errors.New("handler failed")))
+}
+
+// TestSubscribeFailsFastOnMissingPassiveObject is the regression test for the
+// connection teardown: a missing externally managed object must fail the
+// subscription with the actionable message, not spin in the retry loop where
+// reset() drops the connection shared by every other subscription.
+func TestSubscribeFailsFastOnMissingPassiveObject(t *testing.T) {
+	tests := []struct {
+		name        string
+		declareErr  func(*rabbitMQInMemoryBroker)
+		wantMessage string
+	}{
+		{
+			name: "missing exchange",
+			declareErr: func(b *rabbitMQInMemoryBroker) {
+				b.exchangeDeclareErr = &amqp.Error{Code: amqp.NotFound, Reason: "NOT_FOUND - no exchange 'mytopic' in vhost '/'"}
+			},
+			wantMessage: metadataExchangeDeclareModeKey,
+		},
+		{
+			name: "missing queue",
+			declareErr: func(b *rabbitMQInMemoryBroker) {
+				b.queueDeclareErr = &amqp.Error{Code: amqp.NotFound, Reason: "NOT_FOUND - no queue 'consumer-mytopic' in vhost '/'"}
+			},
+			wantMessage: metadataQueueDeclareModeKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			broker := newBroker()
+			tt.declareErr(broker)
+
+			pubsubRabbitMQ := newRabbitMQTest(broker)
+			require.NoError(t, pubsubRabbitMQ.Init(t.Context(), pubsub.Metadata{Base: mdata.Base{
+				Properties: map[string]string{
+					metadataHostnameKey:            "anyhost",
+					metadataConsumerIDKey:          "consumer",
+					metadataExchangeDeclareModeKey: exchangeDeclareModePassive,
+					metadataQueueDeclareModeKey:    queueDeclareModePassive,
+					metadataExchangeKindKey:        amqp.ExchangeTopic,
+				},
+			}}))
+
+			start := time.Now()
+			err := pubsubRabbitMQ.Subscribe(t.Context(), pubsub.SubscribeRequest{Topic: "mytopic"}, nil)
+
+			require.Error(t, err)
+			// The one-minute path is what the retry loop would take.
+			assert.Less(t, time.Since(start), 30*time.Second, "the subscription must fail fast, not sit in the retry loop")
+			assert.Contains(t, err.Error(), "does not exist")
+			assert.Contains(t, err.Error(), tt.wantMessage)
+		})
+	}
+}
+
+// TestDeadLetterFollowsQueueDeclareMode verifies that the dead letter objects
+// are governed by queueDeclareMode, not exchangeDeclareMode. Their names are
+// derived at runtime, so an external topology owner cannot pre-create them.
+func TestDeadLetterFollowsQueueDeclareMode(t *testing.T) {
+	t.Run("declared queue declares its dead letter objects even behind a passive exchange", func(t *testing.T) {
+		broker := newBroker()
+		r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+			ExchangeKind:        amqp.ExchangeTopic,
+			ExchangeDeclareMode: exchangeDeclareModePassive,
+			QueueDeclareMode:    queueDeclareModeDeclare,
+			EnableDeadLetter:    true,
+		})
+
+		_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "consumer-mytopic")
+		require.NoError(t, err)
+
+		assert.Contains(t, broker.declaredQueues, "dlq-consumer-mytopic")
+		assert.Empty(t, broker.passiveQueueDeclares, "dead letter objects are the component's own")
+		for _, e := range broker.declaredExchanges {
+			if e.name == "dlx-consumer-mytopic" {
+				assert.False(t, e.passive, "the dead letter exchange must be declared, not asserted")
+			}
+		}
+	})
+
+	t.Run("passive queue leaves dead lettering to the owner", func(t *testing.T) {
+		broker := newBroker()
+		r := newRabbitMQForExchangeTest(broker, &rabbitmqMetadata{
+			ExchangeKind:        amqp.ExchangeTopic,
+			ExchangeDeclareMode: exchangeDeclareModePassive,
+			QueueDeclareMode:    queueDeclareModePassive,
+			EnableDeadLetter:    true,
+		})
+
+		_, err := r.prepareSubscription(broker, pubsub.SubscribeRequest{Topic: "mytopic"}, "operator-owned-queue")
+		require.NoError(t, err)
+
+		assert.NotContains(t, broker.declaredQueues, "dlq-operator-owned-queue")
+		for _, e := range broker.declaredExchanges {
+			assert.NotEqual(t, "dlx-operator-owned-queue", e.name, "the dead letter exchange must not be touched")
+		}
+	})
 }

--- a/tests/certification/pubsub/rabbitmq/components/hash0/rabbitmq-hash0.yaml
+++ b/tests/certification/pubsub/rabbitmq/components/hash0/rabbitmq-hash0.yaml
@@ -1,0 +1,26 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mq-hash
+spec:
+  type: pubsub.rabbitmq
+  version: v1
+  metadata:
+  - name: consumerID
+    value: hash-partition-0
+  - name: connectionString
+    value: "amqp://test:test@localhost:5672"
+  # The consistent hash exchange is created by the external topology manager;
+  # each partition consumer still declares and binds its own queue, because
+  # consumer queue names are only known at runtime.
+  - name: exchangeDeclareMode
+    value: passive
+  - name: exchangeKind
+    value: x-consistent-hash
+  # Strict in-order processing within a partition.
+  - name: concurrencyMode
+    value: single
+  - name: durable
+    value: true
+  - name: deletedWhenUnused
+    value: false

--- a/tests/certification/pubsub/rabbitmq/components/hash1/rabbitmq-hash1.yaml
+++ b/tests/certification/pubsub/rabbitmq/components/hash1/rabbitmq-hash1.yaml
@@ -1,0 +1,26 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mq-hash
+spec:
+  type: pubsub.rabbitmq
+  version: v1
+  metadata:
+  - name: consumerID
+    value: hash-partition-1
+  - name: connectionString
+    value: "amqp://test:test@localhost:5672"
+  # The consistent hash exchange is created by the external topology manager;
+  # each partition consumer still declares and binds its own queue, because
+  # consumer queue names are only known at runtime.
+  - name: exchangeDeclareMode
+    value: passive
+  - name: exchangeKind
+    value: x-consistent-hash
+  # Strict in-order processing within a partition.
+  - name: concurrencyMode
+    value: single
+  - name: durable
+    value: true
+  - name: deletedWhenUnused
+    value: false

--- a/tests/certification/pubsub/rabbitmq/components/passive/rabbitmq-passive.yaml
+++ b/tests/certification/pubsub/rabbitmq/components/passive/rabbitmq-passive.yaml
@@ -1,0 +1,25 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mq-passive
+spec:
+  type: pubsub.rabbitmq
+  version: v1
+  metadata:
+  - name: consumerID
+    value: passive
+  - name: connectionString
+    value: "amqp://test:test@localhost:5672"
+  # The exchange, the queue and the binding are all owned by an external
+  # topology manager (in production, the RabbitMQ Cluster Kubernetes Topology
+  # Operator). The component must use them and create nothing of its own.
+  - name: exchangeDeclareMode
+    value: passive
+  - name: queueDeclareMode
+    value: passive
+  - name: exchangeKind
+    value: topic
+  - name: durable
+    value: true
+  - name: deletedWhenUnused
+    value: false

--- a/tests/certification/pubsub/rabbitmq/docker-compose.yml
+++ b/tests/certification/pubsub/rabbitmq/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: test
       RABBITMQ_DEFAULT_PASS: test
+    volumes:
+      # Enables rabbitmq_consistent_hash_exchange, which provides the
+      # "x-consistent-hash" exchange type exercised by the partitioning tests.
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins:ro
     hostname: rmq
 networks:
   rabbitmq_go_net:

--- a/tests/certification/pubsub/rabbitmq/enabled_plugins
+++ b/tests/certification/pubsub/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management,rabbitmq_prometheus,rabbitmq_consistent_hash_exchange].

--- a/tests/certification/pubsub/rabbitmq/topology_test.go
+++ b/tests/certification/pubsub/rabbitmq/topology_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dapr/go-sdk/service/common"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/tests/certification/embedded"
+	"github.com/dapr/components-contrib/tests/certification/flow"
+	"github.com/dapr/components-contrib/tests/certification/flow/app"
+	"github.com/dapr/components-contrib/tests/certification/flow/dockercompose"
+	"github.com/dapr/components-contrib/tests/certification/flow/retry"
+	"github.com/dapr/components-contrib/tests/certification/flow/sidecar"
+	"github.com/dapr/dapr/pkg/config/protocol"
+	"github.com/dapr/dapr/pkg/runtime"
+	daprClient "github.com/dapr/go-sdk/client"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	// Externally managed topology ("Topology Operator owns everything").
+	sidecarNamePassive = "dapr-passive"
+	appIDPassive       = "app-passive"
+	pubsubPassive      = "mq-passive"
+	topicPassive       = "passive-topic"
+	// Named by the external owner, not derived from consumerID.
+	queuePassive = "operator-owned-queue"
+
+	// Consistent hash partitioning.
+	sidecarNameHash0 = "dapr-hash-0"
+	sidecarNameHash1 = "dapr-hash-1"
+	appIDHash0       = "app-hash-0"
+	appIDHash1       = "app-hash-1"
+	pubsubHash       = "mq-hash"
+	topicHash        = "hash-topic"
+
+	rabbitMQMgmtURL = "http://localhost:15672"
+
+	// Bucket weight each partition queue is bound with. The weight is the
+	// number of buckets the queue occupies on the hash ring, so a larger
+	// weight spreads the key space more evenly across a small number of
+	// queues; binding every queue with weight 1 gives a workable but coarse
+	// split.
+	hashBucketWeight = "10"
+)
+
+// topologySnapshot is the set of exchange and queue names present on the
+// broker, used to prove that a passive component created nothing.
+type topologySnapshot struct {
+	exchanges []string
+	queues    []string
+}
+
+func fetchTopologySnapshot(t require.TestingT) topologySnapshot {
+	get := func(path string) []string {
+		req, err := http.NewRequest(http.MethodGet, rabbitMQMgmtURL+path, nil)
+		require.NoError(t, err)
+		req.SetBasicAuth("test", "test")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var items []struct {
+			Name string `json:"name"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&items))
+
+		names := make([]string, 0, len(items))
+		for _, item := range items {
+			// Skip the default nameless exchange and RabbitMQ's built-ins.
+			if item.Name == "" || strings.HasPrefix(item.Name, "amq.") {
+				continue
+			}
+			names = append(names, item.Name)
+		}
+		sort.Strings(names)
+
+		return names
+	}
+
+	return topologySnapshot{exchanges: get("/api/exchanges"), queues: get("/api/queues")}
+}
+
+// declareTopologyOutOfBand stands in for the RabbitMQ Cluster Kubernetes
+// Topology Operator: it creates the exchange, the queue and the binding before
+// any Dapr sidecar starts.
+func declareTopologyOutOfBand(exchange, exchangeKind, queue, bindingKey string) flow.Runnable {
+	return func(ctx flow.Context) error {
+		conn, err := amqp.Dial(rabbitMQURL)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		ch, err := conn.Channel()
+		if err != nil {
+			return err
+		}
+		defer ch.Close()
+
+		// Durable and not auto-deleted, which is how an operator-managed
+		// exchange is normally defined and differs from what the component
+		// would declare by default.
+		if err = ch.ExchangeDeclare(exchange, exchangeKind, true, false, false, false, nil); err != nil {
+			return err
+		}
+
+		if queue == "" {
+			return nil
+		}
+
+		if _, err = ch.QueueDeclare(queue, true, false, false, false, nil); err != nil {
+			return err
+		}
+
+		return ch.QueueBind(queue, bindingKey, exchange, false, nil)
+	}
+}
+
+// TestRabbitMQPassiveTopology covers a topology owned end to end by an external
+// manager: the component must bind to the existing exchange, queue and binding,
+// and must not create any topology object of its own.
+func TestRabbitMQPassiveTopology(t *testing.T) {
+	log := logger.NewLogger("dapr.components")
+
+	const numPassiveMessages = 100
+
+	var (
+		mu       sync.Mutex
+		received []string
+	)
+
+	application := func(ctx flow.Context, s common.Service) error {
+		return s.AddTopicEventHandler(&common.Subscription{
+			PubsubName: pubsubPassive,
+			Topic:      topicPassive,
+			Route:      "/passive",
+			Metadata: map[string]string{
+				// The queue the external owner created for us.
+				"queueName": queuePassive,
+			},
+		}, func(_ context.Context, e *common.TopicEvent) (bool, error) {
+			mu.Lock()
+			received = append(received, fmt.Sprintf("%v", e.Data))
+			mu.Unlock()
+
+			return false, nil
+		})
+	}
+
+	var before topologySnapshot
+
+	flow.New(t, "rabbitmq passive topology certification").
+		Step(dockercompose.Run(clusterName, dockerComposeYAML)).
+		Step("wait for rabbitmq readiness",
+			retry.Do(time.Second, 30, amqpReady(rabbitMQURL))).
+		Step("declare topology out-of-band",
+			declareTopologyOutOfBand(topicPassive, "topic", queuePassive, "orders.#")).
+		Step("snapshot topology", func(ctx flow.Context) error {
+			before = fetchTopologySnapshot(ctx.T)
+			require.Contains(ctx.T, before.exchanges, topicPassive)
+			require.Contains(ctx.T, before.queues, queuePassive)
+
+			return nil
+		}).
+		Step(app.Run(appIDPassive, fmt.Sprintf(":%d", appPort+40), application)).
+		Step(sidecar.Run(sidecarNamePassive,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath("./components/passive"),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort+40)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort+30)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort+20)),
+				embedded.WithProfilePort(strconv.Itoa(runtime.DefaultProfilePort+20)),
+				embedded.WithGracefulShutdownDuration(2*time.Second),
+			)...,
+		)).
+		Step("wait for subscription setup", flow.Sleep(5*time.Second)).
+		Step("publish and verify", func(ctx flow.Context) error {
+			client := sidecar.GetClient(ctx, sidecarNamePassive)
+
+			expected := make([]string, numPassiveMessages)
+			for i := range expected {
+				expected[i] = fmt.Sprintf("passive-%03d", i)
+				err := client.PublishEvent(ctx, pubsubPassive, topicPassive, expected[i],
+					daprClient.PublishEventWithMetadata(map[string]string{"routingKey": "orders.created"}))
+				require.NoError(ctx, err, "error publishing message")
+			}
+
+			assert.Eventually(ctx.T, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+
+				return len(received) >= numPassiveMessages
+			}, 60*time.Second, 100*time.Millisecond, "all messages should be delivered through the externally managed topology")
+
+			mu.Lock()
+			got := append([]string(nil), received...)
+			mu.Unlock()
+			sort.Strings(got)
+			assert.Equal(ctx.T, expected, got)
+
+			log.Infof("received %d messages through the operator-managed topology", len(got))
+
+			return nil
+		}).
+		Step("verify no topology was created by the component", func(ctx flow.Context) error {
+			after := fetchTopologySnapshot(ctx.T)
+
+			// The decisive assertion: no queue named after the consumerID, no
+			// dead letter objects, no second exchange.
+			assert.Equal(ctx.T, before.exchanges, after.exchanges, "the component must not create exchanges in passive mode")
+			assert.Equal(ctx.T, before.queues, after.queues, "the component must not create queues in passive mode")
+
+			return nil
+		}).
+		Run()
+}
+
+// TestRabbitMQConsistentHashPartitioning covers partitioned ordering with
+// scale-out: an x-consistent-hash exchange owned by an external manager, two
+// independently scaled consumers, and a per-message routing key.
+//
+// It asserts the three properties that make this an alternative to
+// concurrency=single: every key is handled by exactly one consumer, the key
+// space is spread across all of them, and per-key order is preserved.
+func TestRabbitMQConsistentHashPartitioning(t *testing.T) {
+	log := logger.NewLogger("dapr.components")
+
+	const (
+		numKeys    = 24
+		msgsPerKey = 10
+		totalMsgs  = numKeys * msgsPerKey
+	)
+
+	// partition name -> ordered list of "<key>#<seq>" as observed.
+	var (
+		mu       sync.Mutex
+		observed = map[string][]string{}
+	)
+
+	application := func(partition string) app.SetupFn {
+		return func(ctx flow.Context, s common.Service) error {
+			return s.AddTopicEventHandler(&common.Subscription{
+				PubsubName: pubsubHash,
+				Topic:      topicHash,
+				Route:      "/hash",
+				Metadata: map[string]string{
+					// For a consistent hash exchange the binding key is the
+					// bucket weight of the bound queue.
+					"routingKey": hashBucketWeight,
+				},
+			}, func(_ context.Context, e *common.TopicEvent) (bool, error) {
+				mu.Lock()
+				observed[partition] = append(observed[partition], fmt.Sprintf("%v", e.Data))
+				mu.Unlock()
+
+				return false, nil
+			})
+		}
+	}
+
+	flow.New(t, "rabbitmq consistent hash partitioning certification").
+		Step(dockercompose.Run(clusterName, dockerComposeYAML)).
+		Step("wait for rabbitmq readiness",
+			retry.Do(time.Second, 30, amqpReady(rabbitMQURL))).
+		Step("declare consistent hash exchange out-of-band",
+			declareTopologyOutOfBand(topicHash, "x-consistent-hash", "", "")).
+		Step(app.Run(appIDHash0, fmt.Sprintf(":%d", appPort+41), application("partition-0"))).
+		Step(sidecar.Run(sidecarNameHash0,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath("./components/hash0"),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort+41)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort+40)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort+21)),
+				embedded.WithProfilePort(strconv.Itoa(runtime.DefaultProfilePort+21)),
+				embedded.WithGracefulShutdownDuration(2*time.Second),
+			)...,
+		)).
+		Step(app.Run(appIDHash1, fmt.Sprintf(":%d", appPort+42), application("partition-1"))).
+		Step(sidecar.Run(sidecarNameHash1,
+			append(componentRuntimeOptions(),
+				embedded.WithComponentsPath("./components/hash1"),
+				embedded.WithAppProtocol(protocol.HTTPProtocol, strconv.Itoa(appPort+42)),
+				embedded.WithDaprGRPCPort(strconv.Itoa(runtime.DefaultDaprAPIGRPCPort+50)),
+				embedded.WithDaprHTTPPort(strconv.Itoa(runtime.DefaultDaprHTTPPort+22)),
+				embedded.WithProfilePort(strconv.Itoa(runtime.DefaultProfilePort+22)),
+				embedded.WithGracefulShutdownDuration(2*time.Second),
+			)...,
+		)).
+		Step("wait for subscription setup", flow.Sleep(5*time.Second)).
+		Step("publish partitioned messages", func(ctx flow.Context) error {
+			client := sidecar.GetClient(ctx, sidecarNameHash0)
+
+			// The customer's partition key is a composite of tenant and device
+			// serial; here it is modelled the same way.
+			for k := range numKeys {
+				key := fmt.Sprintf("tenant-%d/serial-%d", k%3, k)
+				for seq := range msgsPerKey {
+					err := client.PublishEvent(ctx, pubsubHash, topicHash,
+						fmt.Sprintf("%s#%d", key, seq),
+						daprClient.PublishEventWithMetadata(map[string]string{"routingKey": key}))
+					require.NoError(ctx, err, "error publishing message")
+				}
+			}
+
+			assert.Eventually(ctx.T, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+
+				return len(observed["partition-0"])+len(observed["partition-1"]) >= totalMsgs
+			}, 90*time.Second, 200*time.Millisecond, "all partitioned messages should be delivered")
+
+			return nil
+		}).
+		Step("verify partitioning and per-key ordering", func(ctx flow.Context) error {
+			mu.Lock()
+			snapshot := map[string][]string{}
+			for partition, msgs := range observed {
+				snapshot[partition] = append([]string(nil), msgs...)
+			}
+			mu.Unlock()
+
+			total := 0
+			keyOwner := map[string]string{}
+			lastSeq := map[string]int{}
+
+			for partition, msgs := range snapshot {
+				total += len(msgs)
+				for _, msg := range msgs {
+					parts := strings.Split(msg, "#")
+					require.Len(ctx.T, parts, 2)
+					key := parts[0]
+					seq, err := strconv.Atoi(parts[1])
+					require.NoError(ctx.T, err)
+
+					// 1. Stickiness: a key never moves between partitions,
+					//    which is what makes per-key ordering possible at all.
+					if owner, ok := keyOwner[key]; ok {
+						assert.Equalf(ctx.T, owner, partition, "key %s was delivered to more than one partition", key)
+					} else {
+						keyOwner[key] = partition
+					}
+
+					// 2. Ordering: within a key, sequence numbers only advance.
+					prev, seen := lastSeq[key]
+					if seen {
+						assert.Equalf(ctx.T, prev+1, seq, "key %s was processed out of order", key)
+					} else {
+						assert.Equalf(ctx.T, 0, seq, "key %s did not start at the first message", key)
+					}
+					lastSeq[key] = seq
+				}
+			}
+
+			assert.Equal(ctx.T, totalMsgs, total, "every message should be delivered exactly once")
+			assert.Len(ctx.T, keyOwner, numKeys)
+
+			// 3. Scale-out: the key space is actually spread, so this is not
+			//    equivalent to a single serial consumer.
+			assert.Len(ctx.T, snapshot, 2, "both partitions should receive work")
+			for partition, msgs := range snapshot {
+				assert.NotEmptyf(ctx.T, msgs, "partition %s received no messages", partition)
+				log.Infof("partition %s handled %d messages", partition, len(msgs))
+			}
+
+			return nil
+		}).
+		Run()
+}


### PR DESCRIPTION
## Description

Adds two metadata options to the RabbitMQ pub/sub component, and support for the `x-consistent-hash` exchange kind.

| Option | Values | Effect |
|---|---|---|
| `exchangeDeclareMode` | `declare` (default) / `passive` | `passive` asserts the topic exchange already exists; never creates or modifies it. |
| `queueDeclareMode` | `declare` (default) / `passive` | `passive` asserts the consumer queue already exists, and leaves `queue.bind` and dead-lettering to its external owner. |

The two are independent rather than one "external topology" switch: an operator-owned exchange paired with queues the component still declares is the combination consistent hash scale-out needs, since consumer queue names are only known at runtime.

Dead-lettering follows `queueDeclareMode`, not `exchangeDeclareMode`. The DLX and DLQ are named from `consumerID` and topic at runtime, so no external owner could pre-create them; they are the component's own objects and belong with the queue. Under `queueDeclareMode: passive` they are left entirely to the queue's owner and `enableDeadLetter` has no effect.

Also here:

- `x-consistent-hash` accepted as an `exchangeKind`; in `passive` mode any broker-supported kind is accepted, since the component never declares it.
- The consistent-hash binding key is validated as a positive integer bucket weight and fails as a terminal subscription error naming the metadata field, rather than as an opaque channel error the subscription retries forever. Skipped when the binding is not ours to make.
- `PRECONDITION_FAILED` and passive-declare-on-missing-object are rewritten into messages that name what conflicted and which option resolves it. Every other AMQP error passes through untouched.

No behaviour change by default: both modes default to `declare`, and existing `exchangeKind` values are unaffected.

## Issue reference

Closes #4553
Closes #4554

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Component metadata (`metadata.yaml`) updated
- [x] Certification test coverage
- [x] Extended the documentation — companion `dapr/docs` PR: dapr/docs#5297

### Tests

Unit tests cover declare/passive dispatch for exchanges and queues, the decorated and pass-through error paths, bucket-weight validation, and metadata parsing for both new fields.

Two certification tests, run through the runtime against a real broker. The suite's `docker-compose.yml` now enables `rabbitmq_consistent_hash_exchange` via a mounted `enabled_plugins` file.

- `TestRabbitMQPassiveTopology` declares the exchange, queue and binding out-of-band, runs a fully passive component against them, then asserts **via the management API that the broker's set of exchanges and queues is unchanged** — no `<consumerID>-<topic>` queue, no dead-letter objects, no second exchange.
- `TestRabbitMQConsistentHashPartitioning` runs two independently scaled consumers against an operator-owned `x-consistent-hash` exchange and asserts every key is handled by exactly one consumer, the key space is spread across both, and per-key order holds. A fanout-like or unordered regression fails it.

