### PR TITLE
feat(azure): support disabling instance discovery

### DIFF
--- a/.build-tools/builtin-authentication-profiles.yaml
+++ b/.build-tools/builtin-authentication-profiles.yaml
@@ -98,6 +98,19 @@ azuread:
           - AzurePublicCloud
           - AzureChinaCloud
           - AzureUSGovernmentCloud
+  - title: "Azure AD: Workload identity"
+    description: Authenticate using Azure AD workload identity.
+    metadata:
+      - name: azureAuthMethods
+        description: |
+          Azure authentication methods to try, in order. Set this to "WorkloadIdentity" to use workload identity.
+        example: '"WorkloadIdentity"'
+      - name: azureDisableInstanceDiscovery
+        description: |
+          Disables Microsoft Entra instance discovery for workload identity. Disabling instance discovery also disables authority validation, so set this only when the configured authority is trusted and instance discovery is not available, such as in a disconnected or private cloud.
+        default: '"false"'
+        example: '"true"'
+        type: bool
   - title: "Azure AD: Client credentials"
     description: |
       Authenticate using Azure AD with client credentials, also known as "service principals".

--- a/common/authentication/azure/auth.go
+++ b/common/authentication/azure/auth.go
@@ -47,6 +47,10 @@ const (
 	imdsEndpoint     = "http://169.254.169.254/metadata/identity/oauth2/token"
 )
 
+var newWorkloadIdentityCredential = func(options *azidentity.WorkloadIdentityCredentialOptions) (azcore.TokenCredential, error) { //nolint:gochecknoglobals
+	return azidentity.NewWorkloadIdentityCredential(options)
+}
+
 // timeoutWrapper prevents a potentially very long timeout when managed identity or CLI credential aren't available
 type timeoutWrapper struct {
 	cred azcore.TokenCredential
@@ -82,6 +86,10 @@ func NewEnvironmentSettings(md map[string]string) (EnvironmentSettings, error) {
 	es := EnvironmentSettings{
 		Metadata: md,
 	}
+	if _, err := es.GetDisableInstanceDiscovery(); err != nil {
+		return es, err
+	}
+
 	azureCloud, err := es.GetAzureEnvironment()
 	if err != nil {
 		return es, err
@@ -102,6 +110,23 @@ func (s EnvironmentSettings) GetAzureEnvironment() (*cloud.Configuration, error)
 		return &cloud.AzureGovernment, nil
 	default:
 		return nil, fmt.Errorf("invalid Azure cloud: %v", envName)
+	}
+}
+
+// GetDisableInstanceDiscovery returns whether Microsoft Entra instance discovery should be disabled for workload identity.
+func (s EnvironmentSettings) GetDisableInstanceDiscovery() (bool, error) {
+	value, ok := s.GetEnvironment("DisableInstanceDiscovery")
+	if !ok || strings.TrimSpace(value) == "" {
+		return false, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid azureDisableInstanceDiscovery value %q: expected true or false", value)
 	}
 }
 
@@ -130,8 +155,16 @@ func (s EnvironmentSettings) addClientCertificateProvider(creds *[]azcore.TokenC
 func (s EnvironmentSettings) addWorkloadIdentityProvider(creds *[]azcore.TokenCredential, errs *[]error) {
 	// workload identity requires values for AZURE_AUTHORITY_HOST, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE, AZURE_TENANT_ID
 	// The workload identity mutating admissions webhook in Kubernetes injects these values into the pod.
-	// These environment variables are read using the default WorkloadIdentityCredentialOptions
-	workloadCred, err := azidentity.NewWorkloadIdentityCredential(nil)
+	// These environment variables are read when their corresponding WorkloadIdentityCredentialOptions fields are unset.
+	disableInstanceDiscovery, err := s.GetDisableInstanceDiscovery()
+	if err != nil {
+		*errs = append(*errs, err)
+		return
+	}
+
+	workloadCred, err := newWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+		DisableInstanceDiscovery: disableInstanceDiscovery,
+	})
 	if err == nil {
 		*creds = append(*creds, workloadCred)
 	} else {
@@ -211,6 +244,10 @@ func getAzureAuthMethods() []string {
 // 5. MSI (we use a timeout of 1 second when no compatible managed identity implementation is available)
 // 6. Azure CLI
 func (s EnvironmentSettings) GetTokenCredential() (azcore.TokenCredential, error) {
+	if _, err := s.GetDisableInstanceDiscovery(); err != nil {
+		return nil, err
+	}
+
 	// Create a chain
 	var creds []azcore.TokenCredential
 	errs := make([]error, 0, 3)

--- a/common/authentication/azure/auth_test.go
+++ b/common/authentication/azure/auth_test.go
@@ -16,16 +16,28 @@ package azure
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (f transportFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 const (
 	fakeTenantID = "14bec2db-7f9a-4f3d-97ca-2d384ac83389"
@@ -84,6 +96,182 @@ func TestAzureCloud(t *testing.T) {
 	require.NotNil(t, testCertConfig.AzureCloud)
 	assert.Equal(t, "https://login.chinacloudapi.cn/", testCertConfig.AzureCloud.ActiveDirectoryAuthorityHost)
 	assert.Equal(t, "core.chinacloudapi.cn", settings.EndpointSuffix(ServiceAzureStorage))
+}
+
+func TestGetDisableInstanceDiscovery(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		setValue  bool
+		expected  bool
+		wantError string
+	}{
+		{name: "missing"},
+		{name: "empty", setValue: true},
+		{name: "whitespace", value: " \t ", setValue: true},
+		{name: "false", value: "false", setValue: true},
+		{name: "mixed case false", value: "FaLsE", setValue: true},
+		{name: "true", value: "true", setValue: true, expected: true},
+		{name: "mixed case and whitespace", value: " TrUe ", setValue: true, expected: true},
+		{
+			name:      "invalid word",
+			value:     "enabled",
+			setValue:  true,
+			wantError: `invalid azureDisableInstanceDiscovery value "enabled": expected true or false`,
+		},
+		{
+			name:      "invalid numeric",
+			value:     "1",
+			setValue:  true,
+			wantError: `invalid azureDisableInstanceDiscovery value "1": expected true or false`,
+		},
+		{
+			name:      "invalid abbreviated",
+			value:     "t",
+			setValue:  true,
+			wantError: `invalid azureDisableInstanceDiscovery value "t": expected true or false`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			properties := map[string]string{}
+			if test.setValue {
+				properties["azureDisableInstanceDiscovery"] = test.value
+			}
+
+			actual, err := (EnvironmentSettings{Metadata: properties}).GetDisableInstanceDiscovery()
+			if test.wantError != "" {
+				require.EqualError(t, err, test.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestWorkloadIdentityDisableInstanceDiscoveryOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		expected bool
+	}{
+		{
+			name:     "missing",
+			metadata: map[string]string{"azureAuthMethods": "WorkloadIdentity"},
+		},
+		{
+			name: "false",
+			metadata: map[string]string{
+				"azureAuthMethods":              "WorkloadIdentity",
+				"azureDisableInstanceDiscovery": "false",
+			},
+		},
+		{
+			name: "true",
+			metadata: map[string]string{
+				"azureAuthMethods":              "WorkloadIdentity",
+				"azureDisableInstanceDiscovery": "true",
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setWorkloadIdentityEnvironment(t, "https://private.example/")
+
+			originalFactory := newWorkloadIdentityCredential
+			var actual bool
+			newWorkloadIdentityCredential = func(options *azidentity.WorkloadIdentityCredentialOptions) (azcore.TokenCredential, error) {
+				actual = options.DisableInstanceDiscovery
+				return originalFactory(options)
+			}
+			t.Cleanup(func() {
+				newWorkloadIdentityCredential = originalFactory
+			})
+
+			credential, err := (EnvironmentSettings{Metadata: test.metadata}).GetTokenCredential()
+			require.NoError(t, err)
+			require.NotNil(t, credential)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestInvalidDisableInstanceDiscovery(t *testing.T) {
+	metadata := map[string]string{
+		"azureDisableInstanceDiscovery": "enabled",
+	}
+
+	_, err := NewEnvironmentSettings(metadata)
+	require.EqualError(t, err, `invalid azureDisableInstanceDiscovery value "enabled": expected true or false`)
+
+	_, err = (EnvironmentSettings{Metadata: metadata}).GetTokenCredential()
+	require.EqualError(t, err, `invalid azureDisableInstanceDiscovery value "enabled": expected true or false`)
+}
+
+func TestWorkloadIdentityDisableInstanceDiscoverySkipsPublicDiscovery(t *testing.T) {
+	const authorityHost = "private.example"
+	setWorkloadIdentityEnvironment(t, "https://"+authorityHost+"/")
+
+	originalFactory := newWorkloadIdentityCredential
+	requestHosts := make([]string, 0, 1)
+	newWorkloadIdentityCredential = func(options *azidentity.WorkloadIdentityCredentialOptions) (azcore.TokenCredential, error) {
+		copiedOptions := *options
+		copiedOptions.Transport = transportFunc(func(req *http.Request) (*http.Response, error) {
+			requestHosts = append(requestHosts, req.URL.Host)
+			if strings.EqualFold(req.URL.Hostname(), "login.microsoftonline.com") {
+				return nil, fmt.Errorf("unexpected Public Microsoft Entra instance discovery request to %s", req.URL)
+			}
+
+			var body string
+			switch req.Method {
+			case http.MethodGet:
+				body = fmt.Sprintf(
+					`{"authorization_endpoint":"https://%[1]s/%[2]s/oauth2/v2.0/authorize","token_endpoint":"https://%[1]s/%[2]s/oauth2/v2.0/token","issuer":"https://%[1]s/%[2]s/v2.0"}`,
+					authorityHost,
+					fakeTenantID,
+				)
+			case http.MethodPost:
+				body = `{"access_token":"test-token","expires_in":3600,"token_type":"Bearer"}`
+			default:
+				return nil, fmt.Errorf("unexpected request method %s", req.Method)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})
+		return originalFactory(&copiedOptions)
+	}
+	t.Cleanup(func() {
+		newWorkloadIdentityCredential = originalFactory
+	})
+
+	settings := EnvironmentSettings{
+		Metadata: map[string]string{
+			"azureAuthMethods":              "WorkloadIdentity",
+			"azureDisableInstanceDiscovery": "true",
+		},
+	}
+	credential, err := settings.GetTokenCredential()
+	require.NoError(t, err)
+
+	token, err := credential.GetToken(t.Context(), policy.TokenRequestOptions{
+		Scopes: []string{"https://storage.azure.com/.default"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "test-token", token.Token)
+	require.NotEmpty(t, requestHosts)
+	for _, host := range requestHosts {
+		require.Equal(t, authorityHost, host)
+	}
 }
 
 func TestEndpointSuffix(t *testing.T) {
@@ -318,6 +506,18 @@ func getTestCert() []byte {
 	certBytes, _ := base64.StdEncoding.DecodeString(testCert)
 
 	return certBytes
+}
+
+func setWorkloadIdentityEnvironment(t *testing.T, authorityHost string) {
+	t.Helper()
+
+	tokenFile := filepath.Join(t.TempDir(), "federated-token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("federated-token"), 0o600))
+
+	t.Setenv("AZURE_AUTHORITY_HOST", authorityHost)
+	t.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", tokenFile)
+	t.Setenv("AZURE_TENANT_ID", fakeTenantID)
 }
 
 func TestFallbackToCLI(t *testing.T) {

--- a/common/authentication/azure/metadata-properties.go
+++ b/common/authentication/azure/metadata-properties.go
@@ -38,6 +38,8 @@ var MetadataKeys = map[string][]string{ //nolint:gochecknoglobals
 	// Identifier for the Azure authentication methods to try (in order), comma-separated
 	// Allowed values (case-insensitive): ClientCredentials, creds, ClientCertificate, cert, WorkloadIdentity, wi, ManagedIdentity, mi, CommandLineInterface, cli, None
 	"AzureAuthMethods": {"azureAuthMethods", "azureADAuthMethods", "entraIDAuthMethods", "microsoftEntraIDAuthMethods"},
+	// Disable Microsoft Entra instance discovery for workload identity
+	"DisableInstanceDiscovery": {"azureDisableInstanceDiscovery"},
 
 	// Metadata keys for storage components
 


### PR DESCRIPTION
Add strict azureDisableInstanceDiscovery metadata handling for workload identity credentials and document the trusted-authority requirement for disconnected clouds.

# Description

Add strict azureDisableInstanceDiscovery metadata handling for workload identity credentials and document the trusted-authority requirement for disconnected clouds.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
