### PR TITLE
docs: point dubbo metadata to binding reference page

### DIFF
--- a/bindings/dubbo/metadata.yaml
+++ b/bindings/dubbo/metadata.yaml
@@ -7,7 +7,7 @@ status: alpha
 title: "Apache Dubbo"
 urls:
   - title: Reference
-    url: https://docs.dapr.io/reference/components-reference/supported-bindings/
+    url: https://docs.dapr.io/reference/components-reference/supported-bindings/dubbo/
 binding:
   output: true
   input: false


### PR DESCRIPTION
## Summary
- Update dubbo binding metadata.yaml to link to the dedicated dubbo reference page instead of the generic bindings index

Fixes #3703

## Test plan
- [x] Verified metadata.yaml URL matches the published dubbo binding docs page