### PR TITLE
fix(pubsub/jetstream): retry NATS reconnect indefinitely to recover after outages

### DIFF
--- a/pubsub/jetstream/jetstream.go
+++ b/pubsub/jetstream/jetstream.go
@@ -57,7 +57,12 @@ func (js *jetstreamPubSub) Init(_ context.Context, metadata pubsub.Metadata) err
 	}
 
 	var opts []nats.Option
-	opts = append(opts, nats.Name(js.meta.Name))
+	// Retry reconnecting indefinitely. Without this, the nats.go client
+	// gives up after the default of 60 reconnect attempts (~2 minutes)
+	// and permanently closes the connection, so any outage longer than
+	// that leaves Publish failing with "nats: connection closed" until
+	// the process is restarted, even after NATS is healthy again.
+	opts = append(opts, nats.Name(js.meta.Name), nats.MaxReconnects(-1))
 
 	// Set nats.UserJWT options when jwt and seed key is provided.
 	if js.meta.Jwt != "" && js.meta.SeedKey != "" {

--- a/pubsub/jetstream/jetstream_test.go
+++ b/pubsub/jetstream/jetstream_test.go
@@ -183,3 +183,30 @@ func TestNewJetStream_DurableQueuePushConsumer(t *testing.T) {
 	case <-time.After(10 * time.Millisecond):
 	}
 }
+
+// TestNewJetStream_InfiniteReconnects asserts that Init configures the NATS
+// connection to retry reconnecting indefinitely. Without this, the nats.go
+// client gives up after its default of 60 reconnect attempts (~2 minutes)
+// and permanently closes the connection, so Publish keeps failing with
+// "nats: connection closed" for any outage longer than that, even once NATS
+// is healthy again, until the process is restarted.
+func TestNewJetStream_InfiniteReconnects(t *testing.T) {
+	ns, nc := setupServerAndStream(t)
+	defer ns.Shutdown()
+	defer nc.Drain()
+
+	bus, ok := NewJetStream(logger.NewLogger("test")).(*jetstreamPubSub)
+	require.True(t, ok)
+	defer bus.Close()
+
+	err := bus.Init(t.Context(), pubsub.Metadata{
+		Base: mdata.Base{
+			Properties: map[string]string{
+				"natsURL": ns.ClientURL(),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, -1, bus.nc.Opts.MaxReconnect)
+}


### PR DESCRIPTION
# Description

The NATS JetStream pub/sub component does not recover from a NATS outage
without a full restart. This is because `nats.Connect` is called without
setting `MaxReconnects`, so the underlying nats.go client (v1.39.1) uses its
default of 60 reconnect attempts at a 2s wait each (~2 minutes). Any outage
longer than that causes the client to give up permanently and close the
connection, after which every `Publish` fails with `nats: connection closed`
even once NATS is healthy again, until the process is restarted.

This PR sets `nats.MaxReconnects(-1)` when connecting, which tells the
nats.go client to retry reconnecting indefinitely instead of giving up. This
only affects reconnect behavior after an established connection drops;
`RetryOnFailedConnect` is left unset, so `Init()` still fails fast on an
initially bad `natsURL`, preserving current behavior for misconfiguration.

## Issue reference

Please reference the issue this PR will close: #4563

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.

Fixes #4563