### PR TITLE
fix(deps): bump github.com/rabbitmq/amqp091-go from 1.10.0 to 1.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/sftp v1.13.7
 	github.com/puzpuzpuz/xsync/v3 v3.5.1
-	github.com/rabbitmq/amqp091-go v1.10.0
+	github.com/rabbitmq/amqp091-go v1.14.0
 	github.com/ravendb/ravendb-go-client v0.0.0-20240723121956-2b87f37fe427
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/riferrei/srclient v0.7.3

--- a/go.sum
+++ b/go.sum
@@ -1437,8 +1437,8 @@ github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
 github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
-github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
-github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/rabbitmq/amqp091-go v1.14.0 h1:RSaT7aOKt/OrkVUyswPDW29lnRz9psuGmfZFBmLqLek=
+github.com/rabbitmq/amqp091-go v1.14.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/ravendb/ravendb-go-client v0.0.0-20240723121956-2b87f37fe427 h1:hOnThDlsq0e4M7Sl3A3MnMlazYJsNuuDDqywa5mI7wQ=
 github.com/ravendb/ravendb-go-client v0.0.0-20240723121956-2b87f37fe427/go.mod h1:Zhu1DOotWGZcjom6CZH+8mJ2AD3fOx0QjVIrbpMxN04=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/tests/certification/go.mod
+++ b/tests/certification/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
-	github.com/rabbitmq/amqp091-go v1.12.0
+	github.com/rabbitmq/amqp091-go v1.14.0
 	github.com/riferrei/srclient v0.7.3
 	github.com/stretchr/testify v1.11.1
 	github.com/tylertreat/comcast v1.0.1

--- a/tests/certification/go.sum
+++ b/tests/certification/go.sum
@@ -1241,8 +1241,8 @@ github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
 github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
-github.com/rabbitmq/amqp091-go v1.12.0 h1:V0v14Iqfs+MwHWihJt/nGS5Ulu0vw572b2Co3mwunkI=
-github.com/rabbitmq/amqp091-go v1.12.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/rabbitmq/amqp091-go v1.14.0 h1:RSaT7aOKt/OrkVUyswPDW29lnRz9psuGmfZFBmLqLek=
+github.com/rabbitmq/amqp091-go v1.14.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/ravendb/ravendb-go-client v0.0.0-20240723121956-2b87f37fe427 h1:hOnThDlsq0e4M7Sl3A3MnMlazYJsNuuDDqywa5mI7wQ=
 github.com/ravendb/ravendb-go-client v0.0.0-20240723121956-2b87f37fe427/go.mod h1:Zhu1DOotWGZcjom6CZH+8mJ2AD3fOx0QjVIrbpMxN04=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
## What this does

Bumps `github.com/rabbitmq/amqp091-go` from **1.10.0 to 1.14.0** in the root module and in `tests/certification`.

This clears **12 security advisories** published on `rabbitmq/amqp091-go`. Three are Critical. Eleven are fixed in v1.13.0. `GHSA-w6r9-248c-frg8` is fixed in v1.14.0 only, so this PR takes v1.14.0 rather than v1.13.0.

| Advisory | Sev | Issue | Fixed in |
| -- | -- | -- | -- |
| [GHSA-33mj-cw25-m34h](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-33mj-cw25-m34h) | **Critical** | No explicit TLS minimum version in the URI parser | 1.13.0 |
| [GHSA-j497-x9hr-x34x](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-j497-x9hr-x34x) | **Critical** | Silent data truncation and state corruption via shortstr integer overflow | 1.13.0 |
| [GHSA-c5pq-fr2g-9jpf](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-c5pq-fr2g-9jpf) | **Critical** | Protocol desync and frame injection via integer overflow in `readLongstr` | 1.13.0 |
| [GHSA-xwwf-m8fg-p9q2](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-xwwf-m8fg-p9q2) | High | Denial of service via sub-spec frame size negotiation | 1.13.0 |
| [GHSA-465g-fh3v-9jw4](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-465g-fh3v-9jw4) | High | Connection config overwrite via unsanitized TLS path parameter injection | 1.13.0 |
| [GHSA-rm6m-hrcw-jw33](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-rm6m-hrcw-jw33) | High | Consumer flooding via signed-to-unsigned cast in `Qos` | 1.13.0 |
| [GHSA-27gv-rfvv-22mv](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-27gv-rfvv-22mv) | High | Plaintext credential exposure via exported PLAIN auth struct fields | 1.13.0 |
| [GHSA-wxx3-cj7g-w73j](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-wxx3-cj7g-w73j) | High | Denial of service via synchronous event channel blocking | 1.13.0 |
| [GHSA-r9c8-gcjp-xfwh](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-r9c8-gcjp-xfwh) | High | Out-of-memory via unbounded body buffer allocation | 1.13.0 |
| [GHSA-4v58-74mf-rjx3](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-4v58-74mf-rjx3) | High | Denial of service via malicious field length | 1.13.0 |
| [GHSA-6c5v-hqjr-5xxp](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-6c5v-hqjr-5xxp) | High | Memory exhaustion via broker-controlled oversized payload | 1.13.0 |
| [GHSA-w6r9-248c-frg8](https://github.com/rabbitmq/amqp091-go/security/advisories/GHSA-w6r9-248c-frg8) | Medium | Pre-negotiation frame limit not enforced to 4KB | **1.14.0** |

Note that most of these are repo-level GHSAs on `rabbitmq/amqp091-go` and have not yet propagated. Eleven of them return `CVE_RECORD_DNE` from MITRE and are absent from NVD, OSV and the GitHub global advisory database. `amqp091-go` has no record at all in `vuln.go.dev`, so `govulncheck` reports none of them. Scanners that read CVE feeds directly do see them.

## Reachability

Three packages import the library:

- `common/component/rabbitmq`
- `pubsub/rabbitmq`
- `bindings/rabbitmq`

Every advisory covers a broker-controlled parse path, so an attacker needs a malicious or compromised broker, or a MITM on the AMQP connection.

## Why two modules

`tests/certification/go.mod` requires `amqp091-go` directly, at v1.12.0. That module needs its own bump to stay consistent under `go mod tidy`. This supersedes #4522, which bumps the certification module only, and to 1.13.0.

## Risk and verification

v1.10.0 to v1.14.0 crosses four minors. The library stays on v1 and the API is compatible, but two releases change behavior:

- **v1.12.0** added automatic connection and channel recovery.
- **v1.13.0** tightened frame, shortstr and longstr validation.

The RabbitMQ certification and conformance suites cover both areas, including the TLS and SASL EXTERNAL fixtures in `mtls_sasl_external/`. Neither suite needs secrets, so both run on this pull request.

Verified locally against `main`:

- `go build` and `go vet` clean on all three packages.
- `go test -tags metadata` passes on all three packages.
- `golangci-lint run` reports 0 issues on all three packages.
- The certification RabbitMQ suites compile against v1.14.0.

The resulting diff is 4 files, 6 insertions and 6 deletions. No transitive dependency changed.

**Reviewers: please gate on the four RabbitMQ jobs** — `pubsub.rabbitmq` and `bindings.rabbitmq` in both the certification and conformance matrices.
