### PR TITLE
fix(snssqs): wrap remaining bare errors in metadata parsing

### DIFF
--- a/pubsub/aws/snssqs/metadata.go
+++ b/pubsub/aws/snssqs/metadata.go
@@ -103,7 +103,7 @@ func (s *snsSqs) getSnsSqsMetadata(meta pubsub.Metadata) (*snsSqsMetadata, error
 	upgradeMetadata(&meta)
 	err := metadata.DecodeMetadata(meta.Properties, md)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error decoding metadata: %w", err)
 	}
 
 	if md.Region != "" {
@@ -166,7 +166,7 @@ func (s *snsSqs) getSnsSqsMetadata(meta pubsub.Metadata) (*snsSqsMetadata, error
 func (md *snsSqsMetadata) setConcurrencyMode(props map[string]string) error {
 	c, err := pubsub.Concurrency(props)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting concurrency mode: %w", err)
 	}
 	md.ConcurrencyMode = c
 


### PR DESCRIPTION
# Description

The AWS SNSSQS pubsub component wraps almost all errors returned from the underlying AWS SDK and internal helpers with fmt.Errorf and context, but two paths in metadata parsing returned the raw error unwrapped: the DecodeMetadata error in getSnsSqsMetadata, and the pubsub.Concurrency error in setConcurrencyMode. This makes error messages inconsistent depending on which validation step fails.

This PR wraps both remaining raw error returns with context, matching the pattern used everywhere else in the component.

## Issue reference

Please reference the issue this PR will close: #1284

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: not applicable, no user facing behavior or documented interface changed
