### PR TITLE
feat(kafka): add maxPollInterval config option

### DIFF
--- a/bindings/kafka/metadata.yaml
+++ b/bindings/kafka/metadata.yaml
@@ -366,6 +366,13 @@ metadata:
       The maximum time between heartbeats before the consumer is considered inactive and will timeout.
     example: '"20s"'
     default: '"10s"'
+  - name: maxPollInterval
+    type: duration
+    description: |
+      The maximum time the consumer group coordinator will wait for a member to rejoin the group, allowing
+      for longer message processing times before the consumer is considered dead and a rebalance is triggered.
+    example: '"5m"'
+    default: '"60s"'
   - name: version
     type: string
     description: |

--- a/common/component/kafka/kafka.go
+++ b/common/component/kafka/kafka.go
@@ -161,6 +161,7 @@ func (k *Kafka) Init(ctx context.Context, metadata map[string]string) error {
 	config.Consumer.Fetch.Default = meta.consumerFetchDefault
 	config.Consumer.Group.Heartbeat.Interval = meta.HeartbeatInterval
 	config.Consumer.Group.Session.Timeout = meta.SessionTimeout
+	config.Consumer.Group.Rebalance.Timeout = meta.MaxPollInterval
 	k.initConsumerGroupRebalanceStrategy(config, metadata)
 	config.ChannelBufferSize = meta.channelBufferSize
 

--- a/common/component/kafka/metadata.go
+++ b/common/component/kafka/metadata.go
@@ -117,6 +117,7 @@ type KafkaMetadata struct {
 	ConsumeRetryInterval    time.Duration       `mapstructure:"consumeRetryInterval"`
 	HeartbeatInterval       time.Duration       `mapstructure:"heartbeatInterval"`
 	SessionTimeout          time.Duration       `mapstructure:"sessionTimeout"`
+	MaxPollInterval         time.Duration       `mapstructure:"maxPollInterval"`
 	Version                 string              `mapstructure:"version"`
 	EscapeHeaders           bool                `mapstructure:"escapeHeaders"`
 	internalVersion         sarama.KafkaVersion `mapstructure:"-"`
@@ -213,6 +214,7 @@ func (k *Kafka) getKafkaMetadata(meta map[string]string) (*KafkaMetadata, error)
 		ClientConnectionKeepAliveInterval:            defaultClientConnectionKeepAliveInterval,
 		HeartbeatInterval:                            3 * time.Second,
 		SessionTimeout:                               10 * time.Second,
+		MaxPollInterval:                              60 * time.Second,
 		SchemaCachingEnabled:                         true,
 		SchemaLatestVersionCacheTTL:                  5 * time.Minute,
 		EscapeHeaders:                                false,

--- a/common/component/kafka/metadata_test.go
+++ b/common/component/kafka/metadata_test.go
@@ -543,6 +543,35 @@ func TestMetadataSessionTimeout(t *testing.T) {
 	})
 }
 
+func TestMetadataMaxPollInterval(t *testing.T) {
+	k := getKafka()
+
+	t.Run("default max poll interval", func(t *testing.T) {
+		// arrange
+		m := getBaseMetadata()
+
+		// act
+		meta, err := k.getKafkaMetadata(m)
+
+		// assert
+		require.NoError(t, err)
+		require.Equal(t, 60*time.Second, meta.MaxPollInterval)
+	})
+
+	t.Run("with max poll interval set", func(t *testing.T) {
+		// arrange
+		m := getBaseMetadata()
+		m["maxPollInterval"] = "5m"
+
+		// act
+		meta, err := k.getKafkaMetadata(m)
+
+		// assert
+		require.NoError(t, err)
+		require.Equal(t, 5*time.Minute, meta.MaxPollInterval)
+	})
+}
+
 func TestGetEventMetadata(t *testing.T) {
 	ts := time.Now()
 

--- a/pubsub/kafka/metadata.yaml
+++ b/pubsub/kafka/metadata.yaml
@@ -327,6 +327,13 @@ metadata:
         The maximum time between heartbeats before the consumer is considered inactive and will timeout.
       example: '"20s"'
       default: '"10s"'
+    - name: maxPollInterval
+      type: duration
+      description: |
+        The maximum time the consumer group coordinator will wait for a member to rejoin the group, allowing
+        for longer message processing times before the consumer is considered dead and a rebalance is triggered.
+      example: '"5m"'
+      default: '"60s"'
     - name: version
       type: string
       description: |


### PR DESCRIPTION
# Description

Dapr's Kafka pubsub and binding components already expose heartbeatInterval and sessionTimeout, but there was no way to configure how long the consumer group coordinator waits for a member to rejoin before triggering a rebalance. This matters for consumers with long running message processing, since a slow handler can cause the consumer to be kicked out of the group and reprocessing to start elsewhere.

This PR adds a maxPollInterval metadata option to the Kafka pubsub and binding components, mapped to Sarama's Consumer.Group.Rebalance.Timeout, which is the closest equivalent Sarama exposes to Kafka's max.poll.interval.ms in the Java client. It defaults to 60s, the same as Sarama's own built in default, so existing deployments are unaffected unless they opt in.

## Issue reference

Please reference the issue this PR will close: #2957

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: not yet opened, the metadata.yaml files in this PR are the source for the generated component reference docs
