### PR TITLE
fix(kafka): route Sarama error messages to error log level

### DIFF
--- a/common/component/kafka/sarama_log_bridge.go
+++ b/common/component/kafka/sarama_log_bridge.go
@@ -14,6 +14,9 @@ limitations under the License.
 package kafka
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/dapr/kit/logger"
 )
 
@@ -22,13 +25,24 @@ type SaramaLogBridge struct {
 }
 
 func (b SaramaLogBridge) Print(v ...interface{}) {
-	b.daprLogger.Debug(v...)
+	b.log(fmt.Sprint(v...))
 }
 
 func (b SaramaLogBridge) Printf(format string, v ...interface{}) {
-	b.daprLogger.Debugf(format, v...)
+	b.log(fmt.Sprintf(format, v...))
 }
 
 func (b SaramaLogBridge) Println(v ...interface{}) {
-	b.daprLogger.Debug(v...)
+	b.log(fmt.Sprintln(v...))
+}
+
+// log routes Sarama's log lines to Error when they report an error, since
+// Sarama's Logger interface has no level of its own and previously
+// everything was logged at Debug, hiding real connectivity/consumer errors.
+func (b SaramaLogBridge) log(msg string) {
+	if strings.Contains(strings.ToLower(msg), "error") {
+		b.daprLogger.Error(msg)
+		return
+	}
+	b.daprLogger.Debug(msg)
 }

--- a/common/component/kafka/sarama_log_bridge_test.go
+++ b/common/component/kafka/sarama_log_bridge_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/kit/logger"
+)
+
+func newTestSaramaLogBridge(buf *bytes.Buffer) SaramaLogBridge {
+	l := logger.NewLogger("sarama_log_bridge_test")
+	l.SetOutputLevel(logger.DebugLevel)
+	l.SetOutput(buf)
+	return SaramaLogBridge{daprLogger: l}
+}
+
+func TestSaramaLogBridgeErrorMessagesLoggedAsError(t *testing.T) {
+	var buf bytes.Buffer
+	b := newTestSaramaLogBridge(&buf)
+
+	b.Printf("kafka: %s", "error while consuming topic/0: read tcp: i/o timeout")
+
+	require.Contains(t, buf.String(), "level=error")
+}
+
+func TestSaramaLogBridgeNonErrorMessagesLoggedAsDebug(t *testing.T) {
+	var buf bytes.Buffer
+	b := newTestSaramaLogBridge(&buf)
+
+	b.Print("kafka: connected to broker")
+
+	require.Contains(t, buf.String(), "level=debug")
+}
+
+func TestSaramaLogBridgePrintlnErrorMessage(t *testing.T) {
+	var buf bytes.Buffer
+	b := newTestSaramaLogBridge(&buf)
+
+	b.Println("kafka: error while consuming: client has run out of available brokers to talk to")
+
+	require.Contains(t, buf.String(), "level=error")
+}


### PR DESCRIPTION
# Description

Sarama's Logger interface only has Print, Printf and Println, with no level of its own. The Kafka component's SaramaLogBridge routed every message from Sarama through daprLogger.Debug, so real errors such as "kafka: error while consuming ...: read tcp ...: i/o timeout" or "kafka: client has run out of available brokers to talk to" were only visible at debug log level. In production, where the default log level is usually info, these errors were completely invisible, making outages hard to diagnose.

This PR checks whether the message text from Sarama indicates an error and, if so, logs it at error level instead of debug. Non error messages keep logging at debug level as before.

## Issue reference

Please reference the issue this PR will close: #3351

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: not applicable, this changes internal logging behavior only
