### PR TITLE
feat(conversation): enable conformance tests and add ollama cert tests

### DIFF
--- a/.github/infrastructure/docker-compose-ollama.yml
+++ b/.github/infrastructure/docker-compose-ollama.yml
@@ -1,0 +1,11 @@
+services:
+  ollama:
+    image: ollama/ollama:0.33.2
+    ports:
+      - "127.0.0.1:11434:11434"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 5s

--- a/.github/scripts/components-scripts/conformance-conversation.ollama-setup.sh
+++ b/.github/scripts/components-scripts/conformance-conversation.ollama-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly COMPOSE_FILE=".github/infrastructure/docker-compose-ollama.yml"
+readonly PROJECT="ollama"
+readonly MODEL="${OLLAMA_MODEL:-qwen2.5:0.5b}"
+
+docker compose -f "${COMPOSE_FILE}" -p "${PROJECT}" up -d --wait
+docker compose -f "${COMPOSE_FILE}" -p "${PROJECT}" exec -T ollama ollama pull "${MODEL}"
+docker compose -f "${COMPOSE_FILE}" -p "${PROJECT}" exec -T ollama ollama run "${MODEL}" "Reply with OK." > /dev/null
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "OLLAMA_ENABLED=1"
+    echo "OLLAMA_MODEL=${MODEL}"
+  } >> "${GITHUB_ENV}"
+fi

--- a/.github/scripts/test-info.mjs
+++ b/.github/scripts/test-info.mjs
@@ -299,6 +299,16 @@ const components = {
         conformanceSetup: 'conformance-configuration.kubernetes-setup.sh',
         sourcePkg: ['configuration/kubernetes'],
     },
+    'conversation.echo': {
+        conformance: true,
+    },
+    'conversation.ollama': {
+        conformance: true,
+        certification: true,
+        requireDocker: true,
+        conformanceSetup: 'conformance-conversation.ollama-setup.sh',
+        conformanceLogs: 'docker-compose-logs.sh ollama',
+    },
     'crypto.azure.keyvault': {
         conformance: true,
         requiredSecrets: [
@@ -982,7 +992,11 @@ function GenerateMatrix(testKind, enableCloudTests) {
         }
 
         // For conformance tests, avoid running Docker and Cloud Tests together.
-        if (enableCloudTests && comp.conformance && comp.requireDocker) {
+        if (
+            testKind === 'conformance' &&
+            enableCloudTests &&
+            comp.requireDocker
+        ) {
             continue
         }
 

--- a/tests/certification/conversation/ollama/README.md
+++ b/tests/certification/conversation/ollama/README.md
@@ -1,0 +1,11 @@
+# Ollama conversation certification testing
+
+The certification test starts Ollama in Docker, pulls the `qwen2.5:0.5b`
+model, starts an embedded Dapr sidecar, and verifies a Conversation Alpha2
+request returns a model response.
+
+Run from this directory with:
+
+```bash
+go test -v
+```

--- a/tests/certification/conversation/ollama/components/ollama.yaml
+++ b/tests/certification/conversation/ollama/components/ollama.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: ollama
+spec:
+  type: conversation.ollama
+  version: v1
+  metadata:
+    - name: model
+      value: qwen2.5:0.5b
+    - name: endpoint
+      value: http://127.0.0.1:11434/v1

--- a/tests/certification/conversation/ollama/config.yaml
+++ b/tests/certification/conversation/ollama/config.yaml
@@ -1,0 +1,6 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: conversation-ollama-config
+spec:
+  features:

--- a/tests/certification/conversation/ollama/ollama_test.go
+++ b/tests/certification/conversation/ollama/ollama_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ollama_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	conversation_ollama "github.com/dapr/components-contrib/conversation/ollama"
+	"github.com/dapr/components-contrib/tests/certification/embedded"
+	"github.com/dapr/components-contrib/tests/certification/flow"
+	"github.com/dapr/components-contrib/tests/certification/flow/dockercompose"
+	"github.com/dapr/components-contrib/tests/certification/flow/sidecar"
+	conversation_loader "github.com/dapr/dapr/pkg/components/conversation"
+	dapr_testing "github.com/dapr/dapr/pkg/testing"
+	dapr "github.com/dapr/go-sdk/client"
+	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
+)
+
+const (
+	componentName     = "ollama"
+	sidecarName       = "conversation-ollama-sidecar"
+	dockerProjectName = "conversation-ollama"
+	dockerComposeYAML = "../../../../.github/infrastructure/docker-compose-ollama.yml"
+	modelName         = "qwen2.5:0.5b"
+)
+
+func TestOllama(t *testing.T) {
+	t.Setenv("OLLAMA_MODEL", modelName)
+
+	ports, err := dapr_testing.GetFreePorts(2)
+	require.NoError(t, err)
+
+	pullModel := func(ctx flow.Context) error {
+		pullCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		out, err := exec.CommandContext(
+			pullCtx,
+			"docker", "compose",
+			"-p", dockerProjectName,
+			"-f", dockerComposeYAML,
+			"exec", "-T", "ollama",
+			"ollama", "pull", modelName,
+		).CombinedOutput()
+		ctx.Log(string(out))
+		if err != nil {
+			return fmt.Errorf("failed to pull Ollama model %s: %w", modelName, err)
+		}
+		return nil
+	}
+
+	testConverse := func(ctx flow.Context) error {
+		client := sidecar.GetClient(ctx, sidecarName)
+		requestCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+
+		resp, err := client.ConverseAlpha2(requestCtx, dapr.ConversationRequestAlpha2{
+			Name: componentName,
+			Inputs: []*dapr.ConversationInputAlpha2{
+				{
+					Messages: []*dapr.ConversationMessageAlpha2{
+						{
+							ConversationMessageOfUser: &dapr.ConversationMessageOfUserAlpha2{
+								Content: []*dapr.ConversationMessageContentAlpha2{
+									{Text: ptr.Of("Reply with a short greeting.")},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Outputs, 1)
+		require.Len(t, resp.Outputs[0].Choices, 1)
+		require.NotEmpty(t, resp.Outputs[0].Choices[0].FinishReason)
+		require.NotEmpty(t, resp.Outputs[0].Choices[0].Message.Content)
+		return nil
+	}
+
+	flow.New(t, "ollama conversation certification").
+		Step(dockercompose.Run(dockerProjectName, dockerComposeYAML)).
+		Step("pull model", pullModel).
+		Step(sidecar.Run(sidecarName,
+			embedded.WithoutApp(),
+			embedded.WithResourcesPath("./components"),
+			embedded.WithDaprGRPCPort(strconv.Itoa(ports[0])),
+			embedded.WithDaprHTTPPort(strconv.Itoa(ports[1])),
+			embedded.WithConversations(newConversationRegistry()),
+		)).
+		Step("converse", testConverse).
+		Run()
+}
+
+func newConversationRegistry() *conversation_loader.Registry {
+	registry := conversation_loader.NewRegistry()
+	registry.Logger = logger.NewLogger("dapr.components")
+	registry.RegisterComponent(conversation_ollama.NewOllama, componentName)
+	return registry
+}

--- a/tests/certification/embedded/embedded.go
+++ b/tests/certification/embedded/embedded.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/components/bindings"
 	"github.com/dapr/dapr/pkg/components/configuration"
+	"github.com/dapr/dapr/pkg/components/conversation"
 	"github.com/dapr/dapr/pkg/components/middleware/http"
 	"github.com/dapr/dapr/pkg/components/pubsub"
 	"github.com/dapr/dapr/pkg/components/secretstores"
@@ -157,6 +158,12 @@ func WithPubSubs(reg *pubsub.Registry) Option {
 func WithConfigurations(reg *configuration.Registry) Option {
 	return func(config *runtime.Config) {
 		config.Registry = config.Registry.WithConfigurations(reg)
+	}
+}
+
+func WithConversations(reg *conversation.Registry) Option {
+	return func(config *runtime.Config) {
+		config.Registry = config.Registry.WithConversations(reg)
 	}
 }
 


### PR DESCRIPTION
Previously, no cert/conf tests have been enabled for the conversation components leading to no starting point or regression tests for components

# Description

Enabling cert/conf tests for the conversation building block components

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
