### PR TITLE
fix(ci): unpin ubuntu runners from 22.04

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,7 +32,7 @@ jobs:
   # subset of the certification tests. This allows all the tests not requiring
   # secrets to be executed on pull requests.
   generate-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set default checkout ref
       run: |
@@ -98,7 +98,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       UNIQUE_ID: ${{github.run_id}}-${{github.run_attempt}}
       GOCOV_VER: "v1.1.0"
@@ -346,7 +346,7 @@ jobs:
 
   post_job:
     name: Post-completion
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: always()
     needs:
       - certification

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -34,7 +34,7 @@ jobs:
   # subset of the conformance tests. This allows all the tests not requiring
   # secrets to be executed on pull requests.
   generate-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set default checkout ref
       run: |
@@ -100,7 +100,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       UNIQUE_ID: ${{github.run_id}}-${{github.run_attempt}}
       GOCOV_VER: "v1.1.0"
@@ -377,7 +377,7 @@ jobs:
 
   post_job:
     name: Post-completion
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: always()
     needs:
       - conformance

--- a/tests/certification/bindings/kafka/docker-compose.yml
+++ b/tests/certification/bindings/kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.0
+    image: confluentinc/cp-zookeeper:7.9.9
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka1:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.9.9
     hostname: kafka1
     container_name: kafka1
     depends_on:
@@ -25,12 +25,11 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092,PLAINTEXT_HOST://localhost:19092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_NUM_PARTITIONS: 10
 
   kafka2:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.9.9
     hostname: kafka2
     container_name: kafka2
     depends_on:
@@ -44,12 +43,11 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_NUM_PARTITIONS: 10
 
   kafka3:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.9.9
     hostname: kafka3
     container_name: kafka3
     depends_on:
@@ -63,6 +61,5 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:9092,PLAINTEXT_HOST://localhost:39092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_NUM_PARTITIONS: 10

--- a/tests/certification/pubsub/kafka/docker-compose.yml
+++ b/tests/certification/pubsub/kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.0
+    image: confluentinc/cp-zookeeper:7.9.9
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka1:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.9.9
     hostname: kafka1
     container_name: kafka1
     depends_on:
@@ -25,12 +25,11 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092,PLAINTEXT_HOST://localhost:19092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_NUM_PARTITIONS: 10
 
   kafka2:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.9.9
     hostname: kafka2
     container_name: kafka2
     depends_on:
@@ -44,12 +43,11 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_NUM_PARTITIONS: 10
 
   kafka3:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.9.9
     hostname: kafka3
     container_name: kafka3
     depends_on:
@@ -63,12 +61,11 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:9092,PLAINTEXT_HOST://localhost:39092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_NUM_PARTITIONS: 10
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.5.3
+    image: confluentinc/cp-schema-registry:7.9.9
     hostname: schema-registry
     container_name: schema-registry
     environment:


### PR DESCRIPTION
# Description

Removes the pin from 22.04 which is limiting the runner pool, this doesn't seem to make a difference at all to runs themselves.

Required a bump to kafka versions which are EOL

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
