### PR TITLE
fix(rabbitmq): cancel the consumer on every exit from the subscribe loop

### DIFF
--- a/pubsub/rabbitmq/rabbitmq.go
+++ b/pubsub/rabbitmq/rabbitmq.go
@@ -552,7 +552,19 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 				false,              // noWait
 				nil,
 			)
+			// The broker can accept the registration even when Consume reports an
+			// error, because the channel is shared and the exception may belong to
+			// another command on it. Cancel on every exit path from here on, so a
+			// registration that did land is not left behind holding its prefetch
+			// allowance. noWait=true avoids blocking if the channel is closing.
+			cancelConsumer := func() {
+				if cancelErr := channel.Cancel(consumerTag, true); cancelErr != nil {
+					r.logger.Debugf("%s failed to cancel consumer %s: %v", logMessagePrefix, consumerTag, cancelErr)
+				}
+			}
+
 			if err != nil {
+				cancelConsumer()
 				errFuncName = "channel.Consume"
 				break
 			}
@@ -566,12 +578,7 @@ func (r *rabbitMQ) subscribeForever(ctx context.Context, req pubsub.SubscribeReq
 			}
 
 			err = r.listenMessages(ctx, channel, msgs, req.Topic, handler)
-			// Always cancel the consumer server-side so RabbitMQ can
-			// release the registration. noWait=true avoids blocking if
-			// the channel is already closing.
-			if cancelErr := channel.Cancel(consumerTag, true); cancelErr != nil {
-				r.logger.Debugf("%s failed to cancel consumer %s: %v", logMessagePrefix, consumerTag, cancelErr)
-			}
+			cancelConsumer()
 			if err != nil {
 				errFuncName = "listenMessages"
 				break

--- a/pubsub/rabbitmq/rabbitmq_test.go
+++ b/pubsub/rabbitmq/rabbitmq_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"slices"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -565,6 +567,15 @@ type rabbitMQInMemoryBroker struct {
 	connectCount    atomic.Int32
 	closeCount      atomic.Int32
 	lastMsgMetadata *amqp.Publishing // Add this field to capture the last message metadata
+
+	// consumeErr, when set, is returned by Consume even though the consumer is
+	// registered, which is what a shared channel does when another command on
+	// it raises a channel-level exception.
+	consumeErr error
+
+	tagsMu        sync.Mutex
+	consumedTags  []string
+	cancelledTags []string
 }
 
 func (r *rabbitMQInMemoryBroker) Qos(prefetchCount, prefetchSize int, global bool) error {
@@ -607,11 +618,23 @@ func (r *rabbitMQInMemoryBroker) QueueBind(name string, key string, exchange str
 }
 
 func (r *rabbitMQInMemoryBroker) Consume(queue string, consumer string, autoAck bool, exclusive bool, noLocal bool, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error) {
-	return r.buffer, nil
+	r.tagsMu.Lock()
+	r.consumedTags = append(r.consumedTags, consumer)
+	r.tagsMu.Unlock()
+	return r.buffer, r.consumeErr
 }
 
 func (r *rabbitMQInMemoryBroker) Cancel(consumer string, noWait bool) error {
+	r.tagsMu.Lock()
+	r.cancelledTags = append(r.cancelledTags, consumer)
+	r.tagsMu.Unlock()
 	return nil
+}
+
+func (r *rabbitMQInMemoryBroker) tags() (consumed, cancelled []string) {
+	r.tagsMu.Lock()
+	defer r.tagsMu.Unlock()
+	return slices.Clone(r.consumedTags), slices.Clone(r.cancelledTags)
 }
 
 func (r *rabbitMQInMemoryBroker) Nack(tag uint64, multiple bool, requeue bool) error {
@@ -835,4 +858,47 @@ func TestPublishMessagePropertiesToMetadataFlag(t *testing.T) {
 		assert.Equal(t, topicName, receivedMsg.Topic)
 		assert.Empty(t, receivedMsg.Metadata, "Metadata should be empty when flag is not set (defaults to false)")
 	})
+}
+
+// A consumer registered on a shared channel survives a Consume error raised by
+// another command on that channel, so the tag has to be cancelled on every exit
+// from the subscribe loop, not only after listenMessages returns. Otherwise the
+// registration is orphaned and keeps holding its prefetch allowance.
+func TestSubscribeForeverCancelsConsumerWhenConsumeFails(t *testing.T) {
+	broker := newBroker()
+	broker.consumeErr = errors.New(errorChannelConnection)
+
+	r := newRabbitMQTest(broker)
+	metadata := pubsub.Metadata{Base: mdata.Base{
+		Properties: map[string]string{
+			metadataHostnameKey:             "anyhost",
+			metadataConsumerIDKey:           "consumer",
+			metadataReconnectWaitSecondsKey: "0",
+		},
+	}}
+	require.NoError(t, r.Init(t.Context(), metadata))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.subscribeForever(ctx, pubsub.SubscribeRequest{Topic: "mytopic"}, "myqueue", func(context.Context, *pubsub.NewMessage) error { return nil }, nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		consumed, _ := broker.tags()
+		return len(consumed) >= 2
+	}, 5*time.Second, 10*time.Millisecond, "expected the subscriber to retry")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscribeForever did not return")
+	}
+
+	consumed, cancelled := broker.tags()
+	for _, tag := range consumed {
+		require.Containsf(t, cancelled, tag, "consumer %s was registered but never cancelled", tag)
+	}
 }


### PR DESCRIPTION
# Description

`subscribeForever` only calls `channel.Cancel(consumerTag, ...)` after `listenMessages` returns. An iteration that breaks on `channel.Consume` therefore drops the tag along with the local variable, and the next iteration registers a new one.

The channel is shared between subscriptions, so `Consume` can report a channel-level exception raised by another command — `503 unexpected command received` during a reconnect storm — while the broker accepted the registration. That consumer is then orphaned and keeps its prefetch allowance, parking `prefetchCount` messages per leak. With `ttlInSeconds` and `enableDeadLetter` set they are eventually dead-lettered rather than redelivered, which is how #4540 was hit in production.

This cancels the consumer once the tag exists, on both exit paths. Both run against the same `channel` the tag was registered on, and `noWait=true` keeps it from blocking when the channel is already closing.

## Issue reference

Fixes #4540

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: not applicable — no user-facing configuration or behaviour change

## Testing

Added `TestSubscribeForeverCancelsConsumerWhenConsumeFails`. The in-memory broker records the tags passed to `Consume` and `Cancel`, and returns a `channel/connection is not open` error from `Consume` while still handing back the delivery channel, which is the shape of the failure above. The test asserts every registered tag is cancelled.

It fails on `main`:

```
consumer myqueue-ef51c54d-... was registered but never cancelled
```

`go test -race ./pubsub/rabbitmq/` and `golangci-lint run ./pubsub/rabbitmq/...` are both clean.

## Release Note

RELEASE NOTE: **FIX** RabbitMQ pubsub leaking AMQP consumers on broker reconnect, parking `prefetchCount` messages per leaked consumer.