### PR TITLE
test(bindings.kafka): gate certification readiness on the real cluster state

### DIFF
--- a/tests/certification/bindings/kafka/kafka_test.go
+++ b/tests/certification/bindings/kafka/kafka_test.go
@@ -240,21 +240,40 @@ func TestKafka_with_retry(t *testing.T) {
 		Step("wait", flow.Sleep(5*time.Second)).
 		Step("wait for kafka readiness", retry.Do(10*time.Second, 30, func(ctx flow.Context) error {
 			config := sarama.NewConfig()
-			config.ClientID = "test-consumer"
-			config.Consumer.Return.Errors = true
+			config.ClientID = "test-readiness"
+			config.Metadata.Full = true
 
-			// Create new consumer
-			client, err := sarama.NewConsumer(brokers, config)
+			client, err := sarama.NewClient(brokers, config)
 			if err != nil {
 				return err
 			}
 			defer client.Close()
 
-			// Ensure the brokers are ready by attempting to consume
-			// a topic partition.
-			_, err = client.ConsumePartition("myTopic", 0, sarama.OffsetOldest)
+			// Every broker must be registered before __consumer_offsets can be
+			// created at KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3, and before
+			// topic creation can spread partitions across the whole cluster.
+			if n := len(client.Brokers()); n < len(brokers) {
+				return fmt.Errorf("only %d/%d brokers registered", n, len(brokers))
+			}
 
-			return err
+			// The topic under test must have a leader for every partition.
+			parts, err := client.Partitions(topicName)
+			if err != nil {
+				return err
+			}
+			for _, part := range parts {
+				if _, err := client.Leader(topicName, part); err != nil {
+					return fmt.Errorf("no leader for %s/%d: %w", topicName, part, err)
+				}
+			}
+
+			// The group coordinator is the real precondition for the consumers:
+			// resolving it requires __consumer_offsets to exist.
+			if _, err := client.Coordinator("readiness-probe"); err != nil {
+				return fmt.Errorf("group coordinator unavailable: %w", err)
+			}
+
+			return nil
 		})).
 		// Run the application logic above.
 		Step(app.Run(appID1, fmt.Sprintf(":%d", appPort),


### PR DESCRIPTION
# Description

The `bindings.kafka` certification test declares the Kafka cluster ready before it actually is, then gives the first two send steps only 60 seconds to deliver 1000 messages. When the cluster converges late, both steps fail with every message missing.

The readiness gate at `tests/certification/bindings/kafka/kafka_test.go:241-258` calls `sarama.NewConsumer(brokers, config)`, which succeeds as soon as any one seed broker answers a metadata request, and then `ConsumePartition("myTopic", 0, sarama.OffsetOldest)`. `myTopic` is not the topic under test — that is `neworder` (`kafka_test.go:73`) — and with `KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'` and no `KAFKA_DEFAULT_REPLICATION_FACTOR` in the compose file it is fabricated at RF=1, so partition 0 only ever needs a single live broker.

Meanwhile the consumer groups the sidecars form need a group coordinator, which needs `__consumer_offsets`, which the compose file pins at `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3` and so cannot be created until all three brokers are registered. The probe's success condition is one broker; the test's real precondition is three.

The step above it, `network.WaitForAddresses` (`kafka_test.go:238`), doesn't help either, since it only proves the TCP socket is dialable and Docker publishes the port before the broker starts serving the Kafka protocol.

The timeout asymmetry explains why the failure signature is so consistent: `sendRecvTest` gets `m.Assert(ctx, time.Minute)` (`kafka_test.go:151`) while every later assertion gets `5*time.Minute` (`kafka_test.go:228`). If the cluster converges between the two, precisely the one-minute steps fail and everything after them passes.

## Evidence

Still reproducing on main — three failures in the last ~50 certification runs that included a `bindings.kafka` job:

- https://github.com/dapr/components-contrib/actions/runs/33895466524/job/101097015308 (main, Sep 4)
- https://github.com/dapr/components-contrib/actions/runs/33776148941/job/100733246429 (Sep 3)
- https://github.com/dapr/components-contrib/actions/runs/33533918893/job/99943539503 (main, Sep 1)

The two main-branch runs share the same signature:

```
Running step: wait for kafka readiness
  retry.go:33: Failure: kafka: client has run out of available brokers to talk to:
               read tcp [::1]:53598->[::1]:29092: read: connection reset by peer
  retry.go:35: Success!
Completed step: wait for kafka readiness
Running step: send and wait(in-order)
  watcher.go:437: Timed out with 1000 items remaining: map[Hello, Messages 000: ...
  watcher.go:437: Timed out with 1000 items remaining: map[Hello, Messages 000: ...
Running step: send and wait(no-order)
  watcher.go:437: Timed out with 1000 items remaining: map[Hello, Messages 000: ...
```

Zero of 1000 messages on both watchers, and then every later step passes. There is no testify output in the log because `watcher.Assert` records a non-fatal failure, so the flow runs to completion and only the test result comes back red.

To confirm the mechanism I ran the existing probe verbatim against the compose cluster with only `zookeeper` and `kafka1` started, alongside the checks this PR adds:

```
--- current readiness probe (kafka_test.go:241) ---
  returned nil after 283ms  <== readiness DECLARED
--- what the consumers actually need ---
  client.Brokers() -> 1
  client.Topics()  -> [_confluent-command myTopic]
  Partitions("neworder") -> 10 partitions, leaders by broker id map[1:10]
  Coordinator()    -> error: kafka server: The coordinator is not available
```

The probe declares a one-broker cluster ready in 283ms while no group coordinator exists at all. `myTopic` appears in the topic list because the probe itself created it; `neworder` is absent because nothing had touched it yet.

The same program against all three brokers:

```
  client.Brokers() -> 3   (ids 1, 2, 3)
  Partitions("neworder") -> 10 partitions, leaders by broker id map[1:3 2:4 3:3]
  Coordinator()    -> broker 3 (localhost:39092)
```

And the replication-factor asymmetry the argument rests on, straight from the broker:

```
Topic: neworder           PartitionCount: 10  ReplicationFactor: 1
Topic: __consumer_offsets PartitionCount: 50  ReplicationFactor: 3   Replicas: 2,3,1
```

For anyone searching: this was not closed by https://github.com/dapr/components-contrib/pull/4225, which added `clientConnectionTopicMetadataRefreshInterval: 15s` to the same component YAMLs in February.

## What changed

The readiness step now gates on what the consumers actually need, in this order:

1. every broker registered — required before `__consumer_offsets` can be created at RF=3, and before topic creation can spread partitions across the cluster;
2. a leader for every partition of the topic under test, `neworder` rather than `myTopic`;
3. a resolvable group coordinator.

The broker count is checked first deliberately: if `neworder` is auto-created while only one broker is registered, all ten RF=1 partitions pin to that one broker, which would change how the later broker-stop steps behave.

The one-minute assert at `kafka_test.go:151` is left alone. With a real readiness gate, 60 seconds for 1000 messages is generous, and raising it would hide the race rather than remove it.

A side effect worth noting: the probe no longer references `myTopic`, so that phantom topic stops being created by this test.

## Verification

Locally, `go test -run TestKafka_with_retry` against the compose cluster passed every assertion with **zero** watcher timeouts, through `send and wait(in-order)` (1000/1000 on both watchers), `send and wait(no-order)`, `stop broker 1/2/3`, `restart broker 3/2/1`, and `assert messages(Component reconnect)`.

The run then hung in `interrupt network`, which uses `tylertreat/comcast` to manipulate host `tc`/`iptables` rules. That step does not work on my machine and is unrelated to this change, so I am relying on CI to exercise it and the consumer-rebalance step that follows.

What this PR does not claim is that it eliminates the flake outright. It removes a readiness gate that is demonstrably a false positive and whose failure mode matches the observed signature exactly; confirmation is CI staying green over subsequent runs. Happy to re-run the certification job a few times on this PR if that would help.

The same `myTopic` probe exists in the pubsub kafka certification test. I've kept this PR scoped to bindings — glad to carry the same fix there in a follow-up if maintainers prefer.

## Issue reference

Closes https://github.com/dapr/components-contrib/issues/4178

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: not applicable — this changes a certification test only, with no user-facing behaviour or documented API affected

RELEASE NOTE: FIX: Bug in bindings.kafka certification tests
