### PR TITLE
fix(ci): ravendb ci

### DIFF
--- a/.github/infrastructure/docker-compose-ravendb.yml
+++ b/.github/infrastructure/docker-compose-ravendb.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - RAVEN_LICENSE={"Id":"b75b6995-5f1f-440f-bcaa-40f7388ecf90","Name":"Vega IT","Keys":["jwX1/epkfQHHLKF0UX8+DRCGP","zwoUaohApGfVHZ0rmZ4Cvaj4a","653+JiPtKVTANiZw6wxdD7XB6","3OfgLC8++bvE8T8JhuTD12PQt","nFzHL2zUPhlP5q+9mI8NmAzbu","tTXscNl13tFX1GLgcWkZYNN80","H7RrWQXwKc+HJ4q1d2catABYE","DNy4xBSYoSQMqKywtLi8wJzEy","MzQVFjc4OTo7PD0+nwIfIJ8CI","CCfAiEgnwIjIJ8CJCCfAiUgnw","ImIJ8CJyCfAiggnwIpIJ8CKiC","fAisgnwIsIJ8CLSCfAi4gnwIv","IJ8CMCCfAzZAAZ8CQiCfAkMgn","wJEIJ8CRSCfAkYgnwJHIJ8CSA","BDJEQJYgVdnwRBYAJd"]}
+      - "RAVEN_LICENSE=${RAVENDBLICENSE:?RAVENDBLICENSE must be set to a RavenDB license JSON}"
       - RAVEN_DATABASE=testdapr
       - RAVEN_Setup_Mode=None
       - RAVEN_License_Eula_Accepted=true

--- a/.github/scripts/test-info.mjs
+++ b/.github/scripts/test-info.mjs
@@ -919,7 +919,7 @@ const components = {
  * @property {boolean?} requireAWSCredentials If true, requires AWS credentials and makes the test "cloud-only"
  * @property {boolean?} requireGCPCredentials If true, requires GCP credentials and makes the test "cloud-only"
  * @property {boolean?} requireCloudflareCredentials If true, requires Cloudflare credentials and makes the test "cloud-only"
- * @property {boolean?} requireRavenDBCredentials If true, requires RavenDB credentials
+ * @property {boolean?} requireRavenDBCredentials If true, requires RavenDB credentials (license) and makes the test "cloud-only"
  * @property {boolean?} requireTerraform If true, requires Terraform
  * @property {boolean?} requireKind If true, requires KinD
  * @property {string?} conformanceSetup Setup script for conformance tests
@@ -973,7 +973,8 @@ function GenerateMatrix(testKind, enableCloudTests) {
                 comp.requiredCerts?.length ||
                 comp.requireAWSCredentials ||
                 comp.requireGCPCredentials ||
-                comp.requireCloudflareCredentials,
+                comp.requireCloudflareCredentials ||
+                comp.requireRavenDBCredentials,
         )
 
         // Skip cloud-only tests if enableCloudTests is false

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -232,6 +232,21 @@ jobs:
         aws-secret-access-key: "${{ secrets.AWS_SECRET_KEY }}"
         aws-region: "${{ env.AWS_REGION }}"
 
+    - name: Set RavenDB env vars
+      if: matrix.require-ravendb-credentials == 'true'
+      env:
+        RAVENDBLICENSE: ${{ secrets.RAVENDBLICENSE }}
+      run: |
+        if [ -z "$RAVENDBLICENSE" ]; then
+          echo "::error::RAVENDBLICENSE secret is not set"
+          exit 1
+        fi
+        {
+          echo "RAVENDBLICENSE<<EOF_RAVENDBLICENSE"
+          echo "$RAVENDBLICENSE"
+          echo "EOF_RAVENDBLICENSE"
+        } >> "$GITHUB_ENV"
+
     - name: Set up Go
       id: setup-go
       uses: actions/setup-go@v7

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -235,6 +235,21 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
         aws-region: us-west-1
 
+    - name: Set RavenDB env vars
+      if: matrix.require-ravendb-credentials == 'true'
+      env:
+        RAVENDBLICENSE: ${{ secrets.RAVENDBLICENSE }}
+      run: |
+        if [ -z "$RAVENDBLICENSE" ]; then
+          echo "::error::RAVENDBLICENSE secret is not set"
+          exit 1
+        fi
+        {
+          echo "RAVENDBLICENSE<<EOF_RAVENDBLICENSE"
+          echo "$RAVENDBLICENSE"
+          echo "EOF_RAVENDBLICENSE"
+        } >> "$GITHUB_ENV"
+
     - name: Start MongoDB
       if: matrix.mongodb-version != ''
       uses: supercharge/mongodb-github-action@1.12.1

--- a/tests/certification/state/ravendb/README.md
+++ b/tests/certification/state/ravendb/README.md
@@ -4,6 +4,7 @@ This project aims to test the RavenDB State Store component under various condit
 
 ## Test plan
 Run:
+export RAVENDBLICENSE="$(cat /path/to/license.json)"
 go test -v -tags "unit certtests" -count=1 .
 
 ## Basic Test for CRUD operations:

--- a/tests/certification/state/ravendb/docker-compose.yml
+++ b/tests/certification/state/ravendb/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - RAVEN_LICENSE={"Id":"b75b6995-5f1f-440f-bcaa-40f7388ecf90","Name":"Vega IT","Keys":["jwX1/epkfQHHLKF0UX8+DRCGP","zwoUaohApGfVHZ0rmZ4Cvaj4a","653+JiPtKVTANiZw6wxdD7XB6","3OfgLC8++bvE8T8JhuTD12PQt","nFzHL2zUPhlP5q+9mI8NmAzbu","tTXscNl13tFX1GLgcWkZYNN80","H7RrWQXwKc+HJ4q1d2catABYE","DNy4xBSYoSQMqKywtLi8wJzEy","MzQVFjc4OTo7PD0+nwIfIJ8CI","CCfAiEgnwIjIJ8CJCCfAiUgnw","ImIJ8CJyCfAiggnwIpIJ8CKiC","fAisgnwIsIJ8CLSCfAi4gnwIv","IJ8CMCCfAzZAAZ8CQiCfAkMgn","wJEIJ8CRSCfAkYgnwJHIJ8CSA","BDJEQJYgVdnwRBYAJd"]}
+      - "RAVEN_LICENSE=${RAVENDBLICENSE:?RAVENDBLICENSE must be set to a RavenDB license JSON}"
       - RAVEN_DATABASE=testdapr
       - RAVEN_Setup_Mode=None
       - RAVEN_License_Eula_Accepted=true


### PR DESCRIPTION
# Description

Migrates ravendb to a secret again for a new licence that doesn't incorporate secrets in the repo.

The workflow will require `/ok-to-test` to be run going forward as it loads a secret, it will not run by default on pull reqeusts.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
